### PR TITLE
bugfix-homescreen - Resolve home screen checks and Android TV layout issues from tester feedback

### DIFF
--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -6,6 +6,7 @@ import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../data/models/aggregated_item.dart';
+import 'connectivity_service.dart';
 
 enum BlurContext { details, browsing, none }
 
@@ -42,9 +43,14 @@ class BackgroundService {
     final client = GetIt.instance<MediaServerClient>();
     final urls = <String>[];
 
+    final isOffline =
+        GetIt.instance.isRegistered<ConnectivityService>() &&
+        !GetIt.instance<ConnectivityService>().canReachServer;
+
     final backdropTags = item.backdropImageTags;
     if (backdropTags.isNotEmpty) {
-      for (var i = 0; i < backdropTags.length; i++) {
+      final limit = isOffline ? 1 : backdropTags.length;
+      for (var i = 0; i < limit; i++) {
         urls.add(client.imageApi.getBackdropImageUrl(
           item.id,
           maxWidth: backdropMaxWidth,
@@ -58,7 +64,8 @@ class BackgroundService {
       final parentBackdropId = item.parentBackdropItemId;
       final parentTags = item.parentBackdropImageTags;
       if (parentBackdropId != null && parentTags.isNotEmpty) {
-        for (var i = 0; i < parentTags.length; i++) {
+        final limit = isOffline ? 1 : parentTags.length;
+        for (var i = 0; i < limit; i++) {
           urls.add(client.imageApi.getBackdropImageUrl(
             parentBackdropId,
             maxWidth: backdropMaxWidth,
@@ -88,9 +95,10 @@ class BackgroundService {
   }
 
   void _loadBackgrounds(List<String> urls) {
-    if (urls.isEmpty) return clearBackgrounds();
+    final uniqueUrls = urls.where((u) => u.isNotEmpty).toSet().toList();
+    if (uniqueUrls.isEmpty) return clearBackgrounds();
     _slideshowTimer?.cancel();
-    _backgrounds = urls;
+    _backgrounds = uniqueUrls;
     _currentIndex = 0;
     _update();
   }

--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -58,7 +58,11 @@ class ThemeMusicService {
   void unregisterDetailScreen(Object token) {
     _activeDetailScreens.remove(token);
     if (_activeDetailScreens.isEmpty) {
-      fadeOutAndStop();
+      if (_player != null) {
+        fadeOutAndStop();
+      } else {
+        stop();
+      }
     }
   }
 
@@ -105,7 +109,7 @@ class ThemeMusicService {
     ThemeAudioPlayer? localPlayer;
     try {
       final data = await _client.itemsApi.getThemeMedia(themeItemId);
-      if (generation != _playGeneration) return;
+      if (generation != _playGeneration || _activeDetailScreens.isEmpty) return;
 
       final songsResult = data['ThemeSongsResult'] as Map<String, dynamic>?;
       final songs =
@@ -121,20 +125,20 @@ class ThemeMusicService {
       _player = localPlayer;
 
       await localPlayer.setVolume(0);
-      if (generation != _playGeneration) {
+      if (generation != _playGeneration || _activeDetailScreens.isEmpty) {
         await _safeDispose(localPlayer);
         return;
       }
 
       await localPlayer.open(url);
-      if (generation != _playGeneration) {
+      if (generation != _playGeneration || _activeDetailScreens.isEmpty) {
         await _safeDispose(localPlayer);
         return;
       }
 
       if (_prefs.get(UserPreferences.themeMusicLoop)) {
         await localPlayer.setLoop();
-        if (generation != _playGeneration) {
+        if (generation != _playGeneration || _activeDetailScreens.isEmpty) {
           await _safeDispose(localPlayer);
           return;
         }
@@ -143,7 +147,7 @@ class ThemeMusicService {
       _fadeIn(generation);
     } catch (_) {
       if (localPlayer != null &&
-          (generation != _playGeneration || _player != localPlayer)) {
+          (generation != _playGeneration || _player != localPlayer || _activeDetailScreens.isEmpty)) {
         await _safeDispose(localPlayer);
       }
     }

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -31,8 +31,9 @@ const _initialArtworkBatch = 12;
 const _backgroundArtworkConcurrency = 4;
 
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 class AllGenresScreen extends StatefulWidget {
   const AllGenresScreen({super.key});

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -33,8 +33,9 @@ const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 double _desktopUiScaleFactor() {
   return GetIt.instance<UserPreferences>()

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -33,8 +33,9 @@ Color get _jellyfinBlue => AppColorScheme.accent;
 const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 double _desktopUiScaleFactor() {
   return GetIt.instance<UserPreferences>()

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -28,8 +28,9 @@ const _initialArtworkBatch = 12;
 const _backgroundArtworkConcurrency = 4;
 
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 class LibraryGenresScreen extends StatefulWidget {
   final String libraryId;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -78,8 +78,9 @@ const _textShadows = [Shadow(blurRadius: 4, color: Colors.black54)];
 const _kCompactBreakpoint = 600.0;
 
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 bool _useDesktopDetailLayout(BuildContext context) {
   final size = MediaQuery.sizeOf(context);

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -390,6 +390,7 @@ class _HomeShellState extends State<_HomeShell>
       _themeMusicRegistered = false;
     }
     _themeMusicService.fadeOutAndStop();
+    _contentRowsKey.currentState?._finishSharedPreview(releaseResources: true);
   }
 
   @override

--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -25,8 +25,9 @@ const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 
 bool _isCompact(BuildContext context) =>
-    PlatformDetection.useMobileUi ||
-    MediaQuery.sizeOf(context).width < _kCompactBreakpoint;
+    !PlatformDetection.isTV &&
+    (PlatformDetection.useMobileUi ||
+        MediaQuery.sizeOf(context).width < _kCompactBreakpoint);
 
 class SeerrBrowseScreen extends StatefulWidget {
   final String? filterId;

--- a/lib/ui/widgets/focus/locked_focus_row.dart
+++ b/lib/ui/widgets/focus/locked_focus_row.dart
@@ -112,6 +112,15 @@ class LockedFocusRowState<T> extends State<LockedFocusRow<T>> {
           _focusedIndex.clamp(0, widget.items.isEmpty ? 0 : widget.items.length - 1);
       _syncItemKeys();
     }
+    if (_hasRowFocus && widget.items.isNotEmpty && _focusedIndex < widget.items.length) {
+      final oldItem = (oldWidget.items.length > _focusedIndex)
+          ? oldWidget.items[_focusedIndex]
+          : null;
+      final newItem = widget.items[_focusedIndex];
+      if (oldItem != newItem) {
+        widget.onIndexChanged?.call(_focusedIndex, newItem);
+      }
+    }
   }
 
   @override

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -109,28 +109,22 @@ class _LeftSidebarState extends State<LeftSidebar> {
     _currentTime = ValueNotifier<String>('');
     _focusNavbarCallback = () {
       if (!mounted) return;
-      if (PlatformDetection.isTV || (PlatformDetection.isDesktop || (PlatformDetection.isWeb && !PlatformDetection.useMobileUi))) {
-        _homeFocusNode.requestFocus();
-      }
+      _homeFocusNode.requestFocus();
     };
     _focusAvatarCallback = () {
       if (!mounted) return;
-      if (PlatformDetection.isTV) {
-        if (_profileFocusNode.context != null) {
-          _profileFocusNode.requestFocus();
-        } else {
-          _expand();
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (!mounted) return;
-            if (_profileFocusNode.context != null) {
-              _profileFocusNode.requestFocus();
-            } else {
-              _homeFocusNode.requestFocus();
-            }
-          });
-        }
-      } else if ((PlatformDetection.isDesktop || (PlatformDetection.isWeb && !PlatformDetection.useMobileUi))) {
-        _homeFocusNode.requestFocus();
+      if (_profileFocusNode.context != null) {
+        _profileFocusNode.requestFocus();
+      } else {
+        _expand();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          if (_profileFocusNode.context != null) {
+            _profileFocusNode.requestFocus();
+          } else {
+            _homeFocusNode.requestFocus();
+          }
+        });
       }
     };
     _previousFocusNavbarCallback = NavigationLayout.focusNavbarNotifier.value;

--- a/lib/util/platform_detection.dart
+++ b/lib/util/platform_detection.dart
@@ -52,7 +52,11 @@ class PlatformDetection {
   /// UI and is handled by [isAppleTV]/[useLeanbackUi].
   static bool get isApple => isIOS || isMacOS;
 
-  static bool get isTV => _isTv || isTizen || isAppleTV;
+  static bool get isTV =>
+      _isTv ||
+      isTizen ||
+      isAppleTV ||
+      const bool.fromEnvironment('MOONFIN_FORCE_TV');
   static bool _isTv = false;
   static void setTvMode(bool value) => _isTv = value;
 


### PR DESCRIPTION
# Pull Request

## Summary
Resolves several quality-of-life bugfixes for the home screen and Android TV layout protections based on tester feedback on Discord.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

1. **Left Sidebar Focus Pathing:** Removed platform-specific filters from `LeftSidebar`'s `_focusNavbarCallback` and `_focusAvatarCallback` so focus is successfully requested on any platform rendering it (important for ATV but also mobile when a controller is attached).
2. **Exiting Detail Screen Theme Playback:** Added `_activeDetailScreens.isEmpty` checks at all yield points in `playForItem()` and updated `unregisterDetailScreen()` so that when the player is null, it immediately triggers `stop()` which increments `_playGeneration` and invalidates in-flight network requests.
3. **Home Screen Media Previews Sync:** 
   - Modified `LockedFocusRow`'s `didUpdateWidget` to fire `onIndexChanged` when the item at the focused index changes (such as during Next Up refreshes) while retaining focus, ensuring metadata, ratings, and media previews remain synced.
   - Updated `HomeScreen.didPushNext` to call `_finishSharedPreview(releaseResources: true)` on the content rows state to fully clean up and release video previews when pushing a details page.
4. **Backdrop Rotation Cycles:** Filtered out duplicate/empty URLs from backdrop slideshows and clamped offline backgrounds to index 0, preventing empty rotation cycles and black screens.
5. **Android TV Layout Protections:** These will hopefully protect TVs from thinking they are phones and causing the visual issues we've been noting:
   - Synchronously queried the `MOONFIN_FORCE_TV` compile define in `PlatformDetection.isTV` to avoid layout race conditions during cold boot.
   - Modified the `_isCompact` helper in all UI screen files to return `false` on TV devices, preventing resolution drops from causing the layout to switch to mobile mode.
   
## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Traversal navigate left from home rows to open the left sidebar using physical inputs.
2. Exit the item details page with home theme music disabled and verify no theme music keeps playing.
3. Focus a Next Up row item, mark it played, return to the home screen, and verify the correct new preview plays.
4. Sideload/launch the app on Android TV and verify the layout does not briefly render in mobile mode.
5. Verify no backdrop cycling attempts happen when only 1 backdrop is present on the server or when offline.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
