### PR TITLE
bugfix-audiobooks - Audiobook interface improvements

### DIFF
--- a/lib/l10n/app_af.arb
+++ b/lib/l10n/app_af.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Tou",
     "audiobookTimeline": "Tydlyn",
     "audiobookTimelineEmpty": "Die tydlyn is leeg",
-    "audiobookWholeBook": "Hele boek",
     "audiobookFocusedTimeline": "Gefokusde tydlyn",
     "audiobookExportBookmarks": "Voer boekmerke uit",
     "audiobookExportNotes": "Voer notas uit",

--- a/lib/l10n/app_ar.arb
+++ b/lib/l10n/app_ar.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "قائمة الانتظار",
     "audiobookTimeline": "المخطط الزمني",
     "audiobookTimelineEmpty": "المخطط الزمني فارغ",
-    "audiobookWholeBook": "الكتاب كاملاً",
     "audiobookFocusedTimeline": "المخطط الزمني المركّز",
     "audiobookExportBookmarks": "تصدير الإشارات المرجعية",
     "audiobookExportNotes": "تصدير الملاحظات",

--- a/lib/l10n/app_be.arb
+++ b/lib/l10n/app_be.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Чарга",
     "audiobookTimeline": "Шкала часу",
     "audiobookTimelineEmpty": "Шкала часу пустая",
-    "audiobookWholeBook": "Уся кніга",
     "audiobookFocusedTimeline": "Сфакусаваная шкала",
     "audiobookExportBookmarks": "Экспартаваць закладкі",
     "audiobookExportNotes": "Экспартаваць нататкі",

--- a/lib/l10n/app_bg.arb
+++ b/lib/l10n/app_bg.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Опашка",
     "audiobookTimeline": "Хронология",
     "audiobookTimelineEmpty": "Хронологията е празна",
-    "audiobookWholeBook": "Цялата книга",
     "audiobookFocusedTimeline": "Фокусирана хронология",
     "audiobookExportBookmarks": "Експортиране на отметките",
     "audiobookExportNotes": "Експортиране на бележките",

--- a/lib/l10n/app_bn.arb
+++ b/lib/l10n/app_bn.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "কিউ",
     "audiobookTimeline": "টাইমলাইন",
     "audiobookTimelineEmpty": "টাইমলাইন খালি",
-    "audiobookWholeBook": "সম্পূর্ণ বই",
     "audiobookFocusedTimeline": "নির্দিষ্ট টাইমলাইন",
     "audiobookExportBookmarks": "বুকমার্ক এক্সপোর্ট করুন",
     "audiobookExportNotes": "নোট এক্সপোর্ট করুন",

--- a/lib/l10n/app_ca.arb
+++ b/lib/l10n/app_ca.arb
@@ -8723,7 +8723,6 @@
     "audiobookQueue": "Cua",
     "audiobookTimeline": "Cronologia",
     "audiobookTimelineEmpty": "La cronologia és buida",
-    "audiobookWholeBook": "Tot el llibre",
     "audiobookFocusedTimeline": "Cronologia enfocada",
     "audiobookExportBookmarks": "Exporta els marcadors",
     "audiobookExportNotes": "Exporta les notes",

--- a/lib/l10n/app_cs.arb
+++ b/lib/l10n/app_cs.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Fronta",
     "audiobookTimeline": "Časová osa",
     "audiobookTimelineEmpty": "Časová osa je prázdná",
-    "audiobookWholeBook": "Celá kniha",
     "audiobookFocusedTimeline": "Přiblížená časová osa",
     "audiobookExportBookmarks": "Exportovat záložky",
     "audiobookExportNotes": "Exportovat poznámky",

--- a/lib/l10n/app_cy.arb
+++ b/lib/l10n/app_cy.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Ciw",
     "audiobookTimeline": "Llinell amser",
     "audiobookTimelineEmpty": "Mae'r llinell amser yn wag",
-    "audiobookWholeBook": "Y Llyfr Cyfan",
     "audiobookFocusedTimeline": "Llinell Amser â Ffocws",
     "audiobookExportBookmarks": "Allforio'r Nodau Tudalen",
     "audiobookExportNotes": "Allforio'r Nodiadau",

--- a/lib/l10n/app_da.arb
+++ b/lib/l10n/app_da.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Kø",
     "audiobookTimeline": "Tidslinje",
     "audiobookTimelineEmpty": "Tidslinjen er tom",
-    "audiobookWholeBook": "Hele bogen",
     "audiobookFocusedTimeline": "Fokuseret tidslinje",
     "audiobookExportBookmarks": "Eksportér bogmærker",
     "audiobookExportNotes": "Eksportér noter",

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Warteschlange",
     "audiobookTimeline": "Zeitleiste",
     "audiobookTimelineEmpty": "Zeitleiste ist leer",
-    "audiobookWholeBook": "Ganzes Buch",
     "audiobookFocusedTimeline": "Fokussierte Zeitleiste",
     "audiobookExportBookmarks": "Lesezeichen exportieren",
     "audiobookExportNotes": "Notizen exportieren",

--- a/lib/l10n/app_el.arb
+++ b/lib/l10n/app_el.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Ουρά",
     "audiobookTimeline": "Χρονολόγιο",
     "audiobookTimelineEmpty": "Το χρονολόγιο είναι κενό",
-    "audiobookWholeBook": "Όλο το βιβλίο",
     "audiobookFocusedTimeline": "Εστιασμένο χρονολόγιο",
     "audiobookExportBookmarks": "Εξαγωγή σελιδοδεικτών",
     "audiobookExportNotes": "Εξαγωγή σημειώσεων",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8682,7 +8682,6 @@
   "audiobookQueue": "Queue",
   "audiobookTimeline": "Timeline",
   "audiobookTimelineEmpty": "Timeline is empty",
-  "audiobookWholeBook": "Whole Book",
   "audiobookFocusedTimeline": "Focused Timeline",
   "audiobookExportBookmarks": "Export Bookmarks",
   "audiobookExportNotes": "Export Notes",

--- a/lib/l10n/app_eo.arb
+++ b/lib/l10n/app_eo.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Vico",
     "audiobookTimeline": "Templinio",
     "audiobookTimelineEmpty": "Templinio estas malplena",
