### PR TITLE
feat-ui - The Return of the Identify

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8945,5 +8945,18 @@
   "watchlistUpdateFailed": "Couldn't update watchlist",
   "@watchlistUpdateFailed": {
     "description": "Snackbar shown when adding/removing a Seerr watchlist item fails"
-  }
+  },
+  "adminSearchParameters": "Search Parameters",
+  "adminCurrentMetadata": "Current Metadata",
+  "adminLabelName": "Name",
+  "adminLabelYear": "Year",
+  "adminLabelImdbId": "IMDb Id",
+  "adminLabelTmdbMovieId": "TheMovieDb Movie Id",
+  "adminLabelTmdbBoxSetId": "TheMovieDb Box Set Id",
+  "adminLabelTvdbBoxSetId": "TheTVDB Box Set Id",
+  "adminLabelTvdbId": "TheTVDB Numerical Id",
+  "adminLabelTvdbSlug": "TheTVDB Slug Movie Id",
+  "adminReplaceImages": "Replace existing images",
+  "adminApply": "Apply",
+  "adminBackToSearch": "Back to Search Criteria"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8947,16 +8947,47 @@
     "description": "Snackbar shown when adding/removing a Seerr watchlist item fails"
   },
   "adminSearchParameters": "Search Parameters",
+  "@adminSearchParameters": {
+    "description": "Column header above the editable fields used to search metadata providers in the Identify dialog"
+  },
   "adminCurrentMetadata": "Current Metadata",
-  "adminLabelName": "Name",
+  "@adminCurrentMetadata": {
+    "description": "Column header above the read-only values currently stored on the item in the Identify dialog"
+  },
   "adminLabelYear": "Year",
+  "@adminLabelYear": {
+    "description": "Label for the release year field in the Identify dialog"
+  },
   "adminLabelImdbId": "IMDb Id",
+  "@adminLabelImdbId": {
+    "description": "Label for the IMDb identifier field in the Identify dialog. IMDb is a brand name and is normally left untranslated"
+  },
   "adminLabelTmdbMovieId": "TheMovieDb Movie Id",
+  "@adminLabelTmdbMovieId": {
+    "description": "Label for the TheMovieDb movie identifier field in the Identify dialog. TheMovieDb is a brand name and is normally left untranslated"
+  },
   "adminLabelTmdbBoxSetId": "TheMovieDb Box Set Id",
+  "@adminLabelTmdbBoxSetId": {
+    "description": "Label for the TheMovieDb collection identifier field in the Identify dialog. TheMovieDb is a brand name and is normally left untranslated"
+  },
   "adminLabelTvdbBoxSetId": "TheTVDB Box Set Id",
+  "@adminLabelTvdbBoxSetId": {
+    "description": "Label for the TheTVDB collection identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated"
+  },
   "adminLabelTvdbId": "TheTVDB Numerical Id",
+  "@adminLabelTvdbId": {
+    "description": "Label for the numeric TheTVDB identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated"
+  },
   "adminLabelTvdbSlug": "TheTVDB Slug Movie Id",
+  "@adminLabelTvdbSlug": {
+    "description": "Label for the TheTVDB slug identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated"
+  },
   "adminReplaceImages": "Replace existing images",
