### PR TITLE
bugfix-homerows - Fix modern row padding slider scaling on mobile

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3379,6 +3379,9 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   double _v2MetadataHeightBudget(UserPreferences prefs) {
+    if (PlatformDetection.useMobileUi) {
+      return 50.0;
+    }
     final hasAdditionalRatings = prefs.get(
       UserPreferences.enableAdditionalRatings,
     );


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the issue where modern home rows padding settings could not shrink row heights or tighten spacing gaps on mobile clients. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #855 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `_v2MetadataHeightBudget()` in `home_screen.dart` to return `50.0` metadata height budget on mobile (`PlatformDetection.useMobileUi`), instead of the `175.0` TV focused metadata budget.
- This allows the modern row height floor calculation on mobile to fall to `327` pixels, enabling the modern padding settings slider to cleanly resize modern rows all the way down to `360` without clipping or causing row overlaps.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Home Row Settings in the client app.
2. Adjust modern home row padding slider down to minimal spacing (`360`).
3. Verify on mobile that spacing between row cards and headers is beautifully minimal and matches the target spacing.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Minimal padding is back:

<img width="1280" height="2856" alt="Screenshot_20260720-224832" src="https://github.com/user-attachments/assets/9e564a96-0f1c-4df3-9f0b-8ebc8ba12637" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
