### PR TITLE
﻿fix(sync) - Prevent home row toggles from re-enabling during profile sync

### DIFF
--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1126,6 +1126,7 @@ class PluginSyncService extends ChangeNotifier {
           }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);
+          _syncSeerrHomeRowsWithSections(sections);
           appliedHomeSections = true;
         }
       }
@@ -1302,6 +1303,7 @@ class PluginSyncService extends ChangeNotifier {
     }
 
     await _prefs.setHomeSectionsConfig(sections);
+    _syncSeerrHomeRowsWithSections(sections);
   }
 
   /// Appends a disabled entry for every built-in HomeSectionType not already in
@@ -1325,6 +1327,17 @@ class PluginSyncService extends ChangeNotifier {
       }
     }
     return order;
+  }
+
+  void _syncSeerrHomeRowsWithSections(List<HomeSectionConfig> sections) {
+    final currentHomeRows = _seerrPrefs.homeRowsConfig;
+    final updated = currentHomeRows.map((row) {
+      final idx = sections.indexWhere((s) => s.type == row.type.homeSectionType);
+      return idx >= 0
+          ? row.copyWith(enabled: sections[idx].enabled)
+          : row.copyWith(enabled: false);
+    }).toList();
+    _seerrPrefs.setHomeRowsConfig(updated);
   }
 
   /// Applies one table-driven field from an incoming profile.

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1126,7 +1126,7 @@ class PluginSyncService extends ChangeNotifier {
           }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);
-          _syncSeerrHomeRowsWithSections(sections);
+          await _syncSeerrHomeRowsWithSections(sections);
           appliedHomeSections = true;
         }
       }
@@ -1202,6 +1202,7 @@ class PluginSyncService extends ChangeNotifier {
               sections.add(entry.copyWith(order: order++));
             }
             await _prefs.setHomeSectionsConfig(sections);
+            await _syncSeerrHomeRowsWithSections(sections);
           }
         }
       }
@@ -1303,11 +1304,16 @@ class PluginSyncService extends ChangeNotifier {
     }
 
     await _prefs.setHomeSectionsConfig(sections);
-    _syncSeerrHomeRowsWithSections(sections);
+    await _syncSeerrHomeRowsWithSections(sections);
   }
 
   /// Appends a disabled entry for every built-in HomeSectionType not already in
   /// [sections] so the settings UI shows every toggle. Returns the next order.
+  ///
+  /// A section the profile doesn't mention carries no opinion, so it lands
+  /// disabled rather than being re-derived from a toggle preference that
+  /// defaults to on. The preferences stay untouched because the profile's own
+  /// synced fields already set them, and writing false would push that back.
   int _appendDisabledBuiltinSections(
     List<HomeSectionConfig> sections,
     int order,
@@ -1317,27 +1323,30 @@ class PluginSyncService extends ChangeNotifier {
       if (type == prefs.HomeSectionType.none || present.contains(type)) {
         continue;
       }
-
       sections.add(
         HomeSectionConfig(type: type, enabled: false, order: order++),
       );
-      final toggle = _rowEnabledPreference(type);
-      if (toggle != null) {
-        _prefs.set(toggle, false);
-      }
     }
     return order;
   }
 
-  void _syncSeerrHomeRowsWithSections(List<HomeSectionConfig> sections) {
-    final currentHomeRows = _seerrPrefs.homeRowsConfig;
-    final updated = currentHomeRows.map((row) {
-      final idx = sections.indexWhere((s) => s.type == row.type.homeSectionType);
-      return idx >= 0
-          ? row.copyWith(enabled: sections[idx].enabled)
-          : row.copyWith(enabled: false);
-    }).toList();
-    _seerrPrefs.setHomeRowsConfig(updated);
+  /// Seerr home rows keep their own copy of the enabled state that the settings
+  /// screens write alongside the section layout, so mirror it here too. Without
+  /// this the home view gates Seerr rows on stale values after a sync.
+  Future<void> _syncSeerrHomeRowsWithSections(
+    List<HomeSectionConfig> sections,
+  ) async {
+    final enabledByType = {
+      for (final section in sections) section.type: section.enabled,
+    };
+    final updated = _seerrPrefs.homeRowsConfig
+        .map(
+          (row) => row.copyWith(
+            enabled: enabledByType[row.type.homeSectionType] ?? false,
+          ),
+        )
+        .toList();
+    await _seerrPrefs.setHomeRowsConfig(updated);
   }
 
   /// Applies one table-driven field from an incoming profile.

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1315,29 +1315,14 @@ class PluginSyncService extends ChangeNotifier {
       if (type == prefs.HomeSectionType.none || present.contains(type)) {
         continue;
       }
-      
-      var isEnabled = false;
-      if (type == prefs.HomeSectionType.rewatch) {
-        isEnabled = _prefs.get(UserPreferences.displayRewatchRow);
-      } else if (type == prefs.HomeSectionType.sinceYouWatched1 ||
-          type == prefs.HomeSectionType.sinceYouWatched2 ||
-          type == prefs.HomeSectionType.sinceYouWatched3 ||
-          type == prefs.HomeSectionType.sinceYouWatched4 ||
-          type == prefs.HomeSectionType.sinceYouWatched5) {
-        final localPref = switch (type) {
-          prefs.HomeSectionType.sinceYouWatched1 => UserPreferences.sinceYouWatched1Enabled,
-          prefs.HomeSectionType.sinceYouWatched2 => UserPreferences.sinceYouWatched2Enabled,
-          prefs.HomeSectionType.sinceYouWatched3 => UserPreferences.sinceYouWatched3Enabled,
-          prefs.HomeSectionType.sinceYouWatched4 => UserPreferences.sinceYouWatched4Enabled,
-          prefs.HomeSectionType.sinceYouWatched5 => UserPreferences.sinceYouWatched5Enabled,
-          _ => throw StateError('Invalid type'),
-        };
-        isEnabled = _prefs.get(localPref);
-      }
-      
+
       sections.add(
-        HomeSectionConfig(type: type, enabled: isEnabled, order: order++),
+        HomeSectionConfig(type: type, enabled: false, order: order++),
       );
+      final toggle = _rowEnabledPreference(type);
+      if (toggle != null) {
+        _prefs.set(toggle, false);
+      }
     }
     return order;
   }
