### PR TITLE
bugfix-resume - Fix Series Resume button

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7653,6 +7653,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 orElse: () => allEpisodes.first,
               );
               targetEpisode = s1e1;
+            } else if (viewModel.nextUp != null) {
+              targetEpisode = viewModel.nextUp!;
             } else {
               final firstUnwatched = allEpisodes.firstWhere(
                 (e) => !e.isPlayed,
@@ -7696,7 +7698,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               startIndex: idx,
             );
             final startPosition = resume
-                ? (selectedEpisode.playbackPosition ?? Duration.zero)
+                ? (selectedEpisode.playbackPosition ??
+                    targetEpisode.playbackPosition ??
+                    Duration.zero)
                 : Duration.zero;
 
             if (!context.mounted) return;

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7648,19 +7648,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
             AggregatedItem targetEpisode;
             if (isFullyWatched || isFullyUnwatched) {
-              final s1e1 = allEpisodes.firstWhere(
+              targetEpisode = allEpisodes.firstWhere(
                 (e) => e.parentIndexNumber == 1 && e.indexNumber == 1,
                 orElse: () => allEpisodes.first,
               );
-              targetEpisode = s1e1;
-            } else if (viewModel.nextUp != null) {
-              targetEpisode = viewModel.nextUp!;
             } else {
-              final firstUnwatched = allEpisodes.firstWhere(
-                (e) => !e.isPlayed,
-                orElse: () => allEpisodes.first,
-              );
-              targetEpisode = firstUnwatched;
+              // Next Up arrives on its own future, so fall back to whatever is part
+              // way through. First unwatched can sit behind the user, since a
+              // skipped episode or a special counts as unwatched.
+              targetEpisode =
+                  viewModel.nextUp ??
+                  allEpisodes.firstWhere(
+                    (e) => !e.isPlayed && (e.playedPercentage ?? 0) > 0,
+                    orElse: () => allEpisodes.firstWhere(
+                      (e) => !e.isPlayed,
+                      orElse: () => allEpisodes.first,
+                    ),
+                  );
             }
 
             final targetSeasonId = targetEpisode.seasonId;
@@ -7698,9 +7702,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               startIndex: idx,
             );
             final startPosition = resume
-                ? (selectedEpisode.playbackPosition ??
-                    targetEpisode.playbackPosition ??
-                    Duration.zero)
+                ? (selectedEpisode.playbackPosition ?? Duration.zero)
                 : Duration.zero;
 
             if (!context.mounted) return;


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where tapping the Resume button on a Series detail screen for a show in progress launched an earlier episode instead of resuming the user's current episode in progress, which could happen if there were unwatched episodes found prior to the "Next Up" episode.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **item_detail_screen.dart** inside `_playInternal` for `case 'Series'` to prioritize `viewModel.nextUp` when launching playback for a show in progress.
- Preserved S1:E1 fallback for shows that are completely unwatched or fully watched.
- Preserved saved playback position timestamp by falling back to `targetEpisode.playbackPosition` if `selectedEpisode.playbackPosition` is null.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why): Simple logic gate change

### Test Steps
1. Navigate to a Series detail page for a TV show that is in progress.
2. Tap the main **Resume** button.
3. Verify that the player opens the current Next Up episode at its saved position rather than starting an earlier, unplayed episode.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
