### PR TITLE
﻿bugfix-playback - Add opaque black backdrop to remove artifacts

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3419,6 +3419,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
+                    const Positioned.fill(
+                      child: ColoredBox(color: Colors.black),
+                    ),
                     _buildVideoSurface(),
                     _buildBringupOverlay(context),
                     if (_isRestoringPosition)


### PR DESCRIPTION
# Pull Request

## Summary
Well, it happened again. Was watching a movie and the nefarious phantom UI elements were bleeding through the top and the bottom of the image. Decided to do some tests and found that adding a background route bleed-through along letterbox borders for non-standard aspect ratio videos fully eliminates the background UI ghosting when modal dialogs are open during playback!

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #237 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added a 100% opaque `Positioned.fill(child: ColoredBox(color: Colors.black))` widget at position 0 of the root `Stack` in `VideoPlayerScreen` (right behind `_buildVideoSurface()`).
- Prevents underlying routes (e.g. `ItemDetailScreen`) from bleeding through along top/bottom letterbox bars on videos with non-traditional aspect ratios (e.g. 1920x804 / 2.39:1).
- Eliminates background UI ghosting when modal dialogs (`Playback Information`, track selectors) are open over the video player.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launched Moonfin on Nvidia Shield (AndroidTV).
2. Played media with non-standard aspect ratio (1920x804 / 2.39:1).
3. Verified top and bottom letterbox borders are 100% solid black without underlying screen lines bleeding through.
4. Opened `Playback Information` dialog during playback and verified no background text/UI ghosts through behind the modal.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### The Bug Is Back (pinkish lines above and below the video frame)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_22-02-14" src="https://github.com/user-attachments/assets/5cd2be2e-db10-4f94-875d-29f2f467d370" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_22-13-42" src="https://github.com/user-attachments/assets/f96e1212-4141-43a6-a783-6e28a66b594b" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_22-17-14" src="https://github.com/user-attachments/assets/dc1915f2-4c6e-4ded-9b4b-febb6c2b0b6f" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-24_22-17-26" src="https://github.com/user-attachments/assets/bf03a06d-925b-47b8-aeec-0c742ca42ae7" />

### The Bug Is Defeated (solid black above and below the video frame)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-25_02-44-50" src="https://github.com/user-attachments/assets/c62984ed-3b0f-4fff-810b-2a98fd52d285" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-25_02-46-00" src="https://github.com/user-attachments/assets/e0b4bfd0-604b-439b-99bf-d0e28c21f205" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-25_02-46-54" src="https://github.com/user-attachments/assets/a42aa935-28a4-4966-8246-6a44beb58857" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