-  "adminApply": "Apply",
-  "adminBackToSearch": "Back to Search Criteria"
+  "@adminReplaceImages": {
+    "description": "Checkbox label in the confirmation dialog shown before applying an identified metadata match"
+  },
+  "adminBackToSearch": "Back to Search Criteria",
+  "@adminBackToSearch": {
+    "description": "Tooltip on the button that returns from the Identify results list to the search form"
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18022,73 +18022,67 @@ abstract class AppLocalizations {
   /// **'Couldn\'t update watchlist'**
   String get watchlistUpdateFailed;
 
-  /// No description provided for @adminSearchParameters.
+  /// Column header above the editable fields used to search metadata providers in the Identify dialog
   ///
   /// In en, this message translates to:
   /// **'Search Parameters'**
   String get adminSearchParameters;
 
-  /// No description provided for @adminCurrentMetadata.
+  /// Column header above the read-only values currently stored on the item in the Identify dialog
   ///
   /// In en, this message translates to:
   /// **'Current Metadata'**
   String get adminCurrentMetadata;
 
-  /// No description provided for @adminLabelName.
-  ///
-  /// In en, this message translates to:
-  /// **'Name'**
-  String get adminLabelName;
-
-  /// No description provided for @adminLabelYear.
+  /// Label for the release year field in the Identify dialog
   ///
   /// In en, this message translates to:
   /// **'Year'**
   String get adminLabelYear;
 
-  /// No description provided for @adminLabelImdbId.
+  /// Label for the IMDb identifier field in the Identify dialog. IMDb is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'IMDb Id'**
   String get adminLabelImdbId;
 
-  /// No description provided for @adminLabelTmdbMovieId.
+  /// Label for the TheMovieDb movie identifier field in the Identify dialog. TheMovieDb is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'TheMovieDb Movie Id'**
   String get adminLabelTmdbMovieId;
 
-  /// No description provided for @adminLabelTmdbBoxSetId.
+  /// Label for the TheMovieDb collection identifier field in the Identify dialog. TheMovieDb is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'TheMovieDb Box Set Id'**
   String get adminLabelTmdbBoxSetId;
 
-  /// No description provided for @adminLabelTvdbBoxSetId.
+  /// Label for the TheTVDB collection identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'TheTVDB Box Set Id'**
   String get adminLabelTvdbBoxSetId;
 
-  /// No description provided for @adminLabelTvdbId.
+  /// Label for the numeric TheTVDB identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'TheTVDB Numerical Id'**
   String get adminLabelTvdbId;
 
-  /// No description provided for @adminLabelTvdbSlug.
+  /// Label for the TheTVDB slug identifier field in the Identify dialog. TheTVDB is a brand name and is normally left untranslated
   ///
   /// In en, this message translates to:
   /// **'TheTVDB Slug Movie Id'**
   String get adminLabelTvdbSlug;
 
-  /// No description provided for @adminReplaceImages.
+  /// Checkbox label in the confirmation dialog shown before applying an identified metadata match
   ///
   /// In en, this message translates to:
   /// **'Replace existing images'**
   String get adminReplaceImages;
 
-  /// No description provided for @adminBackToSearch.
+  /// Tooltip on the button that returns from the Identify results list to the search form
   ///
   /// In en, this message translates to:
   /// **'Back to Search Criteria'**

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18021,6 +18021,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Couldn\'t update watchlist'**
   String get watchlistUpdateFailed;
+
+  /// No description provided for @adminSearchParameters.
+  ///
+  /// In en, this message translates to:
+  /// **'Search Parameters'**
+  String get adminSearchParameters;
+
+  /// No description provided for @adminCurrentMetadata.
+  ///
+  /// In en, this message translates to:
+  /// **'Current Metadata'**
+  String get adminCurrentMetadata;
+
+  /// No description provided for @adminLabelName.
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get adminLabelName;
+
+  /// No description provided for @adminLabelYear.
+  ///
+  /// In en, this message translates to:
+  /// **'Year'**
+  String get adminLabelYear;
+
+  /// No description provided for @adminLabelImdbId.
+  ///
+  /// In en, this message translates to:
+  /// **'IMDb Id'**
+  String get adminLabelImdbId;
+
+  /// No description provided for @adminLabelTmdbMovieId.
+  ///
+  /// In en, this message translates to:
+  /// **'TheMovieDb Movie Id'**
+  String get adminLabelTmdbMovieId;
+
+  /// No description provided for @adminLabelTmdbBoxSetId.
+  ///
+  /// In en, this message translates to:
+  /// **'TheMovieDb Box Set Id'**
+  String get adminLabelTmdbBoxSetId;
+
+  /// No description provided for @adminLabelTvdbBoxSetId.
+  ///
+  /// In en, this message translates to:
+  /// **'TheTVDB Box Set Id'**
+  String get adminLabelTvdbBoxSetId;
+
+  /// No description provided for @adminLabelTvdbId.
+  ///
+  /// In en, this message translates to:
+  /// **'TheTVDB Numerical Id'**
+  String get adminLabelTvdbId;
+
+  /// No description provided for @adminLabelTvdbSlug.
+  ///
+  /// In en, this message translates to:
+  /// **'TheTVDB Slug Movie Id'**
+  String get adminLabelTvdbSlug;
+
+  /// No description provided for @adminReplaceImages.
+  ///
+  /// In en, this message translates to:
+  /// **'Replace existing images'**
+  String get adminReplaceImages;
+
+  /// No description provided for @adminBackToSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Back to Search Criteria'**
+  String get adminBackToSearch;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -10157,4 +10157,40 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -10165,9 +10165,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -10133,4 +10133,40 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -10141,9 +10141,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -10222,4 +10222,40 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -10230,9 +10230,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -10260,4 +10260,40 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -10268,9 +10268,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -10139,9 +10139,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -10131,4 +10131,40 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -10308,4 +10308,40 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -10316,9 +10316,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10195,4 +10195,40 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10203,9 +10203,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -10220,9 +10220,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -10212,4 +10212,40 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10156,9 +10156,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10148,4 +10148,40 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10306,4 +10306,40 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10314,9 +10314,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -10315,4 +10315,40 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -10323,9 +10323,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10075,9 +10075,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10067,6 +10067,42 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -10143,4 +10143,40 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -10151,9 +10151,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10280,9 +10280,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10272,6 +10272,42 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -10161,4 +10161,40 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -10169,9 +10169,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -10089,4 +10089,40 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -10097,9 +10097,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -10179,4 +10179,40 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -10187,9 +10187,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10292,9 +10292,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10284,4 +10284,40 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -10306,9 +10306,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -10298,4 +10298,40 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -10018,9 +10018,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -10010,4 +10010,40 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -10132,9 +10132,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -10124,4 +10124,40 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -10377,4 +10377,40 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -10385,9 +10385,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -10249,4 +10249,40 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -10257,9 +10257,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -10153,4 +10153,40 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -10161,9 +10161,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10238,4 +10238,40 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10246,9 +10246,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9837,4 +9837,40 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9845,9 +9845,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -10199,4 +10199,40 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -10207,9 +10207,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -10231,9 +10231,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -10223,4 +10223,40 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9830,4 +9830,40 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9838,9 +9838,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -10219,4 +10219,40 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -10227,9 +10227,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -10224,9 +10224,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -10216,4 +10216,40 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -10231,4 +10231,40 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -10239,9 +10239,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -10284,9 +10284,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -10276,4 +10276,40 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -10181,9 +10181,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -10173,4 +10173,40 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -10146,4 +10146,40 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -10154,9 +10154,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10205,4 +10205,40 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10213,9 +10213,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -10120,9 +10120,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -10112,4 +10112,40 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -10223,9 +10223,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -10215,4 +10215,40 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10238,6 +10238,42 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10246,9 +10246,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10242,4 +10242,40 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10250,9 +10250,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -10232,4 +10232,40 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -10240,9 +10240,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -10144,4 +10144,40 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -10152,9 +10152,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -10232,9 +10232,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -10224,4 +10224,40 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -10218,4 +10218,40 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -10226,9 +10226,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -10253,4 +10253,40 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -10261,9 +10261,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -10373,9 +10373,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -10365,4 +10365,40 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10170,9 +10170,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10162,4 +10162,40 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -10237,4 +10237,40 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -10245,9 +10245,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -10238,4 +10238,40 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -10246,9 +10246,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -10232,9 +10232,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -10224,4 +10224,40 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -10075,4 +10075,40 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -10083,9 +10083,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -10268,4 +10268,40 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -10276,9 +10276,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -10168,4 +10168,40 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -10176,9 +10176,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -10197,9 +10197,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -10189,4 +10189,40 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -10243,4 +10243,40 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -10251,9 +10251,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -10164,9 +10164,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -10156,4 +10156,40 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -9749,6 +9749,42 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -9757,9 +9757,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9753,9 +9753,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminCurrentMetadata => 'Current Metadata';
 
   @override
-  String get adminLabelName => 'Name';
-
-  @override
   String get adminLabelYear => 'Year';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9745,6 +9745,42 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+
+  @override
+  String get adminSearchParameters => 'Search Parameters';
+
+  @override
+  String get adminCurrentMetadata => 'Current Metadata';
+
+  @override
+  String get adminLabelName => 'Name';
+
+  @override
+  String get adminLabelYear => 'Year';
+
+  @override
+  String get adminLabelImdbId => 'IMDb Id';
+
+  @override
+  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+
+  @override
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+
+  @override
+  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+
+  @override
+  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+
+  @override
+  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+
+  @override
+  String get adminReplaceImages => 'Replace existing images';
+
+  @override
+  String get adminBackToSearch => 'Back to Search Criteria';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/ui/screens/admin/metadata/admin_metadata_edit_screen.dart
+++ b/lib/ui/screens/admin/metadata/admin_metadata_edit_screen.dart
@@ -536,7 +536,9 @@ class _AdminMetadataEditScreenState extends State<AdminMetadataEditScreen> {
     final applied = await IdentifyDialog.show(
       context,
       itemId: widget.itemId,
-      itemType: searchType,
+      // An empty type means unknown, so let the dialog resolve it from the item
+      // rather than posting to /Items/RemoteSearch/ with no type at all.
+      itemType: searchType.isEmpty ? null : searchType,
       itemName: name,
       itemYear: year,
       itemPath: path,

--- a/lib/ui/screens/admin/metadata/admin_metadata_edit_screen.dart
+++ b/lib/ui/screens/admin/metadata/admin_metadata_edit_screen.dart
@@ -10,6 +10,7 @@ import '../../../../l10n/app_localizations.dart';
 import '../../../../util/image_mime.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../widgets/adaptive/adaptive_dialog.dart';
+import '../../../widgets/identify_dialog.dart';
 import '../../detail/modern/widgets/details_tab_bar.dart';
 import '../widgets/admin_form_styles.dart';
 
@@ -524,128 +525,26 @@ class _AdminMetadataEditScreenState extends State<AdminMetadataEditScreen> {
   }
 
   Future<void> _searchAndApplyRemote() async {
-    final l10n = AppLocalizations.of(context);
     final searchType = (_raw['Type'] ?? '').toString();
-    if (searchType.isEmpty) return;
-
-    final queryController =
-        TextEditingController(text: (_raw['Name'] ?? '').toString());
-    final query = await showDialog<String>(
-      context: context,
-      builder: (ctx) => AlertDialog.adaptive(
-        title: Text(l10n.adminMetadataIdentify),
-        content: TextField(
-          controller: queryController,
-          autofocus: true,
-          decoration: adminInputDecoration(label: l10n.name),
-          onSubmitted: (v) => Navigator.pop(ctx, v.trim()),
-        ),
-        actions: [
-          adaptiveDialogAction(
-            onPressed: () => Navigator.pop(ctx),
-            child: Text(l10n.cancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, queryController.text.trim()),
-            child: Text(l10n.search),
-          ),
-        ],
-      ),
-    );
-    queryController.dispose();
-
-    if (query == null || query.isEmpty || !mounted) return;
-
-    final searchInfo = <String, dynamic>{'Name': query};
+    final name = (_raw['Name'] ?? '').toString();
     final year = int.tryParse((_raw['ProductionYear'] ?? '').toString());
-    if (year != null) searchInfo['Year'] = year;
-    final providerIds = _raw['ProviderIds'];
-    if (providerIds is Map && providerIds.isNotEmpty) {
-      searchInfo['ProviderIds'] = Map<String, dynamic>.from(providerIds);
-    }
+    final path = _raw['Path']?.toString();
+    final providerIds = _raw['ProviderIds'] is Map
+        ? Map<String, dynamic>.from(_raw['ProviderIds'])
+        : null;
 
-    try {
-      final results = await _api.searchRemote(searchType, {
-        'SearchInfo': searchInfo,
-        'ItemId': widget.itemId,
-      });
+    final applied = await IdentifyDialog.show(
+      context,
+      itemId: widget.itemId,
+      itemType: searchType,
+      itemName: name,
+      itemYear: year,
+      itemPath: path,
+      providerIds: providerIds,
+    );
 
-      if (!mounted) return;
-      if (results.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(l10n.adminNoRemoteMatches)),
-        );
-        return;
-      }
-
-      final selected = await showDialog<Map<String, dynamic>>(
-        context: context,
-        builder: (ctx) => AlertDialog.adaptive(
-          title: Text(l10n.adminRemoteResults),
-          content: SizedBox(
-            width: (MediaQuery.sizeOf(ctx).width - 32).clamp(280.0, 560.0),
-            height: (MediaQuery.sizeOf(ctx).height * 0.6).clamp(240.0, 520.0),
-            child: ListView.builder(
-              shrinkWrap: true,
-              itemCount: results.length,
-              itemBuilder: (context, index) {
-                final item = results[index];
-                final name = (item['Name'] ?? l10n.unknown).toString();
-                final resultYear = item['ProductionYear']?.toString();
-                final overview = (item['Overview'] ?? '').toString();
-                final provider =
-                    (item['SearchProviderName'] ?? item['ProviderName'] ?? '')
-                        .toString();
-                final imageUrl = item['ImageUrl']?.toString();
-                final subtitle = overview.isNotEmpty ? overview : provider;
-                return ListTile(
-                  leading: imageUrl != null && imageUrl.isNotEmpty
-                      ? ClipRRect(
-                          borderRadius: BorderRadius.circular(4),
-                          child: Image.network(
-                            imageUrl,
-                            width: 40,
-                            height: 60,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, _, _) =>
-                                const Icon(Icons.movie_outlined),
-                          ),
-                        )
-                      : const Icon(Icons.movie_outlined),
-                  title: Text(resultYear != null && resultYear.isNotEmpty
-                      ? '$name ($resultYear)'
-                      : name),
-                  subtitle: subtitle.isEmpty
-                      ? null
-                      : Text(subtitle,
-                          maxLines: 2, overflow: TextOverflow.ellipsis),
-                  isThreeLine: overview.isNotEmpty,
-                  onTap: () => Navigator.pop(ctx, item),
-                );
-              },
-            ),
-          ),
-          actions: [
-            adaptiveDialogAction(
-              onPressed: () => Navigator.pop(ctx),
-              child: Text(l10n.cancel),
-            ),
-          ],
-        ),
-      );
-
-      if (selected == null || !mounted) return;
-      await _api.applyRemoteSearchResult(widget.itemId, selected);
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l10n.adminRemoteMetadataApplied)));
+    if (applied == true && mounted) {
       await _load();
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(l10n.adminRemoteSearchFailed(e.toString()))));
     }
   }
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import '../../widgets/offline_aware_image.dart';
+import '../../widgets/identify_dialog.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -6572,10 +6573,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 onKeyEvent: (_, event) {
                   if (isActivateKey(event)) {
                     Navigator.of(dialogCtx).pop();
-                    ChangeArtworkDialog.show(context, item: item).then((
-                      changed,
-                    ) {
-                      if (changed == true) {
+                    IdentifyDialog.show(
+                      context,
+                      itemId: item.id,
+                      itemType: item.type,
+                      itemName: item.name,
+                      itemYear: item.productionYear,
+                    ).then((applied) {
+                      if (applied == true) {
                         viewModel.load();
                       }
                     });
@@ -6589,11 +6594,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                     return InkWell(
                       onTap: () async {
                         Navigator.of(dialogCtx).pop();
-                        final changed = await ChangeArtworkDialog.show(
+                        final applied = await IdentifyDialog.show(
                           context,
-                          item: item,
+                          itemId: item.id,
+                          itemType: item.type,
+                          itemName: item.name,
+                          itemYear: item.productionYear,
                         );
-                        if (changed == true) {
+                        if (applied == true) {
                           viewModel.load();
                         }
                       },
@@ -6608,10 +6616,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                         ),
                         child: Row(
                           children: [
-                            const Icon(Icons.image, color: Colors.white70),
+                            const Icon(Icons.search, color: Colors.white70),
                             const SizedBox(width: 12),
                             Text(
-                              l10n.changeArtwork,
+                              l10n.adminMetadataIdentify,
                               style: const TextStyle(color: Colors.white),
                             ),
                           ],
@@ -6668,6 +6676,59 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                     },
                   ),
                 ),
+              Focus(
+                onKeyEvent: (_, event) {
+                  if (isActivateKey(event)) {
+                    Navigator.of(dialogCtx).pop();
+                    ChangeArtworkDialog.show(context, item: item).then((
+                      changed,
+                    ) {
+                      if (changed == true) {
+                        viewModel.load();
+                      }
+                    });
+                    return KeyEventResult.handled;
+                  }
+                  return KeyEventResult.ignored;
+                },
+                child: Builder(
+                  builder: (buttonCtx) {
+                    final hasFocus = Focus.of(buttonCtx).hasFocus;
+                    return InkWell(
+                      onTap: () async {
+                        Navigator.of(dialogCtx).pop();
+                        final changed = await ChangeArtworkDialog.show(
+                          context,
+                          item: item,
+                        );
+                        if (changed == true) {
+                          viewModel.load();
+                        }
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: 12,
+                          horizontal: 16,
+                        ),
+                        decoration: BoxDecoration(
+                          color: hasFocus ? Colors.white12 : Colors.transparent,
+                          borderRadius: AppRadius.circular(8),
+                        ),
+                        child: Row(
+                          children: [
+                            const Icon(Icons.image, color: Colors.white70),
+                            const SizedBox(width: 12),
+                            Text(
+                              l10n.changeArtwork,
+                              style: const TextStyle(color: Colors.white),
+                            ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
               if (item.canDelete)
                 Focus(
                   onKeyEvent: (_, event) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import '../../widgets/offline_aware_image.dart';
 import '../../widgets/identify_dialog.dart';
+import '../../widgets/focus/context_action.dart' show canIdentifyItemType;
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -6569,66 +6570,67 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Focus(
-                onKeyEvent: (_, event) {
-                  if (isActivateKey(event)) {
-                    Navigator.of(dialogCtx).pop();
-                    IdentifyDialog.show(
-                      context,
-                      itemId: item.id,
-                      itemType: item.type,
-                      itemName: item.name,
-                      itemYear: item.productionYear,
-                    ).then((applied) {
-                      if (applied == true) {
-                        viewModel.load();
-                      }
-                    });
-                    return KeyEventResult.handled;
-                  }
-                  return KeyEventResult.ignored;
-                },
-                child: Builder(
-                  builder: (buttonCtx) {
-                    final hasFocus = Focus.of(buttonCtx).hasFocus;
-                    return InkWell(
-                      onTap: () async {
-                        Navigator.of(dialogCtx).pop();
-                        final applied = await IdentifyDialog.show(
-                          context,
-                          itemId: item.id,
-                          itemType: item.type,
-                          itemName: item.name,
-                          itemYear: item.productionYear,
-                        );
+              if (canIdentifyItemType(item.type))
+                Focus(
+                  onKeyEvent: (_, event) {
+                    if (isActivateKey(event)) {
+                      Navigator.of(dialogCtx).pop();
+                      IdentifyDialog.show(
+                        context,
+                        itemId: item.id,
+                        itemType: item.type,
+                        itemName: item.name,
+                        itemYear: item.productionYear,
+                      ).then((applied) {
                         if (applied == true) {
                           viewModel.load();
                         }
-                      },
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          vertical: 12,
-                          horizontal: 16,
-                        ),
-                        decoration: BoxDecoration(
-                          color: hasFocus ? Colors.white12 : Colors.transparent,
-                          borderRadius: AppRadius.circular(8),
-                        ),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.search, color: Colors.white70),
-                            const SizedBox(width: 12),
-                            Text(
-                              l10n.adminMetadataIdentify,
-                              style: const TextStyle(color: Colors.white),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
+                      });
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
                   },
+                  child: Builder(
+                    builder: (buttonCtx) {
+                      final hasFocus = Focus.of(buttonCtx).hasFocus;
+                      return InkWell(
+                        onTap: () async {
+                          Navigator.of(dialogCtx).pop();
+                          final applied = await IdentifyDialog.show(
+                            context,
+                            itemId: item.id,
+                            itemType: item.type,
+                            itemName: item.name,
+                            itemYear: item.productionYear,
+                          );
+                          if (applied == true) {
+                            viewModel.load();
+                          }
+                        },
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: 12,
+                            horizontal: 16,
+                          ),
+                          decoration: BoxDecoration(
+                            color: hasFocus ? Colors.white12 : Colors.transparent,
+                            borderRadius: AppRadius.circular(8),
+                          ),
+                          child: Row(
+                            children: [
+                              const Icon(Icons.search, color: Colors.white70),
+                              const SizedBox(width: 12),
+                              Text(
+                                l10n.adminMetadataIdentify,
+                                style: const TextStyle(color: Colors.white),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
-              ),
               if (!PlatformDetection.isTV)
                 Focus(
                   onKeyEvent: (_, event) {

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -13,6 +13,7 @@ import '../../navigation/destinations.dart';
 import '../add_to_collection_dialog.dart';
 import '../add_to_playlist_dialog.dart';
 import '../change_artwork_dialog.dart';
+import '../identify_dialog.dart';
 
 class ItemContextAction {
   final IconData icon;
@@ -199,6 +200,32 @@ List<ItemContextAction> contextActionsFor(
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(l10n.adminMetadataRefreshFailed('$e'))),
             );
+          }
+        },
+      ));
+
+      actions.add(ItemContextAction(
+        icon: Icons.search_outlined,
+        label: l10n.adminMetadataIdentify,
+        onSelect: () async {
+          if (!context.mounted) return;
+          final isTVChild = item.type == 'Episode' || item.type == 'Season';
+          final hasSeriesId = item.seriesId != null && item.seriesId!.isNotEmpty;
+          final targetItemId = (isTVChild && hasSeriesId) ? item.seriesId! : item.id;
+          final targetItemType = (isTVChild && hasSeriesId) ? 'Series' : item.type;
+          final targetItemName = (isTVChild && hasSeriesId)
+              ? (item.seriesName ?? item.name)
+              : item.name;
+
+          final applied = await IdentifyDialog.show(
+            context,
+            itemId: targetItemId,
+            itemType: targetItemType,
+            itemName: targetItemName,
+            itemYear: isTVChild ? null : item.productionYear,
+          );
+          if (applied == true) {
+            onChanged?.call();
           }
         },
       ));

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -27,6 +27,25 @@ class ItemContextAction {
   });
 }
 
+/// Item types the server exposes a `/Items/RemoteSearch/{type}` endpoint for.
+/// Episodes and Seasons qualify because Identify redirects them to their
+/// parent series. Anything else would just 404 with a raw error toast.
+const _identifiableTypes = <String>{
+  'Movie',
+  'Series',
+  'Season',
+  'Episode',
+  'BoxSet',
+  'Person',
+  'MusicAlbum',
+  'MusicArtist',
+  'Book',
+  'Trailer',
+  'MusicVideo',
+};
+
+bool canIdentifyItemType(String? type) => _identifiableTypes.contains(type);
+
 List<ItemContextAction> contextActionsFor(
   BuildContext context,
   AggregatedItem item, {
@@ -204,31 +223,36 @@ List<ItemContextAction> contextActionsFor(
         },
       ));
 
-      actions.add(ItemContextAction(
-        icon: Icons.search_outlined,
-        label: l10n.adminMetadataIdentify,
-        onSelect: () async {
-          if (!context.mounted) return;
-          final isTVChild = item.type == 'Episode' || item.type == 'Season';
-          final hasSeriesId = item.seriesId != null && item.seriesId!.isNotEmpty;
-          final targetItemId = (isTVChild && hasSeriesId) ? item.seriesId! : item.id;
-          final targetItemType = (isTVChild && hasSeriesId) ? 'Series' : item.type;
-          final targetItemName = (isTVChild && hasSeriesId)
-              ? (item.seriesName ?? item.name)
-              : item.name;
+      if (canIdentifyItemType(type)) {
+        actions.add(ItemContextAction(
+          icon: Icons.search_outlined,
+          label: l10n.adminMetadataIdentify,
+          onSelect: () async {
+            if (!context.mounted) return;
+            final isTVChild = item.type == 'Episode' || item.type == 'Season';
+            final hasSeriesId =
+                item.seriesId != null && item.seriesId!.isNotEmpty;
+            final targetItemId =
+                (isTVChild && hasSeriesId) ? item.seriesId! : item.id;
+            final targetItemType =
+                (isTVChild && hasSeriesId) ? 'Series' : item.type;
+            final targetItemName = (isTVChild && hasSeriesId)
+                ? (item.seriesName ?? item.name)
+                : item.name;
 
-          final applied = await IdentifyDialog.show(
-            context,
-            itemId: targetItemId,
-            itemType: targetItemType,
-            itemName: targetItemName,
-            itemYear: isTVChild ? null : item.productionYear,
-          );
-          if (applied == true) {
-            onChanged?.call();
-          }
-        },
-      ));
+            final applied = await IdentifyDialog.show(
+              context,
+              itemId: targetItemId,
+              itemType: targetItemType,
+              itemName: targetItemName,
+              itemYear: isTVChild ? null : item.productionYear,
+            );
+            if (applied == true) {
+              onChanged?.call();
+            }
+          },
+        ));
+      }
     }
 
   }

--- a/lib/ui/widgets/identify_dialog.dart
+++ b/lib/ui/widgets/identify_dialog.dart
@@ -1,15 +1,16 @@
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../preference/user_preferences.dart';
+import '../../util/focus/dpad_keys.dart';
 import '../../util/platform_detection.dart';
 import 'adaptive/adaptive_dialog.dart';
 import 'focus/focusable_button.dart';
+import 'overlay_sheet.dart';
 
 class IdentifyDialog extends StatefulWidget {
   final String itemId;
@@ -38,7 +39,7 @@ class IdentifyDialog extends StatefulWidget {
     String? itemPath,
     Map<String, dynamic>? providerIds,
   }) {
-    return showDialog<bool>(
+    return showFocusRestoringDialog<bool>(
       context: context,
       builder: (ctx) => IdentifyDialog(
         itemId: itemId,
@@ -56,11 +57,16 @@ class IdentifyDialog extends StatefulWidget {
 }
 
 class _IdentifyDialogState extends State<IdentifyDialog> {
+  /// Every focus node list and the d-pad wrap-around logic is sized off this.
+  static const int _fieldCount = 8;
+  static const int _lastFieldIndex = _fieldCount - 1;
+
   late final AdminItemsApi _adminApi;
   late final ItemsApi _itemsApi;
   late final UserPreferences _prefs;
 
   bool _loadingItem = false;
+  String? _loadError;
   bool _searching = false;
   bool _applying = false;
 
@@ -70,7 +76,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
 
   List<Map<String, dynamic>>? _searchResults;
 
-  // Reference Metadata Values (Current Item)
+  // What the item currently has, shown next to each search field.
   String? _refName;
   String? _refYear;
   String? _refImdb;
@@ -80,31 +86,32 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
   String? _refTvdbId;
   String? _refTvdbSlug;
 
-  // Editable Search Parameter Controllers (Blank by default)
-  late final TextEditingController _nameController;
-  late final TextEditingController _yearController;
-  late final TextEditingController _imdbController;
-  late final TextEditingController _tmdbMovieController;
-  late final TextEditingController _tmdbBoxSetController;
-  late final TextEditingController _tvdbBoxSetController;
-  late final TextEditingController _tvdbIdController;
-  late final TextEditingController _tvdbSlugController;
+  // The search fields start blank so a search only uses what the admin types.
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _yearController = TextEditingController();
+  final TextEditingController _imdbController = TextEditingController();
+  final TextEditingController _tmdbMovieController = TextEditingController();
+  final TextEditingController _tmdbBoxSetController = TextEditingController();
+  final TextEditingController _tvdbBoxSetController = TextEditingController();
+  final TextEditingController _tvdbIdController = TextEditingController();
+  final TextEditingController _tvdbSlugController = TextEditingController();
 
-  // FocusNodes and ScrollController for TV Navigation
   final ScrollController _scrollController = ScrollController();
 
   final FocusNode _closeButtonFocusNode = FocusNode(debugLabel: 'identify-close-btn');
   final FocusNode _cancelButtonFocusNode = FocusNode(debugLabel: 'identify-cancel-btn');
   final FocusNode _searchButtonFocusNode = FocusNode(debugLabel: 'identify-search-btn');
 
-  final List<FocusNode> _fieldFocusNodes =
-      List.generate(8, (i) => FocusNode(debugLabel: 'identify-field-$i'));
-  final List<FocusNode> _arrowFocusNodes =
-      List.generate(8, (i) => FocusNode(debugLabel: 'identify-arrow-$i'));
+  final List<FocusNode> _fieldFocusNodes = List.generate(
+      _fieldCount, (i) => FocusNode(debugLabel: 'identify-field-$i'));
+  final List<FocusNode> _arrowFocusNodes = List.generate(
+      _fieldCount, (i) => FocusNode(debugLabel: 'identify-arrow-$i'));
   final List<GlobalKey<CustomTVTextFieldState>> _tvFieldKeys =
-      List.generate(8, (_) => GlobalKey<CustomTVTextFieldState>());
+      List.generate(_fieldCount, (_) => GlobalKey<CustomTVTextFieldState>());
 
   List<FocusNode>? _resultFocusNodes;
+
+  bool get _isTV => PlatformDetection.isTV;
 
   @override
   void initState() {
@@ -115,8 +122,11 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
     _prefs = GetIt.instance<UserPreferences>();
 
     _targetItemId = widget.itemId;
-    final isTVChild = widget.itemType == 'Episode' || widget.itemType == 'Season';
-    _searchType = isTVChild ? 'Series' : (widget.itemType ?? 'Movie');
+    final itemType = widget.itemType?.trim();
+    final isTVChild = itemType == 'Episode' || itemType == 'Season';
+    _searchType = isTVChild
+        ? 'Series'
+        : (itemType == null || itemType.isEmpty ? 'Movie' : itemType);
     _path = widget.itemPath;
 
     final initialProviders = widget.providerIds ?? const {};
@@ -132,18 +142,8 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       _refTvdbSlug = initialProviders['TvdbSlug']?.toString();
     }
 
-    // Search controllers start BLANK by default
-    _nameController = TextEditingController(text: '');
-    _yearController = TextEditingController(text: '');
-    _imdbController = TextEditingController(text: '');
-    _tmdbMovieController = TextEditingController(text: '');
-    _tmdbBoxSetController = TextEditingController(text: '');
-    _tvdbBoxSetController = TextEditingController(text: '');
-    _tvdbIdController = TextEditingController(text: '');
-    _tvdbSlugController = TextEditingController(text: '');
-
-    // Add listeners to auto-scroll focused rows into the visible viewport on TV
-    for (int i = 0; i < 8; i++) {
+    // Keep the focused row on screen while the d-pad walks down the form.
+    for (int i = 0; i < _fieldCount; i++) {
       final idx = i;
       _fieldFocusNodes[idx].addListener(() {
         if (_fieldFocusNodes[idx].hasFocus) {
@@ -157,14 +157,13 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       });
     }
 
-    _fetchItemDetailsIfNeeded();
+    _loadItemDetails();
   }
 
   void _closeDialog([bool? result]) {
+    if (!mounted) return;
     FocusScope.of(context).unfocus();
-    if (mounted) {
-      Navigator.of(context).pop(result);
-    }
+    Navigator.of(context).pop(result);
   }
 
   @override
@@ -197,22 +196,41 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       fn.unfocus();
       fn.dispose();
     }
-    _clearResultFocusNodes();
+    _disposeNodes(_resultFocusNodes);
+    _resultFocusNodes = null;
     super.dispose();
   }
 
-  void _clearResultFocusNodes() {
-    if (_resultFocusNodes != null) {
-      for (final fn in _resultFocusNodes!) {
-        fn.unfocus();
-        fn.dispose();
-      }
-      _resultFocusNodes = null;
+  static void _disposeNodes(List<FocusNode>? nodes) {
+    if (nodes == null) return;
+    for (final fn in nodes) {
+      fn.unfocus();
+      fn.dispose();
     }
   }
 
+  /// Disposes the result focus nodes only after the frame that takes the result
+  /// cards off screen. Disposing them inline would leave the still mounted
+  /// [Focus] widgets holding dead nodes, which throws on the next detach.
+  void _releaseResultFocusNodes() {
+    final stale = _resultFocusNodes;
+    _resultFocusNodes = null;
+    if (stale == null) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _disposeNodes(stale));
+  }
+
+  void _backToSearchForm() {
+    setState(() => _searchResults = null);
+    _releaseResultFocusNodes();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _isTV) {
+        _fieldFocusNodes.first.requestFocus();
+      }
+    });
+  }
+
   void _setupResultFocusNodes(int count) {
-    _clearResultFocusNodes();
+    _releaseResultFocusNodes();
     _resultFocusNodes =
         List.generate(count, (i) => FocusNode(debugLabel: 'identify-result-$i'));
     for (int i = 0; i < count; i++) {
@@ -258,19 +276,24 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
     });
   }
 
-  Future<void> _fetchItemDetailsIfNeeded() async {
-    setState(() => _loadingItem = true);
+  Future<void> _loadItemDetails() async {
+    setState(() {
+      _loadingItem = true;
+      _loadError = null;
+    });
     try {
       var raw = await _itemsApi.getItem(widget.itemId);
 
       if ((raw['Type'] == 'Episode' || raw['Type'] == 'Season') &&
           raw['SeriesId'] != null &&
           raw['SeriesId'].toString().isNotEmpty) {
-        _targetItemId = raw['SeriesId'].toString();
-        _searchType = 'Series';
-        try {
-          raw = await _itemsApi.getItem(_targetItemId);
-        } catch (_) {}
+        final seriesId = raw['SeriesId'].toString();
+        // Episodes and seasons are identified through their series, but only
+        // switch targets once that series has actually loaded, otherwise the
+        // series id would end up paired with episode metadata.
+        final series = await _itemsApi.getItem(seriesId);
+        _targetItemId = seriesId;
+        raw = series;
       }
 
       if (!mounted) return;
@@ -293,12 +316,29 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
           _refTvdbSlug = pIds['TvdbSlug']?.toString();
         }
       });
-    } catch (_) {
+    } catch (e) {
+      // Searching by hand still works without reference values, so say what
+      // went wrong instead of leaving the current metadata column blank.
+      if (mounted) {
+        setState(() => _loadError = '$e');
+      }
     } finally {
       if (mounted) {
         setState(() => _loadingItem = false);
       }
     }
+  }
+
+  Future<List<Map<String, dynamic>>> _searchRemote(
+    Map<String, dynamic> searchInfo, {
+    String? providerName,
+  }) {
+    return _adminApi.searchRemote(_searchType, <String, dynamic>{
+      'SearchInfo': searchInfo,
+      'ItemId': _targetItemId,
+      'IncludeDisabledProviders': false,
+      'SearchProviderName': ?providerName,
+    });
   }
 
   Future<void> _performSearch() async {
@@ -311,6 +351,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
     final nameVal = _nameController.text.trim();
     final yearVal = int.tryParse(_yearController.text.trim());
 
+    // Provider ids are matched case insensitively, so one casing each is enough.
     final providerIds = <String, String>{};
 
     var imdbVal = _imdbController.text.trim();
@@ -319,40 +360,31 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
         imdbVal = 'tt$imdbVal';
       }
       providerIds['Imdb'] = imdbVal;
-      providerIds['IMDb'] = imdbVal;
-      providerIds['imdb'] = imdbVal;
     }
 
     final tmdbVal = _tmdbMovieController.text.trim();
     if (tmdbVal.isNotEmpty) {
       providerIds['Tmdb'] = tmdbVal;
-      providerIds['TMDB'] = tmdbVal;
-      providerIds['tmdb'] = tmdbVal;
     }
 
     final tmdbBoxSetVal = _tmdbBoxSetController.text.trim();
     if (tmdbBoxSetVal.isNotEmpty) {
       providerIds['TmdbBoxSet'] = tmdbBoxSetVal;
-      providerIds['TMDBBoxSet'] = tmdbBoxSetVal;
     }
 
     final tvdbBoxSetVal = _tvdbBoxSetController.text.trim();
     if (tvdbBoxSetVal.isNotEmpty) {
       providerIds['TvdbBoxSet'] = tvdbBoxSetVal;
-      providerIds['TVDBBoxSet'] = tvdbBoxSetVal;
     }
 
     final tvdbVal = _tvdbIdController.text.trim();
     if (tvdbVal.isNotEmpty) {
       providerIds['Tvdb'] = tvdbVal;
-      providerIds['TVDB'] = tvdbVal;
-      providerIds['tvdb'] = tvdbVal;
     }
 
     final tvdbSlugVal = _tvdbSlugController.text.trim();
     if (tvdbSlugVal.isNotEmpty) {
       providerIds['TvdbSlug'] = tvdbSlugVal;
-      providerIds['TVDBSlug'] = tvdbSlugVal;
     }
 
     final searchInfo = <String, dynamic>{
@@ -361,60 +393,33 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       if (providerIds.isNotEmpty) 'ProviderIds': providerIds,
     };
 
-    debugPrint('--> [IdentifyRemoteSearch] Executing search for $_searchType | ItemId: $_targetItemId');
-    debugPrint('--> [IdentifyRemoteSearch] SearchInfo: $searchInfo');
-
     try {
-      List<Map<String, dynamic>> results = await _adminApi.searchRemote(_searchType, {
-        'SearchInfo': searchInfo,
-        'ItemId': _targetItemId,
-        'IncludeDisabledProviders': false,
-      });
+      List<Map<String, dynamic>> results = await _searchRemote(searchInfo);
 
-      // Fallback 1: If TMDB/IMDb is present, try setting explicit SearchProviderName
-      if (results.isEmpty && (providerIds.containsKey('Tmdb') || providerIds.containsKey('Imdb'))) {
-        final altInfoProvider = <String, dynamic>{
-          ...searchInfo,
-          'SearchProviderName': 'TheMovieDb',
-        };
-        debugPrint('--> [IdentifyRemoteSearch] Retry with SearchProviderName: TheMovieDb');
-        results = await _adminApi.searchRemote(_searchType, {
-          'SearchInfo': altInfoProvider,
-          'ItemId': _targetItemId,
-          'IncludeDisabledProviders': false,
-        });
+      // Pin the search to TheMovieDb when a TMDB or IMDb id was given. Note
+      // that SearchProviderName belongs on the query, not inside SearchInfo.
+      if (results.isEmpty &&
+          (providerIds.containsKey('Tmdb') || providerIds.containsKey('Imdb'))) {
+        results = await _searchRemote(searchInfo, providerName: 'TheMovieDb');
       }
 
-      // Fallback 2: Try ProviderIds alone without Name
+      // Retry on the ids alone, in case the typed name blocked the match.
       if (results.isEmpty && providerIds.isNotEmpty && nameVal.isNotEmpty) {
-        final altInfoA = <String, dynamic>{
+        results = await _searchRemote(<String, dynamic>{
           'Name': '',
           'Year': ?yearVal,
           'ProviderIds': providerIds,
-        };
-        debugPrint('--> [IdentifyRemoteSearch] Retry with ProviderIds alone (empty Name)');
-        results = await _adminApi.searchRemote(_searchType, {
-          'SearchInfo': altInfoA,
-          'ItemId': _targetItemId,
-          'IncludeDisabledProviders': false,
         });
       }
 
-      // Fallback 3: Try Name (+ Year) alone
+      // Last resort, drop the ids and search on name and year only.
       if (results.isEmpty && nameVal.isNotEmpty) {
-        final altInfoB = <String, dynamic>{
+        results = await _searchRemote(<String, dynamic>{
           'Name': nameVal,
           'Year': ?yearVal,
-        };
-        debugPrint('--> [IdentifyRemoteSearch] Retry with Name + Year alone');
-        results = await _adminApi.searchRemote(_searchType, {
-          'SearchInfo': altInfoB,
-          'ItemId': _targetItemId,
-          'IncludeDisabledProviders': false,
         });
       }
 
-      debugPrint('<-- [IdentifyRemoteSearch] Results received: ${results.length}');
       if (!mounted) return;
 
       if (results.isEmpty) {
@@ -446,10 +451,11 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
   }
 
   Future<void> _applyResult(Map<String, dynamic> result) async {
+    if (_applying) return;
     final l10n = AppLocalizations.of(context);
     bool replaceAllImages = true;
 
-    final confirmed = await showDialog<bool>(
+    final confirmed = await showFocusRestoringDialog<bool>(
       context: context,
       builder: (ctx) => StatefulBuilder(
         builder: (dialogCtx, setDialogState) => AlertDialog.adaptive(
@@ -507,11 +513,15 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       ),
     );
 
-    if (confirmed != true || !mounted) return;
+    if (confirmed != true || !mounted || _applying) return;
 
     setState(() => _applying = true);
     try {
-      await _adminApi.applyRemoteSearchResult(_targetItemId, result);
+      await _adminApi.applyRemoteSearchResult(
+        _targetItemId,
+        result,
+        replaceAllImages: replaceAllImages,
+      );
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.adminRemoteMetadataApplied)),
@@ -549,16 +559,12 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // Dialog Header
               Row(
                 children: [
                   if (_searchResults != null)
                     IconButton(
                       icon: const Icon(Icons.arrow_back),
-                      onPressed: () {
-                        _clearResultFocusNodes();
-                        setState(() => _searchResults = null);
-                      },
+                      onPressed: _backToSearchForm,
                       tooltip: l10n.adminBackToSearch,
                     ),
                   Expanded(
@@ -569,72 +575,64 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                       style: theme.textTheme.headlineSmall,
                     ),
                   ),
-                  // Requirement 1 & 2: Pronounced X focus & Down navigation & Select/Enter pop
                   Focus(
                     focusNode: _closeButtonFocusNode,
                     onKeyEvent: (_, event) {
-                      if (event is KeyDownEvent) {
-                        final key = event.logicalKey;
-                        if (key == LogicalKeyboardKey.select ||
-                            key == LogicalKeyboardKey.enter ||
-                            key == LogicalKeyboardKey.gameButtonA ||
-                            key == LogicalKeyboardKey.space) {
-                          _closeDialog(false);
-                          return KeyEventResult.handled;
+                      if (!event.isActionable) return KeyEventResult.ignored;
+                      final key = event.logicalKey;
+                      if (key.isSelectKey) {
+                        _closeDialog(false);
+                        return KeyEventResult.handled;
+                      }
+                      if (_isTV && key.isDownKey) {
+                        if (_searchResults != null &&
+                            _resultFocusNodes != null &&
+                            _resultFocusNodes!.isNotEmpty) {
+                          _resultFocusNodes![0].requestFocus();
+                        } else {
+                          _fieldFocusNodes[0].requestFocus();
                         }
-                        if (key == LogicalKeyboardKey.arrowDown) {
-                          if (_searchResults != null &&
-                              _resultFocusNodes != null &&
-                              _resultFocusNodes!.isNotEmpty) {
-                            _resultFocusNodes![0].requestFocus();
-                          } else {
-                            _arrowFocusNodes[0].requestFocus();
-                          }
-                          return KeyEventResult.handled;
-                        }
+                        return KeyEventResult.handled;
                       }
                       return KeyEventResult.ignored;
                     },
                     child: Builder(
                       builder: (btnCtx) {
                         final hasFocus = Focus.of(btnCtx).hasFocus;
-                        return GestureDetector(
+                        return InkWell(
                           onTap: () => _closeDialog(false),
-                          child: InkWell(
-                            onTap: () => _closeDialog(false),
-                            borderRadius: AppRadius.circular(20),
-                            child: AnimatedContainer(
-                              duration: const Duration(milliseconds: 150),
-                              padding: const EdgeInsets.all(6),
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                color: hasFocus
-                                    ? theme.colorScheme.primary.withValues(alpha: 0.25)
-                                    : Colors.transparent,
-                                border: Border.all(
-                                  color: hasFocus
-                                      ? theme.colorScheme.primary
-                                      : Colors.transparent,
-                                  width: 2.5,
-                                ),
-                                boxShadow: hasFocus
-                                    ? [
-                                        BoxShadow(
-                                          color: theme.colorScheme.primary
-                                              .withValues(alpha: 0.6),
-                                          blurRadius: 10,
-                                          spreadRadius: 2,
-                                        )
-                                      ]
-                                    : null,
-                              ),
-                              child: Icon(
-                                Icons.close,
+                          borderRadius: AppRadius.circular(20),
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 150),
+                            padding: const EdgeInsets.all(6),
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: hasFocus
+                                  ? theme.colorScheme.primary.withValues(alpha: 0.25)
+                                  : Colors.transparent,
+                              border: Border.all(
                                 color: hasFocus
                                     ? theme.colorScheme.primary
-                                    : theme.colorScheme.onSurface,
-                                size: 20,
+                                    : Colors.transparent,
+                                width: 2.5,
                               ),
+                              boxShadow: hasFocus
+                                  ? [
+                                      BoxShadow(
+                                        color: theme.colorScheme.primary
+                                            .withValues(alpha: 0.6),
+                                        blurRadius: 10,
+                                        spreadRadius: 2,
+                                      )
+                                    ]
+                                  : null,
+                            ),
+                            child: Icon(
+                              Icons.close,
+                              color: hasFocus
+                                  ? theme.colorScheme.primary
+                                  : theme.colorScheme.onSurface,
+                              size: 20,
                             ),
                           ),
                         );
@@ -645,7 +643,6 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
               ),
               const Divider(height: 12),
 
-              // Dialog Body
               Expanded(
                 child: _loadingItem || _applying
                     ? const Center(child: CircularProgressIndicator())
@@ -654,7 +651,6 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                         : _buildSearchForm(context),
               ),
 
-              // Requirement 5: Compact Button Bar
               if (_searchResults == null) ...[
                 Padding(
                   padding: const EdgeInsets.only(top: 4, bottom: 2),
@@ -664,23 +660,22 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                       Focus(
                         focusNode: _cancelButtonFocusNode,
                         onKeyEvent: (_, event) {
-                          if (event is KeyDownEvent) {
-                            final key = event.logicalKey;
-                            if (key == LogicalKeyboardKey.select ||
-                                key == LogicalKeyboardKey.enter ||
-                                key == LogicalKeyboardKey.gameButtonA ||
-                                key == LogicalKeyboardKey.space) {
-                              _closeDialog(false);
-                              return KeyEventResult.handled;
-                            }
-                            if (key == LogicalKeyboardKey.arrowUp) {
-                              _fieldFocusNodes[7].requestFocus();
-                              return KeyEventResult.handled;
-                            }
-                            if (key == LogicalKeyboardKey.arrowRight) {
-                              _searchButtonFocusNode.requestFocus();
-                              return KeyEventResult.handled;
-                            }
+                          if (!event.isActionable) {
+                            return KeyEventResult.ignored;
+                          }
+                          final key = event.logicalKey;
+                          if (key.isSelectKey) {
+                            _closeDialog(false);
+                            return KeyEventResult.handled;
+                          }
+                          if (!_isTV) return KeyEventResult.ignored;
+                          if (key.isUpKey) {
+                            _fieldFocusNodes[_lastFieldIndex].requestFocus();
+                            return KeyEventResult.handled;
+                          }
+                          if (key.isRightKey) {
+                            _searchButtonFocusNode.requestFocus();
+                            return KeyEventResult.handled;
                           }
                           return KeyEventResult.ignored;
                         },
@@ -709,23 +704,22 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                       Focus(
                         focusNode: _searchButtonFocusNode,
                         onKeyEvent: (_, event) {
-                          if (event is KeyDownEvent) {
-                            final key = event.logicalKey;
-                            if (key == LogicalKeyboardKey.select ||
-                                key == LogicalKeyboardKey.enter ||
-                                key == LogicalKeyboardKey.gameButtonA ||
-                                key == LogicalKeyboardKey.space) {
-                              if (!_searching) _performSearch();
-                              return KeyEventResult.handled;
-                            }
-                            if (key == LogicalKeyboardKey.arrowUp) {
-                              _arrowFocusNodes[7].requestFocus();
-                              return KeyEventResult.handled;
-                            }
-                            if (key == LogicalKeyboardKey.arrowLeft) {
-                              _cancelButtonFocusNode.requestFocus();
-                              return KeyEventResult.handled;
-                            }
+                          if (!event.isActionable) {
+                            return KeyEventResult.ignored;
+                          }
+                          final key = event.logicalKey;
+                          if (key.isSelectKey) {
+                            if (!_searching) _performSearch();
+                            return KeyEventResult.handled;
+                          }
+                          if (!_isTV) return KeyEventResult.ignored;
+                          if (key.isUpKey) {
+                            _arrowFocusNodes[_lastFieldIndex].requestFocus();
+                            return KeyEventResult.handled;
+                          }
+                          if (key.isLeftKey) {
+                            _cancelButtonFocusNode.requestFocus();
+                            return KeyEventResult.handled;
                           }
                           return KeyEventResult.ignored;
                         },
@@ -768,14 +762,54 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
     );
   }
 
+  /// The form rows in d-pad order. Position matters because the focus nodes are
+  /// keyed off it.
+  List<_IdentifyField> _searchFields(AppLocalizations l10n) => [
+        _IdentifyField(l10n.name, _nameController, _refName),
+        _IdentifyField(l10n.adminLabelYear, _yearController, _refYear,
+            keyboardType: TextInputType.number),
+        _IdentifyField(l10n.adminLabelImdbId, _imdbController, _refImdb),
+        _IdentifyField(
+            l10n.adminLabelTmdbMovieId, _tmdbMovieController, _refTmdbMovie),
+        _IdentifyField(
+            l10n.adminLabelTmdbBoxSetId, _tmdbBoxSetController, _refTmdbBoxSet),
+        _IdentifyField(
+            l10n.adminLabelTvdbBoxSetId, _tvdbBoxSetController, _refTvdbBoxSet),
+        _IdentifyField(l10n.adminLabelTvdbId, _tvdbIdController, _refTvdbId),
+        _IdentifyField(
+            l10n.adminLabelTvdbSlug, _tvdbSlugController, _refTvdbSlug),
+      ];
+
   Widget _buildSearchForm(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
+    final fields = _searchFields(l10n);
+    assert(fields.length == _fieldCount);
     return SingleChildScrollView(
       controller: _scrollController,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (_loadError != null) ...[
+            Row(
+              children: [
+                Icon(Icons.warning_amber_rounded,
+                    size: 18, color: theme.colorScheme.error),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    l10n.adminMetadataLoadFailed(_loadError!),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.error,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+          ],
           if (_path != null && _path!.isNotEmpty) ...[
             Container(
               width: double.infinity,
@@ -785,7 +819,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                 borderRadius: AppRadius.circular(8),
               ),
               child: SelectableText(
-                'Path: $_path',
+                '${l10n.path}: $_path',
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontFamily: 'monospace',
                   color: theme.colorScheme.onSurfaceVariant,
@@ -795,7 +829,6 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
             const SizedBox(height: 12),
           ],
 
-          // Column Headers
           Padding(
             padding: const EdgeInsets.only(bottom: 10),
             child: Row(
@@ -810,7 +843,8 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                     ),
                   ),
                 ),
-                const SizedBox(width: 48), // Arrow button spacing
+                // Matches the arrow column: 6px gap + 30px button + 6px gap.
+                const SizedBox(width: 42),
                 Expanded(
                   flex: 2,
                   child: Text(
@@ -825,217 +859,166 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
             ),
           ),
 
-          _buildFieldRow(
-            index: 0,
-            label: l10n.adminLabelName,
-            controller: _nameController,
-            referenceValue: _refName,
-          ),
-          _buildFieldRow(
-            index: 1,
-            label: l10n.adminLabelYear,
-            controller: _yearController,
-            referenceValue: _refYear,
-            keyboardType: TextInputType.number,
-          ),
-          _buildFieldRow(
-            index: 2,
-            label: l10n.adminLabelImdbId,
-            controller: _imdbController,
-            referenceValue: _refImdb,
-          ),
-          _buildFieldRow(
-            index: 3,
-            label: l10n.adminLabelTmdbMovieId,
-            controller: _tmdbMovieController,
-            referenceValue: _refTmdbMovie,
-          ),
-          _buildFieldRow(
-            index: 4,
-            label: l10n.adminLabelTmdbBoxSetId,
-            controller: _tmdbBoxSetController,
-            referenceValue: _refTmdbBoxSet,
-          ),
-          _buildFieldRow(
-            index: 5,
-            label: l10n.adminLabelTvdbBoxSetId,
-            controller: _tvdbBoxSetController,
-            referenceValue: _refTvdbBoxSet,
-          ),
-          _buildFieldRow(
-            index: 6,
-            label: l10n.adminLabelTvdbId,
-            controller: _tvdbIdController,
-            referenceValue: _refTvdbId,
-          ),
-          _buildFieldRow(
-            index: 7,
-            label: l10n.adminLabelTvdbSlug,
-            controller: _tvdbSlugController,
-            referenceValue: _refTvdbSlug,
-          ),
+          for (var i = 0; i < fields.length; i++) _buildFieldRow(i, fields[i]),
         ],
       ),
     );
   }
 
-  Widget _buildFieldRow({
-    required int index,
-    required String label,
-    required TextEditingController controller,
-    required String? referenceValue,
-    TextInputType? keyboardType,
-  }) {
+  Widget _buildFieldRow(int index, _IdentifyField field) {
     final theme = Theme.of(context);
-    final hasReference = referenceValue != null && referenceValue.trim().isNotEmpty;
+    final label = field.label;
+    final controller = field.controller;
+    final keyboardType = field.keyboardType;
+    final reference = field.reference?.trim();
+    final hasReference = reference != null && reference.isNotEmpty;
     final fieldFocusNode = _fieldFocusNodes[index];
     final arrowFocusNode = _arrowFocusNodes[index];
     final tvFieldKey = _tvFieldKeys[index];
+    void pullReference() {
+      if (hasReference) setState(() => controller.text = reference);
+    }
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 10.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          // Left Column: Search Input Field (Uses CustomTVTextField on TV)
+          // Only TV gets the d-pad wrapper. Anywhere else a handler that
+          // swallows space and the arrows would stop them reaching the text
+          // input, so the field would refuse spaces and the caret couldn't move.
           Expanded(
             flex: 3,
-            child: Focus(
-              focusNode: fieldFocusNode,
-              onKeyEvent: (_, event) {
-                if (event is KeyDownEvent) {
-                  final key = event.logicalKey;
-                  if (key == LogicalKeyboardKey.select ||
-                      key == LogicalKeyboardKey.enter ||
-                      key == LogicalKeyboardKey.gameButtonA ||
-                      key == LogicalKeyboardKey.space) {
-                    if (!fieldFocusNode.hasFocus) {
-                      fieldFocusNode.requestFocus();
-                    }
-                    tvFieldKey.currentState?.openKeyboard();
-                    return KeyEventResult.handled;
-                  }
-                  if (key == LogicalKeyboardKey.arrowRight) {
-                    arrowFocusNode.requestFocus();
-                    return KeyEventResult.handled;
-                  }
-                  if (key == LogicalKeyboardKey.arrowDown) {
-                    if (index < 7) {
-                      _fieldFocusNodes[index + 1].requestFocus();
-                    } else {
-                      _cancelButtonFocusNode.requestFocus();
-                    }
-                    return KeyEventResult.handled;
-                  }
-                  if (key == LogicalKeyboardKey.arrowUp) {
-                    if (index > 0) {
-                      _fieldFocusNodes[index - 1].requestFocus();
-                    } else {
-                      _closeButtonFocusNode.requestFocus();
-                    }
-                    return KeyEventResult.handled;
-                  }
-                }
-                return KeyEventResult.ignored;
-              },
-              child: ListenableBuilder(
-                listenable: fieldFocusNode,
-                builder: (ctx, _) {
-                  if (PlatformDetection.isTV) {
-                    final preferSystemIme =
-                        _prefs.get(UserPreferences.preferSystemImeKeyboard);
-                    return GestureDetector(
-                      onTap: () {
+            child: _isTV
+                ? Focus(
+                    focusNode: fieldFocusNode,
+                    onKeyEvent: (_, event) {
+                      if (!event.isActionable) return KeyEventResult.ignored;
+                      final key = event.logicalKey;
+                      if (key.isSelectKey) {
                         if (!fieldFocusNode.hasFocus) {
                           fieldFocusNode.requestFocus();
                         }
                         tvFieldKey.currentState?.openKeyboard();
+                        return KeyEventResult.handled;
+                      }
+                      if (key.isRightKey) {
+                        arrowFocusNode.requestFocus();
+                        return KeyEventResult.handled;
+                      }
+                      if (key.isDownKey) {
+                        if (index < _lastFieldIndex) {
+                          _fieldFocusNodes[index + 1].requestFocus();
+                        } else {
+                          _cancelButtonFocusNode.requestFocus();
+                        }
+                        return KeyEventResult.handled;
+                      }
+                      if (key.isUpKey) {
+                        if (index > 0) {
+                          _fieldFocusNodes[index - 1].requestFocus();
+                        } else {
+                          _closeButtonFocusNode.requestFocus();
+                        }
+                        return KeyEventResult.handled;
+                      }
+                      return KeyEventResult.ignored;
+                    },
+                    child: ListenableBuilder(
+                      listenable: fieldFocusNode,
+                      builder: (ctx, _) {
+                        final preferSystemIme =
+                            _prefs.get(UserPreferences.preferSystemImeKeyboard);
+                        return GestureDetector(
+                          onTap: () {
+                            if (!fieldFocusNode.hasFocus) {
+                              fieldFocusNode.requestFocus();
+                            }
+                            tvFieldKey.currentState?.openKeyboard();
+                          },
+                          child: CustomTVTextField(
+                            key: tvFieldKey,
+                            controller: controller,
+                            isFocused: fieldFocusNode.hasFocus,
+                            inputPurpose: InputPurpose.text,
+                            keyboardType: keyboardType == TextInputType.number
+                                ? KeyboardType.numeric
+                                : KeyboardType.alphabetic,
+                            preferSystemIme: preferSystemIme,
+                            hint: label,
+                            filled: true,
+                            fillColor: theme.colorScheme.surfaceContainerHighest
+                                .withValues(alpha: 0.4),
+                            borderColor: theme.colorScheme.outlineVariant
+                                .withValues(alpha: 0.4),
+                            focusedBorderColor: theme.colorScheme.primary,
+                            hintStyle: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant
+                                  .withValues(alpha: 0.6),
+                            ),
+                            textStyle: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurface,
+                            ),
+                            popParentOnKeyboardClose: false,
+                          ),
+                        );
                       },
-                      child: CustomTVTextField(
-                        key: tvFieldKey,
-                        controller: controller,
-                        isFocused: fieldFocusNode.hasFocus,
-                        inputPurpose: InputPurpose.text,
-                        keyboardType: keyboardType == TextInputType.number
-                            ? KeyboardType.numeric
-                            : KeyboardType.alphabetic,
-                        preferSystemIme: preferSystemIme,
-                        hint: label,
-                        filled: true,
-                        fillColor: theme.colorScheme.surfaceContainerHighest
-                            .withValues(alpha: 0.4),
-                        borderColor: theme.colorScheme.outlineVariant
-                            .withValues(alpha: 0.4),
-                        focusedBorderColor: theme.colorScheme.primary,
-                        hintStyle: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant
-                              .withValues(alpha: 0.6),
-                        ),
-                        textStyle: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurface,
-                        ),
-                        popParentOnKeyboardClose: false,
-                      ),
-                    );
-                  }
-
-                  return TextField(
+                    ),
+                  )
+                : TextField(
                     controller: controller,
+                    focusNode: fieldFocusNode,
                     keyboardType: keyboardType,
+                    textInputAction: TextInputAction.search,
+                    onSubmitted: (_) {
+                      if (!_searching) _performSearch();
+                    },
                     style: theme.textTheme.bodyMedium,
                     decoration: InputDecoration(
                       labelText: label,
                       border: const OutlineInputBorder(),
                       isDense: true,
                     ),
-                  );
-                },
-              ),
-            ),
+                  ),
           ),
           const SizedBox(width: 6),
 
-          // Pull Action Button with explicit Up/Down/Left/Right TV D-pad linking & Select/Enter activation
+          // Copies the current value on the right into the field on the left.
           Focus(
             focusNode: arrowFocusNode,
             onKeyEvent: (_, event) {
-              if (event is KeyDownEvent) {
-                final key = event.logicalKey;
-                if (key == LogicalKeyboardKey.select ||
-                    key == LogicalKeyboardKey.enter ||
-                    key == LogicalKeyboardKey.gameButtonA ||
-                    key == LogicalKeyboardKey.space) {
-                  if (hasReference) {
-                    setState(() {
-                      controller.text = referenceValue.trim();
-                    });
-                  }
-                  return KeyEventResult.handled;
+              if (!event.isActionable) return KeyEventResult.ignored;
+              final key = event.logicalKey;
+              if (key.isSelectKey) {
+                pullReference();
+                return KeyEventResult.handled;
+              }
+              // Normal traversal already reaches this button off TV, so the
+              // arrow keys are left alone there.
+              if (!_isTV) return KeyEventResult.ignored;
+              if (key.isUpKey) {
+                if (index == 0) {
+                  _closeButtonFocusNode.requestFocus();
+                } else {
+                  _arrowFocusNodes[index - 1].requestFocus();
                 }
-                if (key == LogicalKeyboardKey.arrowUp) {
-                  if (index == 0) {
-                    _closeButtonFocusNode.requestFocus();
-                  } else {
-                    _arrowFocusNodes[index - 1].requestFocus();
-                  }
-                  return KeyEventResult.handled;
-                }
-                if (key == LogicalKeyboardKey.arrowDown) {
-                  if (index < 7) {
-                    _arrowFocusNodes[index + 1].requestFocus();
-                  } else {
-                    _searchButtonFocusNode.requestFocus();
-                  }
-                  return KeyEventResult.handled;
-                }
-                if (key == LogicalKeyboardKey.arrowRight) {
+                return KeyEventResult.handled;
+              }
+              if (key.isDownKey) {
+                if (index < _lastFieldIndex) {
+                  _arrowFocusNodes[index + 1].requestFocus();
+                } else {
                   _searchButtonFocusNode.requestFocus();
-                  return KeyEventResult.handled;
                 }
-                if (key == LogicalKeyboardKey.arrowLeft) {
-                  fieldFocusNode.requestFocus();
-                  return KeyEventResult.handled;
-                }
+                return KeyEventResult.handled;
+              }
+              if (key.isRightKey) {
+                _searchButtonFocusNode.requestFocus();
+                return KeyEventResult.handled;
+              }
+              if (key.isLeftKey) {
+                fieldFocusNode.requestFocus();
+                return KeyEventResult.handled;
               }
               return KeyEventResult.ignored;
             },
@@ -1043,13 +1026,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
               builder: (btnCtx) {
                 final hasFocus = Focus.of(btnCtx).hasFocus;
                 return InkWell(
-                  onTap: hasReference
-                      ? () {
-                          setState(() {
-                            controller.text = referenceValue.trim();
-                          });
-                        }
-                      : null,
+                  onTap: hasReference ? pullReference : null,
                   borderRadius: AppRadius.circular(20),
                   child: Container(
                     padding: const EdgeInsets.all(6),
@@ -1083,7 +1060,6 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
 
           const SizedBox(width: 6),
 
-          // Right Column: Non-editable reference text (Borderless reference badge)
           Expanded(
             flex: 2,
             child: Container(
@@ -1101,7 +1077,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
                 ),
               ),
               child: Text(
-                hasReference ? referenceValue.trim() : '—',
+                hasReference ? reference : '-',
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: hasReference
                       ? theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.85)
@@ -1142,29 +1118,27 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
           child: Focus(
             focusNode: resultFocusNode,
             onKeyEvent: (_, event) {
-              if (event is KeyDownEvent) {
-                final key = event.logicalKey;
-                if (key == LogicalKeyboardKey.select ||
-                    key == LogicalKeyboardKey.enter ||
-                    key == LogicalKeyboardKey.gameButtonA ||
-                    key == LogicalKeyboardKey.space) {
-                  _applyResult(item);
-                  return KeyEventResult.handled;
+              if (!event.isActionable) return KeyEventResult.ignored;
+              final key = event.logicalKey;
+              if (key.isSelectKey) {
+                _applyResult(item);
+                return KeyEventResult.handled;
+              }
+              if (!_isTV) return KeyEventResult.ignored;
+              if (key.isUpKey) {
+                if (index == 0) {
+                  _closeButtonFocusNode.requestFocus();
+                } else if (_resultFocusNodes != null && index > 0) {
+                  _resultFocusNodes![index - 1].requestFocus();
                 }
-                if (key == LogicalKeyboardKey.arrowUp) {
-                  if (index == 0) {
-                    _closeButtonFocusNode.requestFocus();
-                  } else if (_resultFocusNodes != null && index > 0) {
-                    _resultFocusNodes![index - 1].requestFocus();
-                  }
-                  return KeyEventResult.handled;
+                return KeyEventResult.handled;
+              }
+              if (key.isDownKey) {
+                if (_resultFocusNodes != null &&
+                    index < _resultFocusNodes!.length - 1) {
+                  _resultFocusNodes![index + 1].requestFocus();
                 }
-                if (key == LogicalKeyboardKey.arrowDown) {
-                  if (_resultFocusNodes != null && index < _resultFocusNodes!.length - 1) {
-                    _resultFocusNodes![index + 1].requestFocus();
-                  }
-                  return KeyEventResult.handled;
-                }
+                return KeyEventResult.handled;
               }
               return KeyEventResult.ignored;
             },
@@ -1271,4 +1245,20 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
       },
     );
   }
+}
+
+/// One row of the search form, pairing an editable field with the value the
+/// item already carries.
+class _IdentifyField {
+  final String label;
+  final TextEditingController controller;
+  final String? reference;
+  final TextInputType? keyboardType;
+
+  const _IdentifyField(
+    this.label,
+    this.controller,
+    this.reference, {
+    this.keyboardType,
+  });
 }

--- a/lib/ui/widgets/identify_dialog.dart
+++ b/lib/ui/widgets/identify_dialog.dart
@@ -1,0 +1,1274 @@
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+import 'package:server_core/server_core.dart';
+
+import '../../l10n/app_localizations.dart';
+import '../../preference/user_preferences.dart';
+import '../../util/platform_detection.dart';
+import 'adaptive/adaptive_dialog.dart';
+import 'focus/focusable_button.dart';
+
+class IdentifyDialog extends StatefulWidget {
+  final String itemId;
+  final String? itemType;
+  final String? itemName;
+  final int? itemYear;
+  final String? itemPath;
+  final Map<String, dynamic>? providerIds;
+
+  const IdentifyDialog({
+    super.key,
+    required this.itemId,
+    this.itemType,
+    this.itemName,
+    this.itemYear,
+    this.itemPath,
+    this.providerIds,
+  });
+
+  static Future<bool?> show(
+    BuildContext context, {
+    required String itemId,
+    String? itemType,
+    String? itemName,
+    int? itemYear,
+    String? itemPath,
+    Map<String, dynamic>? providerIds,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => IdentifyDialog(
+        itemId: itemId,
+        itemType: itemType,
+        itemName: itemName,
+        itemYear: itemYear,
+        itemPath: itemPath,
+        providerIds: providerIds,
+      ),
+    );
+  }
+
+  @override
+  State<IdentifyDialog> createState() => _IdentifyDialogState();
+}
+
+class _IdentifyDialogState extends State<IdentifyDialog> {
+  late final AdminItemsApi _adminApi;
+  late final ItemsApi _itemsApi;
+  late final UserPreferences _prefs;
+
+  bool _loadingItem = false;
+  bool _searching = false;
+  bool _applying = false;
+
+  late String _targetItemId;
+  String? _path;
+  String _searchType = 'Movie';
+
+  List<Map<String, dynamic>>? _searchResults;
+
+  // Reference Metadata Values (Current Item)
+  String? _refName;
+  String? _refYear;
+  String? _refImdb;
+  String? _refTmdbMovie;
+  String? _refTmdbBoxSet;
+  String? _refTvdbBoxSet;
+  String? _refTvdbId;
+  String? _refTvdbSlug;
+
+  // Editable Search Parameter Controllers (Blank by default)
+  late final TextEditingController _nameController;
+  late final TextEditingController _yearController;
+  late final TextEditingController _imdbController;
+  late final TextEditingController _tmdbMovieController;
+  late final TextEditingController _tmdbBoxSetController;
+  late final TextEditingController _tvdbBoxSetController;
+  late final TextEditingController _tvdbIdController;
+  late final TextEditingController _tvdbSlugController;
+
+  // FocusNodes and ScrollController for TV Navigation
+  final ScrollController _scrollController = ScrollController();
+
+  final FocusNode _closeButtonFocusNode = FocusNode(debugLabel: 'identify-close-btn');
+  final FocusNode _cancelButtonFocusNode = FocusNode(debugLabel: 'identify-cancel-btn');
+  final FocusNode _searchButtonFocusNode = FocusNode(debugLabel: 'identify-search-btn');
+
+  final List<FocusNode> _fieldFocusNodes =
+      List.generate(8, (i) => FocusNode(debugLabel: 'identify-field-$i'));
+  final List<FocusNode> _arrowFocusNodes =
+      List.generate(8, (i) => FocusNode(debugLabel: 'identify-arrow-$i'));
+  final List<GlobalKey<CustomTVTextFieldState>> _tvFieldKeys =
+      List.generate(8, (_) => GlobalKey<CustomTVTextFieldState>());
+
+  List<FocusNode>? _resultFocusNodes;
+
+  @override
+  void initState() {
+    super.initState();
+    final client = GetIt.instance<MediaServerClient>();
+    _adminApi = client.adminItemsApi;
+    _itemsApi = client.itemsApi;
+    _prefs = GetIt.instance<UserPreferences>();
+
+    _targetItemId = widget.itemId;
+    final isTVChild = widget.itemType == 'Episode' || widget.itemType == 'Season';
+    _searchType = isTVChild ? 'Series' : (widget.itemType ?? 'Movie');
+    _path = widget.itemPath;
+
+    final initialProviders = widget.providerIds ?? const {};
+
+    if (!isTVChild) {
+      _refName = widget.itemName;
+      _refYear = widget.itemYear?.toString();
+      _refImdb = initialProviders['Imdb']?.toString();
+      _refTmdbMovie = initialProviders['Tmdb']?.toString();
+      _refTmdbBoxSet = initialProviders['TmdbBoxSet']?.toString();
+      _refTvdbBoxSet = initialProviders['TvdbBoxSet']?.toString();
+      _refTvdbId = initialProviders['Tvdb']?.toString();
+      _refTvdbSlug = initialProviders['TvdbSlug']?.toString();
+    }
+
+    // Search controllers start BLANK by default
+    _nameController = TextEditingController(text: '');
+    _yearController = TextEditingController(text: '');
+    _imdbController = TextEditingController(text: '');
+    _tmdbMovieController = TextEditingController(text: '');
+    _tmdbBoxSetController = TextEditingController(text: '');
+    _tvdbBoxSetController = TextEditingController(text: '');
+    _tvdbIdController = TextEditingController(text: '');
+    _tvdbSlugController = TextEditingController(text: '');
+
+    // Add listeners to auto-scroll focused rows into the visible viewport on TV
+    for (int i = 0; i < 8; i++) {
+      final idx = i;
+      _fieldFocusNodes[idx].addListener(() {
+        if (_fieldFocusNodes[idx].hasFocus) {
+          _scrollToIndex(idx);
+        }
+      });
+      _arrowFocusNodes[idx].addListener(() {
+        if (_arrowFocusNodes[idx].hasFocus) {
+          _scrollToIndex(idx);
+        }
+      });
+    }
+
+    _fetchItemDetailsIfNeeded();
+  }
+
+  void _closeDialog([bool? result]) {
+    FocusScope.of(context).unfocus();
+    if (mounted) {
+      Navigator.of(context).pop(result);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _yearController.dispose();
+    _imdbController.dispose();
+    _tmdbMovieController.dispose();
+    _tmdbBoxSetController.dispose();
+    _tvdbBoxSetController.dispose();
+    _tvdbIdController.dispose();
+    _tvdbSlugController.dispose();
+
+    _scrollController.dispose();
+
+    _closeButtonFocusNode.unfocus();
+    _closeButtonFocusNode.dispose();
+
+    _cancelButtonFocusNode.unfocus();
+    _cancelButtonFocusNode.dispose();
+
+    _searchButtonFocusNode.unfocus();
+    _searchButtonFocusNode.dispose();
+
+    for (final fn in _fieldFocusNodes) {
+      fn.unfocus();
+      fn.dispose();
+    }
+    for (final fn in _arrowFocusNodes) {
+      fn.unfocus();
+      fn.dispose();
+    }
+    _clearResultFocusNodes();
+    super.dispose();
+  }
+
+  void _clearResultFocusNodes() {
+    if (_resultFocusNodes != null) {
+      for (final fn in _resultFocusNodes!) {
+        fn.unfocus();
+        fn.dispose();
+      }
+      _resultFocusNodes = null;
+    }
+  }
+
+  void _setupResultFocusNodes(int count) {
+    _clearResultFocusNodes();
+    _resultFocusNodes =
+        List.generate(count, (i) => FocusNode(debugLabel: 'identify-result-$i'));
+    for (int i = 0; i < count; i++) {
+      final idx = i;
+      _resultFocusNodes![idx].addListener(() {
+        if (_resultFocusNodes != null &&
+            idx < _resultFocusNodes!.length &&
+            _resultFocusNodes![idx].hasFocus) {
+          _scrollToResultIndex(idx);
+        }
+      });
+    }
+  }
+
+  void _scrollToIndex(int index) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final fn = _fieldFocusNodes[index];
+      final fnCtx = fn.context ?? _arrowFocusNodes[index].context;
+      if (fnCtx != null && fnCtx.mounted) {
+        Scrollable.ensureVisible(
+          fnCtx,
+          alignment: 0.35,
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOutCubic,
+        );
+      }
+    });
+  }
+
+  void _scrollToResultIndex(int index) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _resultFocusNodes == null || index >= _resultFocusNodes!.length) return;
+      final fnCtx = _resultFocusNodes![index].context;
+      if (fnCtx != null && fnCtx.mounted) {
+        Scrollable.ensureVisible(
+          fnCtx,
+          alignment: 0.35,
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOutCubic,
+        );
+      }
+    });
+  }
+
+  Future<void> _fetchItemDetailsIfNeeded() async {
+    setState(() => _loadingItem = true);
+    try {
+      var raw = await _itemsApi.getItem(widget.itemId);
+
+      if ((raw['Type'] == 'Episode' || raw['Type'] == 'Season') &&
+          raw['SeriesId'] != null &&
+          raw['SeriesId'].toString().isNotEmpty) {
+        _targetItemId = raw['SeriesId'].toString();
+        _searchType = 'Series';
+        try {
+          raw = await _itemsApi.getItem(_targetItemId);
+        } catch (_) {}
+      }
+
+      if (!mounted) return;
+      setState(() {
+        _refName = raw['Name']?.toString();
+        _refYear = raw['ProductionYear']?.toString();
+        if (raw['Path'] != null && raw['Path'].toString().isNotEmpty) {
+          _path = raw['Path'].toString();
+        }
+        if (raw['Type'] != null && raw['Type'].toString().isNotEmpty) {
+          _searchType = raw['Type'].toString();
+        }
+        final pIds = raw['ProviderIds'];
+        if (pIds is Map) {
+          _refImdb = pIds['Imdb']?.toString();
+          _refTmdbMovie = pIds['Tmdb']?.toString();
+          _refTmdbBoxSet = pIds['TmdbBoxSet']?.toString();
+          _refTvdbBoxSet = pIds['TvdbBoxSet']?.toString();
+          _refTvdbId = pIds['Tvdb']?.toString();
+          _refTvdbSlug = pIds['TvdbSlug']?.toString();
+        }
+      });
+    } catch (_) {
+    } finally {
+      if (mounted) {
+        setState(() => _loadingItem = false);
+      }
+    }
+  }
+
+  Future<void> _performSearch() async {
+    final l10n = AppLocalizations.of(context);
+    setState(() {
+      _searching = true;
+      _searchResults = null;
+    });
+
+    final nameVal = _nameController.text.trim();
+    final yearVal = int.tryParse(_yearController.text.trim());
+
+    final providerIds = <String, String>{};
+
+    var imdbVal = _imdbController.text.trim();
+    if (imdbVal.isNotEmpty) {
+      if (RegExp(r'^\d+$').hasMatch(imdbVal)) {
+        imdbVal = 'tt$imdbVal';
+      }
+      providerIds['Imdb'] = imdbVal;
+      providerIds['IMDb'] = imdbVal;
+      providerIds['imdb'] = imdbVal;
+    }
+
+    final tmdbVal = _tmdbMovieController.text.trim();
+    if (tmdbVal.isNotEmpty) {
+      providerIds['Tmdb'] = tmdbVal;
+      providerIds['TMDB'] = tmdbVal;
+      providerIds['tmdb'] = tmdbVal;
+    }
+
+    final tmdbBoxSetVal = _tmdbBoxSetController.text.trim();
+    if (tmdbBoxSetVal.isNotEmpty) {
+      providerIds['TmdbBoxSet'] = tmdbBoxSetVal;
+      providerIds['TMDBBoxSet'] = tmdbBoxSetVal;
+    }
+
+    final tvdbBoxSetVal = _tvdbBoxSetController.text.trim();
+    if (tvdbBoxSetVal.isNotEmpty) {
+      providerIds['TvdbBoxSet'] = tvdbBoxSetVal;
+      providerIds['TVDBBoxSet'] = tvdbBoxSetVal;
+    }
+
+    final tvdbVal = _tvdbIdController.text.trim();
+    if (tvdbVal.isNotEmpty) {
+      providerIds['Tvdb'] = tvdbVal;
+      providerIds['TVDB'] = tvdbVal;
+      providerIds['tvdb'] = tvdbVal;
+    }
+
+    final tvdbSlugVal = _tvdbSlugController.text.trim();
+    if (tvdbSlugVal.isNotEmpty) {
+      providerIds['TvdbSlug'] = tvdbSlugVal;
+      providerIds['TVDBSlug'] = tvdbSlugVal;
+    }
+
+    final searchInfo = <String, dynamic>{
+      'Name': nameVal,
+      'Year': ?yearVal,
+      if (providerIds.isNotEmpty) 'ProviderIds': providerIds,
+    };
+
+    debugPrint('--> [IdentifyRemoteSearch] Executing search for $_searchType | ItemId: $_targetItemId');
+    debugPrint('--> [IdentifyRemoteSearch] SearchInfo: $searchInfo');
+
+    try {
+      List<Map<String, dynamic>> results = await _adminApi.searchRemote(_searchType, {
+        'SearchInfo': searchInfo,
+        'ItemId': _targetItemId,
+        'IncludeDisabledProviders': false,
+      });
+
+      // Fallback 1: If TMDB/IMDb is present, try setting explicit SearchProviderName
+      if (results.isEmpty && (providerIds.containsKey('Tmdb') || providerIds.containsKey('Imdb'))) {
+        final altInfoProvider = <String, dynamic>{
+          ...searchInfo,
+          'SearchProviderName': 'TheMovieDb',
+        };
+        debugPrint('--> [IdentifyRemoteSearch] Retry with SearchProviderName: TheMovieDb');
+        results = await _adminApi.searchRemote(_searchType, {
+          'SearchInfo': altInfoProvider,
+          'ItemId': _targetItemId,
+          'IncludeDisabledProviders': false,
+        });
+      }
+
+      // Fallback 2: Try ProviderIds alone without Name
+      if (results.isEmpty && providerIds.isNotEmpty && nameVal.isNotEmpty) {
+        final altInfoA = <String, dynamic>{
+          'Name': '',
+          'Year': ?yearVal,
+          'ProviderIds': providerIds,
+        };
+        debugPrint('--> [IdentifyRemoteSearch] Retry with ProviderIds alone (empty Name)');
+        results = await _adminApi.searchRemote(_searchType, {
+          'SearchInfo': altInfoA,
+          'ItemId': _targetItemId,
+          'IncludeDisabledProviders': false,
+        });
+      }
+
+      // Fallback 3: Try Name (+ Year) alone
+      if (results.isEmpty && nameVal.isNotEmpty) {
+        final altInfoB = <String, dynamic>{
+          'Name': nameVal,
+          'Year': ?yearVal,
+        };
+        debugPrint('--> [IdentifyRemoteSearch] Retry with Name + Year alone');
+        results = await _adminApi.searchRemote(_searchType, {
+          'SearchInfo': altInfoB,
+          'ItemId': _targetItemId,
+          'IncludeDisabledProviders': false,
+        });
+      }
+
+      debugPrint('<-- [IdentifyRemoteSearch] Results received: ${results.length}');
+      if (!mounted) return;
+
+      if (results.isEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.adminNoRemoteMatches)),
+        );
+        setState(() {
+          _searching = false;
+        });
+      } else {
+        _setupResultFocusNodes(results.length);
+        setState(() {
+          _searchResults = results;
+          _searching = false;
+        });
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && _resultFocusNodes != null && _resultFocusNodes!.isNotEmpty) {
+            _resultFocusNodes![0].requestFocus();
+          }
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.adminRemoteSearchFailed('$e'))),
+      );
+      setState(() => _searching = false);
+    }
+  }
+
+  Future<void> _applyResult(Map<String, dynamic> result) async {
+    final l10n = AppLocalizations.of(context);
+    bool replaceAllImages = true;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (dialogCtx, setDialogState) => AlertDialog.adaptive(
+          title: Text(l10n.adminRemoteResults),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                (result['Name'] ?? l10n.unknown).toString(),
+                style: Theme.of(ctx).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 16),
+              FocusableButton(
+                onPressed: () {
+                  setDialogState(() {
+                    replaceAllImages = !replaceAllImages;
+                  });
+                },
+                borderRadius: 8,
+                padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 4),
+                child: Row(
+                  children: [
+                    Checkbox(
+                      value: replaceAllImages,
+                      onChanged: (val) {
+                        setDialogState(() {
+                          replaceAllImages = val ?? true;
+                        });
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        l10n.adminReplaceImages,
+                        style: Theme.of(ctx).textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            adaptiveDialogAction(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: Text(l10n.cancel),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: Text(l10n.adminApply),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _applying = true);
+    try {
+      await _adminApi.applyRemoteSearchResult(_targetItemId, result);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.adminRemoteMetadataApplied)),
+      );
+      _closeDialog(true);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(l10n.adminRemoteSearchFailed('$e'))),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _applying = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    final width = (MediaQuery.sizeOf(context).width - 32).clamp(340.0, 780.0);
+    final height = (MediaQuery.sizeOf(context).height * 0.92).clamp(420.0, 840.0);
+
+    return Dialog(
+      backgroundColor: theme.colorScheme.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: AppRadius.circular(16),
+      ),
+      child: SizedBox(
+        width: width,
+        height: height,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 14, 20, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Dialog Header
+              Row(
+                children: [
+                  if (_searchResults != null)
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: () {
+                        _clearResultFocusNodes();
+                        setState(() => _searchResults = null);
+                      },
+                      tooltip: l10n.adminBackToSearch,
+                    ),
+                  Expanded(
+                    child: Text(
+                      _searchResults == null
+                          ? l10n.adminMetadataIdentify
+                          : l10n.adminRemoteResults,
+                      style: theme.textTheme.headlineSmall,
+                    ),
+                  ),
+                  // Requirement 1 & 2: Pronounced X focus & Down navigation & Select/Enter pop
+                  Focus(
+                    focusNode: _closeButtonFocusNode,
+                    onKeyEvent: (_, event) {
+                      if (event is KeyDownEvent) {
+                        final key = event.logicalKey;
+                        if (key == LogicalKeyboardKey.select ||
+                            key == LogicalKeyboardKey.enter ||
+                            key == LogicalKeyboardKey.gameButtonA ||
+                            key == LogicalKeyboardKey.space) {
+                          _closeDialog(false);
+                          return KeyEventResult.handled;
+                        }
+                        if (key == LogicalKeyboardKey.arrowDown) {
+                          if (_searchResults != null &&
+                              _resultFocusNodes != null &&
+                              _resultFocusNodes!.isNotEmpty) {
+                            _resultFocusNodes![0].requestFocus();
+                          } else {
+                            _arrowFocusNodes[0].requestFocus();
+                          }
+                          return KeyEventResult.handled;
+                        }
+                      }
+                      return KeyEventResult.ignored;
+                    },
+                    child: Builder(
+                      builder: (btnCtx) {
+                        final hasFocus = Focus.of(btnCtx).hasFocus;
+                        return GestureDetector(
+                          onTap: () => _closeDialog(false),
+                          child: InkWell(
+                            onTap: () => _closeDialog(false),
+                            borderRadius: AppRadius.circular(20),
+                            child: AnimatedContainer(
+                              duration: const Duration(milliseconds: 150),
+                              padding: const EdgeInsets.all(6),
+                              decoration: BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: hasFocus
+                                    ? theme.colorScheme.primary.withValues(alpha: 0.25)
+                                    : Colors.transparent,
+                                border: Border.all(
+                                  color: hasFocus
+                                      ? theme.colorScheme.primary
+                                      : Colors.transparent,
+                                  width: 2.5,
+                                ),
+                                boxShadow: hasFocus
+                                    ? [
+                                        BoxShadow(
+                                          color: theme.colorScheme.primary
+                                              .withValues(alpha: 0.6),
+                                          blurRadius: 10,
+                                          spreadRadius: 2,
+                                        )
+                                      ]
+                                    : null,
+                              ),
+                              child: Icon(
+                                Icons.close,
+                                color: hasFocus
+                                    ? theme.colorScheme.primary
+                                    : theme.colorScheme.onSurface,
+                                size: 20,
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const Divider(height: 12),
+
+              // Dialog Body
+              Expanded(
+                child: _loadingItem || _applying
+                    ? const Center(child: CircularProgressIndicator())
+                    : _searchResults != null
+                        ? _buildResultsList(context)
+                        : _buildSearchForm(context),
+              ),
+
+              // Requirement 5: Compact Button Bar
+              if (_searchResults == null) ...[
+                Padding(
+                  padding: const EdgeInsets.only(top: 4, bottom: 2),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Focus(
+                        focusNode: _cancelButtonFocusNode,
+                        onKeyEvent: (_, event) {
+                          if (event is KeyDownEvent) {
+                            final key = event.logicalKey;
+                            if (key == LogicalKeyboardKey.select ||
+                                key == LogicalKeyboardKey.enter ||
+                                key == LogicalKeyboardKey.gameButtonA ||
+                                key == LogicalKeyboardKey.space) {
+                              _closeDialog(false);
+                              return KeyEventResult.handled;
+                            }
+                            if (key == LogicalKeyboardKey.arrowUp) {
+                              _fieldFocusNodes[7].requestFocus();
+                              return KeyEventResult.handled;
+                            }
+                            if (key == LogicalKeyboardKey.arrowRight) {
+                              _searchButtonFocusNode.requestFocus();
+                              return KeyEventResult.handled;
+                            }
+                          }
+                          return KeyEventResult.ignored;
+                        },
+                        child: Builder(
+                          builder: (btnCtx) {
+                            final hasFocus = Focus.of(btnCtx).hasFocus;
+                            return TextButton(
+                              onPressed: () => _closeDialog(false),
+                              style: TextButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+                                minimumSize: const Size(60, 30),
+                                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                backgroundColor: hasFocus
+                                    ? theme.colorScheme.primary.withValues(alpha: 0.15)
+                                    : null,
+                                side: hasFocus
+                                    ? BorderSide(color: theme.colorScheme.primary, width: 1.5)
+                                    : null,
+                              ),
+                              child: Text(l10n.cancel),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 10),
+                      Focus(
+                        focusNode: _searchButtonFocusNode,
+                        onKeyEvent: (_, event) {
+                          if (event is KeyDownEvent) {
+                            final key = event.logicalKey;
+                            if (key == LogicalKeyboardKey.select ||
+                                key == LogicalKeyboardKey.enter ||
+                                key == LogicalKeyboardKey.gameButtonA ||
+                                key == LogicalKeyboardKey.space) {
+                              if (!_searching) _performSearch();
+                              return KeyEventResult.handled;
+                            }
+                            if (key == LogicalKeyboardKey.arrowUp) {
+                              _arrowFocusNodes[7].requestFocus();
+                              return KeyEventResult.handled;
+                            }
+                            if (key == LogicalKeyboardKey.arrowLeft) {
+                              _cancelButtonFocusNode.requestFocus();
+                              return KeyEventResult.handled;
+                            }
+                          }
+                          return KeyEventResult.ignored;
+                        },
+                        child: Builder(
+                          builder: (btnCtx) {
+                            final hasFocus = Focus.of(btnCtx).hasFocus;
+                            return FilledButton.icon(
+                              onPressed: _searching ? null : _performSearch,
+                              style: FilledButton.styleFrom(
+                                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 4),
+                                minimumSize: const Size(70, 30),
+                                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                side: hasFocus
+                                    ? const BorderSide(color: Colors.white, width: 2.0)
+                                    : null,
+                              ),
+                              icon: _searching
+                                  ? const SizedBox(
+                                      width: 14,
+                                      height: 14,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: Colors.white,
+                                      ),
+                                    )
+                                  : const Icon(Icons.search, size: 16),
+                              label: Text(l10n.search),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchForm(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return SingleChildScrollView(
+      controller: _scrollController,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (_path != null && _path!.isNotEmpty) ...[
+            Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+                borderRadius: AppRadius.circular(8),
+              ),
+              child: SelectableText(
+                'Path: $_path',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontFamily: 'monospace',
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+
+          // Column Headers
+          Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: Row(
+              children: [
+                Expanded(
+                  flex: 3,
+                  child: Text(
+                    l10n.adminSearchParameters,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: theme.colorScheme.primary,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 48), // Arrow button spacing
+                Expanded(
+                  flex: 2,
+                  child: Text(
+                    l10n.adminCurrentMetadata,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+
+          _buildFieldRow(
+            index: 0,
+            label: l10n.adminLabelName,
+            controller: _nameController,
+            referenceValue: _refName,
+          ),
+          _buildFieldRow(
+            index: 1,
+            label: l10n.adminLabelYear,
+            controller: _yearController,
+            referenceValue: _refYear,
+            keyboardType: TextInputType.number,
+          ),
+          _buildFieldRow(
+            index: 2,
+            label: l10n.adminLabelImdbId,
+            controller: _imdbController,
+            referenceValue: _refImdb,
+          ),
+          _buildFieldRow(
+            index: 3,
+            label: l10n.adminLabelTmdbMovieId,
+            controller: _tmdbMovieController,
+            referenceValue: _refTmdbMovie,
+          ),
+          _buildFieldRow(
+            index: 4,
+            label: l10n.adminLabelTmdbBoxSetId,
+            controller: _tmdbBoxSetController,
+            referenceValue: _refTmdbBoxSet,
+          ),
+          _buildFieldRow(
+            index: 5,
+            label: l10n.adminLabelTvdbBoxSetId,
+            controller: _tvdbBoxSetController,
+            referenceValue: _refTvdbBoxSet,
+          ),
+          _buildFieldRow(
+            index: 6,
+            label: l10n.adminLabelTvdbId,
+            controller: _tvdbIdController,
+            referenceValue: _refTvdbId,
+          ),
+          _buildFieldRow(
+            index: 7,
+            label: l10n.adminLabelTvdbSlug,
+            controller: _tvdbSlugController,
+            referenceValue: _refTvdbSlug,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFieldRow({
+    required int index,
+    required String label,
+    required TextEditingController controller,
+    required String? referenceValue,
+    TextInputType? keyboardType,
+  }) {
+    final theme = Theme.of(context);
+    final hasReference = referenceValue != null && referenceValue.trim().isNotEmpty;
+    final fieldFocusNode = _fieldFocusNodes[index];
+    final arrowFocusNode = _arrowFocusNodes[index];
+    final tvFieldKey = _tvFieldKeys[index];
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          // Left Column: Search Input Field (Uses CustomTVTextField on TV)
+          Expanded(
+            flex: 3,
+            child: Focus(
+              focusNode: fieldFocusNode,
+              onKeyEvent: (_, event) {
+                if (event is KeyDownEvent) {
+                  final key = event.logicalKey;
+                  if (key == LogicalKeyboardKey.select ||
+                      key == LogicalKeyboardKey.enter ||
+                      key == LogicalKeyboardKey.gameButtonA ||
+                      key == LogicalKeyboardKey.space) {
+                    if (!fieldFocusNode.hasFocus) {
+                      fieldFocusNode.requestFocus();
+                    }
+                    tvFieldKey.currentState?.openKeyboard();
+                    return KeyEventResult.handled;
+                  }
+                  if (key == LogicalKeyboardKey.arrowRight) {
+                    arrowFocusNode.requestFocus();
+                    return KeyEventResult.handled;
+                  }
+                  if (key == LogicalKeyboardKey.arrowDown) {
+                    if (index < 7) {
+                      _fieldFocusNodes[index + 1].requestFocus();
+                    } else {
+                      _cancelButtonFocusNode.requestFocus();
+                    }
+                    return KeyEventResult.handled;
+                  }
+                  if (key == LogicalKeyboardKey.arrowUp) {
+                    if (index > 0) {
+                      _fieldFocusNodes[index - 1].requestFocus();
+                    } else {
+                      _closeButtonFocusNode.requestFocus();
+                    }
+                    return KeyEventResult.handled;
+                  }
+                }
+                return KeyEventResult.ignored;
+              },
+              child: ListenableBuilder(
+                listenable: fieldFocusNode,
+                builder: (ctx, _) {
+                  if (PlatformDetection.isTV) {
+                    final preferSystemIme =
+                        _prefs.get(UserPreferences.preferSystemImeKeyboard);
+                    return GestureDetector(
+                      onTap: () {
+                        if (!fieldFocusNode.hasFocus) {
+                          fieldFocusNode.requestFocus();
+                        }
+                        tvFieldKey.currentState?.openKeyboard();
+                      },
+                      child: CustomTVTextField(
+                        key: tvFieldKey,
+                        controller: controller,
+                        isFocused: fieldFocusNode.hasFocus,
+                        inputPurpose: InputPurpose.text,
+                        keyboardType: keyboardType == TextInputType.number
+                            ? KeyboardType.numeric
+                            : KeyboardType.alphabetic,
+                        preferSystemIme: preferSystemIme,
+                        hint: label,
+                        filled: true,
+                        fillColor: theme.colorScheme.surfaceContainerHighest
+                            .withValues(alpha: 0.4),
+                        borderColor: theme.colorScheme.outlineVariant
+                            .withValues(alpha: 0.4),
+                        focusedBorderColor: theme.colorScheme.primary,
+                        hintStyle: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant
+                              .withValues(alpha: 0.6),
+                        ),
+                        textStyle: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurface,
+                        ),
+                        popParentOnKeyboardClose: false,
+                      ),
+                    );
+                  }
+
+                  return TextField(
+                    controller: controller,
+                    keyboardType: keyboardType,
+                    style: theme.textTheme.bodyMedium,
+                    decoration: InputDecoration(
+                      labelText: label,
+                      border: const OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+
+          // Pull Action Button with explicit Up/Down/Left/Right TV D-pad linking & Select/Enter activation
+          Focus(
+            focusNode: arrowFocusNode,
+            onKeyEvent: (_, event) {
+              if (event is KeyDownEvent) {
+                final key = event.logicalKey;
+                if (key == LogicalKeyboardKey.select ||
+                    key == LogicalKeyboardKey.enter ||
+                    key == LogicalKeyboardKey.gameButtonA ||
+                    key == LogicalKeyboardKey.space) {
+                  if (hasReference) {
+                    setState(() {
+                      controller.text = referenceValue.trim();
+                    });
+                  }
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowUp) {
+                  if (index == 0) {
+                    _closeButtonFocusNode.requestFocus();
+                  } else {
+                    _arrowFocusNodes[index - 1].requestFocus();
+                  }
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowDown) {
+                  if (index < 7) {
+                    _arrowFocusNodes[index + 1].requestFocus();
+                  } else {
+                    _searchButtonFocusNode.requestFocus();
+                  }
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowRight) {
+                  _searchButtonFocusNode.requestFocus();
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowLeft) {
+                  fieldFocusNode.requestFocus();
+                  return KeyEventResult.handled;
+                }
+              }
+              return KeyEventResult.ignored;
+            },
+            child: Builder(
+              builder: (btnCtx) {
+                final hasFocus = Focus.of(btnCtx).hasFocus;
+                return InkWell(
+                  onTap: hasReference
+                      ? () {
+                          setState(() {
+                            controller.text = referenceValue.trim();
+                          });
+                        }
+                      : null,
+                  borderRadius: AppRadius.circular(20),
+                  child: Container(
+                    padding: const EdgeInsets.all(6),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: hasFocus
+                          ? theme.colorScheme.primary.withValues(alpha: 0.25)
+                          : Colors.transparent,
+                      border: Border.all(
+                        color: hasFocus
+                            ? theme.colorScheme.primary
+                            : Colors.transparent,
+                        width: 2,
+                      ),
+                    ),
+                    child: Icon(
+                      Icons.west,
+                      size: 18,
+                      color: hasFocus
+                          ? theme.colorScheme.primary
+                          : (hasReference
+                              ? theme.colorScheme.primary.withValues(alpha: 0.8)
+                              : theme.colorScheme.onSurfaceVariant
+                                  .withValues(alpha: 0.3)),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+
+          const SizedBox(width: 6),
+
+          // Right Column: Non-editable reference text (Borderless reference badge)
+          Expanded(
+            flex: 2,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.18),
+                borderRadius: AppRadius.circular(6),
+                border: Border(
+                  left: BorderSide(
+                    color: hasReference
+                        ? theme.colorScheme.primary.withValues(alpha: 0.4)
+                        : Colors.transparent,
+                    width: 2.5,
+                  ),
+                ),
+              ),
+              child: Text(
+                hasReference ? referenceValue.trim() : '—',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: hasReference
+                      ? theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.85)
+                      : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.3),
+                  fontStyle: hasReference ? FontStyle.normal : FontStyle.italic,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResultsList(BuildContext context) {
+    final theme = Theme.of(context);
+    final results = _searchResults!;
+
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: results.length,
+      itemBuilder: (context, index) {
+        final item = results[index];
+        final name = (item['Name'] ?? '').toString();
+        final year = item['ProductionYear']?.toString();
+        final overview = (item['Overview'] ?? '').toString();
+        final provider =
+            (item['SearchProviderName'] ?? item['ProviderName'] ?? '').toString();
+        final imageUrl = item['ImageUrl']?.toString();
+        final resultFocusNode = _resultFocusNodes != null && index < _resultFocusNodes!.length
+            ? _resultFocusNodes![index]
+            : null;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Focus(
+            focusNode: resultFocusNode,
+            onKeyEvent: (_, event) {
+              if (event is KeyDownEvent) {
+                final key = event.logicalKey;
+                if (key == LogicalKeyboardKey.select ||
+                    key == LogicalKeyboardKey.enter ||
+                    key == LogicalKeyboardKey.gameButtonA ||
+                    key == LogicalKeyboardKey.space) {
+                  _applyResult(item);
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowUp) {
+                  if (index == 0) {
+                    _closeButtonFocusNode.requestFocus();
+                  } else if (_resultFocusNodes != null && index > 0) {
+                    _resultFocusNodes![index - 1].requestFocus();
+                  }
+                  return KeyEventResult.handled;
+                }
+                if (key == LogicalKeyboardKey.arrowDown) {
+                  if (_resultFocusNodes != null && index < _resultFocusNodes!.length - 1) {
+                    _resultFocusNodes![index + 1].requestFocus();
+                  }
+                  return KeyEventResult.handled;
+                }
+              }
+              return KeyEventResult.ignored;
+            },
+            child: Builder(
+              builder: (cardCtx) {
+                final hasFocus = Focus.of(cardCtx).hasFocus;
+                return Card(
+                  margin: EdgeInsets.zero,
+                  color: hasFocus
+                      ? theme.colorScheme.primaryContainer.withValues(alpha: 0.4)
+                      : theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: AppRadius.circular(10),
+                    side: BorderSide(
+                      color: hasFocus
+                          ? theme.colorScheme.primary
+                          : Colors.transparent,
+                      width: 2,
+                    ),
+                  ),
+                  child: InkWell(
+                    onTap: () => _applyResult(item),
+                    borderRadius: AppRadius.circular(10),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Row(
+                        children: [
+                          ClipRRect(
+                            borderRadius: AppRadius.circular(6),
+                            child: imageUrl != null && imageUrl.isNotEmpty
+                                ? Image.network(
+                                    imageUrl,
+                                    width: 50,
+                                    height: 75,
+                                    fit: BoxFit.cover,
+                                    errorBuilder: (_, _, _) => Container(
+                                      width: 50,
+                                      height: 75,
+                                      color: theme.colorScheme.surfaceContainerHighest,
+                                      child: const Icon(Icons.movie_outlined),
+                                    ),
+                                  )
+                                : Container(
+                                    width: 50,
+                                    height: 75,
+                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    child: const Icon(Icons.movie_outlined),
+                                  ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  year != null && year.isNotEmpty ? '$name ($year)' : name,
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: hasFocus
+                                        ? theme.colorScheme.primary
+                                        : theme.colorScheme.onSurface,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                if (provider.isNotEmpty) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    provider,
+                                    style: theme.textTheme.labelMedium?.copyWith(
+                                      color: theme.colorScheme.primary,
+                                    ),
+                                  ),
+                                ],
+                                if (overview.isNotEmpty) ...[
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    overview,
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                    ),
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                          Icon(
+                            Icons.chevron_right,
+                            color: hasFocus
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/server_core/lib/src/api/admin_items_api.dart
+++ b/packages/server_core/lib/src/api/admin_items_api.dart
@@ -21,10 +21,14 @@ abstract class AdminItemsApi {
   Future<List<Map<String, dynamic>>> searchRemotePerson(
     Map<String, dynamic> query,
   );
+  /// Applies a result returned by [searchRemote] to [itemId]. When
+  /// [replaceAllImages] is false the item keeps its existing artwork and only
+  /// textual metadata is replaced.
   Future<void> applyRemoteSearchResult(
     String itemId,
-    Map<String, dynamic> result,
-  );
+    Map<String, dynamic> result, {
+    bool replaceAllImages = true,
+  });
   Future<Map<String, dynamic>> getRemoteImages(
     String itemId, {
     required ImageType imageType,

--- a/packages/server_jellyfin/lib/src/api/jellyfin_admin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_admin_items_api.dart
@@ -102,14 +102,16 @@ class JellyfinAdminItemsApi implements AdminItemsApi {
   @override
   Future<void> applyRemoteSearchResult(
     String itemId,
-    Map<String, dynamic> result,
-  ) async {
+    Map<String, dynamic> result, {
+    bool replaceAllImages = true,
+  }) async {
     await _requestWithFallback<void>(
       methods: const ['POST'],
       paths: [
         '/Items/RemoteSearch/Apply/$itemId',
         '/Items/$itemId/RemoteSearch/Apply',
       ],
+      queryParameters: {'replaceAllImages': replaceAllImages},
       data: result,
       convert: _ignoreResponse,
     );

--- a/packages/server_jellyfin/lib/src/api/jellyfin_admin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_admin_items_api.dart
@@ -76,9 +76,18 @@ class JellyfinAdminItemsApi implements AdminItemsApi {
     String searchType,
     Map<String, dynamic> query,
   ) async {
+    final normalized = switch (searchType.toLowerCase()) {
+      'movie' => 'Movie',
+      'series' => 'Series',
+      'boxset' => 'BoxSet',
+      'person' => 'Person',
+      'musicalbum' => 'MusicAlbum',
+      'musicartist' => 'MusicArtist',
+      _ => searchType,
+    };
     return _requestWithFallback<List<Map<String, dynamic>>>(
       methods: const ['POST'],
-      paths: ['/Items/RemoteSearch/$searchType'],
+      paths: ['/Items/RemoteSearch/$normalized', '/Items/RemoteSearch/$searchType'],
       data: query,
       convert: _asList,
     );


### PR DESCRIPTION
# Pull Request

## Summary
One of the features I loved in base Jellyfin was to Identify media that might have the wrong meta-data attached to it. This PR incorporates a Jellyfin-style Identify metadata function that allows administrators to identify and update metadata for Movies, TV Shows, and Collections via item context menus and detail page admin controls. Interface improves upon Jellyfin's UI (shows searchable fields with keyboard entry points, that can also be populated from the currently detected meta-data, and is themed) and was designed to be TV-friendly with full d-pad traversal implementations included.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add custom **identify_dialog.dart** with two-column layout: blank search parameters on the left with pull-arrows and current item metadata badges on the right.
- Add Identify action to item long-press context menus (**context_action.dart**) and item detail page admin controls (**item_detail_screen.dart** and **admin_metadata_edit_screen.dart**).
- Automatically redirect Identify action for TV Episode and TV Season items to identify the parent TV Series.
- Add multi-attempt fallback search pipeline with TMDB, TVDB, and IMDb provider key handling.
- Ensure safe dialog dismissal and unfocus handling to prevent FocusNode disposal crashes.
- Add localization strings for Identify dialog UI elements across supported languages.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV and Windows Desktop
- [ ] Not tested (explain why):

### Test Steps
1. Long press a Movie, TV Series, TV Episode, or TV Season card on the Home page or Library.
2. Select "Identify" from the context menu.
3. Verify for TV Episodes and Seasons that the dialog populates reference metadata and path for the parent TV Series.
4. Perform search, select matching remote result, and apply metadata updates.
5. Switch to a non-admin account and ensure that Identify is hidden from long-press menus.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Jellyfin Identify Page and Search Results
<img width="1516" height="1274" alt="2026-07-24_20-19-22_brave" src="https://github.com/user-attachments/assets/4c2ac8ec-d1c5-46d0-af43-679572d3b0c8" />
<img width="1516" height="1267" alt="2026-07-24_20-19-49_brave" src="https://github.com/user-attachments/assets/07229aa0-ffac-4a15-8d66-6d0080a0c2b1" />

### Android TV Interface:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-28-40" src="https://github.com/user-attachments/assets/a016aacc-ea0e-4a56-af3a-a07209e8407c" />

### Navigation between "Arrow" and Blank Text Field:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-39-41" src="https://github.com/user-attachments/assets/1d76e560-ed59-4183-bf6f-10122616289e" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-39-33" src="https://github.com/user-attachments/assets/6a38c699-0886-47f4-b9e6-0042a39e14a5" />

### Moonfin Keyboard Support:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-39-50" src="https://github.com/user-attachments/assets/e10e4bc0-27e1-41c0-9107-cedb78c8a618" />

### Search Example (testing parameters):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-40-12" src="https://github.com/user-attachments/assets/c3e2c72d-1920-446b-861f-9b16889807a5" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-40-22" src="https://github.com/user-attachments/assets/7b84e907-3d9d-40f2-95b5-6a78e4a965dc" />

### Search Example (move name only):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_23-47-20" src="https://github.com/user-attachments/assets/39a7477c-479f-43e8-bdb6-7bcafe215657" />

### Series Identification from Episode Tile:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-25_01-30-20" src="https://github.com/user-attachments/assets/9852d864-c551-46b4-be2f-0b0ae956b2a6" />

### Identify Hidden for Non-Admin Accounts:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-25_01-39-53" src="https://github.com/user-attachments/assets/3178ab35-0be8-48de-81ba-ed0086d1a98c" />

### Matching Windows Desktop Interface:
<img width="2532" height="1374" alt="2026-07-25_01-53-46_moonfin" src="https://github.com/user-attachments/assets/d2b4ee3b-fd49-438a-b681-5fc8c8b68647" />
<img width="2532" height="1374" alt="2026-07-25_01-54-07_moonfin" src="https://github.com/user-attachments/assets/a41c41b5-14b8-40cf-bdca-501e60f9d00c" />
<img width="2532" height="1374" alt="2026-07-25_01-54-13_moonfin" src="https://github.com/user-attachments/assets/749897ae-9169-4456-b677-f8455ad89303" />

### Moonfin Theme
<img width="2532" height="1374" alt="2026-07-25_01-55-12_moonfin" src="https://github.com/user-attachments/assets/d1b682ff-3940-4fba-bc30-e78af7b03ccf" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
