### PR TITLE
fix(ui): don't close dialogs on backspace while editing text, fixes #800

### DIFF
--- a/lib/ui/screens/auth/server_select_screen.dart
+++ b/lib/ui/screens/auth/server_select_screen.dart
@@ -703,7 +703,7 @@ class _ServerSelectScreenState extends State<ServerSelectScreen> {
     try {
       await showFocusRestoringDialog<void>(
         context: context,
-        builder: (ctx) => _AddServerDialog(
+        builder: (ctx) => AddServerDialog(
           l10n: AppLocalizations.of(context),
           controller: _addressController,
           serverRepo: _serverRepo,
@@ -843,22 +843,23 @@ class _FocusableTileState extends State<_FocusableTile> {
   }
 }
 
-class _AddServerDialog extends StatefulWidget {
+class AddServerDialog extends StatefulWidget {
   final AppLocalizations l10n;
   final TextEditingController controller;
   final ServerRepository serverRepo;
 
-  const _AddServerDialog({
+  const AddServerDialog({
+    super.key,
     required this.l10n,
     required this.controller,
     required this.serverRepo,
   });
 
   @override
-  State<_AddServerDialog> createState() => _AddServerDialogState();
+  State<AddServerDialog> createState() => _AddServerDialogState();
 }
 
-class _AddServerDialogState extends State<_AddServerDialog> {
+class _AddServerDialogState extends State<AddServerDialog> {
   final _userPreferences = GetIt.instance<UserPreferences>();
   final _addressFocus = FocusNode(debugLabel: 'addServerAddress');
   final _connectFocus = FocusNode(debugLabel: 'addServerConnect');
@@ -966,6 +967,14 @@ class _AddServerDialogState extends State<_AddServerDialog> {
           _tvFieldKey.currentState?.closeKeyboard();
           _addressFocus.requestFocus();
           return KeyEventResult.handled;
+        }
+        // A focused text field owns backspace (editing the URL); only treat
+        // it as "close dialog" when no editable text has primary focus.
+        final focusContext = FocusManager.instance.primaryFocus?.context;
+        if (focusContext != null &&
+            focusContext.findAncestorWidgetOfExactType<EditableText>() !=
+                null) {
+          return KeyEventResult.ignored;
         }
         _dismissDialog(suppressNextPopRoute: true);
         return KeyEventResult.handled;

--- a/lib/ui/widgets/overlay_sheet.dart
+++ b/lib/ui/widgets/overlay_sheet.dart
@@ -94,6 +94,14 @@ Future<T?> showFocusRestoringDialog<T>({
       onKeyEvent: (node, event) {
         if (!event.logicalKey.isBackKey) return KeyEventResult.ignored;
         if (event is KeyDownEvent) {
+          // A focused text field owns backspace (it's editing, not "back");
+          // don't pop the dialog out from under it.
+          final focusContext = FocusManager.instance.primaryFocus?.context;
+          if (focusContext != null &&
+              focusContext.findAncestorWidgetOfExactType<EditableText>() !=
+                  null) {
+            return KeyEventResult.ignored;
+          }
           DialogBackSuppressor.markDismissed();
           Navigator.of(dialogContext).pop();
           return KeyEventResult.handled;

--- a/test/add_server_dialog_test.dart
+++ b/test/add_server_dialog_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/screens/auth/server_select_screen.dart';
+import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/overlay_sheet.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:moonfin/auth/repositories/server_repository.dart';
+
+class _MockServerRepository extends Mock implements ServerRepository {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    GetIt.instance.registerSingleton<UserPreferences>(UserPreferences(store));
+    ThemeRegistry.setActiveById(ThemeRegistry.moonfinId);
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  Future<({TextEditingController controller, Future<void> closed})>
+  openDialog(WidgetTester tester) async {
+    final controller = TextEditingController(text: 'http://localhos');
+    late Future<void> closed;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.buildTheme(ThemeRegistry.active),
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                // Same presentation path as the real screen: the dialog is
+                // wrapped by showFocusRestoringDialog's back-key handler.
+                closed = showFocusRestoringDialog<void>(
+                  context: context,
+                  builder: (ctx) => AddServerDialog(
+                    l10n: AppLocalizations.of(ctx),
+                    controller: controller,
+                    serverRepo: _MockServerRepository(),
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    return (controller: controller, closed: closed);
+  }
+
+  testWidgets('backspace deletes text instead of closing the dialog', (
+    tester,
+  ) async {
+    final (:controller, :closed) = await openDialog(tester);
+    var didClose = false;
+    closed.then((_) => didClose = true);
+
+    // Desktop branch: plain TextField, autofocused on open.
+    expect(find.byType(TextField), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+    await tester.pump();
+
+    expect(find.byType(AddServerDialog), findsOneWidget);
+    expect(didClose, isFalse);
+    expect(controller.text, 'http://localho');
+  });
+
+  testWidgets('backspace still closes the dialog when not editing text', (
+    tester,
+  ) async {
+    final (:controller, :closed) = await openDialog(tester);
+    var didClose = false;
+    closed.then((_) => didClose = true);
+
+    // Move focus off the field onto the Cancel button: backspace is now
+    // "back", not text editing.
+    tester
+        .widget<OutlinedButton>(
+          find.widgetWithText(OutlinedButton, 'Cancel'),
+        )
+        .focusNode
+        ?.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.backspace);
+    await tester.pumpAndSettle();
+
+    expect(didClose, isTrue);
+    expect(controller.text, 'http://localhos');
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary

Fixes dialogs closing when the user presses Backspace while editing a text field (#800).
showFocusRestoringDialog wraps every dialog in a Focus that pops the route on any back key; on desktop, Backspace in a focused TextField bubbles up through the focus chain into that wrapper, closing the dialog mid-edit. The add-server dialog's own _onDialogKey dismisses the same way one level deeper. Both handlers now exempt the event when primary focus is inside an EditableText, matching the guard the global shortcut scope in app.dart already applies. Backspace with focus anywhere else (buttons, etc.) still dismisses as before.

Note: this is the same symptom as #609 (fixed in 2.3.0 by 3ffe63f3), but a different code path — that fix covered the global handler; the actual close for #800 happens inside the dialog wrapper, which the global handler correctly passes the event to.

## Related Issues
- Fixes #800
- Related to #609

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- lib/ui/widgets/overlay_sheet.dart: showFocusRestoringDialog's back-key wrapper no longer pops the route when primary focus is inside an EditableText — fixes the issue for every dialog using this path
- lib/ui/screens/auth/server_select_screen.dart: same exemption in _onDialogKey, which dismisses one level deeper and would otherwise fire first; _AddServerDialog made public so it can be widget-tested
- test/add_server_dialog_test.dart: new widget test pumping the dialog through the real showFocusRestoringDialog path — verifies Backspace deletes text without closing the dialog when the field is focused, and still closes it when focus is on a button

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [x] macOS
- [x] Windows
- [x] Linux
- [ ] All / Shared code

(Reported on Windows; the fix is in shared key-handling code and applies to desktop platforms.)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Run the new widget tests: flutter test test/add_server_dialog_test.dart — both pass; removing either guard makes the "deletes text" test fail, confirming it reproduces #800
2. Linux debug build: open the Add Server dialog, click the Server Address field, type characters, press Backspace — the character is deleted and the dialog stays open
3. Tab focus to Cancel/Connect and press Backspace — the dialog still dismisses, so back-navigation behavior is unchanged

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

## AI Assistance
Root-cause analysis, fix, and tests were developed with AI assistance (Kimi K3, via OpenCode). The failure chain was verified empirically at each step: the existing global guard was traced with temporary logging in a debug build, the test was confirmed to fail without the fix and pass with it, and the final behavior was verified manually in a Linux debug build. Not manually verified on Windows, though the fix is in platform-shared focus-chain code.