### PR TITLE
bugfix-windows - Fix Windows C++ compilation errors

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -185,9 +185,12 @@ bool FlutterWindow::OnCreate() {
   }
   RegisterPlugins(flutter_controller_->engine());
 
+  native_game_registrar_ = std::make_unique<flutter::PluginRegistrarWindows>(
+      flutter_controller_->engine()->GetRegistrarForPlugin("NativeGame"));
+
   native_game_ = std::make_unique<NativeGame>(
       flutter_controller_->engine()->messenger(),
-      flutter_controller_->engine()->texture_registrar());
+      native_game_registrar_->texture_registrar());
 
   if (!g_hdr_display_channel) {
     g_hdr_display_channel =

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -6,6 +6,8 @@
 
 #include <memory>
 
+#include <flutter/plugin_registrar_windows.h>
+
 #include "native_game.h"
 #include "win32_window.h"
 
@@ -31,6 +33,7 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 
   // Native retro-game playback.
+  std::unique_ptr<flutter::PluginRegistrarWindows> native_game_registrar_;
   std::unique_ptr<NativeGame> native_game_;
 };
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes Windows C++ compilation by retrieving the `texture_registrar` through `PluginRegistrarWindows` instead of the base `FlutterEngine` class.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Included `<flutter/plugin_registrar_windows.h>` in `windows/runner/flutter_window.h`.
- Added a `std::unique_ptr<flutter::PluginRegistrarWindows> native_game_registrar_` private member to the `FlutterWindow` class to manage its lifecycle and keep the registrar (and its texture registrar pointer) alive.
- In `windows/runner/flutter_window.cpp`'s `OnCreate`, retrieved the plugin registrar via `GetRegistrarForPlugin("NativeGame")` and passed its `texture_registrar()` to the `NativeGame` constructor.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [X] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Checked out the branch and verified the project compiles and builds successfully on Windows via `build-windows.ps1` (resulting in a successful installer compile).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
