### PR TITLE
feat-playback - Adjust middle click and play/pause behavior on TV clients

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2547,6 +2547,17 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     });
   }
 
+  // After a transport action from a remote key, reveal the OSD and focus the
+  // seekbar when it was hidden, or the primary button when it was already up.
+  void _revealControlsAfterTransport() {
+    if (!_controlsVisible) {
+      _showControls(focusSeekbar: true);
+    } else {
+      _showControls();
+      _focusTvPrimaryButton();
+    }
+  }
+
   void _focusTvSeekbar({int attempt = 0}) {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !_controlsVisible || _isOsdLocked) return;
@@ -3198,31 +3209,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           return KeyEventResult.ignored;
         case LogicalKeyboardKey.mediaPlay:
           unawaited(_resumeWithConfiguredRewind());
-          if (!_controlsVisible) {
-            _showControls(focusSeekbar: true);
-          } else {
-            _showControls();
-            _focusTvPrimaryButton();
-          }
+          _revealControlsAfterTransport();
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaPause:
           _manager.pause();
-          if (!_controlsVisible) {
-            _showControls(focusSeekbar: true);
-          } else {
-            _showControls();
-            _focusTvPrimaryButton();
-          }
+          _revealControlsAfterTransport();
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaPlayPause:
         case LogicalKeyboardKey.space:
           _togglePlayPause();
-          if (!_controlsVisible) {
-            _showControls(focusSeekbar: true);
-          } else {
-            _showControls();
-            _focusTvPrimaryButton();
-          }
+          _revealControlsAfterTransport();
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaStop:
           _exitPlayback();

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3191,25 +3191,38 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             return KeyEventResult.ignored;
           }
           if (!_controlsVisible) {
+            _togglePlayPause();
             _showControls(focusSeekbar: true);
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;
         case LogicalKeyboardKey.mediaPlay:
           unawaited(_resumeWithConfiguredRewind());
-          _showControls();
-          _focusTvPrimaryButton();
+          if (!_controlsVisible) {
+            _showControls(focusSeekbar: true);
+          } else {
+            _showControls();
+            _focusTvPrimaryButton();
+          }
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaPause:
           _manager.pause();
-          _showControls();
-          _focusTvPrimaryButton();
+          if (!_controlsVisible) {
+            _showControls(focusSeekbar: true);
+          } else {
+            _showControls();
+            _focusTvPrimaryButton();
+          }
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaPlayPause:
         case LogicalKeyboardKey.space:
           _togglePlayPause();
-          _showControls();
-          _focusTvPrimaryButton();
+          if (!_controlsVisible) {
+            _showControls(focusSeekbar: true);
+          } else {
+            _showControls();
+            _focusTvPrimaryButton();
+          }
           return KeyEventResult.handled;
         case LogicalKeyboardKey.mediaStop:
           _exitPlayback();

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -1539,9 +1539,20 @@ final class AppleTvPlayerViewController: UIViewController {
                 return
             case .playPause:
                 togglePlayPause()
+                if !isOsdOnScreen {
+                    focusedZone = .scrubber
+                    updateFocusHighlight()
+                }
                 showOsd()
                 return
             case .select:
+                if !isOsdOnScreen {
+                    togglePlayPause()
+                    focusedZone = .scrubber
+                    updateFocusHighlight()
+                    showOsd()
+                    return
+                }
                 if skipSegmentActive {
                     hideSkipSegment()
                     onSkipSegmentSelect?()

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -1541,8 +1541,11 @@ final class AppleTvPlayerViewController: UIViewController {
                 togglePlayPause()
                 if !isOsdOnScreen {
                     focusedZone = .scrubber
-                    updateFocusHighlight()
+                } else {
+                    focusedZone = .buttons
+                    focusedControlIndex = controls.firstIndex(of: .playPause) ?? 0
                 }
+                updateFocusHighlight()
                 showOsd()
                 return
             case .select:


### PR DESCRIPTION
# Pull Request

## Summary
Adjusted D-pad center click (select/enter) and dedicated play/pause button behaviors on TV and tvOS clients during video playback to instantly play/pause when the OSD is hidden, and focus the seekbar when the OSD appears.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #862 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- In **video_player_screen.dart**, modified select, enter, mediaPlay, mediaPause, mediaPlayPause, and space key handlers to toggle play/pause and focus the seekbar when the OSD is hidden.
- In **AppleTvPlayerViewController.swift**, modified select and playPause buttons in pressesBegan to toggle play/pause and set focus to the scrubber zone (seekbar) when the OSD is hidden.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video and wait for the OSD controls to hide.
2. Press D-pad center click/enter or the play/pause button on the remote; verify playback instantly pauses and the OSD appears with the focus directly on the seekbar (scrubber).
3. With OSD visible, press the dedicated play/pause button; verify playback instantly plays/pauses.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
