### PR TITLE
Fix Skip Intro/Outro close button clipping its own rounded border

### DIFF
--- a/lib/ui/widgets/playback/skip_segment_overlay.dart
+++ b/lib/ui/widgets/playback/skip_segment_overlay.dart
@@ -208,22 +208,26 @@ class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
                 ),
               ),
               if (isDesktop)
-                Positioned(
-                  top: 4,
-                  right: 4,
-                  child: IconButton(
-                    onPressed: widget.onDismiss,
-                    tooltip: l10n.close,
-                    padding: EdgeInsets.zero,
-                    visualDensity: VisualDensity.compact,
-                    constraints: const BoxConstraints.tightFor(
-                      width: 24,
-                      height: 24,
-                    ),
-                    icon: Icon(
-                      Icons.close_rounded,
-                      size: 16,
-                      color: AppColorScheme.onSurface,
+                Positioned.fill(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: IconButton(
+                        onPressed: widget.onDismiss,
+                        tooltip: l10n.close,
+                        padding: EdgeInsets.zero,
+                        visualDensity: VisualDensity.compact,
+                        constraints: const BoxConstraints.tightFor(
+                          width: 24,
+                          height: 24,
+                        ),
+                        icon: Icon(
+                          Icons.close_rounded,
+                          size: 16,
+                          color: AppColorScheme.onSurface,
+                        ),
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
# Pull Request

## Summary
Close button was corner-anchored but the pill has no flat corner, so it stuck outside the curve. Centered it vertically instead.

## Related Issues
Fixes bug I faced while doing some coding

## Type of Change
- [x] Bug fix

## Changes Made
- Reworked the close button's positioning in `SkipSegmentOverlay` from a fixed `top/right` offset to `Positioned.fill` + `Align(centerRight)`.

## Platform
- [x] macOS
- [x] Windows
- [x] Linux

(desktop-only — button only renders `if (isDesktop)`)

## Testing
- [x] Manual testing completed

### Test Steps
1. Play a title with intro/outro skip segments on desktop.
2. Let the Skip Intro/Outro pill appear.
3. Confirm the close button sits inside the pill's rounded border.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced