### PR TITLE
feat(theme) - Add opacity slider for modern detail pages

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3254,6 +3254,34 @@
   "@detailsBackgroundBlur": {
     "description": "Setting for details background blur"
   },
+  "detailsBackgroundOpacity": "Details Background Opacity",
+  "@detailsBackgroundOpacity": {
+    "description": "Setting for details background opacity on modern screens"
+  },
+  "detailsBackgroundOpacitySubtitle": "Adjust amount of opacity on modern detail pages from light to dark.",
+  "@detailsBackgroundOpacitySubtitle": {
+    "description": "Subtitle description of details background opacity"
+  },
+  "opacityLightest": "Lightest",
+  "@opacityLightest": {
+    "description": "Label for lightest opacity setting"
+  },
+  "opacityLight": "Light",
+  "@opacityLight": {
+    "description": "Label for light opacity setting"
+  },
+  "opacityMedium": "Medium",
+  "@opacityMedium": {
+    "description": "Label for medium opacity setting"
+  },
+  "opacityDark": "Dark",
+  "@opacityDark": {
+    "description": "Label for dark opacity setting"
+  },
+  "opacityDarkest": "Darkest",
+  "@opacityDarkest": {
+    "description": "Label for darkest opacity setting"
+  },
   "pixelValue": "{value}px",
   "@pixelValue": {
     "description": "Pixel value display",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3258,30 +3258,6 @@
   "@detailsBackgroundOpacity": {
     "description": "Setting for details background opacity on modern screens"
   },
-  "detailsBackgroundOpacitySubtitle": "Adjust amount of opacity on modern detail pages from light to dark.",
-  "@detailsBackgroundOpacitySubtitle": {
-    "description": "Subtitle description of details background opacity"
-  },
-  "opacityLightest": "Lightest",
-  "@opacityLightest": {
-    "description": "Label for lightest opacity setting"
-  },
-  "opacityLight": "Light",
-  "@opacityLight": {
-    "description": "Label for light opacity setting"
-  },
-  "opacityMedium": "Medium",
-  "@opacityMedium": {
-    "description": "Label for medium opacity setting"
-  },
-  "opacityDark": "Dark",
-  "@opacityDark": {
-    "description": "Label for dark opacity setting"
-  },
-  "opacityDarkest": "Darkest",
-  "@opacityDarkest": {
-    "description": "Label for darkest opacity setting"
-  },
   "pixelValue": "{value}px",
   "@pixelValue": {
     "description": "Pixel value display",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4174,42 +4174,6 @@ abstract class AppLocalizations {
   /// **'Details Background Opacity'**
   String get detailsBackgroundOpacity;
 
-  /// Subtitle description of details background opacity
-  ///
-  /// In en, this message translates to:
-  /// **'Adjust amount of opacity on modern detail pages from light to dark.'**
-  String get detailsBackgroundOpacitySubtitle;
-
-  /// Label for lightest opacity setting
-  ///
-  /// In en, this message translates to:
-  /// **'Lightest'**
-  String get opacityLightest;
-
-  /// Label for light opacity setting
-  ///
-  /// In en, this message translates to:
-  /// **'Light'**
-  String get opacityLight;
-
-  /// Label for medium opacity setting
-  ///
-  /// In en, this message translates to:
-  /// **'Medium'**
-  String get opacityMedium;
-
-  /// Label for dark opacity setting
-  ///
-  /// In en, this message translates to:
-  /// **'Dark'**
-  String get opacityDark;
-
-  /// Label for darkest opacity setting
-  ///
-  /// In en, this message translates to:
-  /// **'Darkest'**
-  String get opacityDarkest;
-
   /// Pixel value display
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4168,6 +4168,48 @@ abstract class AppLocalizations {
   /// **'Details Background Blur'**
   String get detailsBackgroundBlur;
 
+  /// Setting for details background opacity on modern screens
+  ///
+  /// In en, this message translates to:
+  /// **'Details Background Opacity'**
+  String get detailsBackgroundOpacity;
+
+  /// Subtitle description of details background opacity
+  ///
+  /// In en, this message translates to:
+  /// **'Adjust amount of opacity on modern detail pages from light to dark.'**
+  String get detailsBackgroundOpacitySubtitle;
+
+  /// Label for lightest opacity setting
+  ///
+  /// In en, this message translates to:
+  /// **'Lightest'**
+  String get opacityLightest;
+
+  /// Label for light opacity setting
+  ///
+  /// In en, this message translates to:
+  /// **'Light'**
+  String get opacityLight;
+
+  /// Label for medium opacity setting
+  ///
+  /// In en, this message translates to:
+  /// **'Medium'**
+  String get opacityMedium;
+
+  /// Label for dark opacity setting
+  ///
+  /// In en, this message translates to:
+  /// **'Dark'**
+  String get opacityDark;
+
+  /// Label for darkest opacity setting
+  ///
+  /// In en, this message translates to:
+  /// **'Darkest'**
+  String get opacityDarkest;
+
   /// Pixel value display
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2316,6 +2316,28 @@ class AppLocalizationsAf extends AppLocalizations {
   String get detailsBackgroundBlur => 'Besonderhede Agtergrond vervaag';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2319,25 +2319,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2329,25 +2329,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2326,6 +2326,28 @@ class AppLocalizationsAr extends AppLocalizations {
   String get detailsBackgroundBlur => 'تفاصيل طمس الخلفية';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2326,6 +2326,28 @@ class AppLocalizationsBe extends AppLocalizations {
   String get detailsBackgroundBlur => 'Размыццё фону дэталяў';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value пкс';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2329,25 +2329,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value пкс';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2322,6 +2322,28 @@ class AppLocalizationsBg extends AppLocalizations {
   String get detailsBackgroundBlur => 'Замъгляване на фона на детайлите';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2325,25 +2325,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2306,25 +2306,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2303,6 +2303,28 @@ class AppLocalizationsBn extends AppLocalizations {
   String get detailsBackgroundBlur => 'বিশদ বিবরণ পটভূমি ঝাপসা';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2337,6 +2337,28 @@ class AppLocalizationsCa extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detalls Desenfocament de fons';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2340,25 +2340,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2329,25 +2329,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2326,6 +2326,28 @@ class AppLocalizationsCs extends AppLocalizations {
   String get detailsBackgroundBlur => 'Podrobnosti Rozostření pozadí';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2340,25 +2340,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2337,6 +2337,28 @@ class AppLocalizationsCy extends AppLocalizations {
   String get detailsBackgroundBlur => 'Manylion Blur Cefndir';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2312,6 +2312,28 @@ class AppLocalizationsDa extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detaljer Baggrundssløring';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2315,25 +2315,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2397,6 +2397,28 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detail-Hintergrundunschärfe';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2400,25 +2400,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2343,25 +2343,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2340,6 +2340,28 @@ class AppLocalizationsEl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Λεπτομέρειες Θάμπωμα φόντου';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2303,25 +2303,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2300,6 +2300,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get detailsBackgroundBlur => 'Details Background Blur';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2310,6 +2310,28 @@ class AppLocalizationsEo extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detaloj Fona Blur';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2313,25 +2313,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2328,6 +2328,28 @@ class AppLocalizationsEs extends AppLocalizations {
   String get detailsBackgroundBlur => 'Desenfoque de fondo en detalles';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2331,25 +2331,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2321,25 +2321,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2318,6 +2318,28 @@ class AppLocalizationsEt extends AppLocalizations {
   String get detailsBackgroundBlur => 'Üksikasjad Tausta hägu';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2298,6 +2298,28 @@ class AppLocalizationsFa extends AppLocalizations {
   String get detailsBackgroundBlur => 'جزئیات تاری پس زمینه';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2301,25 +2301,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2324,25 +2324,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2321,6 +2321,28 @@ class AppLocalizationsFi extends AppLocalizations {
   String get detailsBackgroundBlur => 'Tiedot taustan sumennus';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2344,25 +2344,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2341,6 +2341,28 @@ class AppLocalizationsFr extends AppLocalizations {
   String get detailsBackgroundBlur => 'Flou d’arrière-plan des détails';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2343,25 +2343,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2340,6 +2340,28 @@ class AppLocalizationsGl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detalles desenfoque de fondo';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2294,6 +2294,28 @@ class AppLocalizationsHe extends AppLocalizations {
   String get detailsBackgroundBlur => 'פרטים טשטוש רקע';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2297,25 +2297,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2303,6 +2303,28 @@ class AppLocalizationsHi extends AppLocalizations {
   String get detailsBackgroundBlur => 'विवरण पृष्ठभूमि धुंधला';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2306,25 +2306,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2428,6 +2428,28 @@ class AppLocalizationsHr extends AppLocalizations {
   String get detailsBackgroundBlur => 'Zamućenje pozadine detalja';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2431,25 +2431,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2329,25 +2329,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2326,6 +2326,28 @@ class AppLocalizationsHu extends AppLocalizations {
   String get detailsBackgroundBlur => 'Részletek hátterének elmosása';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2314,6 +2314,28 @@ class AppLocalizationsId extends AppLocalizations {
   String get detailsBackgroundBlur => 'Blur Latar Belakang Detail';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2317,25 +2317,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2323,6 +2323,28 @@ class AppLocalizationsIt extends AppLocalizations {
   String get detailsBackgroundBlur => 'Sfocatura Sfondo Dettagli';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2326,25 +2326,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2268,25 +2268,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2265,6 +2265,28 @@ class AppLocalizationsJa extends AppLocalizations {
   String get detailsBackgroundBlur => '詳細背景ぼかし';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2322,25 +2322,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value пикс';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2319,6 +2319,28 @@ class AppLocalizationsKk extends AppLocalizations {
   String get detailsBackgroundBlur => 'Мәліметтер Фонды бұлыңғырлау';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value пикс';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2326,25 +2326,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2323,6 +2323,28 @@ class AppLocalizationsKn extends AppLocalizations {
   String get detailsBackgroundBlur => 'ವಿವರಗಳ ಹಿನ್ನೆಲೆ ಮಸುಕು';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2266,25 +2266,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2263,6 +2263,28 @@ class AppLocalizationsKo extends AppLocalizations {
   String get detailsBackgroundBlur => '세부 배경 흐림';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2326,25 +2326,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2323,6 +2323,28 @@ class AppLocalizationsLt extends AppLocalizations {
   String get detailsBackgroundBlur => 'Išsami informacija Fono suliejimas';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2330,25 +2330,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2327,6 +2327,28 @@ class AppLocalizationsLv extends AppLocalizations {
   String get detailsBackgroundBlur => 'Sīkāka informācija Fona aizmiglojums';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2326,6 +2326,28 @@ class AppLocalizationsMk extends AppLocalizations {
   String get detailsBackgroundBlur => 'Детали Заматување на позадината';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2329,25 +2329,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2327,25 +2327,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2324,6 +2324,28 @@ class AppLocalizationsMl extends AppLocalizations {
   String get detailsBackgroundBlur => 'വിശദാംശങ്ങളുടെ പശ്ചാത്തല മങ്ങൽ';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2313,6 +2313,28 @@ class AppLocalizationsMn extends AppLocalizations {
       'Дэлгэрэнгүй мэдээлэл Дэвсгэр бүдгэрүүлэх';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2316,25 +2316,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2313,25 +2313,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2310,6 +2310,28 @@ class AppLocalizationsNb extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detaljer Bakgrunnsuskarphet';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2320,6 +2320,28 @@ class AppLocalizationsNl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Details Achtergrondvervaging';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2323,25 +2323,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2307,6 +2307,28 @@ class AppLocalizationsPa extends AppLocalizations {
   String get detailsBackgroundBlur => 'ਵੇਰਵੇ ਬੈਕਗ੍ਰਾਊਂਡ ਬਲਰ';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2310,25 +2310,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2316,6 +2316,28 @@ class AppLocalizationsPl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Rozmycie tła na stronie szczegółów';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2319,25 +2319,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2325,25 +2325,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2322,6 +2322,28 @@ class AppLocalizationsPt extends AppLocalizations {
   String get detailsBackgroundBlur => 'Desfoque do Fundo de Detalhes';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2329,6 +2329,28 @@ class AppLocalizationsRo extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detalii Blur de fundal';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2332,25 +2332,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2335,6 +2335,28 @@ class AppLocalizationsRu extends AppLocalizations {
   String get detailsBackgroundBlur => 'Детали размытия фона';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value пикс.';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2338,25 +2338,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value пикс.';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2309,6 +2309,28 @@ class AppLocalizationsSi extends AppLocalizations {
   String get detailsBackgroundBlur => 'විස්තර පසුබිම බොඳ කිරීම';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2312,25 +2312,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2333,6 +2333,28 @@ class AppLocalizationsSk extends AppLocalizations {
   String get detailsBackgroundBlur => 'Podrobnosti rozostrenie pozadia';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2336,25 +2336,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2335,6 +2335,28 @@ class AppLocalizationsSl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Zameglitev ozadja podrobnosti';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2338,25 +2338,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2332,25 +2332,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2329,6 +2329,28 @@ class AppLocalizationsSq extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detajet turbullimi i sfondit';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2429,6 +2429,28 @@ class AppLocalizationsSr extends AppLocalizations {
   String get detailsBackgroundBlur => 'Детаљи Замућење позадине';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2432,25 +2432,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value px';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2321,25 +2321,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2318,6 +2318,28 @@ class AppLocalizationsSv extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detaljer Bakgrundsskärpa';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2328,6 +2328,28 @@ class AppLocalizationsSw extends AppLocalizations {
   String get detailsBackgroundBlur => 'Ukungu wa Mandharinyuma ya Maelezo';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2331,25 +2331,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2331,25 +2331,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2328,6 +2328,28 @@ class AppLocalizationsTa extends AppLocalizations {
   String get detailsBackgroundBlur => 'விவரங்கள் பின்னணி தெளிவின்மை';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2324,6 +2324,28 @@ class AppLocalizationsTe extends AppLocalizations {
   String get detailsBackgroundBlur => 'వివరాలు బ్యాక్‌గ్రౌండ్ బ్లర్';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2327,25 +2327,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2297,25 +2297,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2294,6 +2294,28 @@ class AppLocalizationsTh extends AppLocalizations {
   String get detailsBackgroundBlur => 'รายละเอียด พื้นหลังเบลอ';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2330,6 +2330,28 @@ class AppLocalizationsTl extends AppLocalizations {
   String get detailsBackgroundBlur => 'Mga Detalye ng Background Blur';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2333,25 +2333,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2309,6 +2309,28 @@ class AppLocalizationsTr extends AppLocalizations {
   String get detailsBackgroundBlur => 'Detay Arka Plan Bulanıklığı';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2312,25 +2312,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2315,6 +2315,28 @@ class AppLocalizationsUg extends AppLocalizations {
   String get detailsBackgroundBlur => 'تەپسىلاتى ئارقا كۆرۈنۈش';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2318,25 +2318,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2333,6 +2333,28 @@ class AppLocalizationsUk extends AppLocalizations {
   String get detailsBackgroundBlur => 'Розмиття фону деталей';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '$value пкс';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2336,25 +2336,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '$value пкс';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2316,6 +2316,28 @@ class AppLocalizationsVi extends AppLocalizations {
   String get detailsBackgroundBlur => 'Chi tiết Làm mờ nền';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2319,25 +2319,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2252,6 +2252,28 @@ class AppLocalizationsYue extends AppLocalizations {
   String get detailsBackgroundBlur => '細節背景模糊';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2255,25 +2255,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2251,6 +2251,28 @@ class AppLocalizationsZh extends AppLocalizations {
   String get detailsBackgroundBlur => '详情页背景模糊';
 
   @override
+  String get detailsBackgroundOpacity => 'Details Background Opacity';
+
+  @override
+  String get detailsBackgroundOpacitySubtitle =>
+      'Adjust amount of opacity on modern detail pages from light to dark.';
+
+  @override
+  String get opacityLightest => 'Lightest';
+
+  @override
+  String get opacityLight => 'Light';
+
+  @override
+  String get opacityMedium => 'Medium';
+
+  @override
+  String get opacityDark => 'Dark';
+
+  @override
+  String get opacityDarkest => 'Darkest';
+
+  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2254,25 +2254,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get detailsBackgroundOpacity => 'Details Background Opacity';
 
   @override
-  String get detailsBackgroundOpacitySubtitle =>
-      'Adjust amount of opacity on modern detail pages from light to dark.';
-
-  @override
-  String get opacityLightest => 'Lightest';
-
-  @override
-  String get opacityLight => 'Light';
-
-  @override
-  String get opacityMedium => 'Medium';
-
-  @override
-  String get opacityDark => 'Dark';
-
-  @override
-  String get opacityDarkest => 'Darkest';
-
-  @override
   String pixelValue(int value) {
     return '${value}px';
   }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4081,6 +4081,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final base = AppColorScheme.background;
     final item = _vm.item;
     final url = backdropUrl ?? (item?.type == 'Person' ? (_randomBackdropUrl ?? _imageUrl(item!)) : null);
+    final blurAmount = widget.prefs
+        .get(UserPreferences.detailsBackgroundBlurAmount)
+        .toDouble();
+    final opacityFactor = blurAmount / 25.0;
+    final maxAlpha = item?.type == 'Person' ? 0.40 : 0.80;
+    final alpha = opacityFactor * maxAlpha;
+    final gradientScale = 0.3 + 0.7 * opacityFactor;
+
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -4110,7 +4118,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             ),
           ColoredBox(
             color: Colors.black.withValues(
-              alpha: item?.type == 'Person' ? 0.20 : 0.40,
+              alpha: alpha,
             ),
           ),
         ],
@@ -4121,9 +4129,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 begin: Alignment.centerLeft,
                 end: Alignment.centerRight,
                 colors: [
-                  base,
-                  base.withValues(alpha: 0.90),
-                  base.withValues(alpha: 0.45),
+                  base.withValues(alpha: 1.0 * gradientScale),
+                  base.withValues(alpha: 0.90 * gradientScale),
+                  base.withValues(alpha: 0.45 * gradientScale),
                   base.withValues(alpha: 0.0),
                 ],
                 stops: const [0.0, 0.35, 0.60, 0.85],
@@ -4136,8 +4144,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
                 colors: [
-                  base,
-                  base.withValues(alpha: 0.80),
+                  base.withValues(alpha: 1.0 * gradientScale),
+                  base.withValues(alpha: 0.80 * gradientScale),
                   base.withValues(alpha: 0.0),
                 ],
                 stops: const [0.0, 0.45, 0.80],
@@ -4152,7 +4160,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 colors: [
                   base.withValues(alpha: 0.0),
                   base.withValues(alpha: 0.0),
-                  base.withValues(alpha: 0.32),
+                  base.withValues(alpha: 0.32 * gradientScale),
                 ],
                 stops: const [0.0, 0.7, 1.0],
               ),
@@ -4165,8 +4173,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
                 colors: [
-                  base.withValues(alpha: 0.15),
-                  base.withValues(alpha: 0.55),
+                  base.withValues(alpha: 0.15 * gradientScale),
+                  base.withValues(alpha: 0.55 * gradientScale),
                   base,
                 ],
                 stops: const [0.0, 0.55, 1.0],

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4129,7 +4129,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 begin: Alignment.centerLeft,
                 end: Alignment.centerRight,
                 colors: [
-                  base.withValues(alpha: 1.0 * gradientScale),
+                  base.withValues(alpha: gradientScale),
                   base.withValues(alpha: 0.90 * gradientScale),
                   base.withValues(alpha: 0.45 * gradientScale),
                   base.withValues(alpha: 0.0),
@@ -4144,7 +4144,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 begin: Alignment.bottomCenter,
                 end: Alignment.topCenter,
                 colors: [
-                  base.withValues(alpha: 1.0 * gradientScale),
+                  base.withValues(alpha: gradientScale),
                   base.withValues(alpha: 0.80 * gradientScale),
                   base.withValues(alpha: 0.0),
                 ],

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -59,6 +59,17 @@ class _DetailsScreenSettingsScreenState
                       divisions: 25,
                       labelOf: (v) => '$v',
                       onChangeEnd: _pushPersonalizationSync,
+                    )
+                  else
+                    SliderPreferenceTile(
+                      preference: UserPreferences.detailsBackgroundBlurAmount,
+                      title: l10n.detailsBackgroundOpacity,
+                      description: l10n.detailsBackgroundOpacitySubtitle,
+                      icon: Icons.opacity,
+                      min: 0,
+                      max: 25,
+                      divisions: 25,
+                      onChangeEnd: _pushPersonalizationSync,
                     ),
                   if (_prefs.get(UserPreferences.detailScreenStyle) == DetailScreenStyle.modern)
                     SwitchPreferenceTile(

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -64,11 +64,11 @@ class _DetailsScreenSettingsScreenState
                     SliderPreferenceTile(
                       preference: UserPreferences.detailsBackgroundBlurAmount,
                       title: l10n.detailsBackgroundOpacity,
-                      description: l10n.detailsBackgroundOpacitySubtitle,
                       icon: Icons.opacity,
                       min: 0,
                       max: 25,
                       divisions: 25,
+                      labelOf: (v) => '$v',
                       onChangeEnd: _pushPersonalizationSync,
                     ),
                   if (_prefs.get(UserPreferences.detailScreenStyle) == DetailScreenStyle.modern)


### PR DESCRIPTION
# Pull Request

## Summary
Add background opacity slider setting for modern detail screens, reusing the under-the-hood detailsBackgroundBlurAmount preference.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Expose detailsBackgroundBlurAmount preference as detailsBackgroundOpacity slider on Modern detail style in details_screen_settings_screen.dart
- Scale backdrop dark overlay and screen gradients dynamically based on preference value (0 to 25) in modern_detail_content.dart
- Support a lighter range (from 30% up to 100% gradient density) for a brighter backdrop look
- Update English localization key and regenerate translation binding classes

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Details Screen.
2. Select "Modern" layout style.
3. Observe the "Details Background Opacity" slider.
4. Slide it to adjust the background opacity and verify it renders smoothly.
5. Exit Settings, verify details background brightness matches selection.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Brightest
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-26-09" src="https://github.com/user-attachments/assets/57395e4d-8875-443f-8ce8-16ae77a7da35" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-26-19" src="https://github.com/user-attachments/assets/ac4ed370-5ee9-4594-beeb-3ea0074e5d22" />

### Midpoint
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-27-08" src="https://github.com/user-attachments/assets/3984c753-cd70-4b84-8769-e9a4a9f20015" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-27-18" src="https://github.com/user-attachments/assets/03c0ca18-eb5f-4db8-9cb6-2851bf974341" />

### Darkest
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-27-39" src="https://github.com/user-attachments/assets/191895a2-dad3-4060-bebe-8be52d3b5380" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-19_23-27-48" src="https://github.com/user-attachments/assets/8914ee81-8893-4228-97a4-04c0610a284a" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
