### PR TITLE
fix(subtitles): use embedded fonts in ASS renderer

### DIFF
--- a/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
+++ b/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
@@ -728,8 +728,11 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
         private func configureAssIfNeeded(for track: TrackInfo, engine: AetherEngine) {
             guard assConfiguredForTrackID != track.id else { return }
             let attachments = engine.fontAttachments.map { ($0.filename, $0.data) }
-            _ = SubtitleFontLocator.materializeFontsDirectory(attachments: attachments)
-            if assRenderer.configure(header: track.assHeader.flatMap { $0.data(using: .utf8) }) {
+            let fontsDir = SubtitleFontLocator.materializeFontsDirectory(attachments: attachments)
+            if assRenderer.configure(
+                header: track.assHeader.flatMap { $0.data(using: .utf8) },
+                fontsDir: fontsDir
+            ) {
                 assConfiguredForTrackID = track.id
             }
         }

--- a/tvos/Runner/Playback/Aether/AssRenderer.swift
+++ b/tvos/Runner/Playback/Aether/AssRenderer.swift
@@ -19,7 +19,7 @@ final class AssRenderer {
     private var frameWidth: Int32 = 0
     private var frameHeight: Int32 = 0
 
-    func configure(header: Data?) -> Bool {
+    func configure(header: Data?, fontsDir: String? = nil) -> Bool {
         close()
         guard let library = ass_library_init() else { return false }
         self.library = library
@@ -28,7 +28,9 @@ final class AssRenderer {
             return false
         }
         self.renderer = renderer
-        if let fontsDir = SubtitleFontLocator.bundledFontsDirectory() {
+        // Falling back to bundledFontsDirectory() here would drop embedded fonts,
+        // mis-rendering any \fn-styled subtitle line with a substituted system font.
+        if let fontsDir = fontsDir ?? SubtitleFontLocator.bundledFontsDirectory() {
             ass_set_fonts_dir(library, fontsDir)
             ass_set_fonts(
                 renderer,
@@ -195,7 +197,7 @@ final class AssRenderer {
         }
     }
 #else
-    func configure(header: Data?) -> Bool { false }
+    func configure(header: Data?, fontsDir: String? = nil) -> Bool { false }
     func setFrameSize(width: Int32, height: Int32) {}
     func processEvent(_ assLine: String, startMs: Int64, durationMs: Int64) {}
     func render(atTimeMs ms: Int64) -> AssRenderResult { .unchanged }

--- a/tvos/Runner/Playback/Aether/SubtitleFontLocator.swift
+++ b/tvos/Runner/Playback/Aether/SubtitleFontLocator.swift
@@ -21,8 +21,9 @@ enum SubtitleFontLocator {
     }
 
     /// Writes embedded font attachments to a session temp directory (seeded
-    /// with the bundled fallback font) and returns its path. Returns the
-    /// plain bundled directory when there are no attachments.
+    /// with the bundled fonts) and returns its path. Returns the plain bundled
+    /// directory when there are no attachments. An attachment sharing a name
+    /// with a bundled font is written last and wins.
     static func materializeFontsDirectory(attachments: [(filename: String, data: Data)])
         -> String?
     {
@@ -36,9 +37,19 @@ enum SubtitleFontLocator {
         } catch {
             return bundledFontsDirectory()
         }
-        if let bundled = bundledFontsDirectory() {
-            let src = URL(fileURLWithPath: bundled).appendingPathComponent("NotoSans-Regular.ttf")
-            try? fm.copyItem(at: src, to: dir.appendingPathComponent("NotoSans-Regular.ttf"))
+        // Every bundled font comes across, not just the default one. libass
+        // scans this directory and nothing else, so anything left behind stops
+        // being available as a fallback, and a line whose font the release
+        // forgot to attach would render as tofu instead of reaching NotoSansCJK.
+        if let bundled = bundledFontsDirectory(),
+            let names = try? fm.contentsOfDirectory(atPath: bundled)
+        {
+            let source = URL(fileURLWithPath: bundled)
+            for name in names {
+                try? fm.copyItem(
+                    at: source.appendingPathComponent(name),
+                    to: dir.appendingPathComponent(name))
+            }
         }
         for attachment in attachments {
             let name = URL(fileURLWithPath: attachment.filename).lastPathComponent


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where embedded fonts included with ASS subtitles were not being used during subtitle rendering. The renderer now correctly loads and applies embedded fonts, ensuring subtitles display with their intended styling.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Use embedded fonts during subtitle rendering instead of always using fallback fonts.

## Platform
- [ ] Android
- [x] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video with an ASS subtitle track selected
2. Observe whether the embedded font is used, or a fallback one is.

## Screenshots (if applicable)
Before fix (embedded font lost, fallback used):
<img width="1133" height="744" alt="before_fix" src="https://github.com/user-attachments/assets/ea926b57-e826-4883-82ac-8e4e4b262a62" />

After fix (embedded font properly applied):
<img width="1133" height="744" alt="after_fix" src="https://github.com/user-attachments/assets/489c3129-fc30-42b7-b609-36130b4ff992" />


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
