### PR TITLE
Fix 3D Video Setup not selectable on Android API 30+ (XGIMI Halo+)

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -473,10 +473,7 @@ class Media3VideoView(
     private fun newVideoView(): View =
         if (useSurfaceView) {
             SurfaceView(context).apply {
-                // Legacy hybrid composition (older devices without Impeller) otherwise composites
-                // this platform-view SurfaceView behind Flutter and the video renders black; lift it
-                // as a media overlay so it stays visible. The Flutter controls still draw on top.
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) setZOrderMediaOverlay(true)
+                setZOrderMediaOverlay(true)
             }
         } else {
             TextureView(context)


### PR DESCRIPTION
## Summary
Some Android TV/projector devices key their own system-level 3D toggle off the video surface being a real hardware overlay layer. Moonfin only ever lifted its video `SurfaceView` into that layer on Android below API 30, so on API 30+ those devices never recognized Moonfin as doing video playback and refused to enable 3D at all - confirmed on an XGIMI Halo+ (Android 11 / API 30).

## Related Issues
- Closes #224

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Call `setZOrderMediaOverlay(true)` on the video `SurfaceView` on all Android versions instead of only below API 30

## Platform
- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video on an affected device (e.g. XGIMI Halo+)
2. Open the device's 3D Video Setup menu while playback is running
3. Confirm the 3D mode options are selectable instead of showing "3D Mode is supported only with video playbacks"

Only physically verified on one device so far (XGIMI Halo+, Android 11/API 30) - not yet cross-tested on other phones/TV boxes/newer Android versions, so extra eyes from anyone with different Android hardware would help before merge.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced