### PR TITLE
bug-settings - Fix dynamic binding updates in settings preference tiles

### DIFF
--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -333,7 +333,7 @@ class SwitchPreferenceTile extends StatefulWidget {
 }
 
 class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
-  late final PreferenceBinding<bool> _binding;
+  late PreferenceBinding<bool> _binding;
 
   @override
   void initState() {
@@ -342,6 +342,18 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
       GetIt.instance<PreferenceStore>(),
       widget.preference,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant SwitchPreferenceTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.preference != oldWidget.preference) {
+      _binding.dispose();
+      _binding = PreferenceBinding(
+        GetIt.instance<PreferenceStore>(),
+        widget.preference,
+      );
+    }
   }
 
   @override
@@ -434,7 +446,7 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
 
 class _EnumPreferenceTileState<T extends Enum>
     extends State<EnumPreferenceTile<T>> {
-  late final PreferenceBinding<T> _binding;
+  late PreferenceBinding<T> _binding;
   bool _pickerOpen = false;
 
   @override
@@ -444,6 +456,18 @@ class _EnumPreferenceTileState<T extends Enum>
       GetIt.instance<PreferenceStore>(),
       widget.preference,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant EnumPreferenceTile<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.preference != oldWidget.preference) {
+      _binding.dispose();
+      _binding = PreferenceBinding(
+        GetIt.instance<PreferenceStore>(),
+        widget.preference,
+      );
+    }
   }
 
   @override
@@ -603,7 +627,7 @@ class SliderPreferenceTile extends StatefulWidget {
 }
 
 class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
-  late final PreferenceBinding<int> _binding;
+  late PreferenceBinding<int> _binding;
   late final FocusNode _outerFocusNode;
   late final FocusNode _sliderInternalNode;
   bool _outerFocused = false;
@@ -629,6 +653,18 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
       canRequestFocus: false,
       skipTraversal: true,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant SliderPreferenceTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.preference != oldWidget.preference) {
+      _binding.dispose();
+      _binding = PreferenceBinding(
+        GetIt.instance<PreferenceStore>(),
+        widget.preference,
+      );
+    }
   }
 
   @override
@@ -816,7 +852,7 @@ class StringPickerPreferenceTile extends StatefulWidget {
 
 class _StringPickerPreferenceTileState
     extends State<StringPickerPreferenceTile> {
-  late final PreferenceBinding<String> _binding;
+  late PreferenceBinding<String> _binding;
   bool _pickerOpen = false;
 
   @override
@@ -826,6 +862,18 @@ class _StringPickerPreferenceTileState
       GetIt.instance<PreferenceStore>(),
       widget.preference,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant StringPickerPreferenceTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.preference != oldWidget.preference) {
+      _binding.dispose();
+      _binding = PreferenceBinding(
+        GetIt.instance<PreferenceStore>(),
+        widget.preference,
+      );
+    }
   }
 
   @override
@@ -936,7 +984,7 @@ class IntPickerPreferenceTile extends StatefulWidget {
 }
 
 class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
-  late final PreferenceBinding<int> _binding;
+  late PreferenceBinding<int> _binding;
   bool _pickerOpen = false;
 
   @override
@@ -946,6 +994,18 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
       GetIt.instance<PreferenceStore>(),
       widget.preference,
     );
+  }
+
+  @override
+  void didUpdateWidget(covariant IntPickerPreferenceTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.preference != oldWidget.preference) {
+      _binding.dispose();
+      _binding = PreferenceBinding(
+        GetIt.instance<PreferenceStore>(),
+        widget.preference,
+      );
+    }
   }
 
   @override

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -301,6 +301,16 @@ class SettingsListTypography extends StatelessWidget {
   }
 }
 
+PreferenceBinding<T> _rebindOnPreferenceChange<T>(
+  PreferenceBinding<T> current,
+  Preference<T> next,
+  Preference<T> previous,
+) {
+  if (next == previous) return current;
+  current.dispose();
+  return PreferenceBinding(GetIt.instance<PreferenceStore>(), next);
+}
+
 class SwitchPreferenceTile extends StatefulWidget {
   final Preference<bool> preference;
   final String title;
@@ -347,13 +357,11 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
   @override
   void didUpdateWidget(covariant SwitchPreferenceTile oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.preference != oldWidget.preference) {
-      _binding.dispose();
-      _binding = PreferenceBinding(
-        GetIt.instance<PreferenceStore>(),
-        widget.preference,
-      );
-    }
+    _binding = _rebindOnPreferenceChange(
+      _binding,
+      widget.preference,
+      oldWidget.preference,
+    );
   }
 
   @override
