### PR TITLE
feat-settingsync - Allow for Custom Home Rows Sync across devices

### DIFF
--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -152,7 +152,13 @@ class CustomExternalListsService {
           'params': paramsJson,
         },
         options: Options(
-          headers: {'Authorization': 'MediaBrowser Token="$token"'},
+          headers: {
+            'Authorization': buildServerAuthorizationHeader(
+              scheme: 'MediaBrowser',
+              deviceInfo: client.deviceInfo,
+              accessToken: token,
+            ),
+          },
         ),
       );
 

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1124,6 +1124,14 @@ class PluginSyncService extends ChangeNotifier {
               _prefs.set(toggle, c.enabled);
             }
           }
+          final existingCustom = _prefs.homeSectionsConfig
+              .where((c) => c.isPluginDynamic && c.pluginSource == HomeSectionPluginSource.custom)
+              .toList();
+          for (final custom in existingCustom) {
+            if (!sections.any((s) => s.stableId == custom.stableId)) {
+              sections.add(custom.copyWith(enabled: false, order: order++));
+            }
+          }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);
           appliedHomeSections = true;

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1124,13 +1124,21 @@ class PluginSyncService extends ChangeNotifier {
               _prefs.set(toggle, c.enabled);
             }
           }
-          final existingCustom = _prefs.homeSectionsConfig
-              .where((c) => c.isPluginDynamic && c.pluginSource == HomeSectionPluginSource.custom)
-              .toList();
+          // Custom rows the profile doesn't mention haven't been pushed from here yet, so
+          // keep them instead of letting the incoming layout drop them. Matching is on
+          // pluginSection because an edit changes stableId and would leave a stale copy.
+          final incomingCustom = sections
+              .where((s) => s.isPluginDynamic && s.pluginSource == HomeSectionPluginSource.custom)
+              .map((s) => s.pluginSection)
+              .toSet();
+          final existingCustom = _prefs.homeSectionsConfig.where(
+            (c) =>
+                c.isPluginDynamic &&
+                c.pluginSource == HomeSectionPluginSource.custom &&
+                !incomingCustom.contains(c.pluginSection),
+          );
           for (final custom in existingCustom) {
-            if (!sections.any((s) => s.stableId == custom.stableId)) {
-              sections.add(custom.copyWith(enabled: false, order: order++));
-            }
+            sections.add(custom.copyWith(order: order++));
           }
           _appendDisabledBuiltinSections(sections, order);
           await _prefs.setHomeSectionsConfig(sections);

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -95,18 +95,25 @@ class HomeSectionConfig {
         ? HomeSectionKind.builtin
         : HomeSectionKind.fromSerialized(kindRaw);
     final typeName = json['type'] as String? ?? 'none';
+    final pluginSource = HomeSectionPluginSource.fromSerialized(
+      json['pluginSource'] as String?,
+    );
+    final rawServerId = json['serverId']?.toString();
+    final serverId = (rawServerId == null || rawServerId.isEmpty) &&
+            pluginSource == HomeSectionPluginSource.custom
+        ? 'custom'
+        : rawServerId;
+
     return HomeSectionConfig(
       kind: kind,
       type: HomeSectionType.fromSerialized(typeName),
       enabled: json['enabled'] as bool? ?? true,
       order: json['order'] as int? ?? 0,
-      serverId: json['serverId']?.toString(),
+      serverId: serverId,
       pluginSection: json['pluginSection'] as String?,
       pluginAdditionalData: json['pluginAdditionalData'] as String?,
       pluginDisplayText: json['pluginDisplayText'] as String?,
-      pluginSource: HomeSectionPluginSource.fromSerialized(
-        json['pluginSource'] as String?,
-      ),
+      pluginSource: pluginSource,
     );
   }
 
