### PR TITLE
fix theme fadeout and media preview deadlock

### DIFF
--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -9,14 +9,16 @@ import '../../preference/user_preferences.dart';
 import '../models/aggregated_item.dart';
 import 'theme_audio_player.dart';
 
-class ThemeMusicService {
+class ThemeMusicService implements AudioOwnable {
   final MediaServerClient _client;
   final UserPreferences _prefs;
   final PlaybackManager _playbackManager;
+  final PlaybackArbiter _audioArbiter;
 
   ThemeAudioPlayer? _player;
   String? _currentThemeSourceId;
   Timer? _fadeTimer;
+  Completer<void>? _fadeCompleter;
   double _targetVolume = 0.0;
   final Set<Object> _activeDetailScreens = {};
   bool _fadingOut = false;
@@ -30,7 +32,13 @@ class ThemeMusicService {
   static const _fadeStepMs = 50;
   static const _validTypes = {'Series', 'Movie', 'Season', 'Episode', 'BoxSet'};
 
-  ThemeMusicService(this._client, this._prefs, this._playbackManager) {
+  ThemeMusicService(
+    this._client,
+    this._prefs,
+    this._playbackManager,
+    this._audioArbiter,
+  ) {
+    _audioArbiter.register(this);
     _mainPlaybackSub = _playbackManager.state.playingStream.listen((isPlaying) {
       if (isPlaying) {
         fadeOutAndStop();
@@ -49,6 +57,14 @@ class ThemeMusicService {
         }
       },
     );
+  }
+
+  @override
+  AudioProducer get audioProducerId => AudioProducer.themeMusic;
+
+  @override
+  Future<void> onAudioRevoked(RevokeReason reason) {
+    return fadeOutAndStop();
   }
 
   void registerDetailScreen(Object token) {
@@ -121,6 +137,15 @@ class ThemeMusicService {
       final url = _buildAudioUrl(songId);
 
       _targetVolume = _prefs.get(UserPreferences.themeMusicVolume) / 100.0;
+
+      // Ask the arbiter for permission to play. This will revoke existing previews if any.
+      await _audioArbiter.acquire(AudioProducer.themeMusic);
+      if (generation != _playGeneration ||
+          _activeDetailScreens.isEmpty ||
+          _externalAudioActive) {
+        return;
+      }
+
       localPlayer = ThemeAudioPlayer.create();
       _player = localPlayer;
 
@@ -186,12 +211,13 @@ class ThemeMusicService {
     });
   }
 
-  void fadeOutAndStop() {
+  Future<void> fadeOutAndStop() {
     final player = _player;
-    if (player == null || _fadingOut) return;
+    if (player == null || _fadingOut) return _fadeCompleter?.future ?? Future.value();
 
     _fadeTimer?.cancel();
     _fadingOut = true;
+    _fadeCompleter = Completer<void>();
     final generation = _playGeneration;
     final currentVolume = player.currentVolume;
     final steps = _fadeDurationMs ~/ _fadeStepMs;
@@ -200,6 +226,9 @@ class ThemeMusicService {
     _fadeTimer = Timer.periodic(Duration(milliseconds: _fadeStepMs), (timer) {
       if (generation != _playGeneration || _player != player) {
         timer.cancel();
+        if (_fadeCompleter != null && !_fadeCompleter!.isCompleted) {
+          _fadeCompleter!.complete();
+        }
         return;
       }
       step++;
@@ -210,6 +239,8 @@ class ThemeMusicService {
         stop();
       }
     });
+
+    return _fadeCompleter!.future;
   }
 
   void stop() {
@@ -228,6 +259,9 @@ class ThemeMusicService {
         player.pause();
       } catch (_) {}
       unawaited(_safeDispose(player));
+    }
+    if (_fadeCompleter != null && !_fadeCompleter!.isCompleted) {
+      _fadeCompleter!.complete();
     }
   }
 

--- a/lib/data/services/theme_music_service.dart
+++ b/lib/data/services/theme_music_service.dart
@@ -113,6 +113,9 @@ class ThemeMusicService implements AudioOwnable {
         _fadeTimer?.cancel();
         _fadeTimer = null;
         _fadingOut = false;
+        if (_fadeCompleter != null && !_fadeCompleter!.isCompleted) {
+          _fadeCompleter!.complete();
+        }
         _fadeIn(_playGeneration);
       }
       return;

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -191,6 +191,7 @@ void _registerUserScopedSingletons() {
       _getIt<MediaServerClient>(),
       _getIt<UserPreferences>(),
       _getIt<PlaybackManager>(),
+      _getIt<PlaybackArbiter>(),
     ),
   );
   _getIt.registerLazySingletonAsync<SeerrRepository>(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1395,17 +1395,15 @@ class _ContentRowsState extends State<_ContentRows>
         return;
       }
       _previewStartScrollOffset = _scrollController.offset;
-      _activePreviewKey = previewKey;
-      _previewReady = false;
       await _startSharedPreview(item, previewKey);
     });
     _previewDelayTimer = thisTimer;
   }
 
-  bool _isPreviewRequestActive(int requestId, String previewKey) {
+  bool _isPreviewRequestActive(int requestId, String? previewKey) {
     return mounted &&
         requestId == _previewRequestId &&
-        _activePreviewKey == previewKey &&
+        (previewKey == null || _activePreviewKey == previewKey) &&
         _isHomeRouteActive();
   }
 
@@ -1499,7 +1497,7 @@ class _ContentRowsState extends State<_ContentRows>
         return;
       }
       final target = await _resolvePreviewTargetItem(client, item);
-      if (!_isPreviewRequestActive(requestId, previewKey) || target == null) {
+      if (!_isPreviewRequestActive(requestId, null) || target == null) {
         return;
       }
 
@@ -1519,6 +1517,11 @@ class _ContentRowsState extends State<_ContentRows>
       final previewVolume = kIsWeb ? 0.0 : (previewAudioEnabled ? 100.0 : 0.0);
       final useMedia3 = _useMedia3InlinePreview();
       await _audioArbiter.acquire(AudioProducer.inlinePreview);
+
+      // Set the key to trigger the video widget once arbiter finishes aquire.
+      _activePreviewKey = previewKey;
+      _previewReady = false;
+
       if (!_isPreviewRequestActive(requestId, previewKey)) {
         return;
       }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -735,6 +735,8 @@ class _ContentRowsState extends State<_ContentRows>
   bool _windowHasFocus = true;
   bool _holdMediaBarWhileSidebarFocused = false;
 
+  String? _pendingPreviewKey;
+
   final ValueNotifier<String?> _activePreviewKeyNotifier = ValueNotifier(null);
   String? get _activePreviewKey => _activePreviewKeyNotifier.value;
   set _activePreviewKey(String? value) {
@@ -1369,13 +1371,13 @@ class _ContentRowsState extends State<_ContentRows>
     int? rowIndex,
   }) {
     final previewKey = _previewKeyFor(item, rowIndex);
-    if (_activePreviewKey == previewKey) {
+    if (_activePreviewKey == previewKey || _pendingPreviewKey == previewKey) {
       return;
     }
 
     _previewDelayTimer?.cancel();
     _previewDelayTimer = null;
-    if (_activePreviewKey != null) {
+    if (_activePreviewKey != null || _pendingPreviewKey != null) {
       _finishSharedPreview();
     }
 
@@ -1395,6 +1397,7 @@ class _ContentRowsState extends State<_ContentRows>
         return;
       }
       _previewStartScrollOffset = _scrollController.offset;
+      _pendingPreviewKey = previewKey;
       await _startSharedPreview(item, previewKey);
     });
     _previewDelayTimer = thisTimer;
@@ -1403,7 +1406,9 @@ class _ContentRowsState extends State<_ContentRows>
   bool _isPreviewRequestActive(int requestId, String? previewKey) {
     return mounted &&
         requestId == _previewRequestId &&
-        (previewKey == null || _activePreviewKey == previewKey) &&
+        (previewKey == null ||
+            _pendingPreviewKey == previewKey ||
+            _activePreviewKey == previewKey) &&
         _isHomeRouteActive();
   }
 
@@ -1411,7 +1416,8 @@ class _ContentRowsState extends State<_ContentRows>
     final previewKey = _previewKeyFor(item, rowIndex);
     _previewDelayTimer?.cancel();
     _previewDelayTimer = null;
-    if (_activePreviewKey == previewKey && mounted) {
+    if ((_activePreviewKey == previewKey || _pendingPreviewKey == previewKey) &&
+        mounted) {
       _finishSharedPreview();
     }
   }
@@ -1449,9 +1455,10 @@ class _ContentRowsState extends State<_ContentRows>
       _appleTvPreviewPlayer = null;
     }
 
-    if (_activePreviewKey != null || _previewReady) {
+    if (_activePreviewKey != null || _previewReady || _pendingPreviewKey != null) {
       _activePreviewKey = null;
       _previewReady = false;
+      _pendingPreviewKey = null;
     }
     _themeMusicService.setExternalAudioActive(false);
   }
@@ -1518,13 +1525,15 @@ class _ContentRowsState extends State<_ContentRows>
       final useMedia3 = _useMedia3InlinePreview();
       await _audioArbiter.acquire(AudioProducer.inlinePreview);
 
-      // Set the key to trigger the video widget once arbiter finishes aquire.
-      _activePreviewKey = previewKey;
-      _previewReady = false;
-
       if (!_isPreviewRequestActive(requestId, previewKey)) {
         return;
       }
+
+      // Set the key to trigger the video widget once arbiter finishes aquire.
+      _activePreviewKey = previewKey;
+      _pendingPreviewKey = null;
+      _previewReady = false;
+
       if (useMedia3) {
         _previewUsingMedia3 = true;
         await _media3PreviewBackend!.setVolume(previewVolume);

--- a/packages/playback_core/lib/src/playback_arbiter.dart
+++ b/packages/playback_core/lib/src/playback_arbiter.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-enum AudioProducer { mainPlayback, mediaBarTrailer, inlinePreview }
+enum AudioProducer { mainPlayback, mediaBarTrailer, inlinePreview, themeMusic }
 
 enum RevokeReason { exclusive, background }
 
@@ -45,5 +45,7 @@ class PlaybackArbiter {
   }
 
   static bool _isAmbient(AudioProducer p) =>
-      p == AudioProducer.mediaBarTrailer || p == AudioProducer.inlinePreview;
+      p == AudioProducer.mediaBarTrailer ||
+      p == AudioProducer.inlinePreview ||
+      p == AudioProducer.themeMusic;
 }


### PR DESCRIPTION
## Summary
Fixes a deadlock on Android TV that caused a ~10s hang in the player when returning from a detail screen to the home screen. The hang occurred because the theme music player and the media preview player were competing for the same locks during the theme's fade-out.

There's still some issue with enabling themes and previews at the same time on home screen that could be looked at.  It'd probably need to get themes moved out of the homeshell so they could cooperate more easily.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
ThemeMusicService
- Implemented AudioOwnable: Registered the ThemeMusicService with the PlaybackArbiter as a new AudioProducer.themeMusic type.
- Updated fadeOutAndStop() to return a Future using a Completer. This allows the arbiter to synchronize the hand-off between audio sources.
- when a preview or movie takes over, onAudioRevoked now ensures the theme fully completes its fade and native disposal before releasing the arbiter lock.

HomeScreen
- Previews call arbiter's aquire to ensure theme music fades out first before attempting to play.
- Video widget for previews isn't created until after the arbiter has acquired the audio lock. 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. go to details with a theme and let it play
2. return to home screen
3. verify theme fades out within it's 2s window
4. verify media preview starts more quickly after theme is finished
## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