@@ -461,13 +469,11 @@ class _EnumPreferenceTileState<T extends Enum>
   @override
   void didUpdateWidget(covariant EnumPreferenceTile<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.preference != oldWidget.preference) {
-      _binding.dispose();
-      _binding = PreferenceBinding(
-        GetIt.instance<PreferenceStore>(),
-        widget.preference,
-      );
-    }
+    _binding = _rebindOnPreferenceChange(
+      _binding,
+      widget.preference,
+      oldWidget.preference,
+    );
   }
 
   @override
@@ -658,13 +664,11 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
   @override
   void didUpdateWidget(covariant SliderPreferenceTile oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.preference != oldWidget.preference) {
-      _binding.dispose();
-      _binding = PreferenceBinding(
-        GetIt.instance<PreferenceStore>(),
-        widget.preference,
-      );
-    }
+    _binding = _rebindOnPreferenceChange(
+      _binding,
+      widget.preference,
+      oldWidget.preference,
+    );
   }
 
   @override
@@ -867,13 +871,11 @@ class _StringPickerPreferenceTileState
   @override
   void didUpdateWidget(covariant StringPickerPreferenceTile oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.preference != oldWidget.preference) {
-      _binding.dispose();
-      _binding = PreferenceBinding(
-        GetIt.instance<PreferenceStore>(),
-        widget.preference,
-      );
-    }
+    _binding = _rebindOnPreferenceChange(
+      _binding,
+      widget.preference,
+      oldWidget.preference,
+    );
   }
 
   @override
@@ -999,13 +1001,11 @@ class _IntPickerPreferenceTileState extends State<IntPickerPreferenceTile> {
   @override
   void didUpdateWidget(covariant IntPickerPreferenceTile oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.preference != oldWidget.preference) {
-      _binding.dispose();
-      _binding = PreferenceBinding(
-        GetIt.instance<PreferenceStore>(),
-        widget.preference,
-      );
-    }
+    _binding = _rebindOnPreferenceChange(
+      _binding,
+      widget.preference,
+      oldWidget.preference,
+    );
   }
 
   @override


### PR DESCRIPTION
# Pull Request

## Summary
Fixes a bug where conditionally rendered settings (like classic and modern home row paddings) that share a settings tile on the screen bleed their values into each other when toggling the display style.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Changed the internal `_binding` variable from `late final` to `late` across all stateful preference tiles.
- Added `didUpdateWidget` overrides in **preference_tiles.dart** for the following tiles:
  * `SwitchPreferenceTile`
  * `EnumPreferenceTile`
  * `SliderPreferenceTile`
  * `StringPickerPreferenceTile`
  * `IntPickerPreferenceTile`
- Re-initialize and bind `PreferenceBinding` if the `widget.preference` changes dynamically at runtime.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Personalization Settings -> Layout -> Home Screen -> Home Row Display.
2. Toggle Home Rows Style (v1 / v2) to switch between classic and modern padding.
3. Verify that changes to the classic padding slider do not mutate modern padding, and vice versa.
4. Verify that sliders correctly use their previous values instead of resetting or going out-of-bounds.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Screenshots showing no bleedthrough of settings:
<img width="2553" height="1490" alt="2026-07-21_07-57-03_moonfin" src="https://github.com/user-attachments/assets/9c5f8dcb-664f-414c-882b-6e1497f33a0f" />
<img width="2553" height="1490" alt="2026-07-21_07-57-13_moonfin" src="https://github.com/user-attachments/assets/cb026ad7-ee9a-4cc9-b7aa-bd49b2bac0b8" />
<img width="2553" height="1490" alt="2026-07-21_07-57-23_moonfin" src="https://github.com/user-attachments/assets/ee8835bb-42d5-4eb0-9557-e586e9823355" />
<img width="2553" height="1490" alt="2026-07-21_07-57-37_moonfin" src="https://github.com/user-attachments/assets/eff5e4dd-3692-4296-a82c-19aa9c778a34" />
<img width="2553" height="1490" alt="2026-07-21_07-58-14_moonfin" src="https://github.com/user-attachments/assets/2ab47e62-cb23-4348-9e7e-059de3026419" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