@@ -158,7 +165,11 @@ class HomeSectionConfig {
   /// data so multiple instances of the same section can coexist.
   String get stableId {
     if (kind == HomeSectionKind.pluginDynamic) {
-      return 'pluginDynamic:${pluginSource.serializedName}:${serverId ?? ''}:${pluginSection ?? ''}:${pluginAdditionalData ?? ''}';
+      final effectiveServerId = (serverId == null || serverId!.isEmpty) &&
+              pluginSource == HomeSectionPluginSource.custom
+          ? 'custom'
+          : (serverId ?? '');
+      return 'pluginDynamic:${pluginSource.serializedName}:$effectiveServerId:${pluginSection ?? ''}:${pluginAdditionalData ?? ''}';
     }
     return 'builtin:${type.serializedName}';
   }

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -98,18 +98,12 @@ class HomeSectionConfig {
     final pluginSource = HomeSectionPluginSource.fromSerialized(
       json['pluginSource'] as String?,
     );
-    final rawServerId = json['serverId']?.toString();
-    final serverId = (rawServerId == null || rawServerId.isEmpty) &&
-            pluginSource == HomeSectionPluginSource.custom
-        ? 'custom'
-        : rawServerId;
-
     return HomeSectionConfig(
       kind: kind,
       type: HomeSectionType.fromSerialized(typeName),
       enabled: json['enabled'] as bool? ?? true,
       order: json['order'] as int? ?? 0,
-      serverId: serverId,
+      serverId: _normalizedServerId(json['serverId']?.toString(), pluginSource),
       pluginSection: json['pluginSection'] as String?,
       pluginAdditionalData: json['pluginAdditionalData'] as String?,
       pluginDisplayText: json['pluginDisplayText'] as String?,
@@ -160,15 +154,24 @@ class HomeSectionConfig {
     pluginSource: pluginSource ?? this.pluginSource,
   );
 
+  /// Custom rows belong to no server, and an empty serverId coming back from a saved
+  /// layout would give the same row a second identity, so both ends use this placeholder.
+  static String? _normalizedServerId(
+    String? serverId,
+    HomeSectionPluginSource source,
+  ) =>
+      (serverId == null || serverId.isEmpty) &&
+              source == HomeSectionPluginSource.custom
+          ? 'custom'
+          : serverId;
+
   /// Stable identifier suitable for use as a row id / list key. Plugin
   /// entries combine the originating plugin, server, section and additional
   /// data so multiple instances of the same section can coexist.
   String get stableId {
     if (kind == HomeSectionKind.pluginDynamic) {
-      final effectiveServerId = (serverId == null || serverId!.isEmpty) &&
-              pluginSource == HomeSectionPluginSource.custom
-          ? 'custom'
-          : (serverId ?? '');
+      final effectiveServerId =
+          _normalizedServerId(serverId, pluginSource) ?? '';
       return 'pluginDynamic:${pluginSource.serializedName}:$effectiveServerId:${pluginSection ?? ''}:${pluginAdditionalData ?? ''}';
     }
     return 'builtin:${type.serializedName}';


### PR DESCRIPTION
# Pull Request

## Summary
Fixes issues preventing fully custom home rows (e.g. Letterboxd activity, custom IMDb/TMDB lists created via the Custom Home Rows Wizard) from syncing, authenticating on new installs, and propagating across device profiles.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/209

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Fixed `401 Unauthorized` responses from `/Moonfin/CustomRows/Items` on new installs by replacing raw `Authorization` header with `buildServerAuthorizationHeader` in `CustomExternalListsService`.
- Normalized `serverId` to `'custom'` across `fromJson()` deserialization and `stableId` getter in `HomeSectionConfig`.
- Updated `_applyServerSettingsUnbatched()` in `PluginSyncService` to preserve pre-existing custom dynamic sections (`enabled: false`) when applying incoming server profiles.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Created a Custom Home Row (Letterboxd user list "Matt's Activity") on Windows Desktop.
2. Verified item fetching authenticated with `200 OK` on `/Moonfin/CustomRows/Items`.
3. Launched clean Android TV Beta client on Nvidia Shield TV Pro.
4. Confirmed "Matt's Activity" appeared under "Saved Custom Home Rows" in the Custom Home Rows Wizard.
5. Toggled "Matt's Activity" to ON on the Shield and verified items rendered cleanly on the Android TV homepage.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Adding a Custom Home Row in Windows Desktop:
<img width="2539" height="1490" alt="2026-07-26_08-13-01_moonfin" src="https://github.com/user-attachments/assets/196d4911-65d6-4581-8a5c-690fb4ed373a" />

Available in Home Sections:
<img width="850" height="1486" alt="2026-07-26_08-14-20_moonfin" src="https://github.com/user-attachments/assets/9539a5df-8054-42cb-9c82-11f336f520c1" />

Custom Home Row on Windows Desktop:
<img width="2539" height="1490" alt="2026-07-26_08-13-18_moonfin" src="https://github.com/user-attachments/assets/9a418d50-1822-403c-9a38-4f75a0fc8757" />

Synced to Android TV (TV profile, so pulled in disabled):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-26_08-49-08" src="https://github.com/user-attachments/assets/36edef70-e5fc-4267-afdb-2100d874e7c7" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