-    "audiobookWholeBook": "Tuta libro",
     "audiobookFocusedTimeline": "Fokusita templinio",
     "audiobookExportBookmarks": "Eksporti legosignojn",
     "audiobookExportNotes": "Eksporti notojn",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Cola",
     "audiobookTimeline": "Cronología",
     "audiobookTimelineEmpty": "La cronología está vacía",
-    "audiobookWholeBook": "Todo el libro",
     "audiobookFocusedTimeline": "Cronología centrada",
     "audiobookExportBookmarks": "Exportar marcadores",
     "audiobookExportNotes": "Exportar notas",

--- a/lib/l10n/app_et.arb
+++ b/lib/l10n/app_et.arb
@@ -8709,7 +8709,6 @@
     "audiobookQueue": "Järjekord",
     "audiobookTimeline": "Ajajoon",
     "audiobookTimelineEmpty": "Ajajoon on tühi",
-    "audiobookWholeBook": "Kogu raamat",
     "audiobookFocusedTimeline": "Kitsendatud ajajoon",
     "audiobookExportBookmarks": "Ekspordi järjehoidjad",
     "audiobookExportNotes": "Ekspordi märkmed",

--- a/lib/l10n/app_fa.arb
+++ b/lib/l10n/app_fa.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "صف پخش",
     "audiobookTimeline": "خط زمانی",
     "audiobookTimelineEmpty": "خط زمانی خالی است",
-    "audiobookWholeBook": "کل کتاب",
     "audiobookFocusedTimeline": "خط زمانی متمرکز",
     "audiobookExportBookmarks": "برون‌بری نشانک‌ها",
     "audiobookExportNotes": "برون‌بری یادداشت‌ها",

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -8709,7 +8709,6 @@
     "audiobookQueue": "Jono",
     "audiobookTimeline": "Aikajana",
     "audiobookTimelineEmpty": "Aikajana on tyhjä",
-    "audiobookWholeBook": "Koko kirja",
     "audiobookFocusedTimeline": "Rajattu aikajana",
     "audiobookExportBookmarks": "Vie kirjanmerkit",
     "audiobookExportNotes": "Vie muistiinpanot",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -7980,7 +7980,6 @@
     "@settingsAllowSelfSignedCerts": {
         "description": "Setting to trust self-signed TLS certificates"
     },
