### PR TITLE
﻿Fix Playlist library visibility in My Media navigation

### DIFF
--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -165,7 +165,8 @@ class MultiServerRepository {
     final results = await Future.wait(
       sessions.map(
         (session) => _withTimeout(() async {
-          final viewsFuture = session.client.userViewsApi.getUserViews();
+          final viewsFuture =
+              session.client.userViewsApi.getUserViews(includeHidden: true);
           final configFuture = session.client.usersApi
               .getUserConfiguration()
               .then<Set<String>>((config) => config.myMediaExcludes.toSet())

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -165,24 +165,10 @@ class MultiServerRepository {
     final results = await Future.wait(
       sessions.map(
         (session) => _withTimeout(() async {
-          final viewsFuture =
-              session.client.userViewsApi.getUserViews(includeHidden: true);
-          final configFuture = session.client.usersApi
-              .getUserConfiguration()
-              .then<Set<String>>((config) => config.myMediaExcludes.toSet())
-              .catchError((_) => const <String>{});
-
-          final response = await viewsFuture;
-          final Set<String> excludes = await configFuture;
+          final response = await loadVisibleUserViews(session.client);
           final items = response['Items'] as List? ?? [];
 
-          final filteredItems = items.where((item) {
-            final data = item as Map<String, dynamic>;
-            final id = data['Id']?.toString() ?? '';
-            return !excludes.contains(id);
-          });
-
-          return filteredItems.map((item) {
+          return items.map((item) {
             final data = item as Map<String, dynamic>;
             final name = data['Name'] as String? ?? '';
             return AggregatedLibrary(

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -56,7 +56,7 @@ class UserViewsRepository extends ChangeNotifier {
       ).whenComplete(() => _inFlightViewsIncludingHidden = null);
 
   Future<List<AggregatedLibrary>> getUserViews() async {
-    final views = await getAllViews();
+    final views = await getAllViewsIncludingHidden();
     try {
       final config = await _getUserConfig();
       final excludes = config.myMediaExcludes.toSet();

--- a/lib/data/repositories/user_views_repository.dart
+++ b/lib/data/repositories/user_views_repository.dart
@@ -4,8 +4,8 @@ import 'package:server_core/server_core.dart';
 import '../models/aggregated_library.dart';
 
 /// The user's own views. Anything hidden from My Media is left out unless
-/// [includeHidden] is set, which the rows that should stay independent of that
-/// toggle use to see every library the user can reach.
+/// [includeHidden] is set, which callers that apply their own exclude
+/// filtering pass so the list isn't filtered twice.
 Future<List<AggregatedLibrary>> loadUserViews(
   MediaServerClient client, {
   bool includeHidden = false,
@@ -33,6 +33,39 @@ Future<List<AggregatedLibrary>> loadUserViews(
   }).toList();
 }
 
+/// The My Media exclude list, or null when it can't be read.
+Future<Set<String>?> _excludesFrom(Future<UserConfiguration> config) async {
+  try {
+    return (await config).myMediaExcludes.toSet();
+  } catch (_) {
+    return null;
+  }
+}
+
+/// The views response with anything hidden from My Media removed. The server
+/// filters by the exclude list itself, so ask for the full list and apply it
+/// here instead. If the list can't be read, let the server filter so hidden
+/// libraries don't leak through.
+Future<Map<String, dynamic>> loadVisibleUserViews(
+  MediaServerClient client,
+) async {
+  final viewsFuture = client.userViewsApi.getUserViews(includeHidden: true);
+  final excludes = await _excludesFrom(client.usersApi.getUserConfiguration());
+  final response = await viewsFuture;
+
+  if (excludes == null) return client.userViewsApi.getUserViews();
+  if (excludes.isEmpty) return response;
+
+  final items = (response['Items'] as List? ?? [])
+      .where(
+        (item) => !excludes.contains(
+          (item as Map<String, dynamic>)['Id']?.toString() ?? '',
+        ),
+      )
+      .toList();
+  return {...response, 'Items': items};
+}
+
 class UserViewsRepository extends ChangeNotifier {
   final MediaServerClient _client;
   UserConfiguration? _cachedConfig;
@@ -56,15 +89,12 @@ class UserViewsRepository extends ChangeNotifier {
       ).whenComplete(() => _inFlightViewsIncludingHidden = null);
 
   Future<List<AggregatedLibrary>> getUserViews() async {
+    final excludes = await _excludesFrom(_getUserConfig());
+    if (excludes == null) return getAllViews();
+
     final views = await getAllViewsIncludingHidden();
-    try {
-      final config = await _getUserConfig();
-      final excludes = config.myMediaExcludes.toSet();
-      if (excludes.isEmpty) return views;
-      return views.where((v) => !excludes.contains(v.id)).toList();
-    } catch (_) {
-      return views;
-    }
+    if (excludes.isEmpty) return views;
+    return views.where((v) => !excludes.contains(v.id)).toList();
   }
 
   Future<UserConfiguration> _getUserConfig() async {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -19,6 +19,7 @@ import '../utils/next_up_enrichment.dart';
 import '../utils/playlist_utils.dart';
 import 'package:flutter/foundation.dart';
 import '../repositories/seerr_repository.dart';
+import '../repositories/user_views_repository.dart';
 import '../../preference/seerr_preferences.dart';
 import '../viewmodels/seerr_discover_view_model.dart';
 import 'custom_external_lists_service.dart';
@@ -679,28 +680,14 @@ class RowDataSource {
     String serverId, [
     HomeRowType rowType = HomeRowType.libraryTiles,
   ]) async {
-    final viewsFuture = _client.userViewsApi.getUserViews(includeHidden: true);
-    final configFuture = _client.usersApi
-        .getUserConfiguration()
-        .then<Set<String>>((config) => config.myMediaExcludes.toSet())
-        .catchError((_) => const <String>{});
-
-    final response = await viewsFuture;
-    final Set<String> excludes = await configFuture;
-    final items = response['Items'] as List? ?? [];
-
-    final filteredItems = items.where((item) {
-      final data = item as Map<String, dynamic>;
-      final id = data['Id']?.toString() ?? '';
-      return !excludes.contains(id);
-    }).toList();
+    final response = await loadVisibleUserViews(_client);
 
     return _buildRow(
       id: rowType == HomeRowType.libraryTilesSmall
           ? 'libraryTilesSmall'
           : 'libraryTiles',
       title: _l10n.myMedia,
-      response: {...response, 'Items': filteredItems},
+      response: response,
       serverId: serverId,
       rowType: rowType,
     );

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -679,7 +679,7 @@ class RowDataSource {
     String serverId, [
     HomeRowType rowType = HomeRowType.libraryTiles,
   ]) async {
-    final viewsFuture = _client.userViewsApi.getUserViews();
+    final viewsFuture = _client.userViewsApi.getUserViews(includeHidden: true);
     final configFuture = _client.usersApi
         .getUserConfiguration()
         .then<Set<String>>((config) => config.myMediaExcludes.toSet())


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where the Playlists library failed to appear in the My Media navigation bar even when toggled on in Personalization -> Libraries -> Library Visibility.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **user_views_repository.dart** (`getUserViews`) to request user views with `includeHidden: true` from the server API so that virtual libraries like Playlists are retained before client-side visibility filters (`myMediaExcludes`) are applied.
- Updated **multi_server_repository.dart** (`getAggregatedLibraries`) to pass `includeHidden: true` when aggregating user views across multi-server configurations.
- Updated **row_data_source.dart** (`loadLibraryTiles`) to pass `includeHidden: true` when building home screen library tiles.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin client and navigate to Settings -> Personalization -> Libraries -> Library Visibility.
2. Toggle "Show in navigation" ON for the Playlists library.
3. Verify that Playlists appears in the My Media navigation bar and library tiles.
4. Toggle "Show in navigation" OFF for the Playlists library and verify it is hidden as expected.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

It's back!
<img width="2560" height="1555" alt="2026-07-25_20-11-22_moonfin" src="https://github.com/user-attachments/assets/c8c99b31-46ee-4f60-96f2-bd00c8999e38" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
