### PR TITLE
bugfix-windows - Fix fullscreen madness

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -662,7 +662,11 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
       return true;
     }
 
-    if (PlatformDetection.useDesktopUi && key == LogicalKeyboardKey.f11) {
+    final altPressed = HardwareKeyboard.instance.logicalKeysPressed.contains(LogicalKeyboardKey.altLeft) ||
+        HardwareKeyboard.instance.logicalKeysPressed.contains(LogicalKeyboardKey.altRight);
+
+    if (PlatformDetection.useDesktopUi &&
+        (key == LogicalKeyboardKey.f11 || (key == LogicalKeyboardKey.enter && altPressed))) {
       unawaited(FullscreenHelper.toggle());
       return true;
     }
@@ -807,6 +811,9 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
 
   Future<void> _handleWindowClose() async {
     _geometrySaveTimer?.cancel();
+    try {
+      await windowManager.hide();
+    } catch (_) {}
     await _saveWindowGeometry();
     await AppExit.prepareForExit();
     await windowManager.destroy();
@@ -827,8 +834,11 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     }
 
     final key = event.logicalKey;
+    final keys = HardwareKeyboard.instance.logicalKeysPressed;
+    final altPressed = keys.contains(LogicalKeyboardKey.altLeft) ||
+        keys.contains(LogicalKeyboardKey.altRight);
 
-    if (key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.select) {
+    if ((key == LogicalKeyboardKey.enter || key == LogicalKeyboardKey.select) && !altPressed) {
       final targetContext =
           FocusManager.instance.primaryFocus?.context ?? context;
       final activated = Actions.maybeInvoke(

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -662,8 +662,8 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
       return true;
     }
 
-    final altPressed = HardwareKeyboard.instance.logicalKeysPressed.contains(LogicalKeyboardKey.altLeft) ||
-        HardwareKeyboard.instance.logicalKeysPressed.contains(LogicalKeyboardKey.altRight);
+    final altPressed = keys.contains(LogicalKeyboardKey.altLeft) ||
+        keys.contains(LogicalKeyboardKey.altRight);
 
     if (PlatformDetection.useDesktopUi &&
         (key == LogicalKeyboardKey.f11 || (key == LogicalKeyboardKey.enter && altPressed))) {
@@ -811,10 +811,14 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
 
   Future<void> _handleWindowClose() async {
     _geometrySaveTimer?.cancel();
+    // Read the window bounds before hiding so the saved geometry stays correct
+    // on platforms where a hidden window reports stale size or position.
+    await _saveWindowGeometry();
+    // Hide right away so the window disappears instantly while the slower
+    // database and preference teardown finishes.
     try {
       await windowManager.hide();
     } catch (_) {}
-    await _saveWindowGeometry();
     await AppExit.prepareForExit();
     await windowManager.destroy();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,8 +133,11 @@ Future<void> _restoreWindowGeometry() async {
     await windowManager.show();
     await windowManager.focus();
     if (startFullscreen) {
-      // Via FullscreenHelper so its cached state matches the window.
-      await FullscreenHelper.setFullscreen(true);
+      // Delay slightly to let the window render its first frame before transitioning to fullscreen.
+      // This avoids Win32 graphics context race conditions (black screens) and window layout artifacts.
+      Future.delayed(const Duration(milliseconds: 150), () async {
+        await FullscreenHelper.setFullscreen(true);
+      });
     }
   });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -134,10 +134,10 @@ Future<void> _restoreWindowGeometry() async {
     await windowManager.focus();
     if (startFullscreen) {
       // Delay slightly to let the window render its first frame before transitioning to fullscreen.
-      // This avoids Win32 graphics context race conditions (black screens) and window layout artifacts.
-      Future.delayed(const Duration(milliseconds: 150), () async {
+      // This avoids graphics context race conditions (black screens) and window layout artifacts.
+      unawaited(Future.delayed(const Duration(milliseconds: 150), () async {
         await FullscreenHelper.setFullscreen(true);
-      });
+      }));
     }
   });
 }

--- a/lib/util/fullscreen_helper_io.dart
+++ b/lib/util/fullscreen_helper_io.dart
@@ -2,18 +2,18 @@ import 'package:window_manager/window_manager.dart';
 
 import 'platform_detection.dart';
 
-bool _isFullscreen = false;
 bool _wasMaximized = false;
 
 Future<bool> isFullscreen() async {
   if (!PlatformDetection.isDesktop) return false;
-  return _isFullscreen;
+  return windowManager.isFullScreen();
 }
 
 Future<void> setFullscreen(bool value) async {
   if (!PlatformDetection.isDesktop) return;
-  if (value == _isFullscreen) return;
   try {
+    final current = await windowManager.isFullScreen();
+    if (value == current) return;
     if (value) {
       _wasMaximized = await windowManager.isMaximized();
       if (_wasMaximized) {
@@ -21,10 +21,8 @@ Future<void> setFullscreen(bool value) async {
         await windowManager.unmaximize();
       }
       await windowManager.setFullScreen(true);
-      _isFullscreen = true;
     } else {
       await windowManager.setFullScreen(false);
-      _isFullscreen = false;
       if (_wasMaximized) {
         await windowManager.maximize();
         _wasMaximized = false;

--- a/lib/util/platform_detection.dart
+++ b/lib/util/platform_detection.dart
@@ -308,6 +308,7 @@ class PlatformDetection {
   }
 
   static bool get _hasMobileFormFactor {
+    if (isDesktop) return false;
     if (isAndroid || isIOS) return true;
     final size = _screenLogicalSize;
     if (size == null) return _isMobilePlatformSignal;


### PR DESCRIPTION
# Pull Request

## Summary
Resolved a series of Windows desktop window layout, fullscreen toggling, keyboard navigation, and exit lag issues:
1. Fixed app launching with an empty/blank window when configured to start in fullscreen.
2. Fixed layout rendering artifacts (gray side strip) and interface sizing breakage when transitioning in/out of fullscreen mode.
3. Fixed loss of keyboard focus indicators and fullscreen hotkeys (F11/Alt+Enter) in windowed mode.
4. Fixed Alt+Enter simultaneously toggling fullscreen and triggering focused item activation.
5. Accelerated window close visual feedback, removing close lag.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #583 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Startup Fullscreen Delay**: Reverted the `WindowOptions(fullScreen: true)` constructor setting to allow the window to create in standard bounds. Added a 150ms delay inside `lib/main.dart` before calling `setFullscreen(true)`, letting the Flutter engine lay out and paint the initial frame before transitioning.
- **Desktop UI Platform Fix**: Modified `_hasMobileFormFactor` in `platform_detection.dart` to return `false` early on desktop platforms. This prevents small logical window sizes in windowed mode from triggering Mobile UI fallbacks, resolving missing keyboard focus indicators and disabled hotkeys.
- **Alt+Enter & Native Fullscreen Sync**: Modified `FullscreenHelper` to query the native `windowManager.isFullScreen()` state. Map Alt+Enter in `app.dart` to toggle fullscreen. Update `_onKeyEvent` in `app.dart` to ignore `LogicalKeyboardKey.enter` when `Alt` is pressed, avoiding item activation conflicts.
- **Immediate Hide on Close**: Added `windowManager.hide()` at the start of `_handleWindowClose` in `lib/app.dart` to dismiss the window instantly when closed, letting database connection cleanup and preference serialization complete asynchronously in the background.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [X] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built the windows application (`build-windows.ps1`).
2. Toggled F11/Alt+Enter, quit the app using Alt+F4, and verified it instantly closes.
3. Reopened the app and verified it starts directly in fullscreen without black screen freezes or layout artifacts.
4. Verified that windowed mode at any size retains keyboard focus indicators and F11/Alt+Enter hotkeys.
5. Verified Alt+Enter toggles fullscreen without triggering focused button click actions.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