@@ -1715,6 +1700,16 @@ class PluginSyncService extends ChangeNotifier {
       prefs.HomeSectionType.sonarrCalendar =>
         UserPreferences.enableSonarrCalendar,
       prefs.HomeSectionType.rewatch => UserPreferences.displayRewatchRow,
+      prefs.HomeSectionType.sinceYouWatched1 =>
+        UserPreferences.sinceYouWatched1Enabled,
+      prefs.HomeSectionType.sinceYouWatched2 =>
+        UserPreferences.sinceYouWatched2Enabled,
+      prefs.HomeSectionType.sinceYouWatched3 =>
+        UserPreferences.sinceYouWatched3Enabled,
+      prefs.HomeSectionType.sinceYouWatched4 =>
+        UserPreferences.sinceYouWatched4Enabled,
+      prefs.HomeSectionType.sinceYouWatched5 =>
+        UserPreferences.sinceYouWatched5Enabled,
       _ => null,
     };
   }

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -326,6 +326,39 @@ class HomeSectionConfig {
       enabled: false,
       order: 39,
     ),
+    // These carry a toggle preference too, but they still need a section entry.
+    // Without one there was nowhere for turning the row off to persist, so the
+    // next sync kept bringing it back.
+    HomeSectionConfig(
+      type: HomeSectionType.sinceYouWatched1,
+      enabled: false,
+      order: 40,
+    ),
+    HomeSectionConfig(
+      type: HomeSectionType.sinceYouWatched2,
+      enabled: false,
+      order: 41,
+    ),
+    HomeSectionConfig(
+      type: HomeSectionType.sinceYouWatched3,
+      enabled: false,
+      order: 42,
+    ),
+    HomeSectionConfig(
+      type: HomeSectionType.sinceYouWatched4,
+      enabled: false,
+      order: 43,
+    ),
+    HomeSectionConfig(
+      type: HomeSectionType.sinceYouWatched5,
+      enabled: false,
+      order: 44,
+    ),
+    HomeSectionConfig(
+      type: HomeSectionType.rewatch,
+      enabled: false,
+      order: 45,
+    ),
   ];
 
   static bool isSupportedJson(Map<String, dynamic> json) {

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -134,9 +134,7 @@ class SeerrPreferences {
     final sections = HomeSectionConfig.fromJsonString(sectionsJson);
     return SeerrRowConfig.defaults().map((row) {
       final idx = sections.indexWhere((s) => s.type == row.type.homeSectionType);
-      return idx >= 0
-          ? row.copyWith(enabled: sections[idx].enabled)
-          : row.copyWith(enabled: false);
+      return idx >= 0 ? row.copyWith(enabled: sections[idx].enabled) : row;
     }).toList();
   }
 

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -134,7 +134,9 @@ class SeerrPreferences {
     final sections = HomeSectionConfig.fromJsonString(sectionsJson);
     return SeerrRowConfig.defaults().map((row) {
       final idx = sections.indexWhere((s) => s.type == row.type.homeSectionType);
-      return idx >= 0 ? row.copyWith(enabled: sections[idx].enabled) : row;
+      return idx >= 0
+          ? row.copyWith(enabled: sections[idx].enabled)
+          : row.copyWith(enabled: false);
     }).toList();
   }
 
@@ -143,7 +145,7 @@ class SeerrPreferences {
     if (seerrType == null || !enabled) return false;
     final config = homeRowsConfig.firstWhere(
       (c) => c.type == seerrType,
-      orElse: () => SeerrRowConfig(type: seerrType, enabled: true, order: 0),
+      orElse: () => SeerrRowConfig(type: seerrType, enabled: false, order: 0),
     );
     return config.enabled;
   }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where home row toggles for "Rewatch", "Since You Watched", Seerr lists, IMDb lists, TMDB lists, and Radarr/Sonarr Calendars automatically re-enabled themselves after profile synchronization or app restarts, causing me to think I was losing my mind.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated `_appendDisabledBuiltinSections` in **plugin_sync_service.dart** so built-in sections omitted from server profile layouts append as `enabled: false` and explicitly update their corresponding toggle preferences to `false`.
- Added missing `sinceYouWatched1Enabled` .. `sinceYouWatched5Enabled` mappings to `_rowEnabledPreference` in **plugin_sync_service.dart**.
- Added `_syncSeerrHomeRowsWithSections` in **plugin_sync_service.dart** to synchronize `SeerrPreferences.homeRowsConfig` in lockstep with `homeSectionsConfig` whenever server profile sections are applied or reset.
- Updated `_homeRowsConfigFromSections()` and `isSeerrHomeRowEnabled()` in **seerr_preferences.dart** to default unconfigured or omitted Seerr row sections to `enabled: false` instead of falling back to `enabled: true`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Disable Rewatch / Since You Watched rows in home section toggles.
2. Trigger server profile synchronization.
3. Verify rows remain disabled across sync cycles and application restarts.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
