### PR TITLE
feat(audio) - Add Songs sublibrary to Audio page for ULTIMATE RANDOMNESS

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -496,7 +496,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         .whereType<AggregatedItem>()
         .toList();
 
-    if (selectedLetter != null && selectedLetter.isNotEmpty) {
+    if (isSongsBrowse && selectedLetter != null && selectedLetter.isNotEmpty) {
       if (isNumericBucket) {
         mapped = mapped.where((item) {
           final name = (item.sortName ?? item.name).trim().toUpperCase();

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -33,7 +33,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   static const _libraryMetaFields = '';
 
   static const _browseFields =
-      'PrimaryImageAspectRatio,SortName,Type,IsFolder,UserData,CommunityRating,OfficialRating,RunTimeTicks,ProductionYear,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag';
+      'PrimaryImageAspectRatio,SortName,Type,IsFolder,UserData,CommunityRating,OfficialRating,RunTimeTicks,ProductionYear,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,Album,AlbumId,AlbumArtist,Artists';
   // Cap image tags to one per type (server returns all by default)
   static const _imageTypes = 'Primary,Backdrop,Thumb,Banner';
   static const _imageTypeLimit = 1;
@@ -201,7 +201,13 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     }
   }
 
-  String get _prefKey => genreId ?? studioName ?? libraryId;
+  String get _prefKey {
+    final baseKey = genreId ?? studioName ?? libraryId;
+    if (includeItemTypes != null && includeItemTypes!.isNotEmpty) {
+      return '${baseKey}_${includeItemTypes!.join("_")}';
+    }
+    return baseKey;
+  }
 
   String get _imagePrefKey {
     if (genreId != null && libraryId.isNotEmpty) {
@@ -403,10 +409,19 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'SortName';
     }
 
+    final isSongsBrowse =
+        includeItemTypes != null &&
+        includeItemTypes!.length == 1 &&
+        includeItemTypes!.first == 'Audio';
+
     final selectedLetter = _letterFilter.isEmpty ? null : _letterFilter;
     final isNumericBucket = selectedLetter == '#';
-    final nameStartsWith = isNumericBucket ? null : selectedLetter;
-    final nameLessThan = isNumericBucket ? 'A' : null;
+    final nameStartsWith =
+        (isSongsBrowse || isNumericBucket) ? null : selectedLetter;
+    final nameLessThan =
+        (isSongsBrowse || !isNumericBucket) ? null : 'A';
+    final fetchLimit =
+        (isSongsBrowse && selectedLetter != null) ? 500 : pageSize;
 
     final Map<String, dynamic> response;
     if (isAlbumArtistBrowse) {
@@ -454,7 +469,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
             ? 'Ascending'
             : 'Descending',
         startIndex: startIndex,
-        limit: pageSize,
+        limit: fetchLimit,
         recursive: recursive,
         fields: _browseFields,
         filters: filters.isEmpty ? null : filters,
@@ -466,7 +481,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     }
 
     final rawItems = (response['Items'] as List?) ?? [];
-    final mapped = rawItems
+    var mapped = rawItems
         .whereType<Map>()
         .map((raw) => raw.cast<String, dynamic>())
         .map((raw) {
@@ -480,6 +495,21 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         })
         .whereType<AggregatedItem>()
         .toList();
+
+    if (selectedLetter != null && selectedLetter.isNotEmpty) {
+      if (isNumericBucket) {
+        mapped = mapped.where((item) {
+          final name = (item.sortName ?? item.name).trim().toUpperCase();
+          return name.isNotEmpty && !RegExp(r'^[A-Z]').hasMatch(name);
+        }).toList();
+      } else {
+        final prefix = selectedLetter.toUpperCase();
+        mapped = mapped.where((item) {
+          final name = (item.sortName ?? item.name).trim().toUpperCase();
+          return name.startsWith(prefix);
+        }).toList();
+      }
+    }
 
     final filtered = await _filterLibraryItems(mapped);
 

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -360,7 +360,10 @@ enum LibrarySortBy {
   runtime('Runtime', 'Runtime'),
   random('Random', 'Random'),
   criticRating('CriticRating', 'Critic Rating'),
-  communityRating('CommunityRating', 'Community Rating');
+  communityRating('CommunityRating', 'Community Rating'),
+  albumArtist('AlbumArtist,Album,SortName', 'Album Artist'),
+  album('Album,SortName', 'Album'),
+  genre('Genre,SortName', 'Genre');
 
   const LibrarySortBy(this.apiValue, this.displayName);
   final String apiValue;

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
+import 'package:playback_core/playback_core.dart';
 
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/mdblist_repository.dart';
@@ -26,6 +27,7 @@ import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/media_card.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/rating_display.dart';
+import '../detail/item_detail_screen.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -614,6 +616,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                       return AppLocalizations.of(context).albumArtists;
                     } else if (type == 'MusicArtist') {
                       return AppLocalizations.of(context).artists;
+                    } else if (type == 'Audio') {
+                      return AppLocalizations.of(context).songs;
                     }
                   }
                   return _vm.libraryName;
@@ -640,6 +644,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     : context.pop(),
                 onSort: () => _showFilterSortDialog(context),
                 onSettings: () => _showSettingsDialog(context),
+                onShuffle: _isSongsBrowse ? () => _shuffleSongsLibrary() : null,
                 onLetterChanged: (l) => _vm.setLetterFilter(l),
                 onPlayedFilterChanged: (status) => _vm.setPlayedFilter(status),
               ),
@@ -676,6 +681,46 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     );
   }
 
