### PR TITLE
﻿bugfix-ci - Fix PR builds from failing for MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,11 +168,11 @@ jobs:
           MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
         run: |
-          # On PRs from forks the certificate secret is not available. Skip the
-          # signing setup; build-macos.sh produces an unsigned build when no
-          # identity is present.
+          # On PRs from forks the certificate secret isn't available, so skip
+          # the signing setup. build-macos.sh falls back to an ad-hoc signature
+          # when no identity is present.
           if [ -z "$MACOS_CERTIFICATE_BASE64" ]; then
-            echo "No macOS certificate secret; skipping signing setup (unsigned build)."
+            echo "No macOS certificate secret, skipping signing setup (ad-hoc signed build)."
             exit 0
           fi
 

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -97,7 +97,7 @@ fi
 UNSIGNED=0
 if [ -z "$APP_SIGN_ID" ] && [ -z "$TEAM_ID" ]; then
   UNSIGNED=1
-  echo "No signing identity available, building unsigned so PR builds still run."
+  echo "No signing identity available, ad-hoc signing so PR builds still run."
   PBXPROJ="$REPO_ROOT/macos/Runner.xcodeproj/project.pbxproj"
   cp "$PBXPROJ" "$PBXPROJ.signing.bak"
   trap 'mv -f "$PBXPROJ.signing.bak" "$PBXPROJ" 2>/dev/null || true' EXIT
@@ -130,6 +130,11 @@ ARCHIVE_CMD=(
   archive
 )
 if [ "$UNSIGNED" = "1" ]; then
+  # Ad-hoc sign rather than skipping signing. Don't add CODE_SIGNING_REQUIRED=NO
+  # here, because the CocoaPods framework script and the embedded emulator cores
+  # both check it and leave their bundles unsigned, which then fails the final
+  # CodeSign of the app. Arm64 binaries also need at least an ad-hoc signature
+  # to launch at all.
   ARCHIVE_CMD+=( CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="-" )
 else
   ARCHIVE_CMD+=( CODE_SIGN_STYLE=Automatic )

--- a/build-macos.sh
+++ b/build-macos.sh
@@ -130,7 +130,7 @@ ARCHIVE_CMD=(
   archive
 )
 if [ "$UNSIGNED" = "1" ]; then
-  ARCHIVE_CMD+=( CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO )
+  ARCHIVE_CMD+=( CODE_SIGN_STYLE=Manual CODE_SIGN_IDENTITY="-" )
 else
   ARCHIVE_CMD+=( CODE_SIGN_STYLE=Automatic )
   if [ -n "$TEAM_ID" ]; then


### PR DESCRIPTION
# Pull Request

## Summary
Fixes macOS build step failures on GitHub Actions PR runs by removing `CODE_SIGNING_REQUIRED=NO` from the unsigned archive command.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #929 (and many others)

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [X] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Modified `build-macos.sh` to remove `CODE_SIGNING_REQUIRED=NO` from `ARCHIVE_CMD` when building unsigned (`UNSIGNED=1`).
- Passing `CODE_SIGNING_REQUIRED=NO` caused CocoaPods' framework script (`Pods-Runner-frameworks.sh`) to skip ad-hoc signing bundled pod frameworks (`Avfilter.framework`, etc.).
- Removing `CODE_SIGNING_REQUIRED=NO` allows CocoaPods to ad-hoc sign (`-`) embedded pod frameworks so Xcode's final `CodeSign` step on `Moonfin.app` succeeds cleanly.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Needs deployed to GH to confirm fix.  Update see screenshot below for passing build :)

### Test Steps
1. Inspected GitHub Actions log for job 89664080093 (run 30152090807).
2. Traced `Command CodeSign failed with a nonzero exit code` failure on `Avfilter.framework`.
3. Verified CocoaPods framework signing conditions against `CODE_SIGNING_REQUIRED`.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="250" alt="2026-07-25_02-53-54_brave" src="https://github.com/user-attachments/assets/095bd005-d36f-4646-8238-df8141f2784c" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
