### PR TITLE
bugfix-ui - Hide empty Details tab from TV show series pages

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -830,7 +830,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (hasCrew) crew,
           if (hasStudios) studios,
           if (item.chapters.isNotEmpty) chapters,
-          details,
           ...extraTabs,
           if (_vm.parentCollections.isNotEmpty)
             _ModernTab(


### PR DESCRIPTION
Exclude the Details tab from the tabs list returned for Series items, since file-specific stream and codec details do not apply to full shows and the tab is always empty.

# Pull Request

## Summary
Hides the "Details" tab from the TV Show (Series) main pages. Since a TV Show Series does not represent a single playable media file with container/stream/codec information, the Details tab was always empty.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Exclude Details tab from the tab bar list in **modern_detail_content.dart** when the item type is Series.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a TV show main details screen.
2. Verify that the Details tab is no longer listed in the tabs bar at the bottom.
3. Verify that the Details tab is still present on individual episode details screens.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="1743" height="1102" alt="2026-07-21_06-36-09_moonfin" src="https://github.com/user-attachments/assets/8f02d16f-3e87-439e-848d-f4b573643628" />
<img width="1743" height="1102" alt="2026-07-21_06-38-01_moonfin" src="https://github.com/user-attachments/assets/9e965cbc-9aa5-4188-b0ea-392e0ccbc6d6" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