+  bool get _isSongsBrowse =>
+      _vm.includeItemTypes != null &&
+      _vm.includeItemTypes!.contains('Audio');
+
+  Future<void> _playSongFromIndex(int index) async {
+    final manager = GetIt.instance<PlaybackManager>();
+    await manager.playItems(_vm.items, startIndex: index);
+    if (!mounted) return;
+    context.push(Destinations.audioPlayer);
+  }
+
+  Future<void> _shuffleSongsLibrary() async {
+    final client = GetIt.instance<MediaServerClientFactory>()
+        .clientForServerOrActive(widget.serverId);
+    try {
+      final response = await client.itemsApi.getItems(
+        parentId: widget.libraryId,
+        includeItemTypes: const ['Audio'],
+        recursive: true,
+        sortBy: 'Random',
+        limit: 300,
+        fields: 'PrimaryImageAspectRatio,SortName,Type,IsFolder,UserData,CommunityRating,OfficialRating,RunTimeTicks,ProductionYear,ProviderIds,ImageTags,BackdropImageTags,ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,Album,AlbumId,AlbumArtist,Artists',
+      );
+      final rawItems = (response['Items'] as List?) ?? [];
+      final mapped = rawItems
+          .whereType<Map>()
+          .map((raw) => AggregatedItem(
+                id: raw['Id']?.toString() ?? '',
+                serverId: client.baseUrl,
+                rawData: raw.cast<String, dynamic>(),
+              ))
+          .toList();
+      if (mapped.isEmpty) return;
+      final manager = GetIt.instance<PlaybackManager>();
+      await manager.playItems(mapped);
+      if (!mounted) return;
+      context.push(Destinations.audioPlayer);
+    } catch (_) {}
+  }
+
   Widget _buildBody() {
     return switch (_vm.state) {
       LibraryBrowseState.loading => Center(
@@ -698,8 +743,42 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           ],
         ),
       ),
-      LibraryBrowseState.ready => _buildGrid(),
+      LibraryBrowseState.ready => _isSongsBrowse ? _buildSongsList() : _buildGrid(),
     };
