### PR TITLE
fix(subtitles): drive libass rendering from a display-rate ticker instead of the 10 Hz clock

### DIFF
--- a/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
+++ b/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
@@ -92,10 +92,10 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
     private var assConfiguredForTrackID: Int?
     private var assSeenCueIDs = Set<Int>()
 
-    // ASS render cadence: engine.clock.$sourceTime is throttled to ~10 Hz
-    // (shared with tvOS menu/focus UI), so don't render on that tick alone
-    // or animated ASS (\move/\fad/\k) looks stepped. A display-rate ticker
-    // drives the actual renders instead; the engine tick just re-anchors it.
+    // ASS render cadence: engine.clock.$sourceTime arrives on the engine's
+    // 100 ms AVPlayer time observer, which drives a scrub bar, so rendering on
+    // that tick alone leaves animated ASS (\move, \fad, \k) stepping. A
+    // display-rate ticker renders and the engine tick only re-anchors it.
     #if canImport(UIKit)
         private var assDisplayLink: CADisplayLink?
     #elseif canImport(AppKit)
@@ -777,13 +777,14 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
 
     #if canImport(Libass)
         /// Extrapolates past the last engine tick using wall-clock elapsed
-        /// time. Frozen while not playing.
+        /// time, scaled by the rate so a second of wall clock is not taken for
+        /// a second of source. Frozen while not playing.
         private func extrapolatedAssSeconds() -> Double {
             let base = lastKnownSourceTime - subtitleOverlay.delaySeconds
             guard isPlaying else { return base }
             let elapsed = CACurrentMediaTime() - lastKnownSourceTimeHostTime
             guard elapsed > 0 else { return base }
-            return base + elapsed
+            return base + elapsed * Double(rate)
         }
     #endif
 
