### PR TITLE
fix(audio): fix Continue Listening

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7765,7 +7765,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 parentId: item.id,
                 includeItemTypes: const ['Audio'],
                 sortBy: 'ParentIndexNumber,IndexNumber,SortName',
-                fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+                fields: 'PrimaryImageAspectRatio,BasicSyncInfo,UserData,RunTimeTicks',
               );
               tracks = _mapRawItemsForServer(data['Items'], item.serverId);
             }
@@ -7779,7 +7779,25 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               }
               throw PlaybackStartupRecoveryAbortedException();
             }
-            await manager.playItems(tracks);
+            int albumStartIndex = 0;
+            Duration albumStartPos = Duration.zero;
+            if (resume) {
+              final resumeIdx = tracks.indexWhere(
+                (e) =>
+                    !e.isPlayed &&
+                    ((e.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+                        (e.playedPercentage ?? 0) > 0),
+              );
+              if (resumeIdx >= 0) {
+                albumStartIndex = resumeIdx;
+                albumStartPos = tracks[resumeIdx].playbackPosition ?? Duration.zero;
+              }
+            }
+            await manager.playItems(
+              tracks,
+              startIndex: albumStartIndex,
+              startPosition: albumStartPos,
+            );
             break;
 
           case 'Playlist':
@@ -7800,15 +7818,30 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               throw PlaybackStartupRecoveryAbortedException();
             }
             if (!context.mounted) return;
-            // Playlists can contain video, so honor the Dolby Vision
-            // force-transcode check before allowing direct play/stream.
             final dvForceTranscode = await _shouldForceTranscodeForDolbyVision(
               context,
               tracks,
             );
             final directAllowed = !dvForceTranscode && !forceTranscode;
+            int playlistStartIndex = 0;
+            Duration playlistStartPos = Duration.zero;
+            if (resume) {
+              final resumeIdx = tracks.indexWhere(
+                (e) =>
+                    !e.isPlayed &&
+                    ((e.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+                        (e.playedPercentage ?? 0) > 0),
+              );
+              if (resumeIdx >= 0) {
+                playlistStartIndex = resumeIdx;
+                playlistStartPos =
+                    tracks[resumeIdx].playbackPosition ?? Duration.zero;
+              }
+            }
             await manager.playItems(
               tracks,
+              startIndex: playlistStartIndex,
+              startPosition: playlistStartPos,
               enableDirectPlay: directAllowed,
               enableDirectStream: directAllowed,
             );
@@ -7817,7 +7850,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           case 'AudioBook':
             final client = _clientForItem(item);
             const audioChildFields =
-                'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,MediaSources,MediaSourceCount,MediaType,IndexNumber,ParentIndexNumber,Artists,AlbumArtist,Genres,Chapters';
+                'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,MediaSources,MediaSourceCount,MediaType,IndexNumber,ParentIndexNumber,Artists,AlbumArtist,Genres,Chapters,UserData';
             bool isAudioChild(dynamic e) {
               final childType = e is Map ? e['Type']?.toString() : null;
               return childType == 'Audio' || childType == 'AudioBook';
@@ -7836,8 +7869,31 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final rawChildren = (data['Items'] as List?) ?? const [];
             final childItems = rawChildren.where(isAudioChild).toList();
             if (childItems.isNotEmpty) {
+              final children = _mapRawItemsForServer(childItems, item.serverId);
+              int startIndex = 0;
+              Duration startPos = Duration.zero;
+              if (resume) {
+                final resumeIdx = children.indexWhere(
+                  (e) =>
+                      !e.isPlayed &&
+                      ((e.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+                          (e.playedPercentage ?? 0) > 0),
+                );
+                if (resumeIdx >= 0) {
+                  startIndex = resumeIdx;
+                  startPos =
+                      children[resumeIdx].playbackPosition ?? Duration.zero;
+                } else {
+                  final nextUnplayed = children.indexWhere((e) => !e.isPlayed);
+                  if (nextUnplayed >= 0) {
+                    startIndex = nextUnplayed;
+                  }
+                }
+              }
               await manager.playItems(
-                _mapRawItemsForServer(childItems, item.serverId),
+                children,
+                startIndex: startIndex,
+                startPosition: startPos,
               );
               break;
             }
@@ -7859,7 +7915,17 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               );
               final startIndex = siblings.indexWhere((t) => t.id == item.id);
               if (siblings.isNotEmpty && startIndex >= 0) {
-                await manager.playItems(siblings, startIndex: startIndex);
+                final targetSibling = siblings[startIndex];
+                final startPos = resume
+                    ? (targetSibling.playbackPosition ??
+                        item.playbackPosition ??
+                        Duration.zero)
+                    : Duration.zero;
+                await manager.playItems(
+                  siblings,
+                  startIndex: startIndex,
+                  startPosition: startPos,
+                );
                 break;
               }
             }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7780,7 +7780,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               throw PlaybackStartupRecoveryAbortedException();
             }
             int albumStartIndex = 0;