+  }
+
+  Widget _buildSongsList() {
+    if (_vm.items.isEmpty) {
+      return Center(
+        child: Text(
+          AppLocalizations.of(context).noItemsFound,
+          style: const TextStyle(color: Colors.white70),
+        ),
+      );
+    }
+    final isMobile = _isCompact(context);
+    final hPad = isMobile ? 16.0 : _horizontalPadding;
+
+    return CustomScrollView(
+      controller: _scrollController,
+      slivers: [
+        SliverPadding(
+          padding: EdgeInsets.fromLTRB(hPad, 8, hPad, 32),
+          sliver: SliverToBoxAdapter(
+            child: DetailTrackList(
+              tracks: _vm.items,
+              showAlbum: true,
+              getFocusNode: (id) {
+                final index = _vm.items.indexWhere((item) => item.id == id);
+                return getGridItemFocusNode(index < 0 ? 0 : index);
+              },
+              onPlayTrack: (index) => _playSongFromIndex(index),
+              onTrackFocused: (item) => _onItemFocused(item),
+            ),
+          ),
+        ),
+      ],
+    );
   }
 
   Widget _buildGrid() {
@@ -973,6 +1052,7 @@ class _LibraryHeader extends StatelessWidget {
   final VoidCallback onBack;
   final VoidCallback onSort;
   final VoidCallback onSettings;
+  final VoidCallback? onShuffle;
   final ValueChanged<String> onLetterChanged;
   final ValueChanged<PlayedStatusFilter> onPlayedFilterChanged;
 
@@ -994,6 +1074,7 @@ class _LibraryHeader extends StatelessWidget {
     required this.onBack,
     required this.onSort,
     required this.onSettings,
+    this.onShuffle,
     required this.onLetterChanged,
     required this.onPlayedFilterChanged,
   });
@@ -1006,9 +1087,12 @@ class _LibraryHeader extends StatelessWidget {
     final isLandscape = size.width > size.height;
     final isCompactLandscape = isMobile && isLandscape;
     final isCompactPortrait = isMobile && !isLandscape;
-    final showInlineAlpha =
-        sortBy == LibrarySortBy.name && (!isMobile || isCompactLandscape);
-    final showBelowAlpha = sortBy == LibrarySortBy.name && isCompactPortrait;
+    final showAlpha = isMusicBrowse ||
+        sortBy == LibrarySortBy.name ||
+        sortBy == LibrarySortBy.albumArtist ||
+        sortBy == LibrarySortBy.album;
+    final showInlineAlpha = showAlpha && (!isMobile || isCompactLandscape);
+    final showBelowAlpha = showAlpha && isCompactPortrait;
     final topPad = (isMobile ? MediaQuery.of(context).padding.top : 0.0) + 8.0;
     final hPad = isMobile ? 16.0 : _horizontalPadding * desktopScale;
 
@@ -1082,6 +1166,16 @@ class _LibraryHeader extends StatelessWidget {
                 unfocusedIconAlpha: 128,
                 onTap: onSort,
               ),
+              if (onShuffle != null) ...[
+                SizedBox(width: 2 * desktopScale),
+                FocusableToolbarButton(
+                  icon: Icons.shuffle,
+                  size: 30 * desktopScale,
+                  iconSize: 20 * desktopScale,
+                  unfocusedIconAlpha: 128,
+                  onTap: onShuffle!,
+                ),
+              ],
               if (!isMusicBrowse) ...[
                 SizedBox(width: 2 * desktopScale),
                 FocusableToolbarButton(
@@ -1435,6 +1529,8 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
   Widget build(BuildContext context) {
     final vm = widget.vm;
     final isBookBrowse = vm.isBookLibrary;
+    final isSongsBrowse =
+        vm.includeItemTypes != null && vm.includeItemTypes!.contains('Audio');
     final accent = _jellyfinBlue;
     final l10n = AppLocalizations.of(context);
     final surfaceColor = AppColorScheme.surface.withValues(alpha: 0.92);
@@ -1472,22 +1568,47 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
             ),
             Divider(color: dividerColor),
             _sectionHeader(l10n.sortBy, sectionColor),
-            for (final option
-                in (vm.isHomeVideosLibrary || vm.isMixedContentLibrary)
-                    ? const [
-                        LibrarySortBy.name,
-                        LibrarySortBy.dateAdded,
-                        LibrarySortBy.random,
-                      ]
-                    : LibrarySortBy.values.where((o) => !vm.isMusicBrowse || (
-                        o != LibrarySortBy.rating &&
-                        o != LibrarySortBy.criticRating &&
-                        o != LibrarySortBy.communityRating
-                      )))
+            for (final option in () {
+              if (vm.isHomeVideosLibrary || vm.isMixedContentLibrary) {
+                return const [
+                  LibrarySortBy.name,
+                  LibrarySortBy.dateAdded,
+                  LibrarySortBy.random,
+                ];
+              }
+              if (isSongsBrowse) {
+                return const [
+                  LibrarySortBy.name,
+                  LibrarySortBy.dateAdded,
+                  LibrarySortBy.albumArtist,
+                  LibrarySortBy.album,
+                  LibrarySortBy.premiereDate,
+                  LibrarySortBy.runtime,
+                  LibrarySortBy.random,
+                ];
+              }
+              return LibrarySortBy.values.where((o) =>
+                  (!vm.isMusicBrowse ||
+                      (o != LibrarySortBy.rating &&
+                          o != LibrarySortBy.criticRating &&
+                          o != LibrarySortBy.communityRating)) &&
+                  (vm.isMusicBrowse ||
+                      (o != LibrarySortBy.albumArtist &&
+                          o != LibrarySortBy.album &&
+                          o != LibrarySortBy.genre)));
+            }())
               _DialogRadioTile(
-                label: (vm.isMusicBrowse && option == LibrarySortBy.premiereDate)
-                    ? 'Release Date'
-                    : option.displayName,
+                label: () {
+                  if (option == LibrarySortBy.runtime &&
+                      (vm.isMusicBrowse || isSongsBrowse)) {
+                    return 'Length';
+                  }
+                  if (option == LibrarySortBy.premiereDate &&
+                      (vm.isMusicBrowse || isSongsBrowse)) {
+                    return 'Release Date';
+                  }
+                  return option.displayName;
+                }(),
                 selected: vm.sortBy == option,
                 trailing: vm.sortBy == option
                     ? Padding(

--- a/lib/ui/screens/browse/music_browse_screen.dart
+++ b/lib/ui/screens/browse/music_browse_screen.dart
@@ -46,14 +46,19 @@ List<_MusicCategory> _musicCategories(BuildContext context, String libraryId) {
   final l10n = AppLocalizations.of(context);
   return [
     _MusicCategory(
+      Icons.person,
+      l10n.artists,
+      Destinations.library(libraryId, includeItemTypes: const ['AlbumArtist']),
+    ),
+    _MusicCategory(
       Icons.album,
       l10n.albums,
       Destinations.library(libraryId, includeItemTypes: const ['MusicAlbum']),
     ),
     _MusicCategory(
-      Icons.person,
-      l10n.artists,
-      Destinations.library(libraryId, includeItemTypes: const ['AlbumArtist']),
+      Icons.music_note,
+      l10n.songs,
+      Destinations.library(libraryId, includeItemTypes: const ['Audio']),
     ),
     _MusicCategory(
       Icons.queue_music,
@@ -1599,8 +1604,8 @@ Future<void> _playTrackDirectly(BuildContext context, AggregatedItem item) async
 
     if (albumId != null && albumId.isNotEmpty) {
       final factory = GetIt.instance<MediaServerClientFactory>();
-      final client = item.serverId != null
-          ? factory.getClientIfExists(item.serverId!) ??
+      final client = item.serverId.isNotEmpty
+          ? factory.getClientIfExists(item.serverId) ??
                 GetIt.instance<MediaServerClient>()
           : GetIt.instance<MediaServerClient>();
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13725,6 +13725,7 @@ class DetailTrackList extends StatelessWidget {
   final ValueChanged<int>? onMoveUp;
   final ValueChanged<int>? onMoveDown;
   final bool isPlaylist;
+  final bool showAlbum;
   final ImageApi? imageApi;
 
   const DetailTrackList({
@@ -13741,6 +13742,7 @@ class DetailTrackList extends StatelessWidget {
     this.onMoveUp,
     this.onMoveDown,
     this.isPlaylist = false,
+    this.showAlbum = false,
     this.imageApi,
   });
 
@@ -13775,6 +13777,7 @@ class DetailTrackList extends StatelessWidget {
             onMoveDown: onMoveDown,
             isAudiobook: isAudiobook,
             isPlaylist: isPlaylist,
+            showAlbum: showAlbum,
             imageApi: imageApi,
           );
         },
@@ -13826,6 +13829,7 @@ class DetailTrackList extends StatelessWidget {
           onMoveDown: onMoveDown,
           isAudiobook: isAudiobook,
           isPlaylist: isPlaylist,
+          showAlbum: showAlbum,
           imageApi: imageApi,
         ),
       );
@@ -13844,6 +13848,7 @@ class _TrackTile extends StatefulWidget {
   final VoidCallback? onArrowUp;
   final bool isAudiobook;
   final bool isPlaylist;
+  final bool showAlbum;
   final ImageApi? imageApi;
   final int index;
   final int currentIndex;
@@ -13863,6 +13868,7 @@ class _TrackTile extends StatefulWidget {
     this.onArrowUp,
     this.isAudiobook = false,
     this.isPlaylist = false,
+    this.showAlbum = false,
     this.imageApi,
     required this.index,
     required this.currentIndex,
@@ -14011,6 +14017,15 @@ class _TrackTileState extends State<_TrackTile> with FocusStateMixin {
             final artistText = widget.track.artists.isNotEmpty
                 ? widget.track.artists.join(', ')
                 : widget.track.albumArtist ?? '';
+            if (widget.showAlbum) {
+              final albumText = widget.track.album ?? widget.track.rawData['Album'] as String?;
+              if (albumText != null && albumText.isNotEmpty) {
+                if (artistText.isNotEmpty) {
+                  return '$albumText • $artistText';
+                }
+                return albumText;
+              }
+            }
             return artistText.isNotEmpty ? artistText : null;
           }();
 


### PR DESCRIPTION
# Pull Request

## Summary
Adds a new **Songs** sublibrary to the Audio navigation page, displaying individual tracks in a list format with `Album Name • Artist Name` subtitles, custom audio sorting options, song title letter filtering, and full-library shuffle playback.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Category Bar & Desktop Rail Reordering (`music_browse_screen.dart`)**:
  - Reordered Audio sublibrary categories to: **Artists / Albums / Songs / Playlists / Genres / Favorites**.
  - Mapped **Songs** to `Destinations.library(libraryId, includeItemTypes: const ['Audio'])`.

- **Songs Track List Layout & Subtitle (`library_browse_screen.dart` & `item_detail_screen.dart`)**:
  - Rendered `LibraryBrowseScreen` for Songs (`includeItemTypes: ['Audio']`) using a vertical `DetailTrackList`.
  - Added `showAlbum` parameter to `DetailTrackList` and `_TrackTile` to render `Album Name • Artist Name` in the subtitle.
  - Expanded `_browseFields` in `LibraryBrowseViewModel` to fetch `Album`, `AlbumId`, `AlbumArtist`, and `Artists`.

- **Songs Sorting Options (`preference_constants.dart` & `library_browse_screen.dart`)**:
  - Added `albumArtist` and `album` enum values to `LibrarySortBy`.
  - Configured Sort Options dialog for Songs with: Name, Date Added, Album Artist, Album, Release Date, Length (renamed from Runtime for audio), and Random.

- **Song Title Letter Filtering (`library_browse_view_model.dart`)**:
  - Isolated sublibrary preference keys (`_prefKey`) so Songs defaults independently to Name sort.
  - Added client-side letter prefix verification on mapped items in `_fetchPage` so selecting A-Z / # filters songs strictly by song title.

- **Library Shuffle Action (`library_browse_screen.dart`)**:
  - Added a **Shuffle** toolbar button to `_LibraryHeader` when browsing Songs.
  - Queries 300 random songs from the audio library (`sortBy: 'Random', limit: 300`) and starts audio playback in `Destinations.audioPlayer`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the Audio page and verify category order (Artists / Albums / Songs / Playlists / Genres / Favorites).
2. Open the Songs sublibrary and verify tracks display in a list format with `Album Name • Artist Name` in subtitles.
3. Test the Shuffle toolbar button to confirm 300 random tracks queue and start playback in `audioPlayer`.
4. Open the Sort dialog on the Songs page and test sorting by Name, Date Added, Album Artist, Album, Release Date, Length, and Random.
5. Select letters (A-Z, #) on the alpha bar while sorting by Name to verify filtering by song title.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

New area:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_21-51-46" src="https://github.com/user-attachments/assets/4a64ef18-0125-4a6f-8dd6-14a737aa17d9" />

Song list (default sort: by title)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_21-52-14" src="https://github.com/user-attachments/assets/40f94ac9-2490-49d1-84ab-9a655478ed58" />

Sort Options:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_22-08-02" src="https://github.com/user-attachments/assets/7966a048-c39a-4f0a-a884-ba7077663d88" />

Song list (sorted by release year)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_21-52-54" src="https://github.com/user-attachments/assets/2a46535b-d056-4574-a033-9da03e8bfb9b" />

Song list (sorted by length)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_21-53-30" src="https://github.com/user-attachments/assets/bdf24b7e-04c6-44f0-99b8-b70cb1b1d7f3" />

Shuffle in Action! (300 item random playlist)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_22-04-32" src="https://github.com/user-attachments/assets/99b0be52-3a11-408b-b99d-8d58737dad92" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-22_22-06-01" src="https://github.com/user-attachments/assets/2c48cbcd-f6a4-4d85-95db-3515813680db" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