@@ -805,7 +806,9 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
         private func startAssDisplayLinkIfNeeded() {
             guard assDisplayLink == nil else { return }
             #if canImport(UIKit)
-                let link = CADisplayLink(target: self, selector: #selector(handleAssDisplayLinkTick))
+                let link = CADisplayLink(
+                    target: AssTickProxy(owner: self),
+                    selector: #selector(AssTickProxy.tick))
                 link.add(to: .main, forMode: .common)
                 assDisplayLink = link
             #elseif canImport(AppKit)
@@ -822,8 +825,11 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
             assDisplayLink = nil
         }
 
-        @objc private func handleAssDisplayLinkTick() {
+        fileprivate func handleAssDisplayLinkTick() {
             guard assConfiguredForTrackID != nil else { return }
+            // Paused, the extrapolation is frozen and the engine tick still
+            // draws, seeks included, so there is no gap left to fill.
+            guard isPlaying else { return }
             renderAss(atSeconds: extrapolatedAssSeconds())
         }
 
@@ -1007,3 +1013,22 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
         return snapshot
     }
 }
+
+#if canImport(UIKit) && canImport(Libass)
+    /// CADisplayLink retains its target, so it gets a proxy instead of the
+    /// wrapper. A link outliving its stop would otherwise hold the wrapper
+    /// alive and rendering.
+    private final class AssTickProxy: NSObject {
+        private weak var owner: AetherPlayerWrapper?
+
+        init(owner: AetherPlayerWrapper) {
+            self.owner = owner
+        }
+
+        @objc func tick() {
+            MainActor.assumeIsolated {
+                owner?.handleAssDisplayLinkTick()
+            }
+        }
+    }
+#endif

--- a/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
+++ b/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
@@ -3,6 +3,7 @@ import AetherEngine
 import Combine
 import Foundation
 import MediaPlayer
+import QuartzCore
 #if canImport(UIKit)
 import UIKit
 #elseif canImport(AppKit)
@@ -90,6 +91,18 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
     private let assRenderer = AssRenderer()
     private var assConfiguredForTrackID: Int?
     private var assSeenCueIDs = Set<Int>()
+
+    // ASS render cadence: engine.clock.$sourceTime is throttled to ~10 Hz
+    // (shared with tvOS menu/focus UI), so don't render on that tick alone
+    // or animated ASS (\move/\fad/\k) looks stepped. A display-rate ticker
+    // drives the actual renders instead; the engine tick just re-anchors it.
+    #if canImport(UIKit)
+        private var assDisplayLink: CADisplayLink?
+    #elseif canImport(AppKit)
+        private var assDisplayLink: Timer?
+    #endif
+    private var lastKnownSourceTime: Double = 0
+    private var lastKnownSourceTimeHostTime: CFTimeInterval = 0
 
     /// On iOS, `audio_service` (Flutter) owns MPRemoteCommandCenter and the
     /// Now Playing card, and the wrapper driving them too would
@@ -754,11 +767,25 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
     private func tickSubtitles(at sourceTime: Double) {
         subtitleOverlay.update(currentTime: sourceTime)
         #if canImport(Libass)
+            lastKnownSourceTime = sourceTime
+            lastKnownSourceTimeHostTime = CACurrentMediaTime()
             if assConfiguredForTrackID != nil {
-                renderAss(atSeconds: sourceTime - subtitleOverlay.delaySeconds)
+                renderAss(atSeconds: extrapolatedAssSeconds())
             }
         #endif
     }
+
+    #if canImport(Libass)
+        /// Extrapolates past the last engine tick using wall-clock elapsed
+        /// time. Frozen while not playing.
+        private func extrapolatedAssSeconds() -> Double {
+            let base = lastKnownSourceTime - subtitleOverlay.delaySeconds
+            guard isPlaying else { return base }
+            let elapsed = CACurrentMediaTime() - lastKnownSourceTimeHostTime
+            guard elapsed > 0 else { return base }
+            return base + elapsed
+        }
+    #endif
 
     #if canImport(Libass)
         private func configureAssIfNeeded(for track: TrackInfo, engine: AetherEngine) {
@@ -770,7 +797,34 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
                 fontsDir: fontsDir
             ) {
                 assConfiguredForTrackID = track.id
+                startAssDisplayLinkIfNeeded()
             }
+        }
+
+        /// Drives libass at display rate. See comment on `assDisplayLink`.
+        private func startAssDisplayLinkIfNeeded() {
+            guard assDisplayLink == nil else { return }
+            #if canImport(UIKit)
+                let link = CADisplayLink(target: self, selector: #selector(handleAssDisplayLinkTick))
+                link.add(to: .main, forMode: .common)
+                assDisplayLink = link
+            #elseif canImport(AppKit)
+                let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+                    self?.handleAssDisplayLinkTick()
+                }
+                RunLoop.main.add(timer, forMode: .common)
+                assDisplayLink = timer
+            #endif
+        }
+
+        private func stopAssDisplayLink() {
+            assDisplayLink?.invalidate()
+            assDisplayLink = nil
+        }
+
+        @objc private func handleAssDisplayLinkTick() {
+            guard assConfiguredForTrackID != nil else { return }
+            renderAss(atSeconds: extrapolatedAssSeconds())
         }
 
         private func renderAss(atSeconds seconds: Double) {
@@ -797,6 +851,7 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
     private func resetAssState() {
         #if canImport(Libass)
             assRenderer.reset()
+            stopAssDisplayLink()
         #endif
         assConfiguredForTrackID = nil
         assSeenCueIDs.removeAll()


### PR DESCRIPTION
# Pull Request

## Summary
Fixes choppy rendering in animated ASS subtitles on iOS, macOS, and tvOS by decoupling libass rendering from the engine's source-time clock, which is throttled to ~10 Hz because it's shared with the menu/focus UI. A display-rate ticker (CADisplayLink on UIKit, 60 Hz Timer on AppKit) now drives renders, extrapolating forward from the last known source time using wall-clock elapsed time. The engine's 10 Hz tick just re-anchors the extrapolation to correct drift.

## Related Issues
Link related issues or tickets separated by commas.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add a display-rate ticker (assDisplayLink: CADisplayLink on UIKit, timer on AppKit) that drives ASS renders instead of using only the throttled engine.clock.$sourceTime tick
- Add extrapolatedAssSeconds(), which extrapolates the current subtitle time from the last known source time + wall-clock elapsed time (frozen while not playing)
- tickSubtitles(at:) now re-anchors lastKnownSourceTime/lastKnownSourceTimeHostTime on each engine tick rather than rendering directly off it
- Start the display link when ASS is configured (configureAssIfNeeded), stop it on resetAssState()

## Platform
- [ ] Android
- [x] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video with animated ASS subtitles
2. Verify that they render smoothly (at display rate)

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

## Note
I used a 60 Hz timer on AppKit because it has no CADisplayLink, and I wasn't sure about using CVDisplayLink for this and wanted to leave it more up to others.