### PR TITLE
feat(games): add game system/games "library" navigation heirarchy

### DIFF
--- a/lib/data/viewmodels/game_system_browse_view_model.dart
+++ b/lib/data/viewmodels/game_system_browse_view_model.dart
@@ -1,0 +1,275 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../util/game_browse_filter.dart';
+import '../../util/game_library.dart';
+
+enum GameSystemBrowseError { unsupported, loadFailed }
+
+/// Games-scoped state for browsing one retro-game system.
+///
+/// Focus nodes and responsive layout remain in the screen; API work, prepared
+/// search data, debounce timers, selection, and detail caching live here so the
+/// widget does not mix rendering with data orchestration.
+class GameSystemBrowseViewModel extends ChangeNotifier {
+  GameSystemBrowseViewModel({
+    required GamesApi? gamesApi,
+    required this.libraryId,
+    required this.systemId,
+    String? systemName,
+  }) : _gamesApi = gamesApi,
+       _providedSystemName = systemName?.trim();
+
+  static const searchDebounceDuration = Duration(milliseconds: 150);
+  // Descriptions should feel immediate while still ignoring a pointer merely
+  // crossing a card. Full-screen backdrop work can wait until navigation has
+  // clearly settled so normal browsing does not churn blurred backgrounds.
+  static const detailDebounceDuration = Duration(milliseconds: 75);
+  static const backdropDebounceDuration = Duration(milliseconds: 650);
+
+  final GamesApi? _gamesApi;
+  final String libraryId;
+  final String systemId;
+  final String? _providedSystemName;
+
+  bool loading = true;
+  GameSystemBrowseError? error;
+  String selectedLetter = '';
+  String appliedSearchQuery = '';
+  String? resolvedSystemName;
+  List<GameSummary> games = const [];
+  List<GameSummary> visibleGames = const [];
+  Map<String, String> displayTitles = const {};
+  Map<String, GameBrowseTextIndex> _browseIndexes = const {};
+  final Map<String, GameDetail> gameDetails = {};
+  final Map<String, Future<GameDetail?>> _detailRequests = {};
+  GameSummary? activeGame;
+  GameSummary? hudGame;
+  GameSummary? backdropGame;
+  Timer? _detailDebounce;
+  Timer? _backdropDebounce;
+  Timer? _searchDebounce;
+  bool _disposed = false;
+
+  String get displaySystemName => _providedSystemName?.isNotEmpty == true
+      ? _providedSystemName!
+      : (resolvedSystemName ?? systemId);
+
+  Future<void> load() async {
+    loading = true;
+    error = null;
+    _notify();
+
+    final api = _gamesApi;
+    if (api == null) {
+      loading = false;
+      error = GameSystemBrowseError.unsupported;
+      _notify();
+      return;
+    }
+
+    try {
+      final systemNameFuture = _providedSystemName?.isNotEmpty == true
+          ? null
+          : _resolveSystemName(api);
+      final loadedGames = await api.getGames(libraryId, system: systemId);
+      final loadedDisplayTitles = {
+        for (final game in loadedGames)
+          game.id: gameDisplayTitle(game.title, game.fileName),
+      };
+      final loadedIndexes = {
+        for (final game in loadedGames)
+          game.id: GameBrowseTextIndex(
+            loadedDisplayTitles[game.id]!,
+            alternateText: game.fileName,
+          ),
+      };
+      loadedGames.sort(
+        (a, b) => loadedIndexes[a.id]!.sortKey.compareTo(
+          loadedIndexes[b.id]!.sortKey,
+        ),
+      );
+
+      games = loadedGames;
+      displayTitles = loadedDisplayTitles;
+      _browseIndexes = loadedIndexes;
+      resolvedSystemName = systemNameFuture == null
+          ? null
+          : await systemNameFuture;
+      activeGame = null;
+      hudGame = null;
+      backdropGame = null;
+      loading = false;
+      _rebuildVisibleGames();
+      _notify();
+    } catch (exception) {
+      debugPrint(
+        '[GameSystemBrowseViewModel] Failed to load games: $exception',
+      );
+      loading = false;
+      error = GameSystemBrowseError.loadFailed;
+      _notify();
+    }
+  }
+
+  void updateSearch(String query) {
+    _searchDebounce?.cancel();
+    if (query.isEmpty) {
+      appliedSearchQuery = '';
+      _rebuildVisibleGames();
+      _notify();
+      return;
+    }
+    if (appliedSearchQuery.isEmpty && selectedLetter.isNotEmpty) {
+      selectedLetter = '';
+      _rebuildVisibleGames();
+      _notify();
+    }
+    _searchDebounce = Timer(searchDebounceDuration, () {
+      appliedSearchQuery = query;
+      _rebuildVisibleGames();
+      _notify();
+    });
+  }
+
+  void selectLetter(String letter) {
+    selectedLetter = letter;
+    _rebuildVisibleGames();
+    _notify();
+  }
+
+  void activateGame(
+    GameSummary game, {
+    required bool showBackdrop,
+    required bool loadDetails,
+  }) {
+    if (activeGame?.id != game.id) {
+      activeGame = game;
+      _notify();
+    }
+    _detailDebounce?.cancel();
+    _backdropDebounce?.cancel();
+    if (loadDetails) {
+      _detailDebounce = Timer(detailDebounceDuration, () {
+        unawaited(_showHudAfterDetails(game));
+      });
+    }
+    if (showBackdrop) {
+      _backdropDebounce = Timer(backdropDebounceDuration, () {
+        if (activeGame?.id != game.id) return;
+        backdropGame = game;
+        _notify();
+      });
+    }
+  }
+
+  void deactivateGame(GameSummary game) {
+    if (activeGame?.id != game.id) return;
+    clearActiveGame();
+  }
+
+  void clearActiveGame() {
+    _detailDebounce?.cancel();
+    _backdropDebounce?.cancel();
+    if (activeGame == null && hudGame == null && backdropGame == null) return;
+    activeGame = null;
+    hudGame = null;
+    backdropGame = null;
+    _notify();
+  }
+
+  void _rebuildVisibleGames() {
+    final queryWords = gameBrowseQueryWords(appliedSearchQuery);
+    visibleGames = games
+        .where(
+          (game) =>
+              _browseIndexes[game.id]?.matches(
+                queryWords: queryWords,
+                letter: selectedLetter,
+              ) ??
+              true,
+        )
+        .toList(growable: false);
+    final activeId = activeGame?.id;
+    if (activeId != null && !visibleGames.any((game) => game.id == activeId)) {
+      _detailDebounce?.cancel();
+      _backdropDebounce?.cancel();
+      activeGame = null;
+      hudGame = null;
+      backdropGame = null;
+    }
+  }
+
+  Future<String?> _resolveSystemName(GamesApi api) async {
+    try {
+      final systems = await api.getSystems(libraryId);
+      for (final system in systems) {
+        if (system.id.toLowerCase() == systemId.toLowerCase()) {
+          return system.name;
+        }
+      }
+    } catch (exception) {
+      debugPrint(
+        '[GameSystemBrowseViewModel] Failed to resolve system name: '
+        '$exception',
+      );
+    }
+    return null;
+  }
+
+  Future<void> _showHudAfterDetails(GameSummary game) async {
+    await _loadGameDetails(game);
+    if (activeGame?.id != game.id) return;
+    hudGame = game;
+    _notify();
+  }
+
+  Future<GameDetail?> _loadGameDetails(GameSummary game) {
+    final cached = gameDetails[game.id];
+    if (cached != null) return Future.value(cached);
+
+    final pending = _detailRequests[game.id];
+    if (pending != null) return pending;
+
+    final api = _gamesApi;
+    if (api == null) return Future.value();
+
+    late final Future<GameDetail?> request;
+    request = _fetchGameDetails(api, game).whenComplete(() {
+      if (identical(_detailRequests[game.id], request)) {
+        _detailRequests.remove(game.id);
+      }
+    });
+    _detailRequests[game.id] = request;
+    return request;
+  }
+
+  Future<GameDetail?> _fetchGameDetails(GamesApi api, GameSummary game) async {
+    try {
+      final detail = await api.getGame(libraryId, game.id);
+      if (detail == null) return null;
+      gameDetails[game.id] = detail;
+      return detail;
+    } catch (exception) {
+      debugPrint(
+        '[GameSystemBrowseViewModel] Failed to load game details: $exception',
+      );
+      return null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _detailDebounce?.cancel();
+    _backdropDebounce?.cancel();
+    _searchDebounce?.cancel();
+    super.dispose();
+  }
+
+  void _notify() {
+    if (!_disposed) notifyListeners();
+  }
+}

--- a/lib/data/viewmodels/game_system_browse_view_model.dart
+++ b/lib/data/viewmodels/game_system_browse_view_model.dart
@@ -28,6 +28,7 @@ class GameSystemBrowseViewModel extends ChangeNotifier {
   // clearly settled so normal browsing does not churn blurred backgrounds.
   static const detailDebounceDuration = Duration(milliseconds: 75);
   static const backdropDebounceDuration = Duration(milliseconds: 650);
+  static const detailCacheCapacity = 128; // max limit for LRU cache. Semi-arbitrary and tunable if issues arise
 
   final GamesApi? _gamesApi;
   final String libraryId;
@@ -227,8 +228,12 @@ class GameSystemBrowseViewModel extends ChangeNotifier {
   }
 
   Future<GameDetail?> _loadGameDetails(GameSummary game) {
-    final cached = gameDetails[game.id];
-    if (cached != null) return Future.value(cached);
+    final cached = gameDetails.remove(game.id);
+    if (cached != null) {
+      // Map preserves insertion order, so reinsert cache hits to maintain LRU.
+      gameDetails[game.id] = cached;
+      return Future.value(cached);
+    }
 
     final pending = _detailRequests[game.id];
     if (pending != null) return pending;
@@ -250,7 +255,11 @@ class GameSystemBrowseViewModel extends ChangeNotifier {
     try {
       final detail = await api.getGame(libraryId, game.id);
       if (detail == null) return null;
+      gameDetails.remove(game.id);
       gameDetails[game.id] = detail;
+      if (gameDetails.length > detailCacheCapacity) {
+        gameDetails.remove(gameDetails.keys.first);
+      }
       return detail;
     } catch (exception) {
       debugPrint(

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -32,6 +32,7 @@ import '../screens/browse/book_browse_screen.dart';
 import '../screens/browse/music_browse_screen.dart';
 import '../screens/detail/item_detail_screen.dart';
 import '../screens/games/game_library_screen.dart';
+import '../screens/games/game_system_screen.dart';
 import '../screens/games/game_detail_screen.dart';
 import '../screens/playback/game_emulator_screen.dart';
 import '../screens/playback/native_game_player_screen.dart';
@@ -398,6 +399,19 @@ final appRouter = GoRouter(
     ),
 
     // Games
+    GoRoute(
+      path: Destinations.gameSystem,
+      builder: (context, state) {
+        final libraryId = state.pathParameters['libraryId']!;
+        final systemId = state.pathParameters['systemId']!;
+        return GameSystemScreen(
+          key: ValueKey('game-system-$libraryId-$systemId'),
+          libraryId: libraryId,
+          systemId: systemId,
+          systemName: state.uri.queryParameters['name'],
+        );
+      },
+    ),
     GoRoute(
       path: Destinations.gameLibrary,
       builder: (context, state) {

--- a/lib/ui/navigation/destinations.dart
+++ b/lib/ui/navigation/destinations.dart
@@ -84,6 +84,7 @@ class Destinations {
 
   // Games
   static const gameLibrary = '/games/:libraryId';
+  static const gameSystem = '/games/:libraryId/system/:systemId';
   static const gameDetail = '/game/:libraryId/:gameId';
   static const gamePlayer = '/game-player/:libraryId/:gameId';
 
@@ -186,6 +187,20 @@ class Destinations {
   // Games
   static String gamesLibrary(String libraryId) =>
       '/games/${Uri.encodeComponent(libraryId)}';
+  static String gameSystemOf(
+    String libraryId,
+    String systemId, {
+    String? systemName,
+  }) {
+    final base =
+        '/games/${Uri.encodeComponent(libraryId)}/system/${Uri.encodeComponent(systemId)}';
+    final params = <String>[
+      if (systemName != null && systemName.isNotEmpty)
+        'name=${Uri.encodeQueryComponent(systemName)}',
+    ];
+    return params.isEmpty ? base : '$base?${params.join('&')}';
+  }
+
   static String gameDetailOf(String libraryId, String gameId) =>
       '/game/${Uri.encodeComponent(libraryId)}/${Uri.encodeComponent(gameId)}';
   static String gamePlayerOf(

--- a/lib/ui/screens/games/game_library_screen.dart
+++ b/lib/ui/screens/games/game_library_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -6,6 +6,10 @@ import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../../l10n/app_localizations.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
+import '../../../util/focus/grid_focus_node_mixin.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
 import '../../widgets/game/game_system_card.dart';
@@ -22,13 +26,16 @@ class GameLibraryScreen extends StatefulWidget {
   State<GameLibraryScreen> createState() => _GameLibraryScreenState();
 }
 
-class _GameLibraryScreenState extends State<GameLibraryScreen> {
+class _GameLibraryScreenState extends State<GameLibraryScreen>
+    with GridFocusNodeMixin<GameLibraryScreen> {
   final MediaServerClient _client = GetIt.instance<MediaServerClient>();
+  final UserPreferences _prefs = GetIt.instance<UserPreferences>();
 
   bool _loading = true;
-  String? _error;
+  bool _hasError = false;
   List<GameSystem> _systems = const [];
   Map<String, List<GameSummary>> _gamesBySystem = const {};
+  Map<String, int> _gameCountsBySystem = const {};
 
   @override
   void initState() {
@@ -36,79 +43,120 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
     _load();
   }
 
+  @override
+  void dispose() {
+    disposeGridFocusNodes();
+    super.dispose();
+  }
+
   Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _hasError = false;
+    });
     final games = _client.gamesApi;
     if (games == null) {
       setState(() {
         _loading = false;
-        _error = 'This server does not support games.';
+        _hasError = true;
       });
       return;
     }
 
+    // Begin optional previews immediately, but do not make them part of the
+    // critical path for rendering the system list.
+    final previewsFuture = _loadPreviews(games);
     try {
-      // Start both requests together. Platform tiles use a small selection of
-      // their games for artwork, while the platform screen remains responsible
-      // for displaying the complete game grid.
-      final systemsFuture = games.getSystems(widget.libraryId);
-      final allGamesFuture = games.getGames(widget.libraryId);
-      final (systems, allGames) = await (systemsFuture, allGamesFuture).wait;
-      final grouped = <String, List<GameSummary>>{};
-      for (final game in allGames) {
-        grouped
-            .putIfAbsent(game.system.toLowerCase(), () => <GameSummary>[])
-            .add(game);
-      }
+      final systems = await games.getSystems(widget.libraryId);
+      if (!mounted) return;
+      setState(() {
+        _systems = systems;
+        _gamesBySystem = const {};
+        _gameCountsBySystem = {
+          for (final system in systems)
+            if (system.gameCount > 0) system.id.toLowerCase(): system.gameCount,
+        };
+        _loading = false;
+      });
+
+      final previews = await previewsFuture;
+      if (!mounted || previews == null) return;
       final populatedSystems = systems
           .where(
-            (system) => grouped[system.id.toLowerCase()]?.isNotEmpty == true,
+            (system) => (previews.counts[system.id.toLowerCase()] ?? 0) > 0,
           )
           .toList(growable: false);
-      if (!mounted) return;
       setState(() {
         _systems = populatedSystems;
-        _gamesBySystem = grouped;
-        _loading = false;
+        _gamesBySystem = previews.games;
+        _gameCountsBySystem = previews.counts;
+      });
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) cleanupGridFocusNodes(populatedSystems.length);
       });
     } catch (e) {
+      debugPrint('[GameLibraryScreen] Failed to load systems: $e');
       if (!mounted) return;
       setState(() {
         _loading = false;
-        _error = 'Failed to load game platforms: $e';
+        _hasError = true;
       });
+    }
+  }
+
+  Future<_GameSystemPreviews?> _loadPreviews(GamesApi gamesApi) async {
+    try {
+      final allGames = await gamesApi.getGames(widget.libraryId);
+      final previews = <String, List<GameSummary>>{};
+      final counts = <String, int>{};
+      for (final game in allGames) {
+        final key = game.system.toLowerCase();
+        counts[key] = (counts[key] ?? 0) + 1;
+        final systemPreviews = previews.putIfAbsent(key, () => <GameSummary>[]);
+        if (systemPreviews.length < 4) systemPreviews.add(game);
+      }
+      return _GameSystemPreviews(games: previews, counts: counts);
+    } catch (e) {
+      debugPrint('[GameLibraryScreen] Failed to load system previews: $e');
+      return null;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     return Scaffold(
       backgroundColor: AppColorScheme.background,
-      appBar: AppBar(title: Text(widget.title ?? 'Games')),
+      appBar: AppBar(title: Text(widget.title ?? l10n.games)),
       body: _buildBody(),
     );
   }
 
   Widget _buildBody() {
+    final l10n = AppLocalizations.of(context);
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (_error != null) {
+    if (_hasError) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(_error!, textAlign: TextAlign.center),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(l10n.failedToLoadLibrary, textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              FilledButton(onPressed: _load, child: Text(l10n.retry)),
+            ],
+          ),
         ),
       );
     }
     if (_systems.isEmpty) {
-      return const Center(
+      return Center(
         child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text(
-            'No games found.\n\nOrganize ROMs as System/<game>/rom.ext in a Mixed Content '
-            'library, and enable Retro Games in the Moonbase plugin settings.',
-            textAlign: TextAlign.center,
-          ),
+          padding: const EdgeInsets.all(24),
+          child: Text(l10n.noItemsFound, textAlign: TextAlign.center),
         ),
       );
     }
@@ -116,19 +164,43 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final compact = constraints.maxWidth < 600;
-        final horizontalPadding = compact ? 16.0 : 48.0;
+        final desktopScale = _prefs
+            .get(UserPreferences.desktopUiScale)
+            .scaleFactor;
+        final layoutScale = compact ? 1.0 : desktopScale;
+        final horizontalPadding = compact ? 16.0 : 48.0 * layoutScale;
+        final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+        final focusColor = isNeon
+            ? ThemeRegistry.active.borders.focusBorder.color
+            : Color(_prefs.get(UserPreferences.focusColor).colorValue);
+        final cardFocusExpansion = _prefs.get(
+          UserPreferences.cardFocusExpansion,
+        );
+        final textScale = MediaQuery.textScalerOf(context).scale(1);
+        final minimumCardHeight = (compact ? 116.0 : 126.0) * layoutScale;
+        // Theme fonts can have line heights substantially above their nominal
+        // size. Reserve enough growth for a two-line title and count rather
+        // than relying on a font-specific multiplier.
+        final cardHeight = minimumCardHeight + math.max(0, textScale - 1) * 96;
+        final maximumCardWidth = (compact ? 360.0 : 320.0) * layoutScale;
+        final spacing = 18 * layoutScale;
+        final availableWidth = constraints.maxWidth - horizontalPadding * 2;
+        final crossAxisCount =
+            ((availableWidth + spacing) / (maximumCardWidth + spacing))
+                .ceil()
+                .clamp(1, 20);
         return GridView.builder(
           padding: EdgeInsets.fromLTRB(
             horizontalPadding,
-            20,
+            20 * layoutScale,
             horizontalPadding,
-            32,
+            32 * layoutScale,
           ),
           gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: compact ? 360 : 320,
-            mainAxisExtent: compact ? 116 : 126,
-            mainAxisSpacing: 18,
-            crossAxisSpacing: 18,
+            maxCrossAxisExtent: maximumCardWidth,
+            mainAxisExtent: cardHeight,
+            mainAxisSpacing: spacing,
+            crossAxisSpacing: spacing,
           ),
           itemCount: _systems.length,
           itemBuilder: (context, index) {
@@ -137,7 +209,25 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
               libraryId: widget.libraryId,
               system: system,
               games: _gamesBySystem[system.id.toLowerCase()] ?? const [],
+              gameCount:
+                  _gameCountsBySystem[system.id.toLowerCase()] ??
+                  (system.gameCount > 0 ? system.gameCount : null),
               autofocus: PlatformDetection.isTV && index == 0,
+              focusNode: getGridItemFocusNode(index, prefix: 'game_system'),
+              focusColor: focusColor,
+              cardFocusExpansion: cardFocusExpansion,
+              suppressFocusGlow: isNeon,
+              onKeyEvent: (_, event) {
+                if (event.isActionable && event.logicalKey.isRightKey) {
+                  final isLastColumn =
+                      (index % crossAxisCount) == crossAxisCount - 1;
+                  final isLastItem = index == _systems.length - 1;
+                  if (isLastColumn || isLastItem) {
+                    return KeyEventResult.handled;
+                  }
+                }
+                return KeyEventResult.ignored;
+              },
               onTap: () => context.push(
                 Destinations.gameSystemOf(
                   widget.libraryId,
@@ -151,4 +241,11 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
       },
     );
   }
+}
+
+class _GameSystemPreviews {
+  const _GameSystemPreviews({required this.games, required this.counts});
+
+  final Map<String, List<GameSummary>> games;
+  final Map<String, int> counts;
 }

--- a/lib/ui/screens/games/game_library_screen.dart
+++ b/lib/ui/screens/games/game_library_screen.dart
@@ -196,8 +196,8 @@ class _GameLibraryScreenState extends State<GameLibraryScreen>
             horizontalPadding,
             32 * layoutScale,
           ),
-          gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
-            maxCrossAxisExtent: maximumCardWidth,
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
             mainAxisExtent: cardHeight,
             mainAxisSpacing: spacing,
             crossAxisSpacing: spacing,

--- a/lib/ui/screens/games/game_library_screen.dart
+++ b/lib/ui/screens/games/game_library_screen.dart
@@ -1,14 +1,17 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
-import '../../navigation/destinations.dart';
-import '../../widgets/game/game_poster_rail.dart';
 import '../../../util/platform_detection.dart';
+import '../../navigation/destinations.dart';
+import '../../widgets/game/game_system_card.dart';
 
-/// Browses a retro-game library as premium per-system box-art rows. Tapping a game opens the
-/// game detail screen. Responsive card sizing across mobile, desktop, and TV (d-pad focus).
+/// Displays the platforms in a retro-game library. Selecting a platform opens
+/// its vertically scrolling, searchable game grid.
 class GameLibraryScreen extends StatefulWidget {
   const GameLibraryScreen({super.key, required this.libraryId, this.title});
 
@@ -44,15 +47,26 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
     }
 
     try {
-      final systems = await games.getSystems(widget.libraryId);
-      final all = await games.getGames(widget.libraryId);
+      // Start both requests together. Platform tiles use a small selection of
+      // their games for artwork, while the platform screen remains responsible
+      // for displaying the complete game grid.
+      final systemsFuture = games.getSystems(widget.libraryId);
+      final allGamesFuture = games.getGames(widget.libraryId);
+      final (systems, allGames) = await (systemsFuture, allGamesFuture).wait;
       final grouped = <String, List<GameSummary>>{};
-      for (final g in all) {
-        grouped.putIfAbsent(g.system, () => <GameSummary>[]).add(g);
+      for (final game in allGames) {
+        grouped
+            .putIfAbsent(game.system.toLowerCase(), () => <GameSummary>[])
+            .add(game);
       }
+      final populatedSystems = systems
+          .where(
+            (system) => grouped[system.id.toLowerCase()]?.isNotEmpty == true,
+          )
+          .toList(growable: false);
       if (!mounted) return;
       setState(() {
-        _systems = systems;
+        _systems = populatedSystems;
         _gamesBySystem = grouped;
         _loading = false;
       });
@@ -60,7 +74,7 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
       if (!mounted) return;
       setState(() {
         _loading = false;
-        _error = 'Failed to load games: $e';
+        _error = 'Failed to load game platforms: $e';
       });
     }
   }
@@ -68,6 +82,7 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColorScheme.background,
       appBar: AppBar(title: Text(widget.title ?? 'Games')),
       body: _buildBody(),
     );
@@ -98,30 +113,40 @@ class _GameLibraryScreenState extends State<GameLibraryScreen> {
       );
     }
 
-    final cardWidth = PlatformDetection.isTV
-        ? 132.0
-        : (PlatformDetection.useDesktopUi ? 120.0 : 100.0);
-
-    return ListView.builder(
-      padding: const EdgeInsets.symmetric(vertical: 16),
-      itemCount: _systems.length,
-      itemBuilder: (context, index) {
-        final system = _systems[index];
-        final games = _gamesBySystem[system.id] ?? const [];
-        if (games.isEmpty) return const SizedBox.shrink();
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 24),
-          child: GamePosterRail(
-            title: system.name,
-            libraryId: widget.libraryId,
-            games: games,
-            trailingCount: games.length,
-            cardWidth: cardWidth,
-            autofocusFirst: index == 0,
-            onTapGame: (game) => context.push(
-              Destinations.gameDetailOf(widget.libraryId, game.id),
-            ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 600;
+        final horizontalPadding = compact ? 16.0 : 48.0;
+        return GridView.builder(
+          padding: EdgeInsets.fromLTRB(
+            horizontalPadding,
+            20,
+            horizontalPadding,
+            32,
           ),
+          gridDelegate: SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: compact ? 360 : 320,
+            mainAxisExtent: compact ? 116 : 126,
+            mainAxisSpacing: 18,
+            crossAxisSpacing: 18,
+          ),
+          itemCount: _systems.length,
+          itemBuilder: (context, index) {
+            final system = _systems[index];
+            return GameSystemCard(
+              libraryId: widget.libraryId,
+              system: system,
+              games: _gamesBySystem[system.id.toLowerCase()] ?? const [],
+              autofocus: PlatformDetection.isTV && index == 0,
+              onTap: () => context.push(
+                Destinations.gameSystemOf(
+                  widget.libraryId,
+                  system.id,
+                  systemName: system.name,
+                ),
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/ui/screens/games/game_system_screen.dart
+++ b/lib/ui/screens/games/game_system_screen.dart
@@ -1,18 +1,27 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../../data/viewmodels/game_system_browse_view_model.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/user_preferences.dart';
-import '../../../util/game_browse_filter.dart';
 import '../../../util/game_library.dart';
 import '../../../util/focus/dpad_keys.dart';
+import '../../../util/focus/grid_focus_node_mixin.dart';
 import '../../../util/platform_detection.dart';
 import '../../navigation/destinations.dart';
+import '../../widgets/bounded_network_image.dart';
+import '../../widgets/focus/focusable_toolbar_button.dart';
+import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/game/game_alpha_picker_bar.dart';
 import '../../widgets/game/game_poster_card.dart';
 
@@ -34,8 +43,8 @@ class GameSystemScreen extends StatefulWidget {
   State<GameSystemScreen> createState() => _GameSystemScreenState();
 }
 
-class _GameSystemScreenState extends State<GameSystemScreen> {
-  final MediaServerClient _client = GetIt.instance<MediaServerClient>();
+class _GameSystemScreenState extends State<GameSystemScreen>
+    with GridFocusNodeMixin<GameSystemScreen> {
   final UserPreferences _prefs = GetIt.instance<UserPreferences>();
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
@@ -43,33 +52,64 @@ class _GameSystemScreenState extends State<GameSystemScreen> {
   final FocusNode _allLetterFocus = FocusNode(
     debugLabel: 'game_alpha_all_letter',
   );
-
-  bool _loading = true;
-  String? _error;
-  String _selectedLetter = '';
-  List<GameSummary> _games = const [];
-  Map<String, String> _displayTitles = const {};
+  final ScrollController _gridScrollController = ScrollController();
+  late final GameSystemBrowseViewModel _browse;
+  List<GameSummary>? _observedVisibleGames;
+  Timer? _hoverScrollSettle;
+  GameSummary? _hoveredGame;
+  bool _suppressHoverEnrichment = false;
+  Timer? _backdropPreloadTimer;
+  int _backdropPreloadGeneration = 0;
+  String? _backdropPreloadTargetId;
 
   @override
   void initState() {
     super.initState();
+    _browse = GameSystemBrowseViewModel(
+      gamesApi: GetIt.instance<MediaServerClient>().gamesApi,
+      libraryId: widget.libraryId,
+      systemId: widget.systemId,
+      systemName: widget.systemName,
+    )..addListener(_onBrowseChanged);
     _searchController.addListener(_onSearchChanged);
     _searchFocus.addListener(_onSearchFocusChanged);
-    _load();
+    _browse.load();
   }
 
   @override
   void dispose() {
+    _browse.removeListener(_onBrowseChanged);
+    _browse.dispose();
     _searchController.removeListener(_onSearchChanged);
     _searchFocus.removeListener(_onSearchFocusChanged);
     _searchController.dispose();
     _searchFocus.dispose();
     _allLetterFocus.dispose();
+    _gridScrollController.dispose();
+    _hoverScrollSettle?.cancel();
+    _cancelBackdropPreload();
+    disposeGridFocusNodes();
     super.dispose();
   }
 
   void _onSearchChanged() {
-    if (mounted) setState(() {});
+    _browse.updateSearch(_searchController.text);
+  }
+
+  void _onBrowseChanged() {
+    if (!mounted) return;
+    if (_browse.activeGame?.id != _backdropPreloadTargetId) {
+      _cancelBackdropPreload();
+    }
+    final visibleGames = _browse.visibleGames;
+    if (!identical(_observedVisibleGames, visibleGames)) {
+      _observedVisibleGames = visibleGames;
+      gridContentVersion++;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) cleanupGridFocusNodes(visibleGames.length);
+      });
+    }
+    setState(() {});
   }
 
   void _onSearchFocusChanged() {
@@ -85,121 +125,204 @@ class _GameSystemScreenState extends State<GameSystemScreen> {
     return KeyEventResult.handled;
   }
 
-  Future<void> _load() async {
-    final gamesApi = _client.gamesApi;
-    if (gamesApi == null) {
-      setState(() {
-        _loading = false;
-        _error = 'This server does not support games.';
-      });
-      return;
-    }
-
-    try {
-      final games = await gamesApi.getGames(
-        widget.libraryId,
-        system: widget.systemId,
-      );
-      final displayTitles = {
-        for (final game in games)
-          game.id: gameDisplayTitle(game.title, game.fileName),
-      };
-      games.sort(
-        (a, b) => displayTitles[a.id]!.toLowerCase().compareTo(
-          displayTitles[b.id]!.toLowerCase(),
-        ),
-      );
-      if (!mounted) return;
-      setState(() {
-        _games = games;
-        _displayTitles = displayTitles;
-        _loading = false;
-      });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _loading = false;
-        _error = 'Failed to load games: $e';
-      });
-    }
-  }
-
-  List<GameSummary> get _visibleGames {
-    return _games
-        .where((game) {
-          return gameTitleMatchesBrowseFilters(
-            _displayTitles[game.id] ??
-                gameDisplayTitle(game.title, game.fileName),
-            alternateText: game.fileName,
-            query: _searchController.text,
-            letter: _selectedLetter,
-          );
-        })
-        .toList(growable: false);
-  }
-
   @override
   Widget build(BuildContext context) {
-    final title = widget.systemName?.trim();
-    return Scaffold(
+    final compact =
+        PlatformDetection.useMobileUi || MediaQuery.sizeOf(context).width < 600;
+    final screenSize = MediaQuery.sizeOf(context);
+    final textScale = MediaQuery.textScalerOf(context).scale(1);
+    final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
+    final showBackdrop = !compact && !hideBackdrops;
+    final showDetails =
+        !compact &&
+        screenSize.height >= 480 * textScale.clamp(1, 2) &&
+        _prefs.get(UserPreferences.showMediaDetailsOnLibraryPage);
+    final backdropGame = showBackdrop ? _browse.backdropGame : null;
+    final hasBackdrop = backdropGame != null;
+    final scaffold = Scaffold(
       backgroundColor: AppColorScheme.background,
-      appBar: AppBar(
-        title: Text(title?.isNotEmpty == true ? title! : widget.systemId),
+      body: Stack(
+        children: [
+          if (backdropGame != null)
+            Positioned.fill(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 300),
+                child: _GameBrowseBackdrop(
+                  key: ValueKey(backdropGame.id),
+                  libraryId: widget.libraryId,
+                  game: backdropGame,
+                  blur: _prefs
+                      .get(UserPreferences.browsingBackgroundBlurAmount)
+                      .toDouble(),
+                ),
+              ),
+            ),
+          Positioned.fill(
+            child: ColoredBox(
+              color: AppColorScheme.background.withValues(
+                alpha: hasBackdrop ? 0.54 : 0.86,
+              ),
+            ),
+          ),
+          _buildBody(
+            compact,
+            showDetails: showDetails,
+            showBackdrop: showBackdrop,
+          ),
+        ],
       ),
-      body: _buildBody(),
     );
+    if (PlatformDetection.useMobileUi) return scaffold;
+    final targetNode = PlatformDetection.isTV && _browse.visibleGames.isNotEmpty
+        ? getGridItemFocusNode(0, prefix: 'game_grid')
+        : _allLetterFocus;
+    return RequestInitialFocus(targetNode: targetNode, child: scaffold);
   }
 
-  Widget _buildBody() {
-    if (_loading) {
+  Widget _buildBody(
+    bool compact, {
+    required bool showDetails,
+    required bool showBackdrop,
+  }) {
+    if (_browse.loading) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (_error != null) {
+    if (_browse.error != null) {
+      final l10n = AppLocalizations.of(context);
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(24),
-          child: Text(_error!, textAlign: TextAlign.center),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(l10n.failedToLoadLibrary, textAlign: TextAlign.center),
+              const SizedBox(height: 12),
+              FilledButton(onPressed: _browse.load, child: Text(l10n.retry)),
+            ],
+          ),
         ),
       );
     }
 
-    final visibleGames = _visibleGames;
     return Column(
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-          child: Column(
-            children: [
-              ConstrainedBox(
+        _buildHeader(compact, showDetails: showDetails),
+        Expanded(
+          child: _browse.visibleGames.isEmpty
+              ? Center(child: Text(AppLocalizations.of(context).noItemsFound))
+              : _buildGrid(
+                  _browse.visibleGames,
+                  showDetails: showDetails,
+                  showBackdrop: showBackdrop,
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeader(bool compact, {required bool showDetails}) {
+    final systemName = _browse.displaySystemName;
+    final desktopScale = _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final horizontalPadding = compact ? 16.0 : 60.0 * desktopScale;
+    final topPadding = compact ? MediaQuery.paddingOf(context).top + 8 : 8.0;
+    final availableWidth =
+        MediaQuery.sizeOf(context).width - horizontalPadding * 2;
+    final inlineSearch = !compact && availableWidth >= 700 * desktopScale;
+
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        horizontalPadding,
+        topPadding,
+        horizontalPadding,
+        2,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (inlineSearch)
+            _buildInlineTitleAndSearch(systemName, desktopScale)
+          else ...[
+            Center(child: _buildSystemTitle(systemName, desktopScale)),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.center,
+              child: ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 560),
                 child: _buildSearchField(),
               ),
-              const SizedBox(height: 10),
-              GameAlphaPickerBar(
-                selected: _selectedLetter,
-                allFocusNode: _allLetterFocus,
-                onChanged: (letter) => setState(() => _selectedLetter = letter),
+            ),
+          ],
+          if (showDetails) ...[
+            const SizedBox(height: 2),
+            _FocusedGameHud(
+              desktopScale: desktopScale,
+              game: _browse.hudGame,
+              detail: _browse.hudGame == null
+                  ? null
+                  : _browse.gameDetails[_browse.hudGame!.id],
+              displayTitle: _browse.hudGame == null
+                  ? null
+                  : _browse.displayTitles[_browse.hudGame!.id],
+            ),
+          ],
+          SizedBox(height: showDetails ? 2 : 8),
+          Row(
+            children: [
+              FocusableToolbarButton(
+                icon: Icons.arrow_back,
+                tooltip: AppLocalizations.of(context).back,
+                size: 30 * desktopScale,
+                iconSize: 20 * desktopScale,
+                unfocusedIconAlpha: 128,
+                onTap: () => context.popOrHome(),
               ),
-              const SizedBox(height: 4),
-              Align(
-                alignment: Alignment.centerRight,
-                child: Text(
-                  '${visibleGames.length} of ${_games.length}',
-                  style: TextStyle(
-                    color: AppColorScheme.onSurface.withValues(alpha: 0.5),
-                    fontSize: 12,
-                  ),
+              SizedBox(width: 10 * desktopScale),
+              Expanded(
+                child: GameAlphaPickerBar(
+                  selected: _browse.selectedLetter,
+                  allFocusNode: _allLetterFocus,
+                  onChanged: _browse.selectLetter,
                 ),
               ),
             ],
           ),
-        ),
-        Expanded(
-          child: visibleGames.isEmpty
-              ? Center(child: Text(AppLocalizations.of(context).noItemsFound))
-              : _buildGrid(visibleGames),
-        ),
-      ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInlineTitleAndSearch(String systemName, double desktopScale) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final desiredSearchWidth = 400 * desktopScale;
+        final maxSearchWidth = (constraints.maxWidth - 220 * desktopScale) / 2;
+        final searchWidth = desiredSearchWidth < maxSearchWidth
+            ? desiredSearchWidth
+            : maxSearchWidth;
+        return Row(
+          children: [
+            SizedBox(width: searchWidth),
+            Expanded(
+              child: Center(child: _buildSystemTitle(systemName, desktopScale)),
+            ),
+            SizedBox(width: searchWidth, child: _buildSearchField()),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildSystemTitle(String systemName, double desktopScale) {
+    return Text(
+      systemName,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        color: AppColorScheme.onSurface,
+        fontSize: 26 * desktopScale,
+        fontWeight: FontWeight.w300,
+      ),
     );
   }
 
@@ -246,40 +369,190 @@ class _GameSystemScreenState extends State<GameSystemScreen> {
       );
     }
 
-    return TextField(
-      controller: _searchController,
-      focusNode: _searchFocus,
-      style: TextStyle(color: foreground, fontSize: 17),
-      decoration: InputDecoration(
-        hintText: l10n.searchThisLibrary,
-        hintStyle: TextStyle(color: foreground.withValues(alpha: 0.62)),
-        prefixIcon: Icon(Icons.search, color: foreground),
-        suffixIcon: _searchController.text.isEmpty
-            ? null
-            : IconButton(
-                tooltip: 'Clear search',
-                onPressed: _searchController.clear,
-                icon: Icon(Icons.close, color: foreground),
-              ),
-        filled: true,
-        fillColor: fillColor,
-        border: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(24)),
-          borderSide: BorderSide.none,
-        ),
-        enabledBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(24)),
-          borderSide: BorderSide.none,
-        ),
-        focusedBorder: const OutlineInputBorder(
-          borderRadius: BorderRadius.all(Radius.circular(24)),
-          borderSide: BorderSide.none,
+    return ValueListenableBuilder<TextEditingValue>(
+      valueListenable: _searchController,
+      builder: (context, value, _) => TextField(
+        controller: _searchController,
+        focusNode: _searchFocus,
+        style: TextStyle(color: foreground, fontSize: 17),
+        decoration: InputDecoration(
+          hintText: l10n.searchThisLibrary,
+          hintStyle: TextStyle(color: foreground.withValues(alpha: 0.62)),
+          prefixIcon: Icon(Icons.search, color: foreground),
+          suffixIcon: value.text.isEmpty
+              ? null
+              : IconButton(
+                  tooltip: l10n.clear,
+                  onPressed: _searchController.clear,
+                  icon: Icon(Icons.close, color: foreground),
+                ),
+          filled: true,
+          fillColor: fillColor,
+          border: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(24)),
+            borderSide: BorderSide.none,
+          ),
+          enabledBorder: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(24)),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: const OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(24)),
+            borderSide: BorderSide.none,
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildGrid(List<GameSummary> games) {
+  void _scrollToGridRow({
+    required int index,
+    required int crossAxisCount,
+    required double cellHeight,
+    required double mainAxisSpacing,
+  }) {
+    if (!_gridScrollController.hasClients) return;
+    final row = index ~/ crossAxisCount;
+    final rowTop = 8 + row * (cellHeight + mainAxisSpacing);
+    final rowBottom = rowTop + cellHeight;
+    final position = _gridScrollController.position;
+    final current = position.pixels;
+    final viewportHeight = position.viewportDimension;
+    var target = current;
+    if (rowTop - 8 < current) {
+      target = rowTop - 8;
+    } else if (rowBottom + 52 > current + viewportHeight) {
+      target = rowBottom + 52 - viewportHeight;
+    }
+    target = target.clamp(position.minScrollExtent, position.maxScrollExtent);
+    if ((target - current).abs() < 1) return;
+    unawaited(
+      _gridScrollController.animateTo(
+        target,
+        duration: const Duration(milliseconds: 160),
+        curve: Curves.easeOutCubic,
+      ),
+    );
+  }
+
+  void _activateHoveredGame(
+    GameSummary game, {
+    required bool showBackdrop,
+    required bool showDetails,
+  }) {
+    _hoveredGame = game;
+    if (_suppressHoverEnrichment) return;
+    _activateBrowseGame(
+      game,
+      showBackdrop: showBackdrop,
+      showDetails: showDetails,
+    );
+  }
+
+  void _activateBrowseGame(
+    GameSummary game, {
+    required bool showBackdrop,
+    required bool showDetails,
+  }) {
+    _browse.activateGame(
+      game,
+      showBackdrop: showBackdrop,
+      loadDetails: showDetails,
+    );
+    _scheduleBackdropPreload(game, enabled: showBackdrop);
+  }
+
+  void _deactivateHoveredGame(GameSummary game) {
+    if (_hoveredGame?.id == game.id) _hoveredGame = null;
+    _browse.deactivateGame(game);
+  }
+
+  void _onGridPointerSignal(
+    PointerSignalEvent event, {
+    required bool showBackdrop,
+    required bool showDetails,
+  }) {
+    if (event is! PointerScrollEvent) return;
+
+    // A stationary pointer crosses many cards while the wheel moves the grid.
+    // Do not let those transient hover targets compete with poster requests by
+    // fetching their backdrop and details. Once wheel input stops, reactivate
+    // the card still under the pointer; the view model then applies its normal
+    // 250 ms library-style selection debounce.
+    _suppressHoverEnrichment = true;
+    _hoverScrollSettle?.cancel();
+    final hovered = _hoveredGame;
+    if (hovered != null) _browse.deactivateGame(hovered);
+
+    _hoverScrollSettle = Timer(const Duration(milliseconds: 100), () {
+      if (!mounted) return;
+      _suppressHoverEnrichment = false;
+      final settledGame = _hoveredGame;
+      if (settledGame == null) return;
+      _activateBrowseGame(
+        settledGame,
+        showBackdrop: showBackdrop,
+        showDetails: showDetails,
+      );
+    });
+  }
+
+  void _scheduleBackdropPreload(GameSummary game, {required bool enabled}) {
+    if (!enabled) {
+      _cancelBackdropPreload();
+      return;
+    }
+    if (_backdropPreloadTargetId == game.id) return;
+
+    _cancelBackdropPreload();
+    _backdropPreloadTargetId = game.id;
+    final generation = _backdropPreloadGeneration;
+    _backdropPreloadTimer = Timer(const Duration(milliseconds: 200), () {
+      unawaited(_preloadBackdrop(game, generation));
+    });
+  }
+
+  void _cancelBackdropPreload() {
+    _backdropPreloadTimer?.cancel();
+    _backdropPreloadTimer = null;
+    _backdropPreloadTargetId = null;
+    _backdropPreloadGeneration++;
+  }
+
+  Future<void> _preloadBackdrop(GameSummary game, int generation) async {
+    if (!mounted || generation != _backdropPreloadGeneration) return;
+    final blur = _prefs
+        .get(UserPreferences.browsingBackgroundBlurAmount)
+        .toDouble();
+    final urls = <String?>[
+      gameThumbUrl(widget.libraryId, game.id, kind: 'snap'),
+      gameThumbUrl(widget.libraryId, game.id, kind: 'title'),
+      gameThumbUrl(widget.libraryId, game.id),
+    ].nonNulls;
+
+    for (final url in urls) {
+      if (!mounted || generation != _backdropPreloadGeneration) return;
+      try {
+        await BoundedNetworkImage.precache(
+          context,
+          url,
+          layoutWidth: MediaQuery.sizeOf(context).width,
+          scale: blur > 0 ? 0.6 : 1,
+          maxWidth: blur > 0 ? 640 : 1920,
+        );
+        return;
+      } catch (_) {
+        // Try the same snap -> title -> box-art fallback order used by the
+        // visible backdrop, unless focus has already moved to another game.
+      }
+    }
+  }
+
+  Widget _buildGrid(
+    List<GameSummary> games, {
+    required bool showDetails,
+    required bool showBackdrop,
+  }) {
     return LayoutBuilder(
       builder: (context, constraints) {
         final compact = constraints.maxWidth < 600;
@@ -309,38 +582,305 @@ class _GameSystemScreenState extends State<GameSystemScreen> {
             captionGap +
             captionHeight * textScale;
         final childAspectRatio = cardWidth / cardHeight;
-        return GridView.builder(
-          padding: EdgeInsets.fromLTRB(
-            horizontalPadding,
-            8,
-            horizontalPadding,
-            32,
+        final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+        final focusColor = isNeon
+            ? ThemeRegistry.active.borders.focusBorder.color
+            : Color(_prefs.get(UserPreferences.focusColor).colorValue);
+        final cardFocusExpansion = _prefs.get(
+          UserPreferences.cardFocusExpansion,
+        );
+        return Listener(
+          onPointerSignal: (event) => _onGridPointerSignal(
+            event,
+            showBackdrop: showBackdrop,
+            showDetails: showDetails,
           ),
-          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: columnCount,
-            mainAxisSpacing: 14,
-            crossAxisSpacing: spacing,
-            childAspectRatio: childAspectRatio,
-          ),
-          itemCount: games.length,
-          itemBuilder: (context, index) {
-            final game = games[index];
-            return LayoutBuilder(
-              builder: (context, cardConstraints) => GamePosterCard(
-                imageUrl: gameThumbUrl(widget.libraryId, game.id),
-                title: game.title,
-                fileName: game.fileName,
-                seed: game.id,
-                width: cardConstraints.maxWidth,
-                autofocus: index == 0,
-                onTap: () => context.push(
-                  Destinations.gameDetailOf(widget.libraryId, game.id),
+          child: GridView.builder(
+            controller: _gridScrollController,
+            // Build roughly one viewport ahead so browser artwork requests are
+            // already in flight before the next rows become visible.
+            scrollCacheExtent: const ScrollCacheExtent.viewport(1),
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              8,
+              horizontalPadding,
+              32,
+            ),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columnCount,
+              mainAxisSpacing: 14,
+              crossAxisSpacing: spacing,
+              childAspectRatio: childAspectRatio,
+            ),
+            itemCount: games.length,
+            itemBuilder: (context, index) {
+              final game = games[index];
+              return LayoutBuilder(
+                builder: (context, cardConstraints) => GamePosterCard(
+                  imageUrl: gameThumbUrl(widget.libraryId, game.id),
+                  title: game.title,
+                  fileName: game.fileName,
+                  seed: game.id,
+                  width: cardConstraints.maxWidth,
+                  focusNode: getGridItemFocusNode(index, prefix: 'game_grid'),
+                  focusColor: focusColor,
+                  cardFocusExpansion: cardFocusExpansion,
+                  suppressFocusGlow: isNeon,
+                  autoScroll: false,
+                  onFocus: () {
+                    _activateBrowseGame(
+                      game,
+                      showBackdrop: showBackdrop,
+                      showDetails: showDetails,
+                    );
+                    _scrollToGridRow(
+                      index: index,
+                      crossAxisCount: columnCount,
+                      cellHeight: cardHeight,
+                      mainAxisSpacing: 14,
+                    );
+                  },
+                  onFocusLost: () => _browse.deactivateGame(game),
+                  onHoverStart: () => _activateHoveredGame(
+                    game,
+                    showBackdrop: showBackdrop,
+                    showDetails: showDetails,
+                  ),
+                  onHoverEnd: () => _deactivateHoveredGame(game),
+                  onKeyEvent: (_, event) {
+                    if (PlatformDetection.isTV &&
+                        event.isActionable &&
+                        event.logicalKey.isBackKey &&
+                        _allLetterFocus.context != null) {
+                      _allLetterFocus.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                    if (event.isActionable && event.logicalKey.isRightKey) {
+                      final isLastColumn =
+                          (index % columnCount) == columnCount - 1;
+                      final isLastItem = index == games.length - 1;
+                      if (isLastColumn || isLastItem) {
+                        return KeyEventResult.handled;
+                      }
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  onTap: () => context.push(
+                    Destinations.gameDetailOf(widget.libraryId, game.id),
+                  ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         );
       },
     );
+  }
+}
+
+class _FocusedGameHud extends StatelessWidget {
+  const _FocusedGameHud({
+    required this.desktopScale,
+    required this.game,
+    required this.detail,
+    required this.displayTitle,
+  });
+
+  final double desktopScale;
+  final GameSummary? game;
+  final GameDetail? detail;
+  final String? displayTitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final activeGame = game;
+    final textScale = MediaQuery.textScalerOf(
+      context,
+    ).scale(1).clamp(1.0, 2.0).toDouble();
+    final responsiveScale = desktopScale > textScale ? desktopScale : textScale;
+    return SizedBox(
+      // Match the regular library HUD's reserved-height approach so changing
+      // focus content never relays out the alphabet bar or game grid.
+      height: 105 * responsiveScale,
+      child: ClipRect(
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: activeGame == null
+              ? const SizedBox.shrink(key: ValueKey('empty'))
+              : Column(
+                  key: ValueKey(activeGame.id),
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      displayTitle ??
+                          gameDisplayTitle(
+                            activeGame.title,
+                            activeGame.fileName,
+                          ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: AppColorScheme.onSurface,
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    _GameMetadataRow(detail: detail),
+                    if (detail?.overview?.trim() case final overview?
+                        when overview.isNotEmpty) ...[
+                      const SizedBox(height: 5),
+                      Text(
+                        overview,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: AppColorScheme.onSurface.withAlpha(166),
+                          fontSize: 13,
+                          height: 1.25,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GameMetadataRow extends StatelessWidget {
+  const _GameMetadataRow({required this.detail});
+
+  final GameDetail? detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final game = detail;
+    if (game == null) return const SizedBox.shrink();
+
+    final values = <Widget>[
+      if (game.year != null) _metadataText('${game.year}'),
+      if (game.genre?.trim() case final genre? when genre.isNotEmpty)
+        _metadataText(genre),
+      if (game.region?.trim() case final region? when region.isNotEmpty)
+        _metadataText(region),
+      if (game.players != null)
+        _iconMetadata(Icons.group_outlined, '${game.players}'),
+      if (game.rating != null)
+        _iconMetadata(Icons.star, game.rating!.toStringAsFixed(1)),
+    ];
+
+    return Wrap(
+      spacing: 10,
+      runSpacing: 4,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: values,
+    );
+  }
+
+  Widget _metadataText(String value) {
+    return Text(
+      value,
+      style: TextStyle(
+        color: AppColorScheme.onSurface.withAlpha(179),
+        fontSize: 14,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+  }
+
+  Widget _iconMetadata(IconData icon, String value) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: AppColorScheme.onSurface.withAlpha(179)),
+        const SizedBox(width: 3),
+        _metadataText(value),
+      ],
+    );
+  }
+}
+
+class _GameBrowseBackdrop extends StatelessWidget {
+  const _GameBrowseBackdrop({
+    super.key,
+    required this.libraryId,
+    required this.game,
+    required this.blur,
+  });
+
+  final String libraryId;
+  final GameSummary game;
+  final double blur;
+
+  @override
+  Widget build(BuildContext context) {
+    final fallback = gameFallbackColor(game.id);
+    final urls = <String?>[
+      gameThumbUrl(libraryId, game.id, kind: 'snap'),
+      gameThumbUrl(libraryId, game.id, kind: 'title'),
+      gameThumbUrl(libraryId, game.id),
+    ].nonNulls.toList(growable: false);
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                fallback,
+                Color.lerp(fallback, AppColorScheme.background, 0.7)!,
+              ],
+            ),
+          ),
+        ),
+        _GameBrowseBackdropImage(urls: urls, blur: blur),
+      ],
+    );
+  }
+}
+
+class _GameBrowseBackdropImage extends StatelessWidget {
+  const _GameBrowseBackdropImage({
+    required this.urls,
+    required this.blur,
+    this.index = 0,
+  });
+
+  final List<String> urls;
+  final double blur;
+  final int index;
+
+  @override
+  Widget build(BuildContext context) {
+    if (index >= urls.length) return const SizedBox.shrink();
+
+    Widget image = BoundedNetworkImage(
+      imageUrl: urls[index],
+      fit: BoxFit.cover,
+      maxWidth: blur > 0 ? 640 : 1920,
+      scale: blur > 0 ? 0.6 : 1,
+      fadeInDuration: const Duration(milliseconds: 200),
+      errorBuilder: (_, _, _) =>
+          _GameBrowseBackdropImage(urls: urls, blur: blur, index: index + 1),
+    );
+    if (blur <= 0) return image;
+
+    final sigma = GlassSettings.decorativeSigma(blur);
+    image = RepaintBoundary(
+      child: ImageFiltered(
+        imageFilter: ImageFilter.blur(
+          sigmaX: sigma,
+          sigmaY: sigma,
+          tileMode: TileMode.decal,
+        ),
+        child: image,
+      ),
+    );
+    return image;
   }
 }

--- a/lib/ui/screens/games/game_system_screen.dart
+++ b/lib/ui/screens/games/game_system_screen.dart
@@ -23,6 +23,7 @@ import '../../widgets/bounded_network_image.dart';
 import '../../widgets/focus/focusable_toolbar_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/game/game_alpha_picker_bar.dart';
+import '../../widgets/game/game_artwork_load_scheduler.dart';
 import '../../widgets/game/game_poster_card.dart';
 
 /// Browses one retro-game platform using the same vertical grid and alphabet
@@ -50,29 +51,44 @@ class _GameSystemScreenState extends State<GameSystemScreen>
   static const _desktopHorizontalPadding = 60.0;
   static const _gridTopPadding = 8.0;
   static const _gridBottomFocusPeek = 52.0;
+  static const _artworkPrefetchRows = 5;
+  static const _tvArtworkSettleDelay = Duration(milliseconds: 200);
+  static const _otherArtworkSettleDelay = Duration(milliseconds: 120);
+  static const _tvArtworkPrefetchDelay = Duration(milliseconds: 700);
+  static const _otherArtworkPrefetchDelay = Duration(milliseconds: 450);
 
   final UserPreferences _prefs = GetIt.instance<UserPreferences>();
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
   final GlobalKey<CustomTVTextFieldState> _searchTvFieldKey = GlobalKey();
-  final FocusNode _allLetterFocus = FocusNode(
-    debugLabel: 'game_alpha_all_letter',
-  );
+  late final Map<String, FocusNode> _alphaLetterFocusNodes = {
+    for (final letter in GameAlphaPickerBar.letters)
+      letter: FocusNode(
+        debugLabel: 'game_alpha_${letter.isEmpty ? 'all' : letter}',
+      ),
+  };
   final ScrollController _gridScrollController = ScrollController();
+  late final GamesApi? _gamesApi;
+  late final GameArtworkLoadScheduler _artworkScheduler;
   late final GameSystemBrowseViewModel _browse;
   List<GameSummary>? _observedVisibleGames;
   Timer? _hoverScrollSettle;
   GameSummary? _hoveredGame;
   bool _suppressHoverEnrichment = false;
-  Timer? _backdropPreloadTimer;
-  int _backdropPreloadGeneration = 0;
-  String? _backdropPreloadTargetId;
+  Timer? _tvBackReplayGuardTimer;
+  Timer? _artworkSettleTimer;
+  Timer? _artworkPrefetchTimer;
+  bool _ignoreNextTvPop = false;
+  bool _allowTvPop = false;
 
   @override
   void initState() {
     super.initState();
+    _gamesApi = GetIt.instance<MediaServerClient>().gamesApi;
+    _artworkScheduler = GameArtworkLoadScheduler()
+      ..addListener(_onArtworkSchedulerChanged);
     _browse = GameSystemBrowseViewModel(
-      gamesApi: GetIt.instance<MediaServerClient>().gamesApi,
+      gamesApi: _gamesApi,
       libraryId: widget.libraryId,
       systemId: widget.systemId,
       systemName: widget.systemName,
@@ -86,14 +102,20 @@ class _GameSystemScreenState extends State<GameSystemScreen>
   void dispose() {
     _browse.removeListener(_onBrowseChanged);
     _browse.dispose();
+    _artworkScheduler.removeListener(_onArtworkSchedulerChanged);
+    _artworkScheduler.dispose();
     _searchController.removeListener(_onSearchChanged);
     _searchFocus.removeListener(_onSearchFocusChanged);
     _searchController.dispose();
     _searchFocus.dispose();
-    _allLetterFocus.dispose();
+    for (final node in _alphaLetterFocusNodes.values) {
+      node.dispose();
+    }
     _gridScrollController.dispose();
     _hoverScrollSettle?.cancel();
-    _cancelBackdropPreload();
+    _tvBackReplayGuardTimer?.cancel();
+    _artworkSettleTimer?.cancel();
+    _artworkPrefetchTimer?.cancel();
     disposeGridFocusNodes();
     super.dispose();
   }
@@ -102,14 +124,28 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     _browse.updateSearch(_searchController.text);
   }
 
+  void _selectLetter(String letter) {
+    if (letter == _browse.selectedLetter) return;
+
+    // Reset the existing grid before replacing its contents. This keeps the
+    // new filtered viewport at index zero, which is also the initial artwork
+    // scheduler window. Focus remains on the alpha button that invoked this.
+    if (_gridScrollController.hasClients) {
+      _gridScrollController.jumpTo(
+        _gridScrollController.position.minScrollExtent,
+      );
+    }
+    _browse.selectLetter(letter);
+  }
+
   void _onBrowseChanged() {
     if (!mounted) return;
-    if (_browse.activeGame?.id != _backdropPreloadTargetId) {
-      _cancelBackdropPreload();
-    }
     final visibleGames = _browse.visibleGames;
     if (!identical(_observedVisibleGames, visibleGames)) {
       _observedVisibleGames = visibleGames;
+      _artworkSettleTimer?.cancel();
+      _artworkPrefetchTimer?.cancel();
+      _artworkScheduler.clearViewport();
       gridContentVersion++;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) cleanupGridFocusNodes(visibleGames.length);
@@ -122,7 +158,16 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     if (mounted) setState(() {});
   }
 
+  void _onArtworkSchedulerChanged() {
+    if (mounted) setState(() {});
+  }
+
   KeyEventResult _onTvSearchKey(FocusNode node, KeyEvent event) {
+    // Down returns to the alpha letter the user came up from, so it mirrors the
+    // up gesture instead of dropping onto the geometric default below.
+    if (event.isActionable && event.logicalKey.isDownKey) {
+      if (_restoreAlphaFocus()) return KeyEventResult.handled;
+    }
     if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
     if (event is KeyDownEvent) {
       if (!_searchFocus.hasFocus) _searchFocus.requestFocus();
@@ -130,6 +175,176 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     }
     return KeyEventResult.handled;
   }
+
+  bool get _gridHasFocus =>
+      gridItemFocusNodes.values.any((node) => node.hasFocus);
+
+  bool _restoreAlphaFocus() {
+    // Return to the letter that is actually selected (the active filter), so
+    // focus lands on the highlighted letter rather than the last one merely
+    // arrowed past.
+    final alphaFocus = _alphaLetterFocusNodes[_browse.selectedLetter];
+    if (alphaFocus?.context == null) return false;
+    alphaFocus!.requestFocus();
+    return true;
+  }
+
+  void _guardAgainstTvBackReplay() {
+    _ignoreNextTvPop = true;
+    _tvBackReplayGuardTimer?.cancel();
+    _tvBackReplayGuardTimer = Timer(const Duration(milliseconds: 300), () {
+      _ignoreNextTvPop = false;
+    });
+  }
+
+  void _handleTvPop(bool didPop) {
+    if (didPop) return;
+    if (_ignoreNextTvPop) {
+      _ignoreNextTvPop = false;
+      _tvBackReplayGuardTimer?.cancel();
+      return;
+    }
+    if (_gridHasFocus && _restoreAlphaFocus()) return;
+    if (_allowTvPop) return;
+
+    setState(() => _allowTvPop = true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) context.popOrHome();
+    });
+  }
+
+  void _scheduleArtworkWindow({
+    required ScrollMetrics metrics,
+    required int crossAxisCount,
+    required double rowStride,
+    required List<GameSummary> games,
+  }) {
+    _artworkSettleTimer?.cancel();
+    _artworkPrefetchTimer?.cancel();
+    // Stop feeding the old viewport into flutter_cache_manager. Its requests
+    // cannot be cancelled once started, but clearing here caps stale work at
+    // the current four-request batch instead of the whole nearby-row queue.
+    _artworkScheduler.clearViewport();
+    final rowCount = (games.length / crossAxisCount).ceil();
+    if (rowCount == 0) return;
+    final firstVisibleRow = ((metrics.pixels - _gridTopPadding) / rowStride)
+        .floor()
+        .clamp(0, rowCount - 1)
+        .toInt();
+    final lastVisibleRowExclusive =
+        ((metrics.pixels + metrics.viewportDimension - _gridTopPadding) /
+                rowStride)
+            .ceil()
+            .clamp(firstVisibleRow + 1, rowCount)
+            .toInt();
+    final firstRow = (firstVisibleRow - _artworkPrefetchRows)
+        .clamp(0, rowCount - 1)
+        .toInt();
+    final lastRowExclusive = (lastVisibleRowExclusive + _artworkPrefetchRows)
+        .clamp(1, rowCount)
+        .toInt();
+    final visibleFirstIndex = firstVisibleRow * crossAxisCount;
+    final visibleLastIndexExclusive = (lastVisibleRowExclusive * crossAxisCount)
+        .clamp(0, games.length)
+        .toInt();
+
+    final settleDelay = PlatformDetection.isTV
+        ? _tvArtworkSettleDelay
+        : _otherArtworkSettleDelay;
+    _artworkSettleTimer = Timer(settleDelay, () {
+      if (!mounted || !identical(games, _browse.visibleGames)) return;
+      // Submit only the settled viewport first. Rapid intermediate d-pad or
+      // pointer positions never reach the cache manager's non-cancellable FIFO.
+      _showArtworkRange(
+        games,
+        firstIndex: visibleFirstIndex,
+        lastIndexExclusive: visibleLastIndexExclusive,
+        priorityFirstIndex: visibleFirstIndex,
+        priorityLastIndexExclusive: visibleLastIndexExclusive,
+        crossAxisCount: crossAxisCount,
+      );
+    });
+
+    final prefetchDelay = PlatformDetection.isTV
+        ? _tvArtworkPrefetchDelay
+        : _otherArtworkPrefetchDelay;
+    _artworkPrefetchTimer = Timer(prefetchDelay, () {
+      if (!mounted || !identical(games, _browse.visibleGames)) return;
+      // Add nearby rows only after the user remains on this viewport. Visible
+      // URLs stay first in the expanded queue.
+      _showArtworkRange(
+        games,
+        firstIndex: firstRow * crossAxisCount,
+        lastIndexExclusive: (lastRowExclusive * crossAxisCount)
+            .clamp(0, games.length)
+            .toInt(),
+        priorityFirstIndex: visibleFirstIndex,
+        priorityLastIndexExclusive: visibleLastIndexExclusive,
+        crossAxisCount: crossAxisCount,
+      );
+    });
+  }
+
+  void _showArtworkRange(
+    List<GameSummary> games, {
+    required int firstIndex,
+    required int lastIndexExclusive,
+    required int priorityFirstIndex,
+    required int priorityLastIndexExclusive,
+    required int crossAxisCount,
+  }) {
+    if (games.isEmpty || firstIndex >= lastIndexExclusive) return;
+    var priorityStart = priorityFirstIndex.clamp(
+      firstIndex,
+      lastIndexExclusive - 1,
+    );
+    var priorityEnd = priorityLastIndexExclusive.clamp(
+      priorityStart + 1,
+      lastIndexExclusive,
+    );
+
+    // Center the priority block on the focused row so the row the user is on
+    // fetches first and nearby rows expand outward from it, rather than always
+    // starting at the top row of the viewport (which may be partly scrolled
+    // off). Falls back to the passed viewport block when nothing is focused
+    // (e.g. touch scrolling), where there is no "current row".
+    final focusedIndex = _gridHasFocus ? lastFocusedGridIndex : null;
+    if (focusedIndex != null &&
+        focusedIndex >= firstIndex &&
+        focusedIndex < lastIndexExclusive) {
+      final focusedRowStart = focusedIndex - (focusedIndex % crossAxisCount);
+      priorityStart = focusedRowStart.clamp(firstIndex, lastIndexExclusive - 1);
+      priorityEnd = (focusedRowStart + crossAxisCount).clamp(
+        priorityStart + 1,
+        lastIndexExclusive,
+      );
+    }
+
+    final orderedIndexes = gameArtworkLoadOrder(
+      firstIndex: firstIndex,
+      lastIndexExclusive: lastIndexExclusive,
+      visibleFirstIndex: priorityStart,
+      visibleLastIndexExclusive: priorityEnd,
+      crossAxisCount: crossAxisCount,
+      surroundingRows: _artworkPrefetchRows,
+    );
+    final urls = <String>[
+      for (final index in orderedIndexes) ?_gameThumbUrl(games[index].id),
+    ];
+    final priorityIndex =
+        focusedIndex != null &&
+            focusedIndex >= priorityStart &&
+            focusedIndex < priorityEnd
+        ? focusedIndex
+        : priorityStart;
+    _artworkScheduler.showViewport(
+      urls,
+      priorityKey: _gameThumbUrl(games[priorityIndex].id),
+    );
+  }
+
+  String? _gameThumbUrl(String gameId) =>
+      _gamesApi?.thumbUrl(libraryId: widget.libraryId, gameId: gameId);
 
   @override
   Widget build(BuildContext context) {
@@ -188,8 +403,16 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     if (PlatformDetection.useMobileUi) return scaffold;
     final targetNode = PlatformDetection.isTV && _browse.visibleGames.isNotEmpty
         ? getGridItemFocusNode(0, prefix: 'game_grid')
-        : _allLetterFocus;
-    return RequestInitialFocus(targetNode: targetNode, child: scaffold);
+        : _alphaLetterFocusNodes['']!;
+    final content = RequestInitialFocus(
+      targetNode: targetNode,
+      child: scaffold,
+    );
+    return PopScope(
+      canPop: !PlatformDetection.isTV || _allowTvPop,
+      onPopInvokedWithResult: (didPop, _) => _handleTvPop(didPop),
+      child: content,
+    );
   }
 
   Widget _buildBody(
@@ -306,8 +529,9 @@ class _GameSystemScreenState extends State<GameSystemScreen>
               Expanded(
                 child: GameAlphaPickerBar(
                   selected: _browse.selectedLetter,
-                  allFocusNode: _allLetterFocus,
-                  onChanged: _browse.selectLetter,
+                  letterFocusNodes: _alphaLetterFocusNodes,
+                  onNavigateUp: () => _searchFocus.requestFocus(),
+                  onChanged: _selectLetter,
                 ),
               ),
             ],
@@ -484,7 +708,6 @@ class _GameSystemScreenState extends State<GameSystemScreen>
       showBackdrop: showBackdrop,
       loadDetails: showDetails,
     );
-    _scheduleBackdropPreload(game, enabled: showBackdrop);
   }
 
   void _deactivateHoveredGame(GameSummary game) {
@@ -522,57 +745,6 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     });
   }
 
-  void _scheduleBackdropPreload(GameSummary game, {required bool enabled}) {
-    if (!enabled) {
-      _cancelBackdropPreload();
-      return;
-    }
-    if (_backdropPreloadTargetId == game.id) return;
-
-    _cancelBackdropPreload();
-    _backdropPreloadTargetId = game.id;
-    final generation = _backdropPreloadGeneration;
-    _backdropPreloadTimer = Timer(const Duration(milliseconds: 200), () {
-      unawaited(_preloadBackdrop(game, generation));
-    });
-  }
-
-  void _cancelBackdropPreload() {
-    _backdropPreloadTimer?.cancel();
-    _backdropPreloadTimer = null;
-    _backdropPreloadTargetId = null;
-    _backdropPreloadGeneration++;
-  }
-
-  Future<void> _preloadBackdrop(GameSummary game, int generation) async {
-    if (!mounted || generation != _backdropPreloadGeneration) return;
-    final blur = _prefs
-        .get(UserPreferences.browsingBackgroundBlurAmount)
-        .toDouble();
-    final urls = <String?>[
-      gameThumbUrl(widget.libraryId, game.id, kind: 'snap'),
-      gameThumbUrl(widget.libraryId, game.id, kind: 'title'),
-      gameThumbUrl(widget.libraryId, game.id),
-    ].nonNulls;
-
-    for (final url in urls) {
-      if (!mounted || generation != _backdropPreloadGeneration) return;
-      try {
-        await BoundedNetworkImage.precache(
-          context,
-          url,
-          layoutWidth: MediaQuery.sizeOf(context).width,
-          scale: blur > 0 ? 0.6 : 1,
-          maxWidth: blur > 0 ? 640 : 1920,
-        );
-        return;
-      } catch (_) {
-        // Try the same snap -> title -> box-art fallback order used by the
-        // visible backdrop, unless focus has already moved to another game.
-      }
-    }
-  }
-
   Widget _buildGrid(
     List<GameSummary> games, {
     required double desktopScale,
@@ -599,11 +771,42 @@ class _GameSystemScreenState extends State<GameSystemScreen>
         final cardWidth =
             (availableWidth - spacing * (columnCount - 1)) / columnCount;
         final textScale = MediaQuery.textScalerOf(context).scale(1.0);
+        final isRtl = Directionality.of(context) == TextDirection.rtl;
         final cardHeight =
             cardWidth * imageHeightRatio +
             captionGap +
             captionHeight * textScale;
         final childAspectRatio = cardWidth / cardHeight;
+        final rowStride = cardHeight + 14;
+        final initialVisibleRowCount = (constraints.maxHeight / rowStride)
+            .ceil();
+        final initialVisibleLastIndex = (initialVisibleRowCount * columnCount)
+            .clamp(0, games.length)
+            .toInt();
+        final initialArtworkLastIndex =
+            ((initialVisibleRowCount + _artworkPrefetchRows) * columnCount)
+                .clamp(0, games.length)
+                .toInt();
+        final scheduleArtwork = PlatformDetection.isTV;
+        if (scheduleArtwork &&
+            !_artworkScheduler.hasViewport &&
+            games.isNotEmpty) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted ||
+                _artworkScheduler.hasViewport ||
+                !identical(games, _browse.visibleGames)) {
+              return;
+            }
+            _showArtworkRange(
+              games,
+              firstIndex: 0,
+              lastIndexExclusive: initialArtworkLastIndex,
+              priorityFirstIndex: 0,
+              priorityLastIndexExclusive: initialVisibleLastIndex,
+              crossAxisCount: columnCount,
+            );
+          });
+        }
         final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
         final focusColor = isNeon
             ? ThemeRegistry.active.borders.focusBorder.color
@@ -611,86 +814,135 @@ class _GameSystemScreenState extends State<GameSystemScreen>
         final cardFocusExpansion = _prefs.get(
           UserPreferences.cardFocusExpansion,
         );
-        return Listener(
-          onPointerSignal: (event) => _onGridPointerSignal(
-            event,
-            showBackdrop: showBackdrop,
-            showDetails: showDetails,
-          ),
-          child: GridView.builder(
-            controller: _gridScrollController,
-            // Build roughly one viewport ahead so browser artwork requests are
-            // already in flight before the next rows become visible.
-            scrollCacheExtent: const ScrollCacheExtent.viewport(1),
-            padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
-              _gridTopPadding,
-              horizontalPadding,
-              32,
+        return NotificationListener<ScrollNotification>(
+          onNotification: (notification) {
+            // TV navigation uses a small priority queue to keep d-pad focus
+            // ahead of the cache manager's non-cancellable request FIFO.
+            // Pointer-driven platforms use the same lazy image loading as the
+            // standard media grids, allowing incoming rows to paint artwork
+            // while a drag or fling is still in progress.
+            if (!scheduleArtwork) return false;
+            if (notification is ScrollStartNotification) {
+              // Cancel pending prefetch, but keep the current viewport enabled
+              // so already-loaded artwork stays visible while scrolling and the
+              // initial submission is not wiped by a programmatic scroll (e.g.
+              // the first focus). ScrollEnd re-submits the settled window.
+              _artworkSettleTimer?.cancel();
+              _artworkPrefetchTimer?.cancel();
+            } else if (notification is ScrollEndNotification) {
+              _scheduleArtworkWindow(
+                metrics: notification.metrics,
+                crossAxisCount: columnCount,
+                rowStride: rowStride,
+                games: games,
+              );
+            }
+            return false;
+          },
+          child: Listener(
+            onPointerSignal: (event) => _onGridPointerSignal(
+              event,
+              showBackdrop: showBackdrop,
+              showDetails: showDetails,
             ),
-            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: columnCount,
-              mainAxisSpacing: 14,
-              crossAxisSpacing: spacing,
-              childAspectRatio: childAspectRatio,
-            ),
-            itemCount: games.length,
-            itemBuilder: (context, index) {
-              final game = games[index];
-              return GamePosterCard(
-                imageUrl: gameThumbUrl(widget.libraryId, game.id),
-                title: game.title,
-                fileName: game.fileName,
-                seed: game.id,
-                width: cardWidth,
-                focusNode: getGridItemFocusNode(index, prefix: 'game_grid'),
-                focusColor: focusColor,
-                cardFocusExpansion: cardFocusExpansion,
-                suppressFocusGlow: isNeon,
-                autoScroll: false,
-                onFocus: () {
-                  _activateBrowseGame(
+            child: GridView.builder(
+              controller: _gridScrollController,
+              // Pointer-driven platforms construct an extra viewport so their
+              // normal lazy image loading stays ahead of an active scroll. TV
+              // uses the explicit artwork scheduler instead.
+              scrollCacheExtent: scheduleArtwork
+                  ? null
+                  : const ScrollCacheExtent.viewport(1),
+              padding: EdgeInsets.fromLTRB(
+                horizontalPadding,
+                _gridTopPadding,
+                horizontalPadding,
+                32,
+              ),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: columnCount,
+                mainAxisSpacing: 14,
+                crossAxisSpacing: spacing,
+                childAspectRatio: childAspectRatio,
+              ),
+              itemCount: games.length,
+              itemBuilder: (context, index) {
+                final game = games[index];
+                final imageUrl = _gameThumbUrl(game.id);
+                final artworkGeneration = !scheduleArtwork || imageUrl == null
+                    ? null
+                    : _artworkScheduler.generationFor(imageUrl);
+                final column = index % columnCount;
+                final atVisualRightEdge = isRtl
+                    ? column == 0
+                    : column == columnCount - 1 || index == games.length - 1;
+                return GamePosterCard(
+                  imageUrl: imageUrl,
+                  title: game.title,
+                  fileName: game.fileName,
+                  seed: game.id,
+                  width: cardWidth,
+                  focusNode: getGridItemFocusNode(index, prefix: 'game_grid'),
+                  focusColor: focusColor,
+                  cardFocusExpansion: cardFocusExpansion,
+                  suppressFocusGlow: isNeon,
+                  autoScroll: false,
+                  onFocus: () {
+                    _activateBrowseGame(
+                      game,
+                      showBackdrop: showBackdrop,
+                      showDetails: showDetails,
+                    );
+                    _scrollToGridRow(
+                      index: index,
+                      crossAxisCount: columnCount,
+                      cellHeight: cardHeight,
+                      mainAxisSpacing: 14,
+                    );
+                  },
+                  onFocusLost: () => _browse.deactivateGame(game),
+                  onHoverStart: () => _activateHoveredGame(
                     game,
                     showBackdrop: showBackdrop,
                     showDetails: showDetails,
-                  );
-                  _scrollToGridRow(
-                    index: index,
-                    crossAxisCount: columnCount,
-                    cellHeight: cardHeight,
-                    mainAxisSpacing: 14,
-                  );
-                },
-                onFocusLost: () => _browse.deactivateGame(game),
-                onHoverStart: () => _activateHoveredGame(
-                  game,
-                  showBackdrop: showBackdrop,
-                  showDetails: showDetails,
-                ),
-                onHoverEnd: () => _deactivateHoveredGame(game),
-                onKeyEvent: (_, event) {
-                  if (PlatformDetection.isTV &&
-                      event.isActionable &&
-                      event.logicalKey.isBackKey &&
-                      _allLetterFocus.context != null) {
-                    _allLetterFocus.requestFocus();
-                    return KeyEventResult.handled;
-                  }
-                  if (event.isActionable && event.logicalKey.isRightKey) {
-                    final isLastColumn =
-                        (index % columnCount) == columnCount - 1;
-                    final isLastItem = index == games.length - 1;
-                    if (isLastColumn || isLastItem) {
+                  ),
+                  onHoverEnd: () => _deactivateHoveredGame(game),
+                  stopRightTraversal: atVisualRightEdge,
+                  loadArtwork:
+                      imageUrl != null &&
+                      (!scheduleArtwork ||
+                          _artworkScheduler.isEnabled(imageUrl)),
+                  onArtworkLoadFinished:
+                      artworkGeneration == null || imageUrl == null
+                      ? null
+                      : () {
+                          if (!mounted) return;
+                          _artworkScheduler.markFinished(
+                            imageUrl,
+                            artworkGeneration,
+                          );
+                        },
+                  onKeyEvent: (_, event) {
+                    if (PlatformDetection.isTV &&
+                        event.isActionable &&
+                        event.logicalKey.isBackKey &&
+                        _restoreAlphaFocus()) {
+                      if (event is KeyDownEvent) {
+                        _guardAgainstTvBackReplay();
+                      }
                       return KeyEventResult.handled;
                     }
-                  }
-                  return KeyEventResult.ignored;
-                },
-                onTap: () => context.push(
-                  Destinations.gameDetailOf(widget.libraryId, game.id),
-                ),
-              );
-            },
+                    // Right-edge traversal is stopped by [stopRightTraversal]
+                    // above (TV only), which the card honors in its own key
+                    // handler.
+                    return KeyEventResult.ignored;
+                  },
+                  onTap: () => context.push(
+                    Destinations.gameDetailOf(widget.libraryId, game.id),
+                  ),
+                );
+              },
+            ),
           ),
         );
       },
@@ -723,11 +975,11 @@ class _FocusedGameHud extends StatelessWidget {
       // focus content never relays out the alphabet bar or game grid.
       height: 105 * responsiveScale,
       child: ClipRect(
-        child: AnimatedSwitcher(
-          duration: const Duration(milliseconds: 200),
-          child: activeGame == null
-              ? const SizedBox.shrink(key: ValueKey('empty'))
-              : Column(
+        child: activeGame == null
+            ? const SizedBox.shrink()
+            : AnimatedSwitcher(
+                duration: const Duration(milliseconds: 200),
+                child: Column(
                   key: ValueKey(activeGame.id),
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -763,7 +1015,7 @@ class _FocusedGameHud extends StatelessWidget {
                     ],
                   ],
                 ),
-        ),
+              ),
       ),
     );
   }

--- a/lib/ui/screens/games/game_system_screen.dart
+++ b/lib/ui/screens/games/game_system_screen.dart
@@ -1,0 +1,346 @@
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/game_browse_filter.dart';
+import '../../../util/game_library.dart';
+import '../../../util/focus/dpad_keys.dart';
+import '../../../util/platform_detection.dart';
+import '../../navigation/destinations.dart';
+import '../../widgets/game/game_alpha_picker_bar.dart';
+import '../../widgets/game/game_poster_card.dart';
+
+/// Browses one retro-game platform using the same vertical grid and alphabet
+/// filtering interaction as Moonfin's regular media libraries.
+class GameSystemScreen extends StatefulWidget {
+  const GameSystemScreen({
+    super.key,
+    required this.libraryId,
+    required this.systemId,
+    this.systemName,
+  });
+
+  final String libraryId;
+  final String systemId;
+  final String? systemName;
+
+  @override
+  State<GameSystemScreen> createState() => _GameSystemScreenState();
+}
+
+class _GameSystemScreenState extends State<GameSystemScreen> {
+  final MediaServerClient _client = GetIt.instance<MediaServerClient>();
+  final UserPreferences _prefs = GetIt.instance<UserPreferences>();
+  final TextEditingController _searchController = TextEditingController();
+  final FocusNode _searchFocus = FocusNode();
+  final GlobalKey<CustomTVTextFieldState> _searchTvFieldKey = GlobalKey();
+  final FocusNode _allLetterFocus = FocusNode(
+    debugLabel: 'game_alpha_all_letter',
+  );
+
+  bool _loading = true;
+  String? _error;
+  String _selectedLetter = '';
+  List<GameSummary> _games = const [];
+  Map<String, String> _displayTitles = const {};
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(_onSearchChanged);
+    _searchFocus.addListener(_onSearchFocusChanged);
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _searchController.removeListener(_onSearchChanged);
+    _searchFocus.removeListener(_onSearchFocusChanged);
+    _searchController.dispose();
+    _searchFocus.dispose();
+    _allLetterFocus.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _onSearchFocusChanged() {
+    if (mounted) setState(() {});
+  }
+
+  KeyEventResult _onTvSearchKey(FocusNode node, KeyEvent event) {
+    if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+    if (event is KeyDownEvent) {
+      if (!_searchFocus.hasFocus) _searchFocus.requestFocus();
+      _searchTvFieldKey.currentState?.openKeyboard();
+    }
+    return KeyEventResult.handled;
+  }
+
+  Future<void> _load() async {
+    final gamesApi = _client.gamesApi;
+    if (gamesApi == null) {
+      setState(() {
+        _loading = false;
+        _error = 'This server does not support games.';
+      });
+      return;
+    }
+
+    try {
+      final games = await gamesApi.getGames(
+        widget.libraryId,
+        system: widget.systemId,
+      );
+      final displayTitles = {
+        for (final game in games)
+          game.id: gameDisplayTitle(game.title, game.fileName),
+      };
+      games.sort(
+        (a, b) => displayTitles[a.id]!.toLowerCase().compareTo(
+          displayTitles[b.id]!.toLowerCase(),
+        ),
+      );
+      if (!mounted) return;
+      setState(() {
+        _games = games;
+        _displayTitles = displayTitles;
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = 'Failed to load games: $e';
+      });
+    }
+  }
+
+  List<GameSummary> get _visibleGames {
+    return _games
+        .where((game) {
+          return gameTitleMatchesBrowseFilters(
+            _displayTitles[game.id] ??
+                gameDisplayTitle(game.title, game.fileName),
+            alternateText: game.fileName,
+            query: _searchController.text,
+            letter: _selectedLetter,
+          );
+        })
+        .toList(growable: false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = widget.systemName?.trim();
+    return Scaffold(
+      backgroundColor: AppColorScheme.background,
+      appBar: AppBar(
+        title: Text(title?.isNotEmpty == true ? title! : widget.systemId),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(_error!, textAlign: TextAlign.center),
+        ),
+      );
+    }
+
+    final visibleGames = _visibleGames;
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            children: [
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 560),
+                child: _buildSearchField(),
+              ),
+              const SizedBox(height: 10),
+              GameAlphaPickerBar(
+                selected: _selectedLetter,
+                allFocusNode: _allLetterFocus,
+                onChanged: (letter) => setState(() => _selectedLetter = letter),
+              ),
+              const SizedBox(height: 4),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  '${visibleGames.length} of ${_games.length}',
+                  style: TextStyle(
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Expanded(
+          child: visibleGames.isEmpty
+              ? Center(child: Text(AppLocalizations.of(context).noItemsFound))
+              : _buildGrid(visibleGames),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSearchField() {
+    final l10n = AppLocalizations.of(context);
+    final hasFocus = _searchFocus.hasFocus;
+    final fillColor = hasFocus
+        ? AppColorScheme.buttonFocused
+        : AppColorScheme.surface.withValues(alpha: 0.72);
+    final foreground = hasFocus
+        ? AppColorScheme.onButtonFocused
+        : AppColorScheme.onSurface;
+
+    if (PlatformDetection.isTV) {
+      return Focus(
+        focusNode: _searchFocus,
+        onKeyEvent: _onTvSearchKey,
+        child: CustomTVTextField(
+          key: _searchTvFieldKey,
+          controller: _searchController,
+          isFocused: hasFocus,
+          inputPurpose: InputPurpose.search,
+          preferSystemIme: _prefs.get(UserPreferences.preferSystemImeKeyboard),
+          popParentOnKeyboardClose: false,
+          hint: l10n.searchThisLibrary,
+          prefixIcon: Icon(Icons.search, color: foreground),
+          textStyle: TextStyle(color: foreground, fontSize: 17),
+          hintStyle: TextStyle(
+            color: foreground.withValues(alpha: 0.62),
+            fontSize: 17,
+          ),
+          filled: true,
+          fillColor: fillColor,
+          borderRadius: 24,
+          borderColor: Colors.transparent,
+          focusedBorderColor: Colors.transparent,
+          borderWidth: 0,
+          focusedBorderWidth: 0,
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 14,
+            vertical: 11,
+          ),
+        ),
+      );
+    }
+
+    return TextField(
+      controller: _searchController,
+      focusNode: _searchFocus,
+      style: TextStyle(color: foreground, fontSize: 17),
+      decoration: InputDecoration(
+        hintText: l10n.searchThisLibrary,
+        hintStyle: TextStyle(color: foreground.withValues(alpha: 0.62)),
+        prefixIcon: Icon(Icons.search, color: foreground),
+        suffixIcon: _searchController.text.isEmpty
+            ? null
+            : IconButton(
+                tooltip: 'Clear search',
+                onPressed: _searchController.clear,
+                icon: Icon(Icons.close, color: foreground),
+              ),
+        filled: true,
+        fillColor: fillColor,
+        border: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(24)),
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(24)),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(24)),
+          borderSide: BorderSide.none,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGrid(List<GameSummary> games) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 600;
+        final horizontalPadding = compact ? 16.0 : 60.0;
+        const spacing = 12.0;
+        const imageHeightRatio = 1.34;
+        const captionGap = 6.0;
+        const captionHeight = 42.0;
+
+        final availableWidth = constraints.maxWidth - horizontalPadding * 2;
+        final desktopScale = _prefs
+            .get(UserPreferences.desktopUiScale)
+            .scaleFactor;
+        final preferredCardWidth =
+            _prefs.resolveLibraryPosterSize().portraitHeight *
+            (2 / 3) *
+            desktopScale;
+        final columnCount =
+            ((availableWidth + spacing) / (preferredCardWidth + spacing))
+                .floor()
+                .clamp(2, 20);
+        final cardWidth =
+            (availableWidth - spacing * (columnCount - 1)) / columnCount;
+        final textScale = MediaQuery.textScalerOf(context).scale(1.0);
+        final cardHeight =
+            cardWidth * imageHeightRatio +
+            captionGap +
+            captionHeight * textScale;
+        final childAspectRatio = cardWidth / cardHeight;
+        return GridView.builder(
+          padding: EdgeInsets.fromLTRB(
+            horizontalPadding,
+            8,
+            horizontalPadding,
+            32,
+          ),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: columnCount,
+            mainAxisSpacing: 14,
+            crossAxisSpacing: spacing,
+            childAspectRatio: childAspectRatio,
+          ),
+          itemCount: games.length,
+          itemBuilder: (context, index) {
+            final game = games[index];
+            return LayoutBuilder(
+              builder: (context, cardConstraints) => GamePosterCard(
+                imageUrl: gameThumbUrl(widget.libraryId, game.id),
+                title: game.title,
+                fileName: game.fileName,
+                seed: game.id,
+                width: cardConstraints.maxWidth,
+                autofocus: index == 0,
+                onTap: () => context.push(
+                  Destinations.gameDetailOf(widget.libraryId, game.id),
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/screens/games/game_system_screen.dart
+++ b/lib/ui/screens/games/game_system_screen.dart
@@ -45,6 +45,12 @@ class GameSystemScreen extends StatefulWidget {
 
 class _GameSystemScreenState extends State<GameSystemScreen>
     with GridFocusNodeMixin<GameSystemScreen> {
+  static const _compactBreakpoint = 600.0;
+  static const _compactHorizontalPadding = 16.0;
+  static const _desktopHorizontalPadding = 60.0;
+  static const _gridTopPadding = 8.0;
+  static const _gridBottomFocusPeek = 52.0;
+
   final UserPreferences _prefs = GetIt.instance<UserPreferences>();
   final TextEditingController _searchController = TextEditingController();
   final FocusNode _searchFocus = FocusNode();
@@ -128,7 +134,12 @@ class _GameSystemScreenState extends State<GameSystemScreen>
   @override
   Widget build(BuildContext context) {
     final compact =
-        PlatformDetection.useMobileUi || MediaQuery.sizeOf(context).width < 600;
+        PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _compactBreakpoint;
+    final desktopScale = _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final horizontalPadding = compact
+        ? _compactHorizontalPadding
+        : _desktopHorizontalPadding * desktopScale;
     final screenSize = MediaQuery.sizeOf(context);
     final textScale = MediaQuery.textScalerOf(context).scale(1);
     final hideBackdrops = _prefs.get(UserPreferences.hideBackdropsInLibraries);
@@ -166,6 +177,8 @@ class _GameSystemScreenState extends State<GameSystemScreen>
           ),
           _buildBody(
             compact,
+            desktopScale: desktopScale,
+            horizontalPadding: horizontalPadding,
             showDetails: showDetails,
             showBackdrop: showBackdrop,
           ),
@@ -181,6 +194,8 @@ class _GameSystemScreenState extends State<GameSystemScreen>
 
   Widget _buildBody(
     bool compact, {
+    required double desktopScale,
+    required double horizontalPadding,
     required bool showDetails,
     required bool showBackdrop,
   }) {
@@ -206,12 +221,19 @@ class _GameSystemScreenState extends State<GameSystemScreen>
 
     return Column(
       children: [
-        _buildHeader(compact, showDetails: showDetails),
+        _buildHeader(
+          compact,
+          desktopScale: desktopScale,
+          horizontalPadding: horizontalPadding,
+          showDetails: showDetails,
+        ),
         Expanded(
           child: _browse.visibleGames.isEmpty
               ? Center(child: Text(AppLocalizations.of(context).noItemsFound))
               : _buildGrid(
                   _browse.visibleGames,
+                  desktopScale: desktopScale,
+                  horizontalPadding: horizontalPadding,
                   showDetails: showDetails,
                   showBackdrop: showBackdrop,
                 ),
@@ -220,10 +242,13 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     );
   }
 
-  Widget _buildHeader(bool compact, {required bool showDetails}) {
+  Widget _buildHeader(
+    bool compact, {
+    required double desktopScale,
+    required double horizontalPadding,
+    required bool showDetails,
+  }) {
     final systemName = _browse.displaySystemName;
-    final desktopScale = _prefs.get(UserPreferences.desktopUiScale).scaleFactor;
-    final horizontalPadding = compact ? 16.0 : 60.0 * desktopScale;
     final topPadding = compact ? MediaQuery.paddingOf(context).top + 8 : 8.0;
     final availableWidth =
         MediaQuery.sizeOf(context).width - horizontalPadding * 2;
@@ -413,16 +438,16 @@ class _GameSystemScreenState extends State<GameSystemScreen>
   }) {
     if (!_gridScrollController.hasClients) return;
     final row = index ~/ crossAxisCount;
-    final rowTop = 8 + row * (cellHeight + mainAxisSpacing);
+    final rowTop = _gridTopPadding + row * (cellHeight + mainAxisSpacing);
     final rowBottom = rowTop + cellHeight;
     final position = _gridScrollController.position;
     final current = position.pixels;
     final viewportHeight = position.viewportDimension;
     var target = current;
-    if (rowTop - 8 < current) {
-      target = rowTop - 8;
-    } else if (rowBottom + 52 > current + viewportHeight) {
-      target = rowBottom + 52 - viewportHeight;
+    if (rowTop - _gridTopPadding < current) {
+      target = rowTop - _gridTopPadding;
+    } else if (rowBottom + _gridBottomFocusPeek > current + viewportHeight) {
+      target = rowBottom + _gridBottomFocusPeek - viewportHeight;
     }
     target = target.clamp(position.minScrollExtent, position.maxScrollExtent);
     if ((target - current).abs() < 1) return;
@@ -478,7 +503,7 @@ class _GameSystemScreenState extends State<GameSystemScreen>
     // Do not let those transient hover targets compete with poster requests by
     // fetching their backdrop and details. Once wheel input stops, reactivate
     // the card still under the pointer; the view model then applies its normal
-    // 250 ms library-style selection debounce.
+    // detail and backdrop debounce tiers.
     _suppressHoverEnrichment = true;
     _hoverScrollSettle?.cancel();
     final hovered = _hoveredGame;
@@ -550,22 +575,19 @@ class _GameSystemScreenState extends State<GameSystemScreen>
 
   Widget _buildGrid(
     List<GameSummary> games, {
+    required double desktopScale,
+    required double horizontalPadding,
     required bool showDetails,
     required bool showBackdrop,
   }) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final compact = constraints.maxWidth < 600;
-        final horizontalPadding = compact ? 16.0 : 60.0;
         const spacing = 12.0;
         const imageHeightRatio = 1.34;
         const captionGap = 6.0;
         const captionHeight = 42.0;
 
         final availableWidth = constraints.maxWidth - horizontalPadding * 2;
-        final desktopScale = _prefs
-            .get(UserPreferences.desktopUiScale)
-            .scaleFactor;
         final preferredCardWidth =
             _prefs.resolveLibraryPosterSize().portraitHeight *
             (2 / 3) *
@@ -602,7 +624,7 @@ class _GameSystemScreenState extends State<GameSystemScreen>
             scrollCacheExtent: const ScrollCacheExtent.viewport(1),
             padding: EdgeInsets.fromLTRB(
               horizontalPadding,
-              8,
+              _gridTopPadding,
               horizontalPadding,
               32,
             ),
@@ -615,59 +637,57 @@ class _GameSystemScreenState extends State<GameSystemScreen>
             itemCount: games.length,
             itemBuilder: (context, index) {
               final game = games[index];
-              return LayoutBuilder(
-                builder: (context, cardConstraints) => GamePosterCard(
-                  imageUrl: gameThumbUrl(widget.libraryId, game.id),
-                  title: game.title,
-                  fileName: game.fileName,
-                  seed: game.id,
-                  width: cardConstraints.maxWidth,
-                  focusNode: getGridItemFocusNode(index, prefix: 'game_grid'),
-                  focusColor: focusColor,
-                  cardFocusExpansion: cardFocusExpansion,
-                  suppressFocusGlow: isNeon,
-                  autoScroll: false,
-                  onFocus: () {
-                    _activateBrowseGame(
-                      game,
-                      showBackdrop: showBackdrop,
-                      showDetails: showDetails,
-                    );
-                    _scrollToGridRow(
-                      index: index,
-                      crossAxisCount: columnCount,
-                      cellHeight: cardHeight,
-                      mainAxisSpacing: 14,
-                    );
-                  },
-                  onFocusLost: () => _browse.deactivateGame(game),
-                  onHoverStart: () => _activateHoveredGame(
+              return GamePosterCard(
+                imageUrl: gameThumbUrl(widget.libraryId, game.id),
+                title: game.title,
+                fileName: game.fileName,
+                seed: game.id,
+                width: cardWidth,
+                focusNode: getGridItemFocusNode(index, prefix: 'game_grid'),
+                focusColor: focusColor,
+                cardFocusExpansion: cardFocusExpansion,
+                suppressFocusGlow: isNeon,
+                autoScroll: false,
+                onFocus: () {
+                  _activateBrowseGame(
                     game,
                     showBackdrop: showBackdrop,
                     showDetails: showDetails,
-                  ),
-                  onHoverEnd: () => _deactivateHoveredGame(game),
-                  onKeyEvent: (_, event) {
-                    if (PlatformDetection.isTV &&
-                        event.isActionable &&
-                        event.logicalKey.isBackKey &&
-                        _allLetterFocus.context != null) {
-                      _allLetterFocus.requestFocus();
+                  );
+                  _scrollToGridRow(
+                    index: index,
+                    crossAxisCount: columnCount,
+                    cellHeight: cardHeight,
+                    mainAxisSpacing: 14,
+                  );
+                },
+                onFocusLost: () => _browse.deactivateGame(game),
+                onHoverStart: () => _activateHoveredGame(
+                  game,
+                  showBackdrop: showBackdrop,
+                  showDetails: showDetails,
+                ),
+                onHoverEnd: () => _deactivateHoveredGame(game),
+                onKeyEvent: (_, event) {
+                  if (PlatformDetection.isTV &&
+                      event.isActionable &&
+                      event.logicalKey.isBackKey &&
+                      _allLetterFocus.context != null) {
+                    _allLetterFocus.requestFocus();
+                    return KeyEventResult.handled;
+                  }
+                  if (event.isActionable && event.logicalKey.isRightKey) {
+                    final isLastColumn =
+                        (index % columnCount) == columnCount - 1;
+                    final isLastItem = index == games.length - 1;
+                    if (isLastColumn || isLastItem) {
                       return KeyEventResult.handled;
                     }
-                    if (event.isActionable && event.logicalKey.isRightKey) {
-                      final isLastColumn =
-                          (index % columnCount) == columnCount - 1;
-                      final isLastItem = index == games.length - 1;
-                      if (isLastColumn || isLastItem) {
-                        return KeyEventResult.handled;
-                      }
-                    }
-                    return KeyEventResult.ignored;
-                  },
-                  onTap: () => context.push(
-                    Destinations.gameDetailOf(widget.libraryId, game.id),
-                  ),
+                  }
+                  return KeyEventResult.ignored;
+                },
+                onTap: () => context.push(
+                  Destinations.gameDetailOf(widget.libraryId, game.id),
                 ),
               );
             },

--- a/lib/ui/widgets/bounded_network_image.dart
+++ b/lib/ui/widgets/bounded_network_image.dart
@@ -17,6 +17,7 @@ class BoundedNetworkImage extends StatelessWidget {
   final Duration fadeInDuration;
   final Widget Function(BuildContext context, String url, Object error)?
       errorBuilder;
+  final VoidCallback? onLoadFinished;
 
   /// Multiplier applied to the resolved width before clamping. Useful for
   /// blurred images where a low-resolution decode is acceptable.
@@ -35,6 +36,7 @@ class BoundedNetworkImage extends StatelessWidget {
     this.alignment = Alignment.center,
     this.fadeInDuration = Duration.zero,
     this.errorBuilder,
+    this.onLoadFinished,
     this.scale = 1.0,
     this.minWidth = 64,
     this.maxWidth = 1024,
@@ -102,10 +104,21 @@ class BoundedNetworkImage extends StatelessWidget {
             fit: fit,
             alignment: alignment,
             cacheWidth: cacheW,
-            errorBuilder: errorBuilder == null
+            frameBuilder: onLoadFinished == null
                 ? null
-                : (context, error, stackTrace) =>
-                    errorBuilder!(context, imageUrl, error),
+                : (context, child, frame, wasSynchronouslyLoaded) {
+                    if (frame != null || wasSynchronouslyLoaded) {
+                      _notifyLoadFinished();
+                    }
+                    return child;
+                  },
+            errorBuilder: errorBuilder == null && onLoadFinished == null
+                ? null
+                : (context, error, stackTrace) {
+                    _notifyLoadFinished();
+                    return errorBuilder?.call(context, imageUrl, error) ??
+                        const SizedBox.shrink();
+                  },
           );
         }
         return CachedNetworkImage(
@@ -114,11 +127,31 @@ class BoundedNetworkImage extends StatelessWidget {
           alignment: alignment,
           fadeInDuration: fadeInDuration,
           memCacheWidth: cacheW,
-          errorWidget: errorBuilder == null
+          imageBuilder: onLoadFinished == null
               ? null
-              : (context, url, error) => errorBuilder!(context, url, error),
+              : (context, imageProvider) {
+                  _notifyLoadFinished();
+                  return Image(
+                    image: imageProvider,
+                    fit: fit,
+                    alignment: alignment,
+                  );
+                },
+          errorWidget: errorBuilder == null && onLoadFinished == null
+              ? null
+              : (context, url, error) {
+                  _notifyLoadFinished();
+                  return errorBuilder?.call(context, url, error) ??
+                      const SizedBox.shrink();
+                },
         );
       },
     );
+  }
+
+  void _notifyLoadFinished() {
+    final callback = onLoadFinished;
+    if (callback == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) => callback());
   }
 }

--- a/lib/ui/widgets/game/game_alpha_picker_bar.dart
+++ b/lib/ui/widgets/game/game_alpha_picker_bar.dart
@@ -6,6 +6,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/focus/dpad_keys.dart';
+import '../../../util/platform_detection.dart';
 import '../../mixins/focus_state_mixin.dart';
 
 /// Games-scoped copy of Moonfin's standard alphabetical library filter.
@@ -98,51 +99,68 @@ class _GameAlphaLetterButtonState extends State<_GameAlphaLetterButton>
     final prefs = GetIt.instance<UserPreferences>();
     final desktopScale = prefs.get(UserPreferences.desktopUiScale).scaleFactor;
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+    final visualSize = 30 * desktopScale;
+    final targetSize = PlatformDetection.useMobileUi ? 44.0 : visualSize;
 
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setHovered(true),
-      onExit: (_) => setHovered(false),
-      child: Focus(
-        focusNode: widget.focusNode,
-        onFocusChange: setFocused,
-        onKeyEvent: (_, event) {
-          if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
-          // consume release/repeat events too so a restored focus target cannot receive a replayed select press.
-          if (event is KeyDownEvent) widget.onTap();
-          return KeyEventResult.handled;
-        },
-        child: GestureDetector(
-          onTap: widget.onTap,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 120),
-            width: 30 * desktopScale,
-            height: 30 * desktopScale,
-            alignment: Alignment.center,
-            decoration: BoxDecoration(
-              color: widget.isSelected
-                  ? AppColorScheme.onSurface.withAlpha(26)
-                  : null,
-              borderRadius: AppRadius.circular(4),
-              border: showFocusBorder
-                  ? Border.fromBorderSide(
-                      ThemeRegistry.active.borders.focusBorder.copyWith(
-                        color: focusColor,
-                        width: 1.5,
-                      ),
-                    )
-                  : null,
-            ),
-            child: Text(
-              widget.label,
-              style: TextStyle(
-                fontSize: 15 * desktopScale,
-                fontWeight: widget.isSelected
-                    ? FontWeight.w700
-                    : FontWeight.w500,
-                color: widget.isSelected
-                    ? AppColorScheme.accent
-                    : AppColorScheme.onSurface.withAlpha(140),
+    return Semantics(
+      button: true,
+      selected: widget.isSelected,
+      label: widget.label,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setHovered(true),
+        onExit: (_) => setHovered(false),
+        child: Focus(
+          focusNode: widget.focusNode,
+          onFocusChange: setFocused,
+          onKeyEvent: (_, event) {
+            if (!event.logicalKey.isSelectKey) {
+              return KeyEventResult.ignored;
+            }
+            // Consume release/repeat too so focus restoration cannot replay a
+            // Select press on the newly focused control.
+            if (event is KeyDownEvent) widget.onTap();
+            return KeyEventResult.handled;
+          },
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onTap,
+            child: SizedBox(
+              width: targetSize,
+              height: targetSize,
+              child: Center(
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 120),
+                  width: visualSize,
+                  height: visualSize,
+                  alignment: Alignment.center,
+                  decoration: BoxDecoration(
+                    color: widget.isSelected
+                        ? AppColorScheme.onSurface.withAlpha(26)
+                        : null,
+                    borderRadius: AppRadius.circular(4),
+                    border: showFocusBorder
+                        ? Border.fromBorderSide(
+                            ThemeRegistry.active.borders.focusBorder.copyWith(
+                              color: focusColor,
+                              width: 1.5,
+                            ),
+                          )
+                        : null,
+                  ),
+                  child: Text(
+                    widget.label,
+                    style: TextStyle(
+                      fontSize: 15 * desktopScale,
+                      fontWeight: widget.isSelected
+                          ? FontWeight.w700
+                          : FontWeight.w500,
+                      color: widget.isSelected
+                          ? AppColorScheme.accent
+                          : AppColorScheme.onSurface.withAlpha(140),
+                    ),
+                  ),
+                ),
               ),
             ),
           ),

--- a/lib/ui/widgets/game/game_alpha_picker_bar.dart
+++ b/lib/ui/widgets/game/game_alpha_picker_bar.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
+import '../../mixins/focus_state_mixin.dart';
+
+/// Games-scoped copy of Moonfin's standard alphabetical library filter.
+///
+/// Keeping this inside the games feature avoids changing the established media
+/// library browser while preserving the same `All`, `#`, and A-Z interaction.
+class GameAlphaPickerBar extends StatelessWidget {
+  const GameAlphaPickerBar({
+    super.key,
+    required this.selected,
+    required this.onChanged,
+    this.allFocusNode,
+  });
+
+  final String selected;
+  final ValueChanged<String> onChanged;
+  final FocusNode? allFocusNode;
+
+  static const letters = [
+    '',
+    '#',
+    'A',
+    'B',
+    'C',
+    'D',
+    'E',
+    'F',
+    'G',
+    'H',
+    'I',
+    'J',
+    'K',
+    'L',
+    'M',
+    'N',
+    'O',
+    'P',
+    'Q',
+    'R',
+    'S',
+    'T',
+    'U',
+    'V',
+    'W',
+    'X',
+    'Y',
+    'Z',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: letters.map((letter) {
+          return _GameAlphaLetterButton(
+            label: letter.isEmpty ? l10n.all : letter,
+            isSelected: selected == letter,
+            onTap: () => onChanged(letter),
+            focusNode: letter.isEmpty ? allFocusNode : null,
+          );
+        }).toList(),
+      ),
+    );
+  }
+}
+
+class _GameAlphaLetterButton extends StatefulWidget {
+  const _GameAlphaLetterButton({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+    this.focusNode,
+  });
+
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final FocusNode? focusNode;
+
+  @override
+  State<_GameAlphaLetterButton> createState() => _GameAlphaLetterButtonState();
+}
+
+class _GameAlphaLetterButtonState extends State<_GameAlphaLetterButton>
+    with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    final prefs = GetIt.instance<UserPreferences>();
+    final desktopScale = prefs.get(UserPreferences.desktopUiScale).scaleFactor;
+    final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setHovered(true),
+      onExit: (_) => setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onFocusChange: setFocused,
+        onKeyEvent: (_, event) {
+          if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+          // consume release/repeat events too so a restored focus target cannot receive a replayed select press.
+          if (event is KeyDownEvent) widget.onTap();
+          return KeyEventResult.handled;
+        },
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            width: 30 * desktopScale,
+            height: 30 * desktopScale,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: widget.isSelected
+                  ? AppColorScheme.onSurface.withAlpha(26)
+                  : null,
+              borderRadius: AppRadius.circular(4),
+              border: showFocusBorder
+                  ? Border.fromBorderSide(
+                      ThemeRegistry.active.borders.focusBorder.copyWith(
+                        color: focusColor,
+                        width: 1.5,
+                      ),
+                    )
+                  : null,
+            ),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 15 * desktopScale,
+                fontWeight: widget.isSelected
+                    ? FontWeight.w700
+                    : FontWeight.w500,
+                color: widget.isSelected
+                    ? AppColorScheme.accent
+                    : AppColorScheme.onSurface.withAlpha(140),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/game/game_alpha_picker_bar.dart
+++ b/lib/ui/widgets/game/game_alpha_picker_bar.dart
@@ -18,12 +18,17 @@ class GameAlphaPickerBar extends StatelessWidget {
     super.key,
     required this.selected,
     required this.onChanged,
-    this.allFocusNode,
+    this.letterFocusNodes,
+    this.onNavigateUp,
   });
 
   final String selected;
   final ValueChanged<String> onChanged;
-  final FocusNode? allFocusNode;
+  final Map<String, FocusNode>? letterFocusNodes;
+
+  /// Called when the user presses up from any letter, so the screen can move
+  /// focus to the search field above instead of falling through to the grid.
+  final VoidCallback? onNavigateUp;
 
   static const letters = [
     '',
@@ -67,7 +72,8 @@ class GameAlphaPickerBar extends StatelessWidget {
             label: letter.isEmpty ? l10n.all : letter,
             isSelected: selected == letter,
             onTap: () => onChanged(letter),
-            focusNode: letter.isEmpty ? allFocusNode : null,
+            focusNode: letterFocusNodes?[letter],
+            onNavigateUp: onNavigateUp,
           );
         }).toList(),
       ),
@@ -81,12 +87,14 @@ class _GameAlphaLetterButton extends StatefulWidget {
     required this.isSelected,
     required this.onTap,
     this.focusNode,
+    this.onNavigateUp,
   });
 
   final String label;
   final bool isSelected;
   final VoidCallback onTap;
   final FocusNode? focusNode;
+  final VoidCallback? onNavigateUp;
 
   @override
   State<_GameAlphaLetterButton> createState() => _GameAlphaLetterButtonState();
@@ -114,6 +122,14 @@ class _GameAlphaLetterButtonState extends State<_GameAlphaLetterButton>
           focusNode: widget.focusNode,
           onFocusChange: setFocused,
           onKeyEvent: (_, event) {
+            // Up moves to the search field above rather than falling through to
+            // the grid below, which would also scroll it back to the top.
+            if (widget.onNavigateUp != null &&
+                event.isActionable &&
+                event.logicalKey.isUpKey) {
+              widget.onNavigateUp!();
+              return KeyEventResult.handled;
+            }
             if (!event.logicalKey.isSelectKey) {
               return KeyEventResult.ignored;
             }

--- a/lib/ui/widgets/game/game_artwork_load_scheduler.dart
+++ b/lib/ui/widgets/game/game_artwork_load_scheduler.dart
@@ -1,0 +1,151 @@
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+/// Returns a row-aligned artwork queue with visible items first, followed by
+/// surrounding rows expanding outward above and below the viewport.
+List<int> gameArtworkLoadOrder({
+  required int firstIndex,
+  required int lastIndexExclusive,
+  required int visibleFirstIndex,
+  required int visibleLastIndexExclusive,
+  required int crossAxisCount,
+  required int surroundingRows,
+}) {
+  assert(crossAxisCount > 0);
+  assert(surroundingRows >= 0);
+  if (firstIndex >= lastIndexExclusive) return const [];
+
+  final visibleStart = visibleFirstIndex
+      .clamp(firstIndex, lastIndexExclusive - 1)
+      .toInt();
+  final visibleEnd = visibleLastIndexExclusive
+      .clamp(visibleStart + 1, lastIndexExclusive)
+      .toInt();
+  final indexes = <int>[
+    for (var index = visibleStart; index < visibleEnd; index++) index,
+  ];
+
+  for (var distance = 1; distance <= surroundingRows; distance++) {
+    final aboveStart = visibleStart - distance * crossAxisCount;
+    if (aboveStart >= firstIndex) {
+      final aboveEnd = (aboveStart + crossAxisCount)
+          .clamp(firstIndex, visibleStart)
+          .toInt();
+      for (var index = aboveStart; index < aboveEnd; index++) {
+        indexes.add(index);
+      }
+    }
+
+    final belowStart = visibleEnd + (distance - 1) * crossAxisCount;
+    if (belowStart < lastIndexExclusive) {
+      final belowEnd = (belowStart + crossAxisCount)
+          .clamp(belowStart, lastIndexExclusive)
+          .toInt();
+      for (var index = belowStart; index < belowEnd; index++) {
+        indexes.add(index);
+      }
+    }
+  }
+  return indexes;
+}
+
+/// Keeps game artwork ahead of the cache manager's non-cancellable FIFO.
+///
+/// Only a small active batch is submitted at once. Replacing the viewport
+/// discards work that has not started, while callbacks from an older viewport
+/// cannot advance the new queue.
+class GameArtworkLoadScheduler extends ChangeNotifier {
+  GameArtworkLoadScheduler({this.maxConcurrent = 4, this.maxFinished = 400})
+    : assert(maxConcurrent > 0),
+      assert(maxFinished > 0);
+
+  final int maxConcurrent;
+
+  /// Upper bound on remembered "already loaded" keys, so a long browse of a
+  /// large library does not grow this set without limit. Only keys no longer in
+  /// the viewport are evicted, so on-screen artwork is never dropped; a scrolled
+  /// -back item simply re-requests (served from the image cache).
+  final int maxFinished;
+  final Set<String> _finished = <String>{};
+  final Map<String, int> _active = <String, int>{};
+  final Queue<String> _pending = Queue<String>();
+  Set<String> _viewport = <String>{};
+  int _generation = 0;
+
+  bool get hasViewport => _viewport.isNotEmpty;
+
+  @visibleForTesting
+  int get finishedCount => _finished.length;
+
+  bool isEnabled(String key) =>
+      _viewport.contains(key) &&
+      (_finished.contains(key) || _active.containsKey(key));
+
+  int? generationFor(String key) => _active[key];
+
+  void showViewport(Iterable<String> keys, {String? priorityKey}) {
+    final viewport = LinkedHashSet<String>.of(keys);
+    if (setEquals(_viewport, viewport)) return;
+
+    _generation++;
+    _viewport = viewport;
+    _active.clear();
+    _pending.clear();
+
+    if (priorityKey != null &&
+        viewport.contains(priorityKey) &&
+        !_finished.contains(priorityKey)) {
+      _pending.add(priorityKey);
+    }
+    for (final key in viewport) {
+      if (key != priorityKey && !_finished.contains(key)) {
+        _pending.add(key);
+      }
+    }
+
+    _pump();
+    notifyListeners();
+  }
+
+  void markFinished(String key, int generation) {
+    if (_active[key] != generation) return;
+    _active.remove(key);
+    _finished.add(key);
+    _pump();
+    _trimFinished();
+    notifyListeners();
+  }
+
+  /// Evicts the oldest finished keys that are no longer visible once the set
+  /// exceeds [maxFinished]. Iterating a plain [Set] yields insertion order, so
+  /// this drops the least-recently-finished off-screen entries first and never
+  /// an entry still in the viewport.
+  void _trimFinished() {
+    final overflow = _finished.length - maxFinished;
+    if (overflow <= 0) return;
+    final toEvict = <String>[];
+    for (final key in _finished) {
+      if (_viewport.contains(key)) continue;
+      toEvict.add(key);
+      if (toEvict.length >= overflow) break;
+    }
+    _finished.removeAll(toEvict);
+  }
+
+  void clearViewport() {
+    if (_viewport.isEmpty && _active.isEmpty && _pending.isEmpty) return;
+    _generation++;
+    _viewport = <String>{};
+    _active.clear();
+    _pending.clear();
+    notifyListeners();
+  }
+
+  void _pump() {
+    while (_active.length < maxConcurrent && _pending.isNotEmpty) {
+      final key = _pending.removeFirst();
+      _active[key] = _generation;
+    }
+  }
+}

--- a/lib/ui/widgets/game/game_card_focus_frame.dart
+++ b/lib/ui/widgets/game/game_card_focus_frame.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../focus/focus_theme.dart';
+
+/// Games-scoped focus border and glow matching Moonfin's [MediaCard] styling.
+///
+/// Keeping this helper within the games feature avoids coupling retro-game
+/// navigation to the private implementation of the media library browser.
+class GameCardFocusFrame extends StatelessWidget {
+  const GameCardFocusFrame({
+    super.key,
+    required this.active,
+    required this.child,
+    this.focusColor,
+    this.suppressFocusGlow = false,
+  });
+
+  final bool active;
+  final Widget child;
+  final Color? focusColor;
+  final bool suppressFocusGlow;
+
+  @override
+  Widget build(BuildContext context) {
+    final borders = ThemeRegistry.active.borders;
+    final effectiveFocusColor = FocusTheme.resolveColor(context, focusColor);
+    final showGlow =
+        active && !suppressFocusGlow && borders.focusGlow.isNotEmpty;
+
+    return Stack(
+      clipBehavior: Clip.none,
+      fit: StackFit.passthrough,
+      children: [
+        if (showGlow)
+          Positioned(
+            top: -3.5,
+            bottom: -3.5,
+            left: -3.5,
+            right: -3.5,
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: borders.cardRadius + AppRadius.circular(3.5),
+                  boxShadow: borders.focusGlow,
+                ),
+              ),
+            ),
+          ),
+        child,
+        if (active)
+          Positioned(
+            top: -3.5,
+            bottom: -3.5,
+            left: -3.5,
+            right: -3.5,
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: borders.cardRadius + AppRadius.circular(3.5),
+                  border: Border.fromBorderSide(
+                    borders.focusBorder.copyWith(
+                      color: effectiveFocusColor,
+                      width: 3,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/ui/widgets/game/game_poster_card.dart
+++ b/lib/ui/widgets/game/game_poster_card.dart
@@ -1,16 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../util/game_library.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import '../bounded_network_image.dart';
-import '../focus/focusable_wrapper.dart';
 import 'game_card_focus_frame.dart';
 
-/// A box-art card for one game, with a seeded color + controller-icon fallback for the many
-/// games that have no art, and a title caption. Always focusable (d-pad / gamepad navigation
-/// works on every platform, not just TV). Shared by the library rows and the detail screen's
-/// related rail.
+/// A box-art card for one game, with a seeded color + controller-icon fallback
+/// for the many games that have no art, and a title caption. Always focusable
+/// (d-pad / gamepad navigation works on every platform, not just TV). Shared by
+/// the library grid and the detail screen's related rail.
+///
+/// Built on the same self-contained focus pattern as [MediaCard]: the card owns
+/// its own [MouseRegion] + [Focus] + scale animation and draws exactly one focus
+/// border (via [GameCardFocusFrame]). It deliberately does not use
+/// `FocusableWrapper`, so there is no second, wrapper-drawn border to collide
+/// with the frame.
 class GamePosterCard extends StatefulWidget {
   const GamePosterCard({
     super.key,
@@ -30,6 +37,9 @@ class GamePosterCard extends StatefulWidget {
     this.onHoverEnd,
     this.focusNode,
     this.onKeyEvent,
+    this.stopRightTraversal = false,
+    this.loadArtwork = true,
+    this.onArtworkLoadFinished,
     this.autoScroll = true,
   });
 
@@ -49,6 +59,9 @@ class GamePosterCard extends StatefulWidget {
   final VoidCallback? onHoverEnd;
   final FocusNode? focusNode;
   final FocusOnKeyEventCallback? onKeyEvent;
+  final bool stopRightTraversal;
+  final bool loadArtwork;
+  final VoidCallback? onArtworkLoadFinished;
   final bool autoScroll;
 
   @override
@@ -59,11 +72,95 @@ class _GamePosterCardState extends State<GamePosterCard> {
   bool _hovered = false;
   bool _focused = false;
 
+  bool get _active => _hovered || _focused;
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    // Screen-supplied handling (TV back-to-alpha, right-edge stop) wins first,
+    // matching how FocusableWrapper honored its `onKeyEvent` override ahead of
+    // its own defaults.
+    final override = widget.onKeyEvent?.call(node, event);
+    if (override != null && override != KeyEventResult.ignored) return override;
+
+    // Fold the right-edge traversal stop into this single key path instead of a
+    // separate `Shortcuts`/`DoNothingAndStopPropagationIntent` wrapper.
+    if (widget.stopRightTraversal &&
+        event.isActionable &&
+        event.logicalKey.isRightKey) {
+      return KeyEventResult.handled;
+    }
+
+    if (event is KeyDownEvent && event.logicalKey.isSelectKey) {
+      widget.onTap();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  void _handleFocusChange(bool hasFocus) {
+    setState(() => _focused = hasFocus);
+    if (hasFocus) {
+      widget.onFocus?.call();
+      if (widget.autoScroll) {
+        WidgetsBinding.instance.addPostFrameCallback((_) => _scrollIntoView());
+      }
+    } else if (!_hovered) {
+      widget.onFocusLost?.call();
+    }
+  }
+
+  void _scrollIntoView() {
+    if (!mounted) return;
+    Scrollable.ensureVisible(
+      context,
+      alignment: 0.5,
+      alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final active = _active;
+    final scale = widget.cardFocusExpansion && active
+        ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
+        : 1.0;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) {
+        setState(() => _hovered = true);
+        widget.onHoverStart?.call();
+      },
+      onExit: (_) {
+        setState(() => _hovered = false);
+        if (!_focused) widget.onHoverEnd?.call();
+      },
+      child: Focus(
+        focusNode: widget.focusNode,
+        autofocus: widget.autofocus,
+        onKeyEvent: _handleKeyEvent,
+        onFocusChange: _handleFocusChange,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: widget.onTap,
+          child: RepaintBoundary(
+            child: AnimatedScale(
+              scale: scale,
+              duration: const Duration(milliseconds: 150),
+              curve: PlatformDetection.isAppleTV
+                  ? Curves.easeOutCubic
+                  : Curves.linear,
+              child: _buildCard(context, active),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCard(BuildContext context, bool active) {
     final url = widget.imageUrl;
-    final label = gameDisplayTitle(widget.title, widget.fileName);
-    final active = _hovered || _focused;
     final borders = ThemeRegistry.active.borders;
     final baseTextStyle =
         Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
@@ -75,9 +172,10 @@ class _GamePosterCardState extends State<GamePosterCard> {
       shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
     );
 
-    final card = Column(
+    return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // The single focus border + glow lives here and nowhere else.
         GameCardFocusFrame(
           active: active,
           focusColor: widget.focusColor,
@@ -87,13 +185,13 @@ class _GamePosterCardState extends State<GamePosterCard> {
             height: widget.width * 1.34,
             child: ClipRRect(
               borderRadius: borders.cardRadius,
-              child: url == null
+              child: url == null || !widget.loadArtwork
                   ? _Fallback(seed: widget.seed, iconSize: widget.width * 0.3)
                   : Stack(
                       fit: StackFit.expand,
                       children: [
-                        // Keep the normal game fallback visible while Chrome
-                        // fetches and decodes artwork for newly built rows.
+                        // Keep the seeded game fallback visible while artwork
+                        // fetches and decodes for newly built rows.
                         _Fallback(
                           seed: widget.seed,
                           iconSize: widget.width * 0.3,
@@ -102,6 +200,7 @@ class _GamePosterCardState extends State<GamePosterCard> {
                           imageUrl: url,
                           fit: BoxFit.cover,
                           maxWidth: 1024,
+                          onLoadFinished: widget.onArtworkLoadFinished,
                           // The fallback underneath remains visible on error.
                           errorBuilder: (_, _, _) => const SizedBox.shrink(),
                         ),
@@ -114,54 +213,13 @@ class _GamePosterCardState extends State<GamePosterCard> {
         SizedBox(
           width: widget.width,
           child: Text(
-            label,
+            gameDisplayTitle(widget.title, widget.fileName),
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
             style: titleStyle,
           ),
         ),
       ],
-    );
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) {
-        setState(() => _hovered = true);
-        widget.onHoverStart?.call();
-      },
-      onExit: (_) {
-        setState(() => _hovered = false);
-        if (!_focused) widget.onHoverEnd?.call();
-      },
-      child: AnimatedScale(
-        scale: widget.cardFocusExpansion && active
-            ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
-            : 1,
-        duration: const Duration(milliseconds: 150),
-        curve: PlatformDetection.isAppleTV
-            ? Curves.easeOutCubic
-            : Curves.linear,
-        child: FocusableWrapper(
-          onSelect: widget.onTap,
-          autofocus: widget.autofocus,
-          focusNode: widget.focusNode,
-          onKeyEvent: widget.onKeyEvent,
-          onFocusChange: (focused) {
-            setState(() => _focused = focused);
-            if (focused) {
-              widget.onFocus?.call();
-            } else if (!_hovered) {
-              widget.onFocusLost?.call();
-            }
-          },
-          borderRadius: 10,
-          autoScroll: widget.autoScroll,
-          disableScale: true,
-          useBackgroundFocus: false,
-          suppressFocusGlow: true,
-          child: card,
-        ),
-      ),
     );
   }
 }

--- a/lib/ui/widgets/game/game_poster_card.dart
+++ b/lib/ui/widgets/game/game_poster_card.dart
@@ -1,14 +1,17 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../util/game_library.dart';
+import '../../../util/platform_detection.dart';
+import '../bounded_network_image.dart';
 import '../focus/focusable_wrapper.dart';
+import 'game_card_focus_frame.dart';
 
 /// A box-art card for one game, with a seeded color + controller-icon fallback for the many
 /// games that have no art, and a title caption. Always focusable (d-pad / gamepad navigation
 /// works on every platform, not just TV). Shared by the library rows and the detail screen's
 /// related rail.
-class GamePosterCard extends StatelessWidget {
+class GamePosterCard extends StatefulWidget {
   const GamePosterCard({
     super.key,
     required this.imageUrl,
@@ -18,6 +21,16 @@ class GamePosterCard extends StatelessWidget {
     required this.onTap,
     this.width = 108,
     this.autofocus = false,
+    this.focusColor,
+    this.cardFocusExpansion = true,
+    this.suppressFocusGlow = false,
+    this.onFocus,
+    this.onFocusLost,
+    this.onHoverStart,
+    this.onHoverEnd,
+    this.focusNode,
+    this.onKeyEvent,
+    this.autoScroll = true,
   });
 
   final String? imageUrl;
@@ -27,49 +40,128 @@ class GamePosterCard extends StatelessWidget {
   final VoidCallback onTap;
   final double width;
   final bool autofocus;
+  final Color? focusColor;
+  final bool cardFocusExpansion;
+  final bool suppressFocusGlow;
+  final VoidCallback? onFocus;
+  final VoidCallback? onFocusLost;
+  final VoidCallback? onHoverStart;
+  final VoidCallback? onHoverEnd;
+  final FocusNode? focusNode;
+  final FocusOnKeyEventCallback? onKeyEvent;
+  final bool autoScroll;
+
+  @override
+  State<GamePosterCard> createState() => _GamePosterCardState();
+}
+
+class _GamePosterCardState extends State<GamePosterCard> {
+  bool _hovered = false;
+  bool _focused = false;
 
   @override
   Widget build(BuildContext context) {
-    final url = imageUrl;
-    final label = gameDisplayTitle(title, fileName);
+    final url = widget.imageUrl;
+    final label = gameDisplayTitle(widget.title, widget.fileName);
+    final active = _hovered || _focused;
+    final borders = ThemeRegistry.active.borders;
+    final baseTextStyle =
+        Theme.of(context).textTheme.bodySmall ?? const TextStyle(fontSize: 12);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final titleStyle = baseTextStyle.copyWith(
+      color: isNeon ? AppColorScheme.accent : baseTextStyle.color,
+      fontWeight: FontWeight.bold,
+      fontSize: (baseTextStyle.fontSize ?? 12) + 1,
+      shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
+    );
 
     final card = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ClipRRect(
-          borderRadius: BorderRadius.circular(10),
+        GameCardFocusFrame(
+          active: active,
+          focusColor: widget.focusColor,
+          suppressFocusGlow: widget.suppressFocusGlow,
           child: SizedBox(
-            width: width,
-            height: width * 1.34,
-            child: url == null
-                ? _Fallback(seed: seed, iconSize: width * 0.3)
-                : CachedNetworkImage(
-                    imageUrl: url,
-                    fit: BoxFit.cover,
-                    errorWidget: (_, _, _) =>
-                        _Fallback(seed: seed, iconSize: width * 0.3),
-                  ),
+            width: widget.width,
+            height: widget.width * 1.34,
+            child: ClipRRect(
+              borderRadius: borders.cardRadius,
+              child: url == null
+                  ? _Fallback(seed: widget.seed, iconSize: widget.width * 0.3)
+                  : Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        // Keep the normal game fallback visible while Chrome
+                        // fetches and decodes artwork for newly built rows.
+                        _Fallback(
+                          seed: widget.seed,
+                          iconSize: widget.width * 0.3,
+                        ),
+                        BoundedNetworkImage(
+                          imageUrl: url,
+                          fit: BoxFit.cover,
+                          maxWidth: 1024,
+                          // The fallback underneath remains visible on error.
+                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                        ),
+                      ],
+                    ),
+            ),
           ),
         ),
         const SizedBox(height: 6),
         SizedBox(
-          width: width,
+          width: widget.width,
           child: Text(
             label,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(color: Colors.white70, fontSize: 12),
+            style: titleStyle,
           ),
         ),
       ],
     );
 
-    return FocusableWrapper(
-      onSelect: onTap,
-      autofocus: autofocus,
-      borderRadius: 10,
-      autoScroll: true,
-      child: card,
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) {
+        setState(() => _hovered = true);
+        widget.onHoverStart?.call();
+      },
+      onExit: (_) {
+        setState(() => _hovered = false);
+        if (!_focused) widget.onHoverEnd?.call();
+      },
+      child: AnimatedScale(
+        scale: widget.cardFocusExpansion && active
+            ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
+            : 1,
+        duration: const Duration(milliseconds: 150),
+        curve: PlatformDetection.isAppleTV
+            ? Curves.easeOutCubic
+            : Curves.linear,
+        child: FocusableWrapper(
+          onSelect: widget.onTap,
+          autofocus: widget.autofocus,
+          focusNode: widget.focusNode,
+          onKeyEvent: widget.onKeyEvent,
+          onFocusChange: (focused) {
+            setState(() => _focused = focused);
+            if (focused) {
+              widget.onFocus?.call();
+            } else if (!_hovered) {
+              widget.onFocusLost?.call();
+            }
+          },
+          borderRadius: 10,
+          autoScroll: widget.autoScroll,
+          disableScale: true,
+          useBackgroundFocus: false,
+          suppressFocusGlow: true,
+          child: card,
+        ),
+      ),
     );
   }
 }
@@ -85,7 +177,11 @@ class _Fallback extends StatelessWidget {
     return ColoredBox(
       color: gameFallbackColor(seed),
       child: Center(
-        child: Icon(Icons.videogame_asset, size: iconSize, color: Colors.white70),
+        child: Icon(
+          Icons.videogame_asset,
+          size: iconSize,
+          color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/game/game_poster_rail.dart
+++ b/lib/ui/widgets/game/game_poster_rail.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../../preference/user_preferences.dart';
 import '../../../util/game_library.dart';
 import 'game_poster_card.dart';
 
@@ -31,6 +34,13 @@ class GamePosterRail extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final prefs = GetIt.instance<UserPreferences>();
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final focusColor = isNeon
+        ? ThemeRegistry.active.borders.focusBorder.color
+        : Color(prefs.get(UserPreferences.focusColor).colorValue);
+    final cardFocusExpansion = prefs.get(UserPreferences.cardFocusExpansion);
+    final textScale = MediaQuery.textScalerOf(context).scale(1);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -57,7 +67,7 @@ class GamePosterRail extends StatelessWidget {
           ),
         ),
         SizedBox(
-          height: cardWidth * 1.34 + 44,
+          height: cardWidth * 1.34 + 6 + 42 * textScale,
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
             padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -70,6 +80,9 @@ class GamePosterRail extends StatelessWidget {
               seed: games[i].id,
               width: cardWidth,
               autofocus: autofocusFirst && i == 0,
+              focusColor: focusColor,
+              cardFocusExpansion: cardFocusExpansion,
+              suppressFocusGlow: isNeon,
               onTap: () => onTapGame(games[i]),
             ),
           ),

--- a/lib/ui/widgets/game/game_system_card.dart
+++ b/lib/ui/widgets/game/game_system_card.dart
@@ -2,59 +2,86 @@ import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
+import '../../../l10n/app_localizations.dart';
 import '../../../util/game_library.dart';
+import '../../../util/platform_detection.dart';
 import '../bounded_network_image.dart';
 import '../focus/focusable_wrapper.dart';
+import 'game_card_focus_frame.dart';
 
 /// A focusable, artwork-backed platform tile used at the root of a retro-game
 /// library.
-class GameSystemCard extends StatelessWidget {
+class GameSystemCard extends StatefulWidget {
   const GameSystemCard({
     super.key,
     required this.libraryId,
     required this.system,
     required this.games,
+    required this.gameCount,
     required this.onTap,
     this.autofocus = false,
+    this.focusColor,
+    this.cardFocusExpansion = true,
+    this.suppressFocusGlow = false,
+    this.focusNode,
+    this.onKeyEvent,
   });
 
   final String libraryId;
   final GameSystem system;
   final List<GameSummary> games;
+  final int? gameCount;
   final VoidCallback onTap;
   final bool autofocus;
+  final Color? focusColor;
+  final bool cardFocusExpansion;
+  final bool suppressFocusGlow;
+  final FocusNode? focusNode;
+  final FocusOnKeyEventCallback? onKeyEvent;
+
+  @override
+  State<GameSystemCard> createState() => _GameSystemCardState();
+}
+
+class _GameSystemCardState extends State<GameSystemCard> {
+  bool _hovered = false;
+  bool _focused = false;
 
   @override
   Widget build(BuildContext context) {
-    final seedColor = gameFallbackColor(system.id);
-    final countLabel = games.length == 1 ? '1 game' : '${games.length} games';
+    final seedColor = gameFallbackColor(widget.system.id);
+    final countLabel = widget.gameCount == null
+        ? null
+        : AppLocalizations.of(context).itemCountLabel(widget.gameCount!);
+    final active = _hovered || _focused;
+    final borders = ThemeRegistry.active.borders;
 
-    return FocusableWrapper(
-      autofocus: autofocus,
-      autoScroll: true,
-      borderRadius: 14,
-      semanticLabel: '${system.name}, $countLabel',
-      onSelect: onTap,
+    final card = GameCardFocusFrame(
+      active: active,
+      focusColor: widget.focusColor,
+      suppressFocusGlow: widget.suppressFocusGlow,
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: borders.cardRadius,
         child: DecoratedBox(
           decoration: BoxDecoration(
             color: seedColor,
-            border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+            border: Border.all(
+              color: AppColorScheme.onSurface.withValues(alpha: 0.08),
+            ),
           ),
           child: Stack(
             fit: StackFit.expand,
             children: [
               _SystemArtworkStrip(
-                libraryId: libraryId,
-                games: games.take(4).toList(growable: false),
+                libraryId: widget.libraryId,
+                games: widget.games,
                 fallbackColor: seedColor,
               ),
               DecoratedBox(
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
-                    begin: Alignment.centerLeft,
-                    end: Alignment.centerRight,
+                    begin: AlignmentDirectional.centerStart,
+                    end: AlignmentDirectional.centerEnd,
                     colors: [
                       Colors.black.withValues(alpha: 0.86),
                       Colors.black.withValues(alpha: 0.58),
@@ -73,7 +100,7 @@ class GameSystemCard extends StatelessWidget {
                       height: 46,
                       decoration: BoxDecoration(
                         color: Colors.black.withValues(alpha: 0.34),
-                        borderRadius: BorderRadius.circular(12),
+                        borderRadius: AppRadius.circular(12),
                       ),
                       child: const Icon(
                         Icons.sports_esports,
@@ -88,7 +115,7 @@ class GameSystemCard extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
                           Text(
-                            system.name,
+                            widget.system.name,
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                             style: const TextStyle(
@@ -100,22 +127,26 @@ class GameSystemCard extends StatelessWidget {
                               ],
                             ),
                           ),
-                          const SizedBox(height: 6),
-                          Text(
-                            countLabel,
-                            style: TextStyle(
-                              color: Colors.white.withValues(alpha: 0.76),
-                              fontSize: 13,
-                              shadows: const [
-                                Shadow(color: Colors.black, blurRadius: 4),
-                              ],
+                          if (countLabel != null) ...[
+                            const SizedBox(height: 6),
+                            Text(
+                              countLabel,
+                              style: TextStyle(
+                                color: Colors.white.withValues(alpha: 0.76),
+                                fontSize: 13,
+                                shadows: const [
+                                  Shadow(color: Colors.black, blurRadius: 4),
+                                ],
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                       ),
                     ),
                     Icon(
-                      Icons.chevron_right,
+                      Directionality.of(context) == TextDirection.rtl
+                          ? Icons.chevron_left
+                          : Icons.chevron_right,
                       color: Colors.white.withValues(alpha: 0.72),
                     ),
                   ],
@@ -123,6 +154,37 @@ class GameSystemCard extends StatelessWidget {
               ),
             ],
           ),
+        ),
+      ),
+    );
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: AnimatedScale(
+        scale: widget.cardFocusExpansion && active
+            ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
+            : 1,
+        duration: const Duration(milliseconds: 150),
+        curve: PlatformDetection.isAppleTV
+            ? Curves.easeOutCubic
+            : Curves.linear,
+        child: FocusableWrapper(
+          autofocus: widget.autofocus,
+          focusNode: widget.focusNode,
+          onKeyEvent: widget.onKeyEvent,
+          autoScroll: true,
+          useComfortableZone: true,
+          disableScale: true,
+          useBackgroundFocus: false,
+          suppressFocusGlow: true,
+          semanticLabel: countLabel == null
+              ? widget.system.name
+              : '${widget.system.name}, $countLabel',
+          onFocusChange: (focused) => setState(() => _focused = focused),
+          onSelect: widget.onTap,
+          child: card,
         ),
       ),
     );

--- a/lib/ui/widgets/game/game_system_card.dart
+++ b/lib/ui/widgets/game/game_system_card.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../../l10n/app_localizations.dart';
 import '../../../util/game_library.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import '../bounded_network_image.dart';
-import '../focus/focusable_wrapper.dart';
 import 'game_card_focus_frame.dart';
 
 /// A focusable, artwork-backed platform tile used at the root of a retro-game
@@ -158,35 +159,84 @@ class _GameSystemCardState extends State<GameSystemCard> {
       ),
     );
 
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: AnimatedScale(
-        scale: widget.cardFocusExpansion && active
-            ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
-            : 1,
-        duration: const Duration(milliseconds: 150),
-        curve: PlatformDetection.isAppleTV
-            ? Curves.easeOutCubic
-            : Curves.linear,
-        child: FocusableWrapper(
-          autofocus: widget.autofocus,
+    final semanticLabel = countLabel == null
+        ? widget.system.name
+        : '${widget.system.name}, $countLabel';
+
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: Focus(
           focusNode: widget.focusNode,
-          onKeyEvent: widget.onKeyEvent,
-          autoScroll: true,
-          useComfortableZone: true,
-          disableScale: true,
-          useBackgroundFocus: false,
-          suppressFocusGlow: true,
-          semanticLabel: countLabel == null
-              ? widget.system.name
-              : '${widget.system.name}, $countLabel',
-          onFocusChange: (focused) => setState(() => _focused = focused),
-          onSelect: widget.onTap,
-          child: card,
+          autofocus: widget.autofocus,
+          onKeyEvent: _handleKeyEvent,
+          onFocusChange: (focused) {
+            setState(() => _focused = focused);
+            if (focused) {
+              WidgetsBinding.instance.addPostFrameCallback(
+                (_) => _scrollIntoView(),
+              );
+            }
+          },
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onTap,
+            child: RepaintBoundary(
+              child: AnimatedScale(
+                scale: widget.cardFocusExpansion && active
+                    ? (PlatformDetection.isAppleTV ? 1.12 : 1.05)
+                    : 1,
+                duration: const Duration(milliseconds: 150),
+                curve: PlatformDetection.isAppleTV
+                    ? Curves.easeOutCubic
+                    : Curves.linear,
+                child: card,
+              ),
+            ),
+          ),
         ),
       ),
+    );
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    final override = widget.onKeyEvent?.call(node, event);
+    if (override != null && override != KeyEventResult.ignored) return override;
+    if (event is KeyDownEvent && event.logicalKey.isSelectKey) {
+      widget.onTap();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  // Mirrors FocusableWrapper's comfortable-zone auto-scroll: only recenter the
+  // tile when it drifts outside the middle 60% of the viewport.
+  void _scrollIntoView() {
+    if (!mounted) return;
+    final renderObject = context.findRenderObject();
+    final scrollable = Scrollable.maybeOf(context);
+    if (renderObject == null || scrollable == null) return;
+    final viewport = scrollable.context.findRenderObject();
+    if (viewport is RenderBox && renderObject is RenderBox) {
+      final viewportSize = viewport.size.height;
+      final itemTop = renderObject
+          .localToGlobal(Offset.zero, ancestor: viewport)
+          .dy;
+      final itemBottom = itemTop + renderObject.size.height;
+      if (itemTop >= viewportSize * 0.2 && itemBottom <= viewportSize * 0.8) {
+        return;
+      }
+    }
+    Scrollable.ensureVisible(
+      context,
+      alignment: 0.5,
+      alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
     );
   }
 }

--- a/lib/ui/widgets/game/game_system_card.dart
+++ b/lib/ui/widgets/game/game_system_card.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../../util/game_library.dart';
+import '../bounded_network_image.dart';
+import '../focus/focusable_wrapper.dart';
+
+/// A focusable, artwork-backed platform tile used at the root of a retro-game
+/// library.
+class GameSystemCard extends StatelessWidget {
+  const GameSystemCard({
+    super.key,
+    required this.libraryId,
+    required this.system,
+    required this.games,
+    required this.onTap,
+    this.autofocus = false,
+  });
+
+  final String libraryId;
+  final GameSystem system;
+  final List<GameSummary> games;
+  final VoidCallback onTap;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    final seedColor = gameFallbackColor(system.id);
+    final countLabel = games.length == 1 ? '1 game' : '${games.length} games';
+
+    return FocusableWrapper(
+      autofocus: autofocus,
+      autoScroll: true,
+      borderRadius: 14,
+      semanticLabel: '${system.name}, $countLabel',
+      onSelect: onTap,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(14),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: seedColor,
+            border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
+          ),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              _SystemArtworkStrip(
+                libraryId: libraryId,
+                games: games.take(4).toList(growable: false),
+                fallbackColor: seedColor,
+              ),
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.centerLeft,
+                    end: Alignment.centerRight,
+                    colors: [
+                      Colors.black.withValues(alpha: 0.86),
+                      Colors.black.withValues(alpha: 0.58),
+                      Colors.black.withValues(alpha: 0.18),
+                    ],
+                    stops: const [0, 0.52, 1],
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(18),
+                child: Row(
+                  children: [
+                    Container(
+                      width: 46,
+                      height: 46,
+                      decoration: BoxDecoration(
+                        color: Colors.black.withValues(alpha: 0.34),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Icon(
+                        Icons.sports_esports,
+                        color: Colors.white,
+                        size: 28,
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            system.name,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 18,
+                              fontWeight: FontWeight.w700,
+                              shadows: [
+                                Shadow(color: Colors.black, blurRadius: 5),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            countLabel,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.76),
+                              fontSize: 13,
+                              shadows: const [
+                                Shadow(color: Colors.black, blurRadius: 4),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    Icon(
+                      Icons.chevron_right,
+                      color: Colors.white.withValues(alpha: 0.72),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SystemArtworkStrip extends StatelessWidget {
+  const _SystemArtworkStrip({
+    required this.libraryId,
+    required this.games,
+    required this.fallbackColor,
+  });
+
+  final String libraryId;
+  final List<GameSummary> games;
+  final Color fallbackColor;
+
+  @override
+  Widget build(BuildContext context) {
+    if (games.isEmpty) {
+      return ColoredBox(
+        color: Color.lerp(fallbackColor, AppColorScheme.background, 0.28)!,
+      );
+    }
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final game in games)
+          Expanded(
+            child: _SystemGameArtwork(
+              imageUrl: gameThumbUrl(libraryId, game.id),
+              fallbackColor: gameFallbackColor(game.id),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SystemGameArtwork extends StatelessWidget {
+  const _SystemGameArtwork({
+    required this.imageUrl,
+    required this.fallbackColor,
+  });
+
+  final String? imageUrl;
+  final Color fallbackColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = imageUrl;
+    if (url == null) return _fallback();
+
+    return BoundedNetworkImage(
+      imageUrl: url,
+      fit: BoxFit.cover,
+      maxWidth: 320,
+      errorBuilder: (_, _, _) => _fallback(),
+    );
+  }
+
+  Widget _fallback() {
+    return ColoredBox(
+      color: fallbackColor,
+      child: const Center(
+        child: Icon(Icons.videogame_asset, color: Colors.white54, size: 26),
+      ),
+    );
+  }
+}

--- a/lib/util/game_browse_filter.dart
+++ b/lib/util/game_browse_filter.dart
@@ -1,0 +1,119 @@
+/// Returns whether [title] matches the active game-library search and alphabet
+/// filters. [alternateText] lets callers include the ROM filename without
+/// changing the title used for alphabetical bucketing. Search terms match word
+/// prefixes, so `river` matches `River Raid` but not `Night Driver`.
+bool gameTitleMatchesBrowseFilters(
+  String title, {
+  String alternateText = '',
+  String query = '',
+  String letter = '',
+}) {
+  final normalizedTitle = title.trim();
+  final normalizedQuery = query.trim();
+
+  if (normalizedQuery.isNotEmpty) {
+    final titleWords = {
+      ..._searchWords(normalizedTitle),
+      ..._searchWords(alternateText),
+    };
+    final queryWords = _searchWords(normalizedQuery);
+    if (queryWords.isNotEmpty &&
+        !queryWords.every(
+          (term) => titleWords.any((word) => word.startsWith(term)),
+        )) {
+      return false;
+    }
+  }
+
+  return _matchesAlphabeticalBucket(normalizedTitle, letter);
+}
+
+/// Breaks search text into words while retaining non-ASCII letters. Search
+/// terms match word prefixes rather than arbitrary text inside another word.
+List<String> _searchWords(String value) {
+  return value
+      .toLowerCase()
+      .split(_wordSeparators)
+      .where((word) => word.isNotEmpty)
+      .toList(growable: false);
+}
+
+final RegExp _wordSeparators = RegExp(r'''[\s\-_./\\,:;!?()[\]{}'"+&]+''');
+
+bool _matchesAlphabeticalBucket(String title, String selectedBucket) {
+  if (selectedBucket.isEmpty) return true;
+  return _alphabeticalBucket(title) == selectedBucket.toUpperCase();
+}
+
+String _alphabeticalBucket(String value) {
+  final trimmed = value.trimLeft();
+  if (trimmed.isEmpty) return '#';
+
+  final initial = String.fromCharCode(trimmed.runes.first).toUpperCase();
+  final folded = _accentFolds[initial] ?? initial;
+  if (folded.length != 1) return '#';
+
+  final unit = folded.codeUnitAt(0);
+  return unit >= 0x41 && unit <= 0x5A ? folded : '#';
+}
+
+const Map<String, String> _accentFolds = {
+  'À': 'A',
+  'Á': 'A',
+  'Â': 'A',
+  'Ã': 'A',
+  'Ä': 'A',
+  'Å': 'A',
+  'Ā': 'A',
+  'Ă': 'A',
+  'Ą': 'A',
+  'Æ': 'A',
+  'Ç': 'C',
+  'Ć': 'C',
+  'Č': 'C',
+  'Ð': 'D',
+  'Ď': 'D',
+  'Đ': 'D',
+  'È': 'E',
+  'É': 'E',
+  'Ê': 'E',
+  'Ë': 'E',
+  'Ē': 'E',
+  'Ė': 'E',
+  'Ę': 'E',
+  'Ě': 'E',
+  'Ì': 'I',
+  'Í': 'I',
+  'Î': 'I',
+  'Ï': 'I',
+  'Ī': 'I',
+  'Į': 'I',
+  'Ł': 'L',
+  'Ñ': 'N',
+  'Ń': 'N',
+  'Ň': 'N',
+  'Ò': 'O',
+  'Ó': 'O',
+  'Ô': 'O',
+  'Õ': 'O',
+  'Ö': 'O',
+  'Ø': 'O',
+  'Ō': 'O',
+  'Ő': 'O',
+  'Ś': 'S',
+  'Š': 'S',
+  'Ş': 'S',
+  'Þ': 'T',
+  'Ù': 'U',
+  'Ú': 'U',
+  'Û': 'U',
+  'Ü': 'U',
+  'Ū': 'U',
+  'Ů': 'U',
+  'Ű': 'U',
+  'Ý': 'Y',
+  'Ÿ': 'Y',
+  'Ź': 'Z',
+  'Ž': 'Z',
+  'Ż': 'Z',
+};

--- a/lib/util/game_browse_filter.dart
+++ b/lib/util/game_browse_filter.dart
@@ -8,42 +8,53 @@ bool gameTitleMatchesBrowseFilters(
   String query = '',
   String letter = '',
 }) {
-  final normalizedTitle = title.trim();
-  final normalizedQuery = query.trim();
+  return GameBrowseTextIndex(
+    title,
+    alternateText: alternateText,
+  ).matches(queryWords: gameBrowseQueryWords(query), letter: letter);
+}
 
-  if (normalizedQuery.isNotEmpty) {
-    final titleWords = {
-      ..._searchWords(normalizedTitle),
-      ..._searchWords(alternateText),
-    };
-    final queryWords = _searchWords(normalizedQuery);
+/// Search and sort data prepared once for an item in a game library.
+///
+/// Large systems can contain thousands of ROMs, so callers should retain this
+/// object rather than repeatedly tokenizing titles on every search keystroke.
+class GameBrowseTextIndex {
+  GameBrowseTextIndex(String title, {String alternateText = ''})
+    : searchWords = {..._searchWords(title), ..._searchWords(alternateText)},
+      alphabeticalBucket = _alphabeticalBucket(title),
+      sortKey = _foldForBrowse(title.trim()).toLowerCase();
+
+  final Set<String> searchWords;
+  final String alphabeticalBucket;
+  final String sortKey;
+
+  bool matches({required List<String> queryWords, String letter = ''}) {
     if (queryWords.isNotEmpty &&
         !queryWords.every(
-          (term) => titleWords.any((word) => word.startsWith(term)),
+          (term) => searchWords.any((word) => word.startsWith(term)),
         )) {
       return false;
     }
+    return letter.isEmpty || alphabeticalBucket == letter.toUpperCase();
   }
-
-  return _matchesAlphabeticalBucket(normalizedTitle, letter);
 }
+
+/// Tokenizes a query once for use against prepared [GameBrowseTextIndex] data.
+List<String> gameBrowseQueryWords(String query) => _searchWords(query.trim());
 
 /// Breaks search text into words while retaining non-ASCII letters. Search
 /// terms match word prefixes rather than arbitrary text inside another word.
 List<String> _searchWords(String value) {
-  return value
+  return _foldForBrowse(value)
       .toLowerCase()
       .split(_wordSeparators)
       .where((word) => word.isNotEmpty)
       .toList(growable: false);
 }
 
-final RegExp _wordSeparators = RegExp(r'''[\s\-_./\\,:;!?()[\]{}'"+&]+''');
-
-bool _matchesAlphabeticalBucket(String title, String selectedBucket) {
-  if (selectedBucket.isEmpty) return true;
-  return _alphabeticalBucket(title) == selectedBucket.toUpperCase();
-}
+final RegExp _wordSeparators = RegExp(
+  r'''[\s\-_./\\,:;!?()[\]{}'"+&\u2010-\u2015\u2018\u2019\u201c\u201d]+''',
+);
 
 String _alphabeticalBucket(String value) {
   final trimmed = value.trimLeft();
@@ -55,6 +66,15 @@ String _alphabeticalBucket(String value) {
 
   final unit = folded.codeUnitAt(0);
   return unit >= 0x41 && unit <= 0x5A ? folded : '#';
+}
+
+String _foldForBrowse(String value) {
+  final result = StringBuffer();
+  for (final rune in value.runes) {
+    final character = String.fromCharCode(rune);
+    result.write(_accentFolds[character.toUpperCase()] ?? character);
+  }
+  return result.toString();
 }
 
 const Map<String, String> _accentFolds = {

--- a/test/data/viewmodels/game_system_browse_view_model_test.dart
+++ b/test/data/viewmodels/game_system_browse_view_model_test.dart
@@ -1,0 +1,216 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/viewmodels/game_system_browse_view_model.dart';
+import 'package:server_core/server_core.dart';
+
+void main() {
+  late _FakeGamesApi api;
+  late GameSystemBrowseViewModel viewModel;
+
+  setUp(() {
+    api = _FakeGamesApi();
+    viewModel = GameSystemBrowseViewModel(
+      gamesApi: api,
+      libraryId: 'retro',
+      systemId: 'atari2600',
+    );
+  });
+
+  tearDown(() => viewModel.dispose());
+
+  test('loads sorted games without inventing an active selection', () async {
+    await viewModel.load();
+
+    expect(viewModel.loading, isFalse);
+    expect(viewModel.error, isNull);
+    expect(viewModel.displaySystemName, 'Atari 2600');
+    expect(viewModel.visibleGames.map((game) => game.title), [
+      'Élite',
+      'River Raid',
+    ]);
+    expect(viewModel.activeGame, isNull);
+    expect(api.detailRequests, 0);
+  });
+
+  test('debounces filtering and folds accents', () async {
+    await viewModel.load();
+
+    viewModel.updateSearch('elite');
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(viewModel.visibleGames, hasLength(2));
+
+    await Future<void>.delayed(const Duration(milliseconds: 75));
+    expect(viewModel.visibleGames.map((game) => game.title), ['Élite']);
+  });
+
+  test('starting a search resets an existing alphabet filter', () async {
+    await viewModel.load();
+    viewModel.selectLetter('R');
+    expect(viewModel.selectedLetter, 'R');
+    expect(viewModel.visibleGames.map((game) => game.title), ['River Raid']);
+
+    viewModel.updateSearch('elite');
+
+    expect(viewModel.selectedLetter, isEmpty);
+    expect(viewModel.visibleGames, hasLength(2));
+    await Future<void>.delayed(const Duration(milliseconds: 175));
+    expect(viewModel.visibleGames.map((game) => game.title), ['Élite']);
+  });
+
+  test('only requests details when the caller displays the HUD', () async {
+    await viewModel.load();
+    final game = viewModel.visibleGames.first;
+
+    viewModel.activateGame(game, showBackdrop: false, loadDetails: false);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(api.detailRequests, 0);
+
+    viewModel.activateGame(game, showBackdrop: false, loadDetails: true);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    expect(api.detailRequests, 1);
+    expect(viewModel.hudGame?.id, game.id);
+    expect(viewModel.gameDetails[game.id]?.overview, 'Game overview');
+  });
+
+  test(
+    'reveals the title and description together after the hover guard',
+    () async {
+      await viewModel.load();
+      final game = viewModel.visibleGames.first;
+
+      viewModel.activateGame(game, showBackdrop: false, loadDetails: true);
+
+      expect(viewModel.activeGame?.id, game.id);
+      expect(viewModel.hudGame, isNull);
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+      expect(viewModel.hudGame?.id, game.id);
+      expect(viewModel.gameDetails[game.id]?.overview, 'Game overview');
+    },
+  );
+
+  test('loads description details before changing the backdrop', () async {
+    await viewModel.load();
+    final game = viewModel.visibleGames.first;
+
+    viewModel.activateGame(game, showBackdrop: true, loadDetails: true);
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+
+    expect(api.detailRequests, 1);
+    expect(viewModel.backdropGame, isNull);
+
+    await Future<void>.delayed(const Duration(milliseconds: 575));
+    expect(viewModel.backdropGame?.id, game.id);
+  });
+
+  test('unsupported servers expose a stable error state', () async {
+    final unsupported = GameSystemBrowseViewModel(
+      gamesApi: null,
+      libraryId: 'retro',
+      systemId: 'atari2600',
+    );
+    addTearDown(unsupported.dispose);
+
+    await unsupported.load();
+
+    expect(unsupported.loading, isFalse);
+    expect(unsupported.error, GameSystemBrowseError.unsupported);
+  });
+}
+
+class _FakeGamesApi implements GamesApi {
+  int detailRequests = 0;
+
+  static const _games = [
+    GameSummary(
+      id: 'river',
+      title: 'River Raid',
+      system: 'atari2600',
+      core: 'stella',
+      fileName: 'River Raid (USA).a26',
+    ),
+    GameSummary(
+      id: 'elite',
+      title: 'Élite',
+      system: 'atari2600',
+      core: 'stella',
+      fileName: 'Elite (Europe).a26',
+    ),
+  ];
+
+  @override
+  Future<List<GameSummary>> getGames(
+    String libraryId, {
+    String? system,
+  }) async => [..._games];
+
+  @override
+  Future<List<GameSystem>> getSystems(String libraryId) async => const [
+    GameSystem(
+      id: 'atari2600',
+      name: 'Atari 2600',
+      core: 'stella',
+      gameCount: 2,
+    ),
+  ];
+
+  @override
+  Future<GameDetail?> getGame(String libraryId, String gameId) async {
+    detailRequests++;
+    final game = _games.firstWhere((candidate) => candidate.id == gameId);
+    return GameDetail(
+      id: game.id,
+      title: game.title,
+      system: game.system,
+      core: game.core,
+      fileName: game.fileName,
+      sizeBytes: 0,
+      bios: const [],
+      overview: 'Game overview',
+    );
+  }
+
+  @override
+  Future<List<GameLibrary>> getLibraries() async => const [];
+
+  @override
+  String thumbUrl({
+    required String libraryId,
+    required String gameId,
+    String kind = 'boxart',
+  }) => '';
+
+  @override
+  String playerUrl({
+    required String libraryId,
+    required String gameId,
+    required String core,
+    String? biosId,
+    String? gameName,
+    bool includeSaveUrl = false,
+  }) => '';
+
+  @override
+  Future<void> downloadRom(
+    String libraryId,
+    String gameId,
+    String destPath, {
+    void Function(int received, int total)? onProgress,
+  }) async {}
+
+  @override
+  Future<void> downloadBios(
+    String libraryId,
+    String biosId,
+    String destPath,
+  ) async {}
+
+  @override
+  Future<List<int>?> getSave(String gameId, {String kind = 'state'}) async =>
+      null;
+
+  @override
+  Future<void> putSave(
+    String gameId,
+    List<int> data, {
+    String kind = 'state',
+  }) async {}
+}

--- a/test/data/viewmodels/game_system_browse_view_model_test.dart
+++ b/test/data/viewmodels/game_system_browse_view_model_test.dart
@@ -101,6 +101,78 @@ void main() {
     expect(viewModel.backdropGame?.id, game.id);
   });
 
+  testWidgets('detail cache evicts the least recently used entry', (
+    tester,
+  ) async {
+    final games = List.generate(
+      GameSystemBrowseViewModel.detailCacheCapacity + 1,
+      (index) => GameSummary(
+        id: 'game-${index.toString().padLeft(3, '0')}',
+        title: 'Game ${index.toString().padLeft(3, '0')}',
+        system: 'atari2600',
+        core: 'stella',
+        fileName: 'Game ${index.toString().padLeft(3, '0')}.a26',
+      ),
+    );
+    final cacheApi = _FakeGamesApi(games: games);
+    final cacheViewModel = GameSystemBrowseViewModel(
+      gamesApi: cacheApi,
+      libraryId: 'retro',
+      systemId: 'atari2600',
+    );
+    addTearDown(cacheViewModel.dispose);
+    await cacheViewModel.load();
+
+    final orderedGames = cacheViewModel.games;
+    for (
+      var index = 0;
+      index < GameSystemBrowseViewModel.detailCacheCapacity;
+      index++
+    ) {
+      cacheViewModel.activateGame(
+        orderedGames[index],
+        showBackdrop: false,
+        loadDetails: true,
+      );
+      await tester.pump(GameSystemBrowseViewModel.detailDebounceDuration);
+      await tester.pump();
+    }
+
+    expect(
+      cacheViewModel.gameDetails,
+      hasLength(GameSystemBrowseViewModel.detailCacheCapacity),
+    );
+    final mostRecentlyReused = orderedGames.first;
+    cacheViewModel.activateGame(
+      mostRecentlyReused,
+      showBackdrop: false,
+      loadDetails: true,
+    );
+    await tester.pump(GameSystemBrowseViewModel.detailDebounceDuration);
+    await tester.pump();
+
+    final newlyLoaded = orderedGames.last;
+    cacheViewModel.activateGame(
+      newlyLoaded,
+      showBackdrop: false,
+      loadDetails: true,
+    );
+    await tester.pump(GameSystemBrowseViewModel.detailDebounceDuration);
+    await tester.pump();
+
+    expect(
+      cacheViewModel.gameDetails,
+      hasLength(GameSystemBrowseViewModel.detailCacheCapacity),
+    );
+    expect(cacheViewModel.gameDetails, contains(mostRecentlyReused.id));
+    expect(cacheViewModel.gameDetails, isNot(contains(orderedGames[1].id)));
+    expect(cacheViewModel.gameDetails, contains(newlyLoaded.id));
+    expect(
+      cacheApi.detailRequests,
+      GameSystemBrowseViewModel.detailCacheCapacity + 1,
+    );
+  });
+
   test('unsupported servers expose a stable error state', () async {
     final unsupported = GameSystemBrowseViewModel(
       gamesApi: null,
@@ -117,9 +189,12 @@ void main() {
 }
 
 class _FakeGamesApi implements GamesApi {
-  int detailRequests = 0;
+  _FakeGamesApi({List<GameSummary>? games}) : games = games ?? _defaultGames;
 
-  static const _games = [
+  int detailRequests = 0;
+  final List<GameSummary> games;
+
+  static const _defaultGames = [
     GameSummary(
       id: 'river',
       title: 'River Raid',
@@ -140,22 +215,22 @@ class _FakeGamesApi implements GamesApi {
   Future<List<GameSummary>> getGames(
     String libraryId, {
     String? system,
-  }) async => [..._games];
+  }) async => [...games];
 
   @override
-  Future<List<GameSystem>> getSystems(String libraryId) async => const [
+  Future<List<GameSystem>> getSystems(String libraryId) async => [
     GameSystem(
       id: 'atari2600',
       name: 'Atari 2600',
       core: 'stella',
-      gameCount: 2,
+      gameCount: games.length,
     ),
   ];
 
   @override
   Future<GameDetail?> getGame(String libraryId, String gameId) async {
     detailRequests++;
-    final game = _games.firstWhere((candidate) => candidate.id == gameId);
+    final game = games.firstWhere((candidate) => candidate.id == gameId);
     return GameDetail(
       id: game.id,
       title: game.title,

--- a/test/ui/widgets/game/game_alpha_picker_bar_test.dart
+++ b/test/ui/widgets/game/game_alpha_picker_bar_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/game/game_alpha_picker_bar.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    GetIt.instance.registerSingleton<UserPreferences>(UserPreferences(store));
+    ThemeRegistry.setActiveById(ThemeRegistry.moonfinId);
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  testWidgets('reports up navigation from a focused letter', (tester) async {
+    final aFocus = FocusNode();
+    addTearDown(aFocus.dispose);
+    var upCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.buildTheme(ThemeRegistry.active),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: GameAlphaPickerBar(
+            selected: 'A',
+            letterFocusNodes: {'A': aFocus},
+            onNavigateUp: () => upCount++,
+            onChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    aFocus.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+    await tester.pump();
+    expect(upCount, 1);
+  });
+}

--- a/test/ui/widgets/game/game_artwork_load_scheduler_test.dart
+++ b/test/ui/widgets/game/game_artwork_load_scheduler_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/game/game_artwork_load_scheduler.dart';
+
+void main() {
+  test('orders nearby rows outward above then below the viewport', () {
+    expect(
+      gameArtworkLoadOrder(
+        firstIndex: 0,
+        lastIndexExclusive: 18,
+        visibleFirstIndex: 6,
+        visibleLastIndexExclusive: 12,
+        crossAxisCount: 3,
+        surroundingRows: 2,
+      ),
+      [
+        6, 7, 8, 9, 10, 11, // Visible rows.
+        3, 4, 5, 12, 13, 14, // One row above, then one below.
+        0, 1, 2, 15, 16, 17, // Two rows above, then two below.
+      ],
+    );
+  });
+
+  test('limits submissions and advances as artwork finishes', () {
+    final scheduler = GameArtworkLoadScheduler(maxConcurrent: 2);
+
+    scheduler.showViewport(const ['a', 'b', 'c'], priorityKey: 'b');
+
+    expect(scheduler.isEnabled('b'), isTrue);
+    expect(scheduler.isEnabled('a'), isTrue);
+    expect(scheduler.isEnabled('c'), isFalse);
+
+    scheduler.markFinished('b', scheduler.generationFor('b')!);
+
+    expect(scheduler.isEnabled('c'), isTrue);
+  });
+
+  test(
+    'replaces pending work and ignores completions from an old viewport',
+    () {
+      final scheduler = GameArtworkLoadScheduler(maxConcurrent: 2);
+      scheduler.showViewport(const ['a', 'b', 'c']);
+      final oldGeneration = scheduler.generationFor('a')!;
+
+      scheduler.showViewport(const ['z1', 'z2', 'z3'], priorityKey: 'z2');
+
+      expect(scheduler.isEnabled('c'), isFalse);
+      expect(scheduler.isEnabled('z2'), isTrue);
+      expect(scheduler.isEnabled('z1'), isTrue);
+      expect(scheduler.isEnabled('z3'), isFalse);
+
+      scheduler.markFinished('a', oldGeneration);
+      expect(scheduler.isEnabled('z3'), isFalse);
+
+      scheduler.markFinished('z2', scheduler.generationFor('z2')!);
+      expect(scheduler.isEnabled('z3'), isTrue);
+    },
+  );
+
+  test('caps remembered finished keys but never drops an on-screen one', () {
+    final scheduler = GameArtworkLoadScheduler(maxConcurrent: 4, maxFinished: 3);
+
+    void showAndFinish(List<String> keys) {
+      scheduler.showViewport(keys);
+      for (final key in keys) {
+        final generation = scheduler.generationFor(key);
+        if (generation != null) scheduler.markFinished(key, generation);
+      }
+    }
+
+    // 'persistent' stays visible in every viewport; the rest scroll away.
+    for (var batch = 0; batch < 20; batch++) {
+      showAndFinish(['persistent', 'a$batch', 'b$batch', 'c$batch']);
+      expect(scheduler.isEnabled('persistent'), isTrue);
+    }
+
+    // The current viewport is still fully enabled after all the churn.
+    expect(scheduler.isEnabled('a19'), isTrue);
+    expect(scheduler.isEnabled('b19'), isTrue);
+    expect(scheduler.isEnabled('c19'), isTrue);
+
+    // The remembered set is bounded by the on-screen keys rather than growing
+    // with every batch (20 * 4 = 80 keys would accumulate without the cap).
+    expect(scheduler.finishedCount, lessThanOrEqualTo(4));
+  });
+
+  test('prioritizes current viewport keys ahead of nearby rows', () {
+    final scheduler = GameArtworkLoadScheduler(maxConcurrent: 4);
+
+    scheduler.showViewport(const [
+      'current-1',
+      'current-2',
+      'current-3',
+      'current-4',
+      'above',
+    ], priorityKey: 'current-3');
+
+    expect(scheduler.isEnabled('current-3'), isTrue);
+    expect(scheduler.isEnabled('current-1'), isTrue);
+    expect(scheduler.isEnabled('current-2'), isTrue);
+    expect(scheduler.isEnabled('current-4'), isTrue);
+    expect(scheduler.isEnabled('above'), isFalse);
+  });
+}

--- a/test/ui/widgets/game/game_poster_card_test.dart
+++ b/test/ui/widgets/game/game_poster_card_test.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/bounded_network_image.dart';
+import 'package:moonfin/ui/widgets/focus/focusable_wrapper.dart';
+import 'package:moonfin/ui/widgets/game/game_card_focus_frame.dart';
 import 'package:moonfin/ui/widgets/game/game_poster_card.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
@@ -79,6 +83,105 @@ void main() {
       find.text('A deliberately long two-line game title'),
       findsOneWidget,
     );
+  });
+
+  testWidgets('can defer artwork without losing the fallback', (tester) async {
+    await tester.pumpWidget(
+      _TestApp(
+        child: GamePosterCard(
+          imageUrl: 'https://example.invalid/poster.jpg',
+          title: 'Deferred',
+          fileName: 'deferred.rom',
+          seed: 'deferred',
+          width: 110,
+          loadArtwork: false,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    expect(find.byType(BoundedNetworkImage), findsNothing);
+    expect(find.byIcon(Icons.videogame_asset), findsOneWidget);
+  });
+
+  testWidgets('TV right traversal stops at the row edge', (tester) async {
+    final firstFocus = FocusNode();
+    final secondFocus = FocusNode();
+    final alphaFocus = FocusNode();
+    addTearDown(firstFocus.dispose);
+    addTearDown(secondFocus.dispose);
+    addTearDown(alphaFocus.dispose);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            GamePosterCard(
+              imageUrl: null,
+              title: 'First',
+              fileName: 'first.rom',
+              seed: 'first',
+              width: 110,
+              focusNode: firstFocus,
+              onTap: () {},
+            ),
+            GamePosterCard(
+              imageUrl: null,
+              title: 'Second',
+              fileName: 'second.rom',
+              seed: 'second',
+              width: 110,
+              focusNode: secondFocus,
+              stopRightTraversal: true,
+              onTap: () {},
+            ),
+            Focus(
+              focusNode: alphaFocus,
+              child: const SizedBox(width: 30, height: 30),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    firstFocus.requestFocus();
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(secondFocus.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+    await tester.pump();
+    expect(secondFocus.hasFocus, isTrue);
+    expect(alphaFocus.hasFocus, isFalse);
+  });
+
+  testWidgets('uses only the game focus frame around artwork', (tester) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: GamePosterCard(
+          imageUrl: null,
+          title: 'Focused',
+          fileName: 'focused.rom',
+          seed: 'focused',
+          width: 110,
+          focusNode: focusNode,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    // The card owns its focus visuals; there is a single border source (the
+    // game focus frame) and no FocusableWrapper to draw a second outline.
+    expect(find.byType(FocusableWrapper), findsNothing);
+    expect(find.byType(GameCardFocusFrame), findsOneWidget);
   });
 }
 

--- a/test/ui/widgets/game/game_poster_card_test.dart
+++ b/test/ui/widgets/game/game_poster_card_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/game/game_poster_card.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+void main() {
+  setUp(() => ThemeRegistry.setActiveById(ThemeRegistry.moonfinId));
+
+  testWidgets('focus and hover callbacks follow actual interaction', (
+    tester,
+  ) async {
+    final focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    var focused = 0;
+    var focusLost = 0;
+    var hoverStarted = 0;
+    var hoverEnded = 0;
+
+    await tester.pumpWidget(
+      _TestApp(
+        child: GamePosterCard(
+          imageUrl: null,
+          title: 'River Raid',
+          fileName: 'River Raid (USA).a26',
+          seed: 'river-raid',
+          width: 110,
+          focusNode: focusNode,
+          onFocus: () => focused++,
+          onFocusLost: () => focusLost++,
+          onHoverStart: () => hoverStarted++,
+          onHoverEnd: () => hoverEnded++,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focused, 1);
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(find.byType(GamePosterCard)));
+    await tester.pump();
+    expect(hoverStarted, 1);
+
+    // Leaving with keyboard focus retained must not clear the active item.
+    await mouse.moveTo(const Offset(1000, 1000));
+    await tester.pump();
+    expect(hoverEnded, 0);
+
+    focusNode.unfocus();
+    await tester.pump();
+    expect(focusLost, 1);
+  });
+
+  testWidgets('large text can use the card intrinsic caption height', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestApp(
+        textScaler: const TextScaler.linear(3),
+        child: GamePosterCard(
+          imageUrl: null,
+          title: 'A deliberately long two-line game title',
+          fileName: 'long-title.rom',
+          seed: 'long-title',
+          width: 110,
+          onTap: () {},
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.text('A deliberately long two-line game title'),
+      findsOneWidget,
+    );
+  });
+}
+
+class _TestApp extends StatelessWidget {
+  const _TestApp({required this.child, this.textScaler = TextScaler.noScaling});
+
+  final Widget child;
+  final TextScaler textScaler;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: AppTheme.buildTheme(ThemeRegistry.active),
+      home: MediaQuery(
+        data: MediaQueryData(textScaler: textScaler),
+        child: Scaffold(body: Center(child: child)),
+      ),
+    );
+  }
+}

--- a/test/ui/widgets/game/game_system_card_test.dart
+++ b/test/ui/widgets/game/game_system_card_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/game/game_system_card.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:server_core/server_core.dart';
+
+void main() {
+  setUp(() => ThemeRegistry.setActiveById(ThemeRegistry.moonfinId));
+
+  testWidgets('supports localized count, RTL, and large text', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.buildTheme(ThemeRegistry.active),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Directionality(
+          textDirection: TextDirection.rtl,
+          child: MediaQuery(
+            data: MediaQueryData(textScaler: TextScaler.linear(3)),
+            child: Scaffold(
+              body: Center(
+                child: SizedBox(width: 360, height: 320, child: _Card()),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('707 items'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_left), findsOneWidget);
+  });
+}
+
+class _Card extends StatelessWidget {
+  const _Card();
+
+  @override
+  Widget build(BuildContext context) {
+    return GameSystemCard(
+      libraryId: 'retro',
+      system: const GameSystem(
+        id: 'atari2600',
+        name: 'Atari 2600 with a long localized name',
+        core: 'stella',
+        gameCount: 707,
+      ),
+      games: const [],
+      gameCount: 707,
+      onTap: () {},
+    );
+  }
+}

--- a/test/util/game_browse_filter_test.dart
+++ b/test/util/game_browse_filter_test.dart
@@ -71,6 +71,36 @@ void main() {
       expect(gameTitleMatchesBrowseFilters('Ōkami', letter: 'O'), isTrue);
     });
 
+    test('folds accents consistently when searching', () {
+      expect(gameTitleMatchesBrowseFilters('Élite', query: 'elite'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('Ōkami', query: 'okami'), isTrue);
+    });
+
+    test('treats Unicode dashes and quotes as word separators', () {
+      expect(
+        gameTitleMatchesBrowseFilters(
+          'Spider‑Man “Maximum Carnage”',
+          query: 'man max',
+        ),
+        isTrue,
+      );
+    });
+
+    test('prepared indexes can be reused across queries', () {
+      final index = GameBrowseTextIndex(
+        'River Raid',
+        alternateText: 'River Raid (USA).a26',
+      );
+      expect(
+        index.matches(queryWords: gameBrowseQueryWords('riv'), letter: 'R'),
+        isTrue,
+      );
+      expect(
+        index.matches(queryWords: gameBrowseQueryWords('raid'), letter: 'A'),
+        isFalse,
+      );
+    });
+
     test('applies search and alphabet filters together', () {
       expect(
         gameTitleMatchesBrowseFilters(

--- a/test/util/game_browse_filter_test.dart
+++ b/test/util/game_browse_filter_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/game_browse_filter.dart';
+
+void main() {
+  group('gameTitleMatchesBrowseFilters', () {
+    test('matches word prefixes without regard to case', () {
+      expect(
+        gameTitleMatchesBrowseFilters('Super Mario World', query: 'mArIo'),
+        isTrue,
+      );
+      expect(
+        gameTitleMatchesBrowseFilters('Super Mario World', query: 'mar wor'),
+        isTrue,
+      );
+      expect(
+        gameTitleMatchesBrowseFilters('Chrono Trigger', query: 'mario'),
+        isFalse,
+      );
+    });
+
+    test('does not match text from the middle of a word', () {
+      expect(
+        gameTitleMatchesBrowseFilters('River Raid', query: 'river'),
+        isTrue,
+      );
+      expect(
+        gameTitleMatchesBrowseFilters('Night Driver', query: 'river'),
+        isFalse,
+      );
+    });
+
+    test('can match a ROM filename without matching inside its words', () {
+      expect(
+        gameTitleMatchesBrowseFilters(
+          'A Different Display Title',
+          alternateText: 'River Raid (USA).a26',
+          query: 'river',
+        ),
+        isTrue,
+      );
+      expect(
+        gameTitleMatchesBrowseFilters(
+          'A Different Display Title',
+          alternateText: 'Night Driver (USA).a26',
+          query: 'river',
+        ),
+        isFalse,
+      );
+    });
+
+    test('separator-only queries do not filter the library', () {
+      expect(gameTitleMatchesBrowseFilters('Adventure', query: '.-\''), isTrue);
+    });
+
+    test('matches an alphabetical bucket', () {
+      expect(gameTitleMatchesBrowseFilters('Adventure', letter: 'A'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('Zelda', letter: 'A'), isFalse);
+    });
+
+    test('folds accents and places other initials in the hash bucket', () {
+      expect(
+        gameTitleMatchesBrowseFilters('3-D Tic-Tac-Toe', letter: '#'),
+        isTrue,
+      );
+      expect(gameTitleMatchesBrowseFilters('.hack', letter: '#'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('[BIOS] PS1', letter: '#'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('~Homebrew', letter: '#'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('Asteroids', letter: '#'), isFalse);
+      expect(gameTitleMatchesBrowseFilters('Élite', letter: '#'), isFalse);
+      expect(gameTitleMatchesBrowseFilters('Élite', letter: 'E'), isTrue);
+      expect(gameTitleMatchesBrowseFilters('Ōkami', letter: 'O'), isTrue);
+    });
+
+    test('applies search and alphabet filters together', () {
+      expect(
+        gameTitleMatchesBrowseFilters(
+          'Advance Wars',
+          query: 'wars',
+          letter: 'A',
+        ),
+        isTrue,
+      );
+      expect(
+        gameTitleMatchesBrowseFilters('Star Wars', query: 'wars', letter: 'A'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Provide a brief description of what this PR changes and why.

## Type of Change
- [ ] Bug fix
- [X ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

For the recent retro game feature added (thanks, really cool!), I've tweaked the retro ROM library page and navigation. 
With multiple systems each containing hundreds of ROMs, it's bit of a pain to navigate. I added a root screen, which is a game system level view, that you can then drill down into to search and vertically scroll through the game list and search (using Moonfin's look/feel).  It searches on  word prefixes so if for example you search for "River", it returns "River Raid" and not "Night Driver" games. On my disk/library I have folders that are organized by system then the ROMs are located inside those folders. 

I mostly replicated the functionality of the Moonfin library navigation...which means cut/pasting/duplication of code.  I also "respected" Moonfin's poster-size and scale user preferences. 

I didn't try to extract widgets like the alphabet sorter out into a shared widget because I thought it too ambious/dangerous to be refactoring all of that unrelated library code. I did however make a shared widget for this games implementation which could be used as a template for a future refactoring effort. 

I should also add, I didn't do any i18n with my change(s). There's existing need from the base implementation that - so perhaps this all should be one PR to deal with it? 



Screenshots below. I'll not be offended if this gets totally refactored/gutted as I am still getting familiar with the code base. 

Please give extra scrutiny as this is my 1st PR into the Moonfin world and probably is a little more ambitious than I should've taken on for my 1st one :-). 


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ X] All / Shared code

## Testing
I've tested the web client, android and android TV.  I don't have any Apple "ecosystem" devices (or emulators setup) so it's untested there and other devices like Roku et al

- [X] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Some devices like Apple or Roku I don't have physically or emulators 

### Test Steps
1. Setup the retro game llibrary
2. Open the retro library via Moonfin
3. Drill into each system (which is the parent folder on disk)

## Screenshots (if applicable)

<img width="1574" height="880" alt="image" src="https://github.com/user-attachments/assets/488a819c-39e8-483e-a802-f2784cc0a6f2" />

<img width="1507" height="908" alt="image" src="https://github.com/user-attachments/assets/7c4f2e1a-1742-452b-b437-28fce6a5f18b" />

<img width="1502" height="912" alt="image" src="https://github.com/user-attachments/assets/aa1d6f77-6d7e-4974-a564-f1b73c1e3826" />

## Checklist
- [X ] Code builds successfully
- [ X] Code follows project style and conventions
- [X ] No unnecessary commented-out code
- [X ] No new warnings introduced