-            Duration albumStartPos = Duration.zero;
             if (resume) {
               final resumeIdx = tracks.indexWhere(
                 (e) =>
@@ -7790,13 +7789,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               );
               if (resumeIdx >= 0) {
                 albumStartIndex = resumeIdx;
-                albumStartPos = tracks[resumeIdx].playbackPosition ?? Duration.zero;
               }
             }
+            // Music remembers which track was playing but starts it from the
+            // beginning, matching standard music player behavior.
             await manager.playItems(
               tracks,
               startIndex: albumStartIndex,
-              startPosition: albumStartPos,
             );
             break;
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -23,6 +23,7 @@ import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
+import '../../../widgets/marquee_text.dart';
 import '../../../widgets/media_card.dart';
 import '../../../widgets/rating_display.dart';
 import '../../../widgets/focus/focusable_wrapper.dart';
@@ -790,6 +791,35 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   bool _isAudiobook(AggregatedItem item) =>
       item.type == 'AudioBook' ||
       (item.type == 'Book' && item.rawData['MediaType'] == 'Audio');
+
+  String? _getAuthorName(AggregatedItem item) {
+    if (item.artists.isNotEmpty) {
+      return item.artists.join(', ');
+    }
+    if (item.albumArtist != null && item.albumArtist!.trim().isNotEmpty) {
+      return item.albumArtist!.trim();
+    }
+    if (item.albumArtists.isNotEmpty) {
+      final name = item.albumArtists.first['Name'] as String?;
+      if (name != null && name.trim().isNotEmpty) return name.trim();
+    }
+    if (item.seriesName != null && item.seriesName!.trim().isNotEmpty) {
+      return item.seriesName!.trim();
+    }
+    final rawAuthor =
+        item.rawData['Author'] as String? ?? item.rawData['Writer'] as String?;
+    if (rawAuthor != null && rawAuthor.trim().isNotEmpty) return rawAuthor.trim();
+
+    final people = item.people;
+    for (final p in people) {
+      final role = p['Type']?.toString() ?? p['Role']?.toString() ?? '';
+      if (role == 'Author' || role == 'Writer') {
+        final name = p['Name'] as String?;
+        if (name != null && name.trim().isNotEmpty) return name.trim();
+      }
+    }
+    return null;
+  }
 
   List<_ModernTab> _tabsFor(AggregatedItem item, AppLocalizations l10n) {
     final hasCast = _vm.actors.isNotEmpty;
@@ -3292,12 +3322,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
 
     final isMusicAlbumOrPlaylist = item.type == 'Playlist' || item.type == 'MusicAlbum';
-    if (isMusicAlbumOrPlaylist) {
+    final isAudiobookOrBook = item.type == 'AudioBook' ||
+        item.type == 'Book' ||
+        (item.type == 'Audio' && item.isAudioLike) ||
+        item.isAudiobook;
+
+    if (isMusicAlbumOrPlaylist || isAudiobookOrBook) {
       final l10n = AppLocalizations.of(context);
       final coverUrl = _imageUrl(item);
+      final isBookLayout = isAudiobookOrBook || item.type == 'Book';
       final coverImage = Container(
         width: 180,
-        height: 180,
+        height: isBookLayout ? 240 : 180,
         decoration: BoxDecoration(
           borderRadius: AppRadius.circular(12),
           border: Border.all(
@@ -3322,7 +3358,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               : Container(
                   color: Colors.white.withValues(alpha: 0.05),
                   child: Icon(
-                    item.type == 'MusicAlbum' ? Icons.album : Icons.playlist_play,
+                    isBookLayout
+                        ? Icons.menu_book
+                        : (item.type == 'MusicAlbum' ? Icons.album : Icons.playlist_play),
                     color: Colors.white24,
                     size: 64,
                   ),
@@ -3330,22 +3368,29 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ),
       );
 
-      final artistName = item.albumArtist;
+      final authorOrArtistName = isBookLayout
+          ? (_getAuthorName(item) ?? item.albumArtist)
+          : item.albumArtist;
 
       final playlistInfo = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text(
-            item.name,
-            style: textTheme.displaySmall?.copyWith(
-              fontWeight: FontWeight.w700,
-              color: Colors.white,
-              shadows: _neonTextGlow(12),
+          ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: _landscape ? 600 : (MediaQuery.sizeOf(context).width - 40),
+            ),
+            child: MarqueeText(
+              text: item.name,
+              style: textTheme.displaySmall?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: Colors.white,
+                shadows: _neonTextGlow(12),
+              ) ?? const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 28),
             ),
           ),
-          if (item.type == 'MusicAlbum' && artistName != null) ...[
-            const SizedBox(height: 4),
+          if (authorOrArtistName != null && authorOrArtistName.trim().isNotEmpty) ...[
+            const SizedBox(height: 6),
             Focus(
               focusNode: _artistFocusNode,
               onKeyEvent: (node, event) {
@@ -3399,7 +3444,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                             : null,
                       ),
                       child: Text(
-                        artistName,
+                        authorOrArtistName,
                         style: textTheme.titleMedium?.copyWith(
                           color: AppColorScheme.accent,
                           fontWeight: FontWeight.bold,
@@ -3415,15 +3460,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           const SizedBox(height: 8),
           Text(
             () {
-              final count = _vm.tracks.length;
-              final trackText = l10n.trackCount(count);
               final parts = <String>[];
-              if (item.type == 'MusicAlbum' && item.productionYear != null) {
+              if (item.productionYear != null) {
                 parts.add(item.productionYear.toString());
               }
-              parts.add(trackText);
+              final runtime = item.runtime;
+              if (runtime != null && runtime.inMinutes > 0) {
+                parts.add(_formatDuration(runtime));
+              } else if (!isBookLayout && _vm.tracks.isNotEmpty) {
+                final count = _vm.tracks.length;
+                parts.add(l10n.trackCount(count));
+              }
+              if (isAudiobookOrBook) {
+                parts.add(l10n.audiobooks);
+              }
               if (item.genres.isNotEmpty) {
-                final genresList = item.type == 'Playlist' ? item.genres : item.genres.take(2);
+                final genresList = item.genres.take(2);
                 parts.add(genresList.join(', '));
               }
               return parts.join(' • ');
@@ -3457,9 +3509,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               downTarget: _vm.tracks.isNotEmpty
                   ? _trackFocusNodes.putIfAbsent(_vm.tracks.first.id, () => FocusNode())
                   : null,
-              upTarget: item.type == 'MusicAlbum' && artistName != null
-                  ? _artistFocusNode
-                  : null,
+              upTarget: authorOrArtistName != null ? _artistFocusNode : null,
               autoPlay: widget.autoPlay,
               modernStyle: true,
               fullWidthPrimary: !_landscape,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3465,7 +3465,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 parts.add(item.productionYear.toString());
               }
               final runtime = item.runtime;
-              if (runtime != null && runtime.inMinutes > 0) {
+              if (isBookLayout && runtime != null && runtime.inMinutes > 0) {
                 parts.add(_formatDuration(runtime));
               } else if (!isBookLayout && _vm.tracks.isNotEmpty) {
                 final count = _vm.tracks.length;
@@ -3509,7 +3509,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               downTarget: _vm.tracks.isNotEmpty
                   ? _trackFocusNodes.putIfAbsent(_vm.tracks.first.id, () => FocusNode())
                   : null,
-              upTarget: authorOrArtistName != null ? _artistFocusNode : null,
+              upTarget:
+                  authorOrArtistName != null && authorOrArtistName.trim().isNotEmpty
+                      ? _artistFocusNode
+                      : null,
               autoPlay: widget.autoPlay,
               modernStyle: true,
               fullWidthPrimary: !_landscape,


### PR DESCRIPTION
# Pull Request

## Summary
Fixes two issues with the audiobook and audio "Continue Listening" feature: missing metadata (cover art, author info, marquee title) on the item detail screen, and playback position resetting to 0:00 when clicking the Resume button. Note per standard music player design:

1. Music Songs / Tracks: Standard music player design (and Jellyfin's server behavior) remembers the album that was playing and the track but resumes music at the start of the track (00:00). Resuming mid-song after closing the app or returning to an album is usually jarring for music listening, so the player starts it from the beginning.
2. Audiobooks & Podcasts: Because long-form audio requires precise progress tracking, the mm:ss / hh:mm:ss timestamp is saved so we can resume from the exact value.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated _buildHero in modern_detail_content.dart to support AudioBook, Book, and Audio items with cover image (_imageUrl(item)), author name formatting (_getAuthorName(item)), marquee scrolling title via MarqueeText, and duration metadata line.
- Updated _playInternal under case 'AudioBook':, case 'MusicAlbum':, and case 'Playlist': in item_detail_screen.dart to pass startIndex and startPosition (derived from track playbackPosition/UserData) into manager.playItems when resuming playback.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Audiobooks library or Continue Listening shelf.
2. Select an Audiobook with saved progress (e.g. at 1h 33m).
3. Verify cover art, author name, marquee title scrolling, and metadata are correctly displayed on the item detail screen.
4. Click "Resume from 1h 33m" button and confirm audio player opens and resumes playback at 1h 33m instead of 0:00.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### OLD INTERFACE/BEHAVIOUR:
<img width="1280" height="2856" alt="Screenshot_20260722-125403" src="https://github.com/user-attachments/assets/66da0e92-52e5-4f87-9804-4ddf80dd64b3" />
<img width="1280" height="2856" alt="Screenshot_20260722-125411" src="https://github.com/user-attachments/assets/f364f88a-e134-44cb-9d77-39f7858ee0ab" />
<img width="1280" height="2856" alt="Screenshot_20260722-125418" src="https://github.com/user-attachments/assets/3d19ec2b-5808-4c08-9b0d-2f84a951d27a" />

### UPDATED INTERFACE/BEHAVIOUR:

Audiobooks (some minimal adjustment to details page):
<img width="1280" height="2856" alt="Screenshot_20260722-174937" src="https://github.com/user-attachments/assets/cba96911-4e49-4eba-bded-e7db6e89a135" />
<img width="1280" height="2856" alt="Screenshot_20260722-174949" src="https://github.com/user-attachments/assets/016aaba9-3331-46b2-b7b1-06b74f065dcd" />

Music (remembers album/song position):
<img width="1280" height="2856" alt="Screenshot_20260722-175057" src="https://github.com/user-attachments/assets/d4326f5d-edb1-46b8-ac7d-adb169159af7" />
<img width="1280" height="2856" alt="Screenshot_20260722-175042" src="https://github.com/user-attachments/assets/d65649bf-2340-41c6-9a4e-2aaf42775ba7" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
