### PR TITLE
﻿feat-playback - Harden audio track selection consistency 

### DIFF
--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -538,6 +538,8 @@ void registerPlaybackModule() {
       preferDefaultAudioTrack: prefs.get(UserPreferences.preferDefaultAudioTrack) as bool? ?? false,
       preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription) as bool? ?? false,
       explicitAudioIndex: explicitIndex,
+      lastExplicitAudioIndex: manager.lastExplicitAudioIndex,
+      lastExplicitAudioTitle: manager.lastExplicitAudioTitle,
     );
   };
 
@@ -550,6 +552,8 @@ void registerPlaybackModule() {
       preferDefaultAudioTrack: prefs.get(UserPreferences.preferDefaultAudioTrack) as bool? ?? false,
       preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription) as bool? ?? false,
       explicitAudioIndex: manager.audioSelectionExplicit ? manager.audioStreamIndex : null,
+      lastExplicitAudioIndex: manager.lastExplicitAudioIndex,
+      lastExplicitAudioTitle: manager.lastExplicitAudioTitle,
     );
 
     final activeAudioStream = audioStreams.firstWhere(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6761,15 +6761,19 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     }
 
     final prefs = GetIt.instance<UserPreferences>();
+    final manager = GetIt.instance<PlaybackManager>();
     return computeEffectiveAudioIndex(
       audioStreams: audioStreams,
-      preferredAudioLanguage: prefs.get(UserPreferences.defaultAudioLanguage),
+      preferredAudioLanguage: manager.lastExplicitAudioLanguage ??
+          prefs.get(UserPreferences.defaultAudioLanguage),
       fallbackAudioLanguage: prefs.get(UserPreferences.fallbackAudioLanguage),
       preferDefaultAudioTrack: prefs.get(
         UserPreferences.preferDefaultAudioTrack,
       ),
       preferAudioDescription: prefs.get(UserPreferences.preferAudioDescription),
       explicitAudioIndex: null,
+      lastExplicitAudioIndex: manager.lastExplicitAudioIndex,
+      lastExplicitAudioTitle: manager.lastExplicitAudioTitle,
     );
   }
 

--- a/lib/util/audio_track_logic.dart
+++ b/lib/util/audio_track_logic.dart
@@ -39,6 +39,8 @@ int? computeEffectiveAudioIndex({
   required bool preferDefaultAudioTrack,
   required bool preferAudioDescription,
   int? explicitAudioIndex,
+  int? lastExplicitAudioIndex,
+  String? lastExplicitAudioTitle,
 }) {
   final streams = audioStreams.where((s) => s['Type'] == 'Audio').toList();
   if (streams.isEmpty) return null;
@@ -69,26 +71,82 @@ int? computeEffectiveAudioIndex({
     }
   }
 
+  final normTitle = lastExplicitAudioTitle?.trim().toLowerCase();
+
   // 5. Match preferred language
   final preferredMatches = candidates.where((s) => matchLang(s['Language'], preferredAudioLanguage)).toList();
   if (preferredMatches.isNotEmpty) {
+    // 5a. Prefer exact same track index.
+    if (lastExplicitAudioIndex != null) {
+      final m = preferredMatches.firstWhere(
+        (s) => s['Index'] == lastExplicitAudioIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
+    // 5b. Prefer same track name (handles position shifts).
+    if (normTitle != null && normTitle.isNotEmpty) {
+      final m = preferredMatches.firstWhere(
+        (s) => _trackTitle(s)?.trim().toLowerCase() == normTitle,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
     return _rankAudioCandidates(preferredMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
   }
 
   // 6. Match fallback language
   final fallbackMatches = candidates.where((s) => matchLang(s['Language'], fallbackAudioLanguage)).toList();
   if (fallbackMatches.isNotEmpty) {
+    // 6a. Prefer exact same track index.
+    if (lastExplicitAudioIndex != null) {
+      final m = fallbackMatches.firstWhere(
+        (s) => s['Index'] == lastExplicitAudioIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
+    // 6b. Prefer same track name.
+    if (normTitle != null && normTitle.isNotEmpty) {
+      final m = fallbackMatches.firstWhere(
+        (s) => _trackTitle(s)?.trim().toLowerCase() == normTitle,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
     return _rankAudioCandidates(fallbackMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
   }
 
   // 7. Match English fallback
   final englishMatches = candidates.where((s) => matchLang(s['Language'], 'eng')).toList();
   if (englishMatches.isNotEmpty) {
+    // 7a. Prefer exact same track index.
+    if (lastExplicitAudioIndex != null) {
+      final m = englishMatches.firstWhere(
+        (s) => s['Index'] == lastExplicitAudioIndex,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
+    // 7b. Prefer same track name.
+    if (normTitle != null && normTitle.isNotEmpty) {
+      final m = englishMatches.firstWhere(
+        (s) => _trackTitle(s)?.trim().toLowerCase() == normTitle,
+        orElse: () => const <String, dynamic>{},
+      );
+      if (m.isNotEmpty) return m['Index'] as int?;
+    }
     return _rankAudioCandidates(englishMatches, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
   }
 
   // 8. Fall back to default track or first candidate
   return _rankAudioCandidates(candidates, preferDefaultAudioTrack, preferAudioDescription)['Index'] as int?;
+}
+
+String? _trackTitle(Map<String, dynamic> stream) {
+  final t = stream['Title']?.toString();
+  if (t != null && t.isNotEmpty) return t;
+  return stream['DisplayTitle']?.toString();
 }
 
 Map<String, dynamic> _rankAudioCandidates(

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -62,6 +62,8 @@ class PlaybackManager implements AudioOwnable {
   String? _pendingItemMediaSourceId;
   String? _lastItemId;
   String? _lastExplicitAudioLanguage;
+  int? _lastExplicitAudioIndex;
+  String? _lastExplicitAudioTitle;
   String? _lastExplicitSubtitleLanguage;
   bool? _lastExplicitSubtitleEnabled;
   Duration _lastKnownPosition = Duration.zero;
@@ -160,6 +162,8 @@ class PlaybackManager implements AudioOwnable {
   bool get audioSelectionExplicit => _audioSelectionExplicit;
   bool get subtitleSelectionExplicit => _subtitleSelectionExplicit;
   String? get lastExplicitAudioLanguage => _lastExplicitAudioLanguage;
+  int? get lastExplicitAudioIndex => _lastExplicitAudioIndex;
+  String? get lastExplicitAudioTitle => _lastExplicitAudioTitle;
   String? get lastExplicitSubtitleLanguage => _lastExplicitSubtitleLanguage;
   bool? get lastExplicitSubtitleEnabled => _lastExplicitSubtitleEnabled;
   bool get playbackDeferredToExternalPlayer => _deferPlaybackToExternalPlayer;
@@ -932,6 +936,8 @@ class PlaybackManager implements AudioOwnable {
     _clearPendingItemOverrides();
     _lastItemId = null;
     _lastExplicitAudioLanguage = null;
+    _lastExplicitAudioIndex = null;
+    _lastExplicitAudioTitle = null;
     _lastExplicitSubtitleLanguage = null;
     _lastExplicitSubtitleEnabled = null;
     _isAutoNexting = false;
@@ -1171,6 +1177,8 @@ class PlaybackManager implements AudioOwnable {
           resolution.mediaStreams,
           _lastExplicitAudioLanguage,
           'Audio',
+          preferredIndex: _lastExplicitAudioIndex,
+          preferredTitle: _lastExplicitAudioTitle,
         );
         if (matchedIdx != null && _audioStreamIndex != matchedIdx) {
           _audioStreamIndex = matchedIdx;
@@ -1246,6 +1254,8 @@ class PlaybackManager implements AudioOwnable {
       );
       if (stream.isNotEmpty) {
         _lastExplicitAudioLanguage = _extractLanguage(stream);
+        _lastExplicitAudioIndex = _audioStreamIndex;
+        _lastExplicitAudioTitle = _extractTrackTitle(stream);
       }
     }
 
@@ -1755,6 +1765,8 @@ class PlaybackManager implements AudioOwnable {
       );
       if (selectedStream.isNotEmpty) {
         _lastExplicitAudioLanguage = _extractLanguage(selectedStream);
+        _lastExplicitAudioIndex = streamIndex;
+        _lastExplicitAudioTitle = _extractTrackTitle(selectedStream);
       }
     }
 
@@ -2359,6 +2371,8 @@ class PlaybackManager implements AudioOwnable {
     _deferPlaybackToExternalPlayer = false;
     _lastItemId = null;
     _lastExplicitAudioLanguage = null;
+    _lastExplicitAudioIndex = null;
+    _lastExplicitAudioTitle = null;
     _lastExplicitSubtitleLanguage = null;
     _lastExplicitSubtitleEnabled = null;
     _audioStreamIndex = null;
@@ -2549,6 +2563,8 @@ class PlaybackManager implements AudioOwnable {
         newStreams,
         _lastExplicitAudioLanguage,
         'Audio',
+        preferredIndex: _lastExplicitAudioIndex,
+        preferredTitle: _lastExplicitAudioTitle,
       );
     } else {
       _audioStreamIndex = null;
@@ -2673,8 +2689,32 @@ bool _languagesMatch(Map? stream, String? targetLanguage) {
   return iso3Candidate.isNotEmpty && iso3Candidate == iso3Target;
 }
 
-int? _matchStreamIndexByLanguage(List<Map<String, dynamic>> streams, String? lang, String type) {
+int? _matchStreamIndexByLanguage(
+  List<Map<String, dynamic>> streams,
+  String? lang,
+  String type, {
+  int? preferredIndex,
+  String? preferredTitle,
+}) {
   final candidates = streams.where((s) => s['Type'] == type).toList();
+  // Tier 1: exact index that also language-matches.
+  if (preferredIndex != null) {
+    final i = candidates.indexWhere(
+      (s) => s['Index'] == preferredIndex && _languagesMatch(s, lang),
+    );
+    if (i >= 0) return candidates[i]['Index'] as int?;
+  }
+  // Tier 2: same track name that language-matches (handles track-number shifts).
+  if (preferredTitle != null && preferredTitle.isNotEmpty) {
+    final normTitle = preferredTitle.trim().toLowerCase();
+    final i = candidates.indexWhere(
+      (s) =>
+          _languagesMatch(s, lang) &&
+          _extractTrackTitle(s)?.trim().toLowerCase() == normTitle,
+    );
+    if (i >= 0) return candidates[i]['Index'] as int?;
+  }
+  // Tier 3: first stream that language-matches.
   final i = candidates.indexWhere((s) => _languagesMatch(s, lang));
   return i >= 0 ? candidates[i]['Index'] as int? : null;
 }
@@ -2697,6 +2737,19 @@ String? _extractLanguage(Map? stream) {
     }
   }
   return lang;
+}
+
+/// Returns the most descriptive non-empty title for an audio stream,
+/// preferring [Title] over [DisplayTitle]. Used to match tracks that have
+/// shifted position between episodes (e.g. an alternate-dub track that moved
+/// from index 3 to index 4 because the server added another track).
+String? _extractTrackTitle(Map<dynamic, dynamic>? stream) {
+  if (stream == null) return null;
+  final title = stream['Title']?.toString();
+  if (title != null && title.isNotEmpty) return title;
+  final display = stream['DisplayTitle']?.toString();
+  if (display != null && display.isNotEmpty) return display;
+  return null;
 }
 
 const Map<String, String> _kLanguageKeywords = {


### PR DESCRIPTION
# Pull Request

## Summary
Adds a multi-tier audio track persistence across episode auto-advance. When a user explicitly selects an audio track, we remember the track index, title, and language and uses all three to find the best matching track on the next episode — rather than always defaulting to the first occurrence of the preferred language.

## Related Issues
Link related issues or tickets separated by commas.

Tester feedback.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `_lastExplicitAudioIndex` and `_lastExplicitAudioTitle` fields (with public getters) to `PlaybackManager` alongside the existing `_lastExplicitAudioLanguage`. Both are populated in `changeAudioTrack` and after post-resolution audio index saves, and cleared in all stop/reset paths.
- Added `_extractTrackTitle` private helper in `playback_manager.dart` that reads `Title` then `DisplayTitle` from a stream map.
- Updated `_matchStreamIndexByLanguage` with optional `preferredIndex` and `preferredTitle` params implementing the three-tier lookup (exact index → same track name → first language match).
- Updated `computeEffectiveAudioIndex` in `audio_track_logic.dart` with `lastExplicitAudioIndex` and `lastExplicitAudioTitle` params; each language cohort (preferred, fallback, English) now tries index-match then title-match before channel-count ranking.
- Added `_trackTitle` helper in `audio_track_logic.dart`.
- Propagated `manager.lastExplicitAudioIndex` and `manager.lastExplicitAudioTitle` through both `audioTrackSelector` and `subtitleTrackSelector` callbacks in `playback_module.dart`.
- Updated `_effectiveAudioStreamIndex` in `item_detail_screen.dart` to read `manager.lastExplicitAudioLanguage`, `lastExplicitAudioIndex`, and `lastExplicitAudioTitle` so the detail page audio badge reflects the correct active track.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested with some combinations locally but don't have any files that perfectly matches the tester's situation so can't 100% confirm we've nailed it.
- [ ] Not tested (explain why):

### Test Steps
1. Begin playback of a TV series episode that has multiple audio tracks in the same language (e.g. Tracks 2 and 3 are both English, with Track 3 being a preferred dub variant labelled "English - Alternate Dub").
2. During playback, open the audio track selector and switch to Track 3.
3. Skip to the next episode via auto-advance or manually.
4. Verify the next episode selects Track 3 (not Track 2) — Tier 1 exact index match.
5. Test Tier 2: on a different episode where an extra audio track was added before the dub, pushing "English - Alternate Dub" to Track 4. Verify the app finds it by name and selects Track 4.
6. Test Tier 3: on an episode that only has one English track. Verify the app gracefully falls back to that single track rather than going silent.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