-    "audiobookWholeBook": "Livre entier",
     "audiobookSleepRemaining": "{remaining} restant",
     "@audiobookSleepRemaining": {
         "placeholders": {

--- a/lib/l10n/app_gl.arb
+++ b/lib/l10n/app_gl.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Cola",
     "audiobookTimeline": "Cronoloxía",
     "audiobookTimelineEmpty": "A cronoloxía está baleira",
-    "audiobookWholeBook": "Todo o libro",
     "audiobookFocusedTimeline": "Cronoloxía enfocada",
     "audiobookExportBookmarks": "Exportar os marcadores",
     "audiobookExportNotes": "Exportar as notas",

--- a/lib/l10n/app_he.arb
+++ b/lib/l10n/app_he.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "תור",
     "audiobookTimeline": "ציר זמן",
     "audiobookTimelineEmpty": "ציר הזמן ריק",
-    "audiobookWholeBook": "הספר כולו",
     "audiobookFocusedTimeline": "ציר זמן ממוקד",
     "audiobookExportBookmarks": "ייצוא סימניות",
     "audiobookExportNotes": "ייצוא הערות",

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "कतार",
     "audiobookTimeline": "टाइमलाइन",
     "audiobookTimelineEmpty": "टाइमलाइन खाली है",
-    "audiobookWholeBook": "पूरी किताब",
     "audiobookFocusedTimeline": "केंद्रित टाइमलाइन",
     "audiobookExportBookmarks": "बुकमार्क एक्सपोर्ट करें",
     "audiobookExportNotes": "नोट्स एक्सपोर्ट करें",

--- a/lib/l10n/app_hr.arb
+++ b/lib/l10n/app_hr.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Red",
     "audiobookTimeline": "Vremenska crta",
     "audiobookTimelineEmpty": "Vremenska crta je prazna",
-    "audiobookWholeBook": "Cijela knjiga",
     "audiobookFocusedTimeline": "Fokusirana vremenska crta",
     "audiobookExportBookmarks": "Izvezi oznake",
     "audiobookExportNotes": "Izvezi bilješke",

--- a/lib/l10n/app_hu.arb
+++ b/lib/l10n/app_hu.arb
@@ -8155,7 +8155,6 @@
     "audiobookNotes": "Jegyzetek",
     "audiobookQueue": "Sor",
     "audiobookTimelineEmpty": "Az idővonal üres",
-    "audiobookWholeBook": "Teljes könyv",
     "audiobookFocusedTimeline": "Fókuszált idővonal",
     "audiobookExportNotes": "Jegyzetek exportálása",
     "audiobookExportAll": "Összes exportálása",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Antrean",
     "audiobookTimeline": "Lini Masa",
     "audiobookTimelineEmpty": "Lini masa kosong",
-    "audiobookWholeBook": "Seluruh Buku",
     "audiobookFocusedTimeline": "Lini Masa Terfokus",
     "audiobookExportBookmarks": "Ekspor Markah",
     "audiobookExportNotes": "Ekspor Catatan",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Coda",
     "audiobookTimeline": "Timeline",
     "audiobookTimelineEmpty": "La timeline è vuota",
-    "audiobookWholeBook": "Tutto il Libro",
     "audiobookFocusedTimeline": "Timeline Focalizzata",
     "audiobookExportBookmarks": "Esporta Segnalibri",
     "audiobookExportNotes": "Esporta Note",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -8709,7 +8709,6 @@
     "audiobookQueue": "キュー",
     "audiobookTimeline": "タイムライン",
     "audiobookTimelineEmpty": "タイムラインは空です",
-    "audiobookWholeBook": "本全体",
     "audiobookFocusedTimeline": "注目のタイムライン",
     "audiobookExportBookmarks": "ブックマークを書き出す",
     "audiobookExportNotes": "メモを書き出す",

--- a/lib/l10n/app_kk.arb
+++ b/lib/l10n/app_kk.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Кезек",
     "audiobookTimeline": "Уақыт шкаласы",
     "audiobookTimelineEmpty": "Уақыт шкаласы бос",
-    "audiobookWholeBook": "Бүкіл кітап",
     "audiobookFocusedTimeline": "Фокустелген шкала",
     "audiobookExportBookmarks": "Бетбелгілерді экспорттау",
     "audiobookExportNotes": "Ескертпелерді экспорттау",

--- a/lib/l10n/app_kn.arb
+++ b/lib/l10n/app_kn.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "ಸರತಿ",
     "audiobookTimeline": "ಟೈಮ್‌ಲೈನ್",
     "audiobookTimelineEmpty": "ಟೈಮ್‌ಲೈನ್ ಖಾಲಿಯಾಗಿದೆ",
-    "audiobookWholeBook": "ಸಂಪೂರ್ಣ ಪುಸ್ತಕ",
     "audiobookFocusedTimeline": "ಕೇಂದ್ರೀಕೃತ ಟೈಮ್‌ಲೈನ್",
     "audiobookExportBookmarks": "ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ",
     "audiobookExportNotes": "ಟಿಪ್ಪಣಿಗಳನ್ನು ರಫ್ತು ಮಾಡಿ",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -8709,7 +8709,6 @@
     "audiobookQueue": "재생 대기열",
     "audiobookTimeline": "타임라인",
     "audiobookTimelineEmpty": "타임라인이 비어 있습니다",
-    "audiobookWholeBook": "전체 책",
     "audiobookFocusedTimeline": "집중 타임라인",
     "audiobookExportBookmarks": "북마크 내보내기",
     "audiobookExportNotes": "메모 내보내기",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17368,12 +17368,6 @@ abstract class AppLocalizations {
   /// **'Timeline is empty'**
   String get audiobookTimelineEmpty;
 
-  /// No description provided for @audiobookWholeBook.
-  ///
-  /// In en, this message translates to:
-  /// **'Whole Book'**
-  String get audiobookWholeBook;
-
   /// No description provided for @audiobookFocusedTimeline.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -9772,9 +9772,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Die tydlyn is leeg';
 
   @override
-  String get audiobookWholeBook => 'Hele boek';
-
-  @override
   String get audiobookFocusedTimeline => 'Gefokusde tydlyn';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -9748,9 +9748,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'المخطط الزمني فارغ';
 
   @override
-  String get audiobookWholeBook => 'الكتاب كاملاً';
-
-  @override
   String get audiobookFocusedTimeline => 'المخطط الزمني المركّز';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -9836,9 +9836,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Шкала часу пустая';
 
   @override
-  String get audiobookWholeBook => 'Уся кніга';
-
-  @override
   String get audiobookFocusedTimeline => 'Сфакусаваная шкала';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -9875,9 +9875,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Хронологията е празна';
 
   @override
-  String get audiobookWholeBook => 'Цялата книга';
-
-  @override
   String get audiobookFocusedTimeline => 'Фокусирана хронология';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -9751,9 +9751,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'টাইমলাইন খালি';
 
   @override
-  String get audiobookWholeBook => 'সম্পূর্ণ বই';
-
-  @override
   String get audiobookFocusedTimeline => 'নির্দিষ্ট টাইমলাইন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -9921,9 +9921,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'La cronologia és buida';
 
   @override
-  String get audiobookWholeBook => 'Tot el llibre';
-
-  @override
   String get audiobookFocusedTimeline => 'Cronologia enfocada';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -9809,9 +9809,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Časová osa je prázdná';
 
   @override
-  String get audiobookWholeBook => 'Celá kniha';
-
-  @override
   String get audiobookFocusedTimeline => 'Přiblížená časová osa';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -9828,9 +9828,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Mae\'r llinell amser yn wag';
 
   @override
-  String get audiobookWholeBook => 'Y Llyfr Cyfan';
-
-  @override
   String get audiobookFocusedTimeline => 'Llinell Amser â Ffocws';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -9763,9 +9763,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Tidslinjen er tom';
 
   @override
-  String get audiobookWholeBook => 'Hele bogen';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokuseret tidslinje';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -9921,9 +9921,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Zeitleiste ist leer';
 
   @override
-  String get audiobookWholeBook => 'Ganzes Buch';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokussierte Zeitleiste';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -9926,9 +9926,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Το χρονολόγιο είναι κενό';
 
   @override
-  String get audiobookWholeBook => 'Όλο το βιβλίο';
-
-  @override
   String get audiobookFocusedTimeline => 'Εστιασμένο χρονολόγιο';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9686,9 +9686,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Timeline is empty';
 
   @override
-  String get audiobookWholeBook => 'Whole Book';
-
-  @override
   String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -9758,9 +9758,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Templinio estas malplena';
 
   @override
-  String get audiobookWholeBook => 'Tuta libro';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokusita templinio';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9881,9 +9881,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audiobookTimelineEmpty => 'La cronología está vacía';
 
   @override
-  String get audiobookWholeBook => 'Todo el libro';
-
-  @override
   String get audiobookFocusedTimeline => 'Cronología centrada';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -9781,9 +9781,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Ajajoon on tühi';
 
   @override
-  String get audiobookWholeBook => 'Kogu raamat';
-
-  @override
   String get audiobookFocusedTimeline => 'Kitsendatud ajajoon';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -9708,9 +9708,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'خط زمانی خالی است';
 
   @override
-  String get audiobookWholeBook => 'کل کتاب';
-
-  @override
   String get audiobookFocusedTimeline => 'خط زمانی متمرکز';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -9799,9 +9799,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Aikajana on tyhjä';
 
   @override
-  String get audiobookWholeBook => 'Koko kirja';
-
-  @override
   String get audiobookFocusedTimeline => 'Rajattu aikajana';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9895,9 +9895,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'La chronologie est vide';
 
   @override
-  String get audiobookWholeBook => 'Livre entier';
-
-  @override
   String get audiobookFocusedTimeline => 'Chronologie ciblée';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -9909,9 +9909,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'A cronoloxía está baleira';
 
   @override
-  String get audiobookWholeBook => 'Todo o libro';
-
-  @override
   String get audiobookFocusedTimeline => 'Cronoloxía enfocada';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -9629,9 +9629,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ציר הזמן ריק';
 
   @override
-  String get audiobookWholeBook => 'הספר כולו';
-
-  @override
   String get audiobookFocusedTimeline => 'ציר זמן ממוקד';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -9743,9 +9743,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'टाइमलाइन खाली है';
 
   @override
-  String get audiobookWholeBook => 'पूरी किताब';
-
-  @override
   String get audiobookFocusedTimeline => 'केंद्रित टाइमलाइन';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -9995,9 +9995,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Vremenska crta je prazna';
 
   @override
-  String get audiobookWholeBook => 'Cijela knjiga';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokusirana vremenska crta';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -9865,9 +9865,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Az idővonal üres';
 
   @override
-  String get audiobookWholeBook => 'Teljes könyv';
-
-  @override
   String get audiobookFocusedTimeline => 'Fókuszált idővonal';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -9770,9 +9770,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Lini masa kosong';
 
   @override
-  String get audiobookWholeBook => 'Seluruh Buku';
-
-  @override
   String get audiobookFocusedTimeline => 'Lini Masa Terfokus';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -9845,9 +9845,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'La timeline è vuota';
 
   @override
-  String get audiobookWholeBook => 'Tutto il Libro';
-
-  @override
   String get audiobookFocusedTimeline => 'Timeline Focalizzata';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9464,9 +9464,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'タイムラインは空です';
 
   @override
-  String get audiobookWholeBook => '本全体';
-
-  @override
   String get audiobookFocusedTimeline => '注目のタイムライン';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -9815,9 +9815,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Уақыт шкаласы бос';
 
   @override
-  String get audiobookWholeBook => 'Бүкіл кітап';
-
-  @override
   String get audiobookFocusedTimeline => 'Фокустелген шкала';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -9839,9 +9839,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ಟೈಮ್‌ಲೈನ್ ಖಾಲಿಯಾಗಿದೆ';
 
   @override
-  String get audiobookWholeBook => 'ಸಂಪೂರ್ಣ ಪುಸ್ತಕ';
-
-  @override
   String get audiobookFocusedTimeline => 'ಕೇಂದ್ರೀಕೃತ ಟೈಮ್‌ಲೈನ್';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9457,9 +9457,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audiobookTimelineEmpty => '타임라인이 비어 있습니다';
 
   @override
-  String get audiobookWholeBook => '전체 책';
-
-  @override
   String get audiobookFocusedTimeline => '집중 타임라인';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -9836,9 +9836,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Laiko juosta tuščia';
 
   @override
-  String get audiobookWholeBook => 'Visa knyga';
-
-  @override
   String get audiobookFocusedTimeline => 'Sutelkta laiko juosta';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -9828,9 +9828,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Laika josla ir tukša';
 
   @override
-  String get audiobookWholeBook => 'Visa grāmata';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokusētā laika josla';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -9847,9 +9847,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Временската линија е празна';
 
   @override
-  String get audiobookWholeBook => 'Цела книга';
-
-  @override
   String get audiobookFocusedTimeline => 'Фокусирана временска линија';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -9888,9 +9888,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ടൈംലൈൻ ശൂന്യമാണ്';
 
   @override
-  String get audiobookWholeBook => 'മുഴുവൻ പുസ്തകം';
-
-  @override
   String get audiobookFocusedTimeline => 'കേന്ദ്രീകൃത ടൈംലൈൻ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -9793,9 +9793,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Цагийн шугам хоосон байна';
 
   @override
-  String get audiobookWholeBook => 'Бүтэн ном';
-
-  @override
   String get audiobookFocusedTimeline => 'Төвлөрсөн цагийн шугам';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -9766,9 +9766,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Tidslinjen er tom';
 
   @override
-  String get audiobookWholeBook => 'Hele boken';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokusert tidslinje';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -9818,9 +9818,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'De tijdlijn is leeg';
 
   @override
-  String get audiobookWholeBook => 'Hele boek';
-
-  @override
   String get audiobookFocusedTimeline => 'Gerichte tijdlijn';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -9728,9 +9728,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ਟਾਈਮਲਾਈਨ ਖਾਲੀ ਹੈ';
 
   @override
-  String get audiobookWholeBook => 'ਪੂਰੀ ਕਿਤਾਬ';
-
-  @override
   String get audiobookFocusedTimeline => 'ਕੇਂਦਰਿਤ ਟਾਈਮਲਾਈਨ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -9828,9 +9828,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Oś czasu jest pusta';
 
   @override
-  String get audiobookWholeBook => 'Cała książka';
-
-  @override
   String get audiobookFocusedTimeline => 'Wybrany fragment osi czasu';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -9848,9 +9848,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audiobookTimelineEmpty => 'A linha do tempo está vazia';
 
   @override
-  String get audiobookWholeBook => 'Livro Inteiro';
-
-  @override
   String get audiobookFocusedTimeline => 'Linha do Tempo Focada';
 
   @override
@@ -19984,9 +19981,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
 
   @override
   String get audiobookTimelineEmpty => 'A linha do tempo está vazia';
-
-  @override
-  String get audiobookWholeBook => 'Livro inteiro';
 
   @override
   String get audiobookFocusedTimeline => 'Linha do tempo focada';
@@ -30125,9 +30119,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
 
   @override
   String get audiobookTimelineEmpty => 'A linha temporal está vazia';
-
-  @override
-  String get audiobookWholeBook => 'Livro completo';
 
   @override
   String get audiobookFocusedTimeline => 'Linha temporal focada';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -9854,9 +9854,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Cronologia este goală';
 
   @override
-  String get audiobookWholeBook => 'Toată cartea';
-
-  @override
   String get audiobookFocusedTimeline => 'Cronologie focalizată';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -9849,9 +9849,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Хронология пуста';
 
   @override
-  String get audiobookWholeBook => 'Вся книга';
-
-  @override
   String get audiobookFocusedTimeline => 'Текущий фрагмент';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -9761,9 +9761,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'කාල රේඛාව හිස්ය';
 
   @override
-  String get audiobookWholeBook => 'සම්පූර්ණ පොත';
-
-  @override
   String get audiobookFocusedTimeline => 'නාභිගත කාල රේඛාව';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -9837,9 +9837,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Časová os je prázdna';
 
   @override
-  String get audiobookWholeBook => 'Celá kniha';
-
-  @override
   String get audiobookFocusedTimeline => 'Zameraná časová os';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -9837,9 +9837,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Časovnica je prazna';
 
   @override
-  String get audiobookWholeBook => 'Celotna knjiga';
-
-  @override
   String get audiobookFocusedTimeline => 'Osredotočena časovnica';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -9863,9 +9863,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Vija kohore është bosh';
 
   @override
-  String get audiobookWholeBook => 'I gjithë libri';
-
-  @override
   String get audiobookFocusedTimeline => 'Vija kohore e fokusuar';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -9984,9 +9984,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Временска линија је празна';
 
   @override
-  String get audiobookWholeBook => 'Цела књига';
-
-  @override
   String get audiobookFocusedTimeline => 'Фокусирана временска линија';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -9781,9 +9781,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Tidslinjen är tom';
 
   @override
-  String get audiobookWholeBook => 'Hela boken';
-
-  @override
   String get audiobookFocusedTimeline => 'Fokuserad tidslinje';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -9849,9 +9849,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Ratiba ya muda ni tupu';
 
   @override
-  String get audiobookWholeBook => 'Kitabu Kizima';
-
-  @override
   String get audiobookFocusedTimeline => 'Ratiba ya Muda Iliyolengwa';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -9851,9 +9851,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audiobookTimelineEmpty => 'காலவரிசை காலியாக உள்ளது';
 
   @override
-  String get audiobookWholeBook => 'முழுப் புத்தகம்';
-
-  @override
   String get audiobookFocusedTimeline => 'மையப்படுத்திய காலவரிசை';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -9842,9 +9842,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audiobookTimelineEmpty => 'టైమ్‌లైన్ ఖాళీగా ఉంది';
 
   @override
-  String get audiobookWholeBook => 'మొత్తం పుస్తకం';
-
-  @override
   String get audiobookFocusedTimeline => 'కేంద్రీకృత టైమ్‌లైన్';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -9693,9 +9693,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ไทม์ไลน์ว่างเปล่า';
 
   @override
-  String get audiobookWholeBook => 'ทั้งเล่ม';
-
-  @override
   String get audiobookFocusedTimeline => 'ไทม์ไลน์เฉพาะจุด';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -9882,9 +9882,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Walang laman ang timeline';
 
   @override
-  String get audiobookWholeBook => 'Buong Aklat';
-
-  @override
   String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -9785,9 +9785,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Zaman Çizelgesi boş';
 
   @override
-  String get audiobookWholeBook => 'Tüm Kitap';
-
-  @override
   String get audiobookFocusedTimeline => 'Odaklanmış Zaman Çizelgesi';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -9806,9 +9806,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get audiobookTimelineEmpty => 'ۋاقىت ئوقى قۇرۇق';
 
   @override
-  String get audiobookWholeBook => 'پۈتۈن كىتاب';
-
-  @override
   String get audiobookFocusedTimeline => 'مەركەزلەشكەن ۋاقىت ئوقى';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -9859,9 +9859,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Хронологія порожня';
 
   @override
-  String get audiobookWholeBook => 'Уся книга';
-
-  @override
   String get audiobookFocusedTimeline => 'Сфокусована хронологія';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -9770,9 +9770,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get audiobookTimelineEmpty => 'Dòng thời gian trống';
 
   @override
-  String get audiobookWholeBook => 'Toàn bộ sách';
-
-  @override
   String get audiobookFocusedTimeline => 'Dòng thời gian thu hẹp';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -9380,9 +9380,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get audiobookTimelineEmpty => '時間軸係空嘅';
 
   @override
-  String get audiobookWholeBook => '成本書';
-
-  @override
   String get audiobookFocusedTimeline => '聚焦時間軸';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9376,9 +9376,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audiobookTimelineEmpty => '时间轴为空';
 
   @override
-  String get audiobookWholeBook => '整本书';
-
-  @override
   String get audiobookFocusedTimeline => '聚焦时间轴';
 
   @override
@@ -19018,9 +19015,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get audiobookTimelineEmpty => '時間軸是空的';
-
-  @override
-  String get audiobookWholeBook => '整本書';
 
   @override
   String get audiobookFocusedTimeline => '聚焦時間軸';

--- a/lib/l10n/app_lt.arb
+++ b/lib/l10n/app_lt.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Eilė",
     "audiobookTimeline": "Laiko juosta",
     "audiobookTimelineEmpty": "Laiko juosta tuščia",
-    "audiobookWholeBook": "Visa knyga",
     "audiobookFocusedTimeline": "Sutelkta laiko juosta",
     "audiobookExportBookmarks": "Eksportuoti žymes",
     "audiobookExportNotes": "Eksportuoti pastabas",

--- a/lib/l10n/app_lv.arb
+++ b/lib/l10n/app_lv.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Rinda",
     "audiobookTimeline": "Laika josla",
     "audiobookTimelineEmpty": "Laika josla ir tukša",
-    "audiobookWholeBook": "Visa grāmata",
     "audiobookFocusedTimeline": "Fokusētā laika josla",
     "audiobookExportBookmarks": "Eksportēt grāmatzīmes",
     "audiobookExportNotes": "Eksportēt piezīmes",

--- a/lib/l10n/app_mk.arb
+++ b/lib/l10n/app_mk.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Редица",
     "audiobookTimeline": "Временска линија",
     "audiobookTimelineEmpty": "Временската линија е празна",
-    "audiobookWholeBook": "Цела книга",
     "audiobookFocusedTimeline": "Фокусирана временска линија",
     "audiobookExportBookmarks": "Извези ги обележувачите",
     "audiobookExportNotes": "Извези ги белешките",

--- a/lib/l10n/app_ml.arb
+++ b/lib/l10n/app_ml.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "ക്യൂ",
     "audiobookTimeline": "ടൈംലൈൻ",
     "audiobookTimelineEmpty": "ടൈംലൈൻ ശൂന്യമാണ്",
-    "audiobookWholeBook": "മുഴുവൻ പുസ്തകം",
     "audiobookFocusedTimeline": "കേന്ദ്രീകൃത ടൈംലൈൻ",
     "audiobookExportBookmarks": "ബുക്ക്മാർക്കുകൾ എക്സ്പോർട്ട് ചെയ്യുക",
     "audiobookExportNotes": "കുറിപ്പുകൾ എക്സ്പോർട്ട് ചെയ്യുക",

--- a/lib/l10n/app_mn.arb
+++ b/lib/l10n/app_mn.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Дараалал",
     "audiobookTimeline": "Цагийн шугам",
     "audiobookTimelineEmpty": "Цагийн шугам хоосон байна",
-    "audiobookWholeBook": "Бүтэн ном",
     "audiobookFocusedTimeline": "Төвлөрсөн цагийн шугам",
     "audiobookExportBookmarks": "Хавчуургыг экспортлох",
     "audiobookExportNotes": "Тэмдэглэлийг экспортлох",

--- a/lib/l10n/app_nb.arb
+++ b/lib/l10n/app_nb.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Kø",
     "audiobookTimeline": "Tidslinje",
     "audiobookTimelineEmpty": "Tidslinjen er tom",
-    "audiobookWholeBook": "Hele boken",
     "audiobookFocusedTimeline": "Fokusert tidslinje",
     "audiobookExportBookmarks": "Eksporter bokmerker",
     "audiobookExportNotes": "Eksporter notater",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Wachtrij",
     "audiobookTimeline": "Tijdlijn",
     "audiobookTimelineEmpty": "De tijdlijn is leeg",
-    "audiobookWholeBook": "Hele boek",
     "audiobookFocusedTimeline": "Gerichte tijdlijn",
     "audiobookExportBookmarks": "Bladwijzers exporteren",
     "audiobookExportNotes": "Notities exporteren",

--- a/lib/l10n/app_pa.arb
+++ b/lib/l10n/app_pa.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "ਕਤਾਰ",
     "audiobookTimeline": "ਟਾਈਮਲਾਈਨ",
     "audiobookTimelineEmpty": "ਟਾਈਮਲਾਈਨ ਖਾਲੀ ਹੈ",
-    "audiobookWholeBook": "ਪੂਰੀ ਕਿਤਾਬ",
     "audiobookFocusedTimeline": "ਕੇਂਦਰਿਤ ਟਾਈਮਲਾਈਨ",
     "audiobookExportBookmarks": "ਬੁੱਕਮਾਰਕ ਨਿਰਯਾਤ ਕਰੋ",
     "audiobookExportNotes": "ਨੋਟਸ ਨਿਰਯਾਤ ਕਰੋ",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Kolejka",
     "audiobookTimeline": "Oś czasu",
     "audiobookTimelineEmpty": "Oś czasu jest pusta",
-    "audiobookWholeBook": "Cała książka",
     "audiobookFocusedTimeline": "Wybrany fragment osi czasu",
     "audiobookExportBookmarks": "Eksportuj zakładki",
     "audiobookExportNotes": "Eksportuj notatki",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Fila",
     "audiobookTimeline": "Linha do Tempo",
     "audiobookTimelineEmpty": "A linha do tempo está vazia",
-    "audiobookWholeBook": "Livro Inteiro",
     "audiobookFocusedTimeline": "Linha do Tempo Focada",
     "audiobookExportBookmarks": "Exportar Marcadores",
     "audiobookExportNotes": "Exportar Notas",

--- a/lib/l10n/app_pt_BR.arb
+++ b/lib/l10n/app_pt_BR.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Fila",
     "audiobookTimeline": "Linha do tempo",
     "audiobookTimelineEmpty": "A linha do tempo está vazia",
-    "audiobookWholeBook": "Livro inteiro",
     "audiobookFocusedTimeline": "Linha do tempo focada",
     "audiobookExportBookmarks": "Exportar marcadores",
     "audiobookExportNotes": "Exportar notas",

--- a/lib/l10n/app_pt_PT.arb
+++ b/lib/l10n/app_pt_PT.arb
@@ -8716,7 +8716,6 @@
     "audiobookQueue": "Fila",
     "audiobookTimeline": "Linha temporal",
     "audiobookTimelineEmpty": "A linha temporal está vazia",
-    "audiobookWholeBook": "Livro completo",
     "audiobookFocusedTimeline": "Linha temporal focada",
     "audiobookExportBookmarks": "Exportar marcadores",
     "audiobookExportNotes": "Exportar notas",

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Coadă",
     "audiobookTimeline": "Cronologie",
     "audiobookTimelineEmpty": "Cronologia este goală",
-    "audiobookWholeBook": "Toată cartea",
     "audiobookFocusedTimeline": "Cronologie focalizată",
     "audiobookExportBookmarks": "Exportă marcajele",
     "audiobookExportNotes": "Exportă notițele",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Очередь",
     "audiobookTimeline": "Хронология",
     "audiobookTimelineEmpty": "Хронология пуста",
-    "audiobookWholeBook": "Вся книга",
     "audiobookFocusedTimeline": "Текущий фрагмент",
     "audiobookExportBookmarks": "Экспорт закладок",
     "audiobookExportNotes": "Экспорт заметок",

--- a/lib/l10n/app_si.arb
+++ b/lib/l10n/app_si.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "පෝලිම",
     "audiobookTimeline": "කාල රේඛාව",
     "audiobookTimelineEmpty": "කාල රේඛාව හිස්ය",
-    "audiobookWholeBook": "සම්පූර්ණ පොත",
     "audiobookFocusedTimeline": "නාභිගත කාල රේඛාව",
     "audiobookExportBookmarks": "පිටු සලකුණු නිර්යාත කරන්න",
     "audiobookExportNotes": "සටහන් නිර්යාත කරන්න",

--- a/lib/l10n/app_sk.arb
+++ b/lib/l10n/app_sk.arb
@@ -8712,7 +8712,6 @@
     "audiobookQueue": "Fronta",
     "audiobookTimeline": "Časová os",
     "audiobookTimelineEmpty": "Časová os je prázdna",
-    "audiobookWholeBook": "Celá kniha",
     "audiobookFocusedTimeline": "Zameraná časová os",
     "audiobookExportBookmarks": "Exportovať záložky",
     "audiobookExportNotes": "Exportovať poznámky",

--- a/lib/l10n/app_sl.arb
+++ b/lib/l10n/app_sl.arb
@@ -8712,7 +8712,6 @@
     "audiobookQueue": "Vrsta",
     "audiobookTimeline": "Časovnica",
     "audiobookTimelineEmpty": "Časovnica je prazna",
-    "audiobookWholeBook": "Celotna knjiga",
     "audiobookFocusedTimeline": "Osredotočena časovnica",
     "audiobookExportBookmarks": "Izvozi zaznamke",
     "audiobookExportNotes": "Izvozi zapiske",

--- a/lib/l10n/app_sq.arb
+++ b/lib/l10n/app_sq.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Radha",
     "audiobookTimeline": "Vija kohore",
     "audiobookTimelineEmpty": "Vija kohore është bosh",
-    "audiobookWholeBook": "I gjithë libri",
     "audiobookFocusedTimeline": "Vija kohore e fokusuar",
     "audiobookExportBookmarks": "Eksporto faqeshënuesit",
     "audiobookExportNotes": "Eksporto shënimet",

--- a/lib/l10n/app_sr.arb
+++ b/lib/l10n/app_sr.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Ред",
     "audiobookTimeline": "Временска линија",
     "audiobookTimelineEmpty": "Временска линија је празна",
-    "audiobookWholeBook": "Цела књига",
     "audiobookFocusedTimeline": "Фокусирана временска линија",
     "audiobookExportBookmarks": "Извези обележиваче",
     "audiobookExportNotes": "Извези белешке",

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Kö",
     "audiobookTimeline": "Tidslinje",
     "audiobookTimelineEmpty": "Tidslinjen är tom",
-    "audiobookWholeBook": "Hela boken",
     "audiobookFocusedTimeline": "Fokuserad tidslinje",
     "audiobookExportBookmarks": "Exportera bokmärken",
     "audiobookExportNotes": "Exportera anteckningar",

--- a/lib/l10n/app_sw.arb
+++ b/lib/l10n/app_sw.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Foleni",
     "audiobookTimeline": "Ratiba ya Muda",
     "audiobookTimelineEmpty": "Ratiba ya muda ni tupu",
-    "audiobookWholeBook": "Kitabu Kizima",
     "audiobookFocusedTimeline": "Ratiba ya Muda Iliyolengwa",
     "audiobookExportBookmarks": "Hamisha Alamisho",
     "audiobookExportNotes": "Hamisha Vidokezo",

--- a/lib/l10n/app_ta.arb
+++ b/lib/l10n/app_ta.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "வரிசை",
     "audiobookTimeline": "காலவரிசை",
     "audiobookTimelineEmpty": "காலவரிசை காலியாக உள்ளது",
-    "audiobookWholeBook": "முழுப் புத்தகம்",
     "audiobookFocusedTimeline": "மையப்படுத்திய காலவரிசை",
     "audiobookExportBookmarks": "புக்மார்க்குகளை ஏற்றுமதி செய்",
     "audiobookExportNotes": "குறிப்புகளை ஏற்றுமதி செய்",

--- a/lib/l10n/app_te.arb
+++ b/lib/l10n/app_te.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "క్యూ",
     "audiobookTimeline": "టైమ్‌లైన్",
     "audiobookTimelineEmpty": "టైమ్‌లైన్ ఖాళీగా ఉంది",
-    "audiobookWholeBook": "మొత్తం పుస్తకం",
     "audiobookFocusedTimeline": "కేంద్రీకృత టైమ్‌లైన్",
     "audiobookExportBookmarks": "బుక్‌మార్క్‌లను ఎగుమతి చేయండి",
     "audiobookExportNotes": "గమనికలను ఎగుమతి చేయండి",

--- a/lib/l10n/app_th.arb
+++ b/lib/l10n/app_th.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "คิว",
     "audiobookTimeline": "ไทม์ไลน์",
     "audiobookTimelineEmpty": "ไทม์ไลน์ว่างเปล่า",
-    "audiobookWholeBook": "ทั้งเล่ม",
     "audiobookFocusedTimeline": "ไทม์ไลน์เฉพาะจุด",
     "audiobookExportBookmarks": "ส่งออกที่คั่นหนังสือ",
     "audiobookExportNotes": "ส่งออกบันทึก",

--- a/lib/l10n/app_tl.arb
+++ b/lib/l10n/app_tl.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Queue",
     "audiobookTimeline": "Timeline",
     "audiobookTimelineEmpty": "Walang laman ang timeline",
-    "audiobookWholeBook": "Buong Aklat",
     "audiobookFocusedTimeline": "Focused Timeline",
     "audiobookExportBookmarks": "I-export ang Mga Bookmark",
     "audiobookExportNotes": "I-export ang Mga Tala",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -8407,7 +8407,6 @@
         "description": "Setting to trust self-signed TLS certificates"
     },
     "settingsAlwaysExpandNavbarLabels": "Üst gezinti çubuğundaki metin etiketlerini her zaman göster",
-    "audiobookWholeBook": "Tüm Kitap",
     "adminRepoSortDateNewest": "Ekleme Tarihi (Önce En Yeni)",
     "@adminRepoSortDateNewest": {
         "description": "Repository sort option, newest added first"

--- a/lib/l10n/app_ug.arb
+++ b/lib/l10n/app_ug.arb
@@ -8718,7 +8718,6 @@
     "audiobookQueue": "ئۆچرەت",
     "audiobookTimeline": "ۋاقىت ئوقى",
     "audiobookTimelineEmpty": "ۋاقىت ئوقى قۇرۇق",
-    "audiobookWholeBook": "پۈتۈن كىتاب",
     "audiobookFocusedTimeline": "مەركەزلەشكەن ۋاقىت ئوقى",
     "audiobookExportBookmarks": "خەتكۈشلەرنى چىقىرىش",
     "audiobookExportNotes": "ئىزاھاتلارنى چىقىرىش",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Черга",
     "audiobookTimeline": "Хронологія",
     "audiobookTimelineEmpty": "Хронологія порожня",
-    "audiobookWholeBook": "Уся книга",
     "audiobookFocusedTimeline": "Сфокусована хронологія",
     "audiobookExportBookmarks": "Експортувати закладки",
     "audiobookExportNotes": "Експортувати нотатки",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "Hàng đợi",
     "audiobookTimeline": "Dòng thời gian",
     "audiobookTimelineEmpty": "Dòng thời gian trống",
-    "audiobookWholeBook": "Toàn bộ sách",
     "audiobookFocusedTimeline": "Dòng thời gian thu hẹp",
     "audiobookExportBookmarks": "Xuất dấu trang",
     "audiobookExportNotes": "Xuất ghi chú",

--- a/lib/l10n/app_yue.arb
+++ b/lib/l10n/app_yue.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "佇列",
     "audiobookTimeline": "時間軸",
     "audiobookTimelineEmpty": "時間軸係空嘅",
-    "audiobookWholeBook": "成本書",
     "audiobookFocusedTimeline": "聚焦時間軸",
     "audiobookExportBookmarks": "匯出書籤",
     "audiobookExportNotes": "匯出筆記",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -7994,7 +7994,6 @@
     "audiobookNotes": "笔记",
     "audiobookQueue": "队列",
     "audiobookTimeline": "时间轴",
-    "audiobookWholeBook": "整本书",
     "audiobookFocusedTimeline": "聚焦时间轴",
     "audiobookExportBookmarks": "导出书签",
     "audiobookExportNotes": "导出笔记",

--- a/lib/l10n/app_zh_Hant.arb
+++ b/lib/l10n/app_zh_Hant.arb
@@ -8713,7 +8713,6 @@
     "audiobookQueue": "佇列",
     "audiobookTimeline": "時間軸",
     "audiobookTimelineEmpty": "時間軸是空的",
-    "audiobookWholeBook": "整本書",
     "audiobookFocusedTimeline": "聚焦時間軸",
     "audiobookExportBookmarks": "匯出書籤",
     "audiobookExportNotes": "匯出筆記",

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -958,6 +958,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             } else if (ev.type == TimelineEventType.bookmark) {
               _manager.seekTo(Duration(
                   milliseconds: (ev.originalObject as AudiobookBookmark).positionMs));
+              if (!tv && mounted) {
+                Navigator.of(context).pop();
+              }
             } else if (ev.type == TimelineEventType.note) {
               _manager.seekTo(Duration(
                   milliseconds: (ev.originalObject as AudiobookNote).positionMs));
@@ -982,7 +985,12 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       AudiobookDrawerTab.bookmarks => AudiobookBookmarksList(
           item: item,
           service: _bookmarks,
-          onJump: (b) => _manager.seekTo(Duration(milliseconds: b.positionMs)),
+          onJump: (b) {
+            _manager.seekTo(Duration(milliseconds: b.positionMs));
+            if (!tv && mounted) {
+              Navigator.of(context).pop();
+            }
+          },
           tvFocusedIndex: tvIdx,
           tvSubIndex: subIdx,
           onExport: () {

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -80,10 +80,9 @@ class AudiobookBookOverview extends StatelessWidget {
               ),
               Expanded(
                 child: Text(
-                  l10n.audiobookWholeBook,
+                  formatAudiobookClock(position),
                   style: TextStyle(
                     fontSize: 11,
-                    fontStyle: FontStyle.italic,
                     color: AppColorScheme.onSurface.withValues(alpha: 0.5),
                   ),
                   textAlign: TextAlign.center,

--- a/lib/ui/widgets/audiobook/audiobook_sheets.dart
+++ b/lib/ui/widgets/audiobook/audiobook_sheets.dart
@@ -837,7 +837,7 @@ class _NoteEditorSheetState extends State<_NoteEditorSheet> {
     final prefs = GetIt.instance<UserPreferences>();
     final preferSystemIme = prefs.get(UserPreferences.preferSystemImeKeyboard);
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
-    final bottomPadding = isTV ? AppSpacing.spaceLg : (AppSpacing.spaceLg + MediaQuery.viewInsetsOf(context).bottom);
+    final bottomPadding = AppSpacing.spaceLg;
 
     return FocusScope(
       node: _focusScopeNode,


### PR DESCRIPTION
# Pull Request

## Summary
Three wife-approved improvements for the audiobook player interface, including bookmark selection behavior, progress bar info, and note editor layout fixes.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **audiobook_player_view.dart**: Dismiss the modal bottom sheet/drawer on mobile when a bookmark is tapped (both inside the Bookmarks and Timeline lists) using Navigator.of(context).pop().
- **audiobook_progress_bar.dart**: Replaced the static "Whole Book" center label with the current playback duration (using formatAudiobookClock).
- **audiobook_sheets.dart**: Fixed layout height overflow and unresponsive Save/Cancel buttons when the keyboard is open by removing duplicate keyboard bottom inset padding from the note editor sheet.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Install and run the mobile-beta client build.
2. Open the audiobook player on a mobile device and open the bookmarks/drawer panel.
3. Tap on any bookmark item: verify that the player successfully jumps to the selected position and dismisses the bottom sheet drawer.
4. Verify the center label above the play button dynamically displays the current playback position in clock format (e.g., HH:MM:SS or MM:SS) instead of "Whole Book".
5. Open the note editor modal: verify that typing a note displays the keyboard, the Save/Cancel buttons sit above the keyboard, and tapping "Save" works immediately without having to close the keyboard first.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="1280" height="2856" alt="Screenshot_20260721-090931" src="https://github.com/user-attachments/assets/2a1b9e4f-8728-40f6-ba3c-696830920eeb" />
<img width="1280" height="2856" alt="Screenshot_20260721-091105" src="https://github.com/user-attachments/assets/302289a3-dd08-44b5-ba02-ca377d1b7f60" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
