### PR TITLE
feat-playlists Repopulate playlist page with alternate types and fix chapters

### DIFF
--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -14,7 +14,8 @@ bool isPlaylistNonEmpty(
 }
 
 bool isAudioPlaylistSummary(AggregatedItem item) {
-  return (item.rawData['MediaType'] as String?) == 'Audio';
+  final resolved = resolveItemMediaType(item.rawData);
+  return resolved == 'Audio';
 }
 
 bool hasPlaylistEntryId(AggregatedItem item) {
@@ -22,24 +23,92 @@ bool hasPlaylistEntryId(AggregatedItem item) {
   return entryId != null && entryId.isNotEmpty;
 }
 
-bool playlistItemMatchesMediaType(Map<String, dynamic> raw, String mediaType) {
-  final itemMediaType = raw['MediaType'] as String?;
-  if (itemMediaType != null) {
-    return itemMediaType == mediaType;
+/// Resolves the media type category of an individual item.
+/// Concrete `Type` (`Movie`, `Episode`, `MusicVideo`, `Video`, `AudioBook`, etc.)
+/// takes precedence over `MediaType` to handle Jellyfin metadata mismatches.
+String resolveItemMediaType(Map<String, dynamic> raw) {
+  final itemType = raw['Type'] as String?;
+  if (itemType == 'Movie' ||
+      itemType == 'Episode' ||
+      itemType == 'Video' ||
+      itemType == 'MusicVideo' ||
+      itemType == 'Trailer' ||
+      itemType == 'Clip') {
+    return 'Video';
+  }
+  if (itemType == 'AudioBook') {
+    return 'AudioBook';
+  }
+  if (itemType == 'Audio') {
+    return 'Audio';
+  }
+  if (itemType == 'Book') {
+    return 'Book';
+  }
+  if (itemType == 'Game') {
+    return 'Game';
+  }
+  if (itemType == 'Photo') {
+    return 'Photo';
   }
 
-  final itemType = raw['Type'] as String?;
-  return switch (mediaType) {
-    'Audio' => itemType == 'Audio',
-    'Video' =>
-      itemType == 'Video' ||
-          itemType == 'Movie' ||
-          itemType == 'Episode' ||
-          itemType == 'MusicVideo' ||
-          itemType == 'Trailer' ||
-          itemType == 'Clip',
-    _ => false,
-  };
+  final summaryMediaType = raw['MediaType'] as String?;
+  if (summaryMediaType != null &&
+      summaryMediaType.isNotEmpty &&
+      summaryMediaType != 'Unknown') {
+    if (summaryMediaType == 'Video') return 'Video';
+    if (summaryMediaType == 'Audio') return 'Audio';
+    if (summaryMediaType == 'Book') return 'Book';
+    if (summaryMediaType == 'Game') return 'Game';
+    if (summaryMediaType == 'Photo') return 'Photo';
+  }
+
+  return 'Unknown';
+}
+
+bool playlistItemMatchesMediaType(Map<String, dynamic> raw, String mediaType) {
+  return resolveItemMediaType(raw) == mediaType;
+}
+
+/// Resolves the playlist category (`Video`, `Audio`, `AudioBook`, `Book`, `Game`, `Photo`, or `Mixed`).
+Future<String> resolvePlaylistCategory(
+  MediaServerClient client,
+  AggregatedItem item, {
+  bool assumeNonEmptyWhenUnknown = false,
+}) async {
+  if (item.type != 'Playlist') {
+    return resolveItemMediaType(item.rawData);
+  }
+
+  if (!isPlaylistNonEmpty(
+    item,
+    assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
+  )) {
+    return 'Mixed';
+  }
+
+  try {
+    final response = await client.itemsApi.getPlaylistItems(item.id);
+    final rawItems = ((response['Items'] as List?) ?? const [])
+        .cast<Map<String, dynamic>>();
+    if (rawItems.isEmpty) {
+      return 'Mixed';
+    }
+
+    final categories = rawItems.map(resolveItemMediaType).toSet();
+    if (categories.length == 1) {
+      return categories.first != 'Unknown' ? categories.first : 'Mixed';
+    }
+    return 'Mixed';
+  } catch (_) {
+    final summaryMediaType = item.rawData['MediaType'] as String?;
+    if (summaryMediaType != null &&
+        summaryMediaType.isNotEmpty &&
+        summaryMediaType != 'Unknown') {
+      return summaryMediaType;
+    }
+    return 'Mixed';
+  }
 }
 
 Future<bool> playlistContainsOnlyMediaType(
@@ -48,36 +117,12 @@ Future<bool> playlistContainsOnlyMediaType(
   String mediaType, {
   bool assumeNonEmptyWhenUnknown = false,
 }) async {
-  if (item.type != 'Playlist') {
-    return false;
-  }
-
-  final count = item.childCount ?? item.recursiveItemCount;
-  if (count == 0) {
-    return false;
-  }
-
-  final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null && summaryMediaType != mediaType) {
-    return false;
-  }
-
-  try {
-    final response = await client.itemsApi.getPlaylistItems(item.id);
-    final rawItems = ((response['Items'] as List?) ?? const [])
-        .cast<Map<String, dynamic>>();
-    if (rawItems.isEmpty) {
-      return false;
-    }
-    return rawItems.every(
-      (raw) => playlistItemMatchesMediaType(raw, mediaType),
-    );
-  } catch (_) {
-    if (count == null) {
-      return assumeNonEmptyWhenUnknown && summaryMediaType == mediaType;
-    }
-    return summaryMediaType == mediaType;
-  }
+  final category = await resolvePlaylistCategory(
+    client,
+    item,
+    assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
+  );
+  return category == mediaType;
 }
 
 Future<bool> playlistHasBrowsableItems(
@@ -85,38 +130,11 @@ Future<bool> playlistHasBrowsableItems(
   AggregatedItem item, {
   bool assumeNonEmptyWhenUnknown = false,
 }) async {
-  if (item.type != 'Playlist' ||
-      !isPlaylistNonEmpty(
-        item,
-        assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
-      )) {
-    return false;
-  }
-
-  final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null &&
-      summaryMediaType != 'Audio' &&
-      summaryMediaType != 'Unknown') {
-    return true;
-  }
-
-  try {
-    final response = await client.itemsApi.getPlaylistItems(item.id);
-    final rawItems = ((response['Items'] as List?) ?? const [])
-        .cast<Map<String, dynamic>>();
-    if (rawItems.isEmpty) {
-      return false;
-    }
-    return rawItems.any((raw) => !playlistItemMatchesMediaType(raw, 'Audio'));
-  } catch (_) {
-    if (summaryMediaType != null) {
-      return summaryMediaType != 'Audio' && summaryMediaType != 'Unknown';
-    }
-    return isPlaylistNonEmpty(
-      item,
-      assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
-    );
-  }
+  if (item.type != 'Playlist') return true;
+  return isPlaylistNonEmpty(
+    item,
+    assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
+  );
 }
 
 Future<List<AggregatedItem>> filterBrowsablePlaylists(

--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -23,50 +23,35 @@ bool hasPlaylistEntryId(AggregatedItem item) {
   return entryId != null && entryId.isNotEmpty;
 }
 
-/// Resolves the media type category of an individual item.
-/// Concrete `Type` (`Movie`, `Episode`, `MusicVideo`, `Video`, `AudioBook`, etc.)
-/// takes precedence over `MediaType` to handle Jellyfin metadata mismatches.
+/// The category an individual item belongs to. Its concrete `Type` wins over
+/// `MediaType`, which reports a music video as Audio and can't tell an audiobook
+/// from a song.
 String resolveItemMediaType(Map<String, dynamic> raw) {
-  final itemType = raw['Type'] as String?;
-  if (itemType == 'Movie' ||
-      itemType == 'Episode' ||
-      itemType == 'Video' ||
-      itemType == 'MusicVideo' ||
-      itemType == 'Trailer' ||
-      itemType == 'Clip') {
-    return 'Video';
-  }
-  if (itemType == 'AudioBook') {
-    return 'AudioBook';
-  }
-  if (itemType == 'Audio') {
-    return 'Audio';
-  }
-  if (itemType == 'Book') {
-    return 'Book';
-  }
-  if (itemType == 'Photo') {
-    return 'Photo';
-  }
-
-  final summaryMediaType = raw['MediaType'] as String?;
-  if (summaryMediaType != null &&
-      summaryMediaType.isNotEmpty &&
-      summaryMediaType != 'Unknown') {
-    if (summaryMediaType == 'Video') return 'Video';
-    if (summaryMediaType == 'Audio') return 'Audio';
-    if (summaryMediaType == 'Book') return 'Book';
-    if (summaryMediaType == 'Photo') return 'Photo';
-  }
-
-  return 'Unknown';
+  return switch (raw['Type'] as String?) {
+    'Movie' || 'Episode' || 'Video' || 'MusicVideo' || 'Trailer' || 'Clip' =>
+      'Video',
+    'AudioBook' => 'AudioBook',
+    'Audio' => 'Audio',
+    'Book' => 'Book',
+    'Photo' => 'Photo',
+    _ => _categoryForMediaType(raw['MediaType'] as String?),
+  };
 }
 
-bool playlistItemMatchesMediaType(Map<String, dynamic> raw, String mediaType) {
-  return resolveItemMediaType(raw) == mediaType;
+/// A server `MediaType` mapped onto the same categories [resolveItemMediaType]
+/// returns. The server only reports Video, Audio, Book or Photo here.
+String _categoryForMediaType(String? mediaType) {
+  return switch (mediaType) {
+    'Video' => 'Video',
+    'Audio' => 'Audio',
+    'Book' => 'Book',
+    'Photo' => 'Photo',
+    _ => 'Unknown',
+  };
 }
 
-/// Resolves the playlist category (`Video`, `Audio`, `AudioBook`, `Book`, `Game`, `Photo`, or `Mixed`).
+/// The category a playlist belongs to, one of Video, Audio, AudioBook, Book,
+/// Photo or Mixed. Mixed also covers a playlist that's empty or unreadable.
 Future<String> resolvePlaylistCategory(
   MediaServerClient client,
   AggregatedItem item, {
@@ -83,11 +68,14 @@ Future<String> resolvePlaylistCategory(
     return 'Mixed';
   }
 
-  final summaryMediaType = item.rawData['MediaType'] as String?;
-  if (summaryMediaType != null &&
-      summaryMediaType.isNotEmpty &&
-      summaryMediaType != 'Unknown') {
-    return summaryMediaType;
+  // Video, Book and Photo summaries are specific enough to take at face value.
+  // Audio isn't, since the server calls both music and audiobooks Audio, and
+  // tags a playlist of music videos Audio too.
+  final summaryCategory = _categoryForMediaType(
+    item.rawData['MediaType'] as String?,
+  );
+  if (summaryCategory != 'Audio' && summaryCategory != 'Unknown') {
+    return summaryCategory;
   }
 
   try {
@@ -122,16 +110,28 @@ Future<bool> playlistContainsOnlyMediaType(
   return category == mediaType;
 }
 
+/// Whether a playlist belongs in a video playlist row. Audio only playlists are
+/// left out because they have a row of their own, so counting them here would
+/// list the same playlist twice on the home screen.
 Future<bool> playlistHasBrowsableItems(
   MediaServerClient client,
   AggregatedItem item, {
   bool assumeNonEmptyWhenUnknown = false,
 }) async {
-  if (item.type != 'Playlist') return true;
-  return isPlaylistNonEmpty(
+  if (item.type != 'Playlist') return false;
+  if (!isPlaylistNonEmpty(
+    item,
+    assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
+  )) {
+    return false;
+  }
+
+  final category = await resolvePlaylistCategory(
+    client,
     item,
     assumeNonEmptyWhenUnknown: assumeNonEmptyWhenUnknown,
   );
+  return category != 'Audio' && category != 'AudioBook';
 }
 
 Future<List<AggregatedItem>> filterBrowsablePlaylists(

--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -45,9 +45,6 @@ String resolveItemMediaType(Map<String, dynamic> raw) {
   if (itemType == 'Book') {
     return 'Book';
   }
-  if (itemType == 'Game') {
-    return 'Game';
-  }
   if (itemType == 'Photo') {
     return 'Photo';
   }
@@ -59,7 +56,6 @@ String resolveItemMediaType(Map<String, dynamic> raw) {
     if (summaryMediaType == 'Video') return 'Video';
     if (summaryMediaType == 'Audio') return 'Audio';
     if (summaryMediaType == 'Book') return 'Book';
-    if (summaryMediaType == 'Game') return 'Game';
     if (summaryMediaType == 'Photo') return 'Photo';
   }
 

--- a/lib/data/utils/playlist_utils.dart
+++ b/lib/data/utils/playlist_utils.dart
@@ -83,6 +83,13 @@ Future<String> resolvePlaylistCategory(
     return 'Mixed';
   }
 
+  final summaryMediaType = item.rawData['MediaType'] as String?;
+  if (summaryMediaType != null &&
+      summaryMediaType.isNotEmpty &&
+      summaryMediaType != 'Unknown') {
+    return summaryMediaType;
+  }
+
   try {
     final response = await client.itemsApi.getPlaylistItems(item.id);
     final rawItems = ((response['Items'] as List?) ?? const [])
@@ -97,12 +104,6 @@ Future<String> resolvePlaylistCategory(
     }
     return 'Mixed';
   } catch (_) {
-    final summaryMediaType = item.rawData['MediaType'] as String?;
-    if (summaryMediaType != null &&
-        summaryMediaType.isNotEmpty &&
-        summaryMediaType != 'Unknown') {
-      return summaryMediaType;
-    }
     return 'Mixed';
   }
 }

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -123,17 +123,80 @@ class LibraryBrowseViewModel extends ChangeNotifier {
 
   ImageApi get imageApi => _client.imageApi;
 
+  late bool _groupByType;
+  bool get groupByType => _groupByType;
+
+  final Set<String> _playlistTypeFilters = {
+    'Video',
+    'Audio',
+    'AudioBook',
+    'Book',
+    'Game',
+    'Photo',
+    'Mixed',
+  };
+  Set<String> get playlistTypeFilters => _playlistTypeFilters;
+
+  final Map<String, String> _playlistCategoryMap = {};
+
+  String categoryForPlaylist(AggregatedItem item) {
+    return _playlistCategoryMap[item.id] ?? 'Mixed';
+  }
+
+  Map<String, List<AggregatedItem>> get groupedPlaylists {
+    final Map<String, List<AggregatedItem>> groups = {
+      'Video': [],
+      'Audio': [],
+      'AudioBook': [],
+      'Book': [],
+      'Game': [],
+      'Photo': [],
+      'Mixed': [],
+    };
+    for (final item in _items) {
+      final cat = categoryForPlaylist(item);
+      groups.putIfAbsent(cat, () => []).add(item);
+    }
+    groups.removeWhere((key, value) => value.isEmpty);
+    return groups;
+  }
+
+  Future<void> setGroupByType(bool value) async {
+    if (_groupByType == value) return;
+    _groupByType = value;
+    await _prefs.set(UserPreferences.playlistsGroupByType, value);
+    notifyListeners();
+  }
+
+  Future<void> togglePlaylistTypeFilter(String type) async {
+    if (_playlistTypeFilters.contains(type)) {
+      if (_playlistTypeFilters.length > 1) {
+        _playlistTypeFilters.remove(type);
+      }
+    } else {
+      _playlistTypeFilters.add(type);
+    }
+    await load();
+  }
+
   Future<List<AggregatedItem>> _filterLibraryItems(
     List<AggregatedItem> items,
   ) async {
     if (!isPlaylistBrowse) return items;
 
-    return filterBrowsablePlaylists(
-      _client,
-      items,
-      mediaType: isMusicBrowse ? 'Audio' : null,
-      assumeNonEmptyWhenUnknown: !isMusicBrowse,
+    final resolved = await Future.wait(
+      items.map((item) async {
+        if (item.type != 'Playlist') return item;
+        final category = await resolvePlaylistCategory(_client, item);
+        _playlistCategoryMap[item.id] = category;
+        if (_playlistTypeFilters.contains(category)) {
+          return item;
+        }
+        return null;
+      }),
     );
+
+    return resolved.whereType<AggregatedItem>().toList();
   }
 
   void setFocusedItem(AggregatedItem? item) {
@@ -176,6 +239,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         favoritesOnly ||
         _prefs.get(UserPreferences.libraryFavoriteFilter(_prefKey));
     _letterFilter = '';
+    _groupByType = _prefs.get(UserPreferences.playlistsGroupByType);
     _imageType = _prefs.get(UserPreferences.libraryImageType(_imagePrefKey));
     _posterSize = _readScopedPosterSize();
     _lastGroupCollectionsValue = _prefs.get(UserPreferences.groupItemsIntoCollections);

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -6,6 +6,7 @@ import '../../preference/preference_constants.dart';
 import '../../preference/user_preferences.dart';
 import '../models/aggregated_item.dart';
 import '../repositories/mdblist_repository.dart';
+import '../utils/bounded_concurrency.dart';
 import '../utils/playlist_utils.dart';
 
 enum LibraryBrowseState { loading, ready, error }
@@ -136,10 +137,25 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   };
   Set<String> get playlistTypeFilters => _playlistTypeFilters;
 
+  static const _playlistCategoryConcurrency = 6;
+
   final Map<String, String> _playlistCategoryMap = {};
 
   String categoryForPlaylist(AggregatedItem item) {
     return _playlistCategoryMap[item.id] ?? 'Mixed';
+  }
+
+  /// The loaded playlists the type checkboxes let through. Filtering here rather
+  /// than while paging keeps ticking a box a repaint instead of a fresh load.
+  List<AggregatedItem> get visiblePlaylists {
+    if (!isPlaylistBrowse) return _items;
+    return _items
+        .where(
+          (item) =>
+              item.type != 'Playlist' ||
+              _playlistTypeFilters.contains(categoryForPlaylist(item)),
+        )
+        .toList();
   }
 
   Map<String, List<AggregatedItem>> get groupedPlaylists {
@@ -151,9 +167,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       'Photo': [],
       'Mixed': [],
     };
-    for (final item in _items) {
-      final cat = categoryForPlaylist(item);
-      groups.putIfAbsent(cat, () => []).add(item);
+    for (final item in visiblePlaylists) {
+      groups.putIfAbsent(categoryForPlaylist(item), () => []).add(item);
     }
     groups.removeWhere((key, value) => value.isEmpty);
     return groups;
@@ -166,15 +181,15 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> togglePlaylistTypeFilter(String type) async {
+  void togglePlaylistTypeFilter(String type) {
     if (_playlistTypeFilters.contains(type)) {
-      if (_playlistTypeFilters.length > 1) {
-        _playlistTypeFilters.remove(type);
-      }
+      // Clearing the last one would leave the page blank with no way back.
+      if (_playlistTypeFilters.length == 1) return;
+      _playlistTypeFilters.remove(type);
     } else {
       _playlistTypeFilters.add(type);
     }
-    await load();
+    notifyListeners();
   }
 
   Future<List<AggregatedItem>> _filterLibraryItems(
@@ -182,19 +197,34 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   ) async {
     if (!isPlaylistBrowse) return items;
 
-    final resolved = await Future.wait(
-      items.map((item) async {
-        if (item.type != 'Playlist') return item;
-        final category = await resolvePlaylistCategory(_client, item);
-        _playlistCategoryMap[item.id] = category;
-        if (_playlistTypeFilters.contains(category)) {
-          return item;
-        }
-        return null;
-      }),
+    // A playlist the summary can't settle costs a request of its own, so keep a
+    // lid on how many are in flight at once.
+    final categories = await mapBounded<AggregatedItem, String>(
+      items,
+      _playlistCategoryConcurrency,
+      (item) => item.type != 'Playlist'
+          ? Future.value(null)
+          : resolvePlaylistCategory(
+              _client,
+              item,
+              assumeNonEmptyWhenUnknown: !isMusicBrowse,
+            ),
     );
 
-    return resolved.whereType<AggregatedItem>().toList();
+    final kept = <AggregatedItem>[];
+    for (var i = 0; i < items.length; i++) {
+      final item = items[i];
+      final category = categories[i];
+      if (category != null) {
+        _playlistCategoryMap[item.id] = category;
+        // A music library's playlist tab only ever listed audio.
+        if (isMusicBrowse && category != 'Audio' && category != 'AudioBook') {
+          continue;
+        }
+      }
+      kept.add(item);
+    }
+    return kept;
   }
 
   void setFocusedItem(AggregatedItem? item) {
@@ -282,6 +312,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     _filteredOutCount = 0;
     _fetchedCount = 0;
     _renderedItemIds.clear();
+    _playlistCategoryMap.clear();
     _totalCountKnown = true;
     _hasMoreFromPageSize = false;
     notifyListeners();

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -131,7 +131,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     'Audio',
     'AudioBook',
     'Book',
-    'Game',
     'Photo',
     'Mixed',
   };
@@ -149,7 +148,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       'Audio': [],
       'AudioBook': [],
       'Book': [],
-      'Game': [],
       'Photo': [],
       'Mixed': [],
     };

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9060,5 +9060,65 @@
   "adminBackToSearch": "Back to Search Criteria",
   "@adminBackToSearch": {
     "description": "Tooltip on the button that returns from the Identify results list to the search form"
+  },
+  "grouping": "Grouping",
+  "@grouping": {
+    "description": "Section header in the library display dialog for grouping options"
+  },
+  "groupByType": "Group by Type",
+  "@groupByType": {
+    "description": "Checkbox label to group playlists by their media type category"
+  },
+  "playlistTypes": "Playlist Types",
+  "@playlistTypes": {
+    "description": "Section header in the library display dialog for filtering playlist categories"
+  },
+  "playlistTypeVideo": "Video",
+  "@playlistTypeVideo": {
+    "description": "Filter checkbox label for video playlists"
+  },
+  "playlistTypeAudio": "Audio (Music)",
+  "@playlistTypeAudio": {
+    "description": "Filter checkbox label for audio/music playlists"
+  },
+  "playlistTypeAudiobook": "Audiobook",
+  "@playlistTypeAudiobook": {
+    "description": "Filter checkbox label for audiobook playlists"
+  },
+  "playlistTypeBook": "Book",
+  "@playlistTypeBook": {
+    "description": "Filter checkbox label for book playlists"
+  },
+  "playlistTypePhoto": "Photo",
+  "@playlistTypePhoto": {
+    "description": "Filter checkbox label for photo playlists"
+  },
+  "playlistTypeMixed": "Mixed",
+  "@playlistTypeMixed": {
+    "description": "Filter checkbox label for mixed media playlists"
+  },
+  "videoPlaylistsSection": "Video Playlists",
+  "@videoPlaylistsSection": {
+    "description": "Section header above video playlists when Group by Type is enabled"
+  },
+  "audioPlaylistsSection": "Audio Playlists",
+  "@audioPlaylistsSection": {
+    "description": "Section header above audio playlists when Group by Type is enabled"
+  },
+  "audiobookPlaylistsSection": "Audiobook Playlists",
+  "@audiobookPlaylistsSection": {
+    "description": "Section header above audiobook playlists when Group by Type is enabled"
+  },
+  "bookPlaylistsSection": "Book Playlists",
+  "@bookPlaylistsSection": {
+    "description": "Section header above book playlists when Group by Type is enabled"
+  },
+  "photoPlaylistsSection": "Photo Playlists",
+  "@photoPlaylistsSection": {
+    "description": "Section header above photo playlists when Group by Type is enabled"
+  },
+  "mixedPlaylistsSection": "Mixed Playlists",
+  "@mixedPlaylistsSection": {
+    "description": "Section header above mixed playlists when Group by Type is enabled"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -18189,6 +18189,96 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Back to Search Criteria'**
   String get adminBackToSearch;
+
+  /// Section header in the library display dialog for grouping options
+  ///
+  /// In en, this message translates to:
+  /// **'Grouping'**
+  String get grouping;
+
+  /// Checkbox label to group playlists by their media type category
+  ///
+  /// In en, this message translates to:
+  /// **'Group by Type'**
+  String get groupByType;
+
+  /// Section header in the library display dialog for filtering playlist categories
+  ///
+  /// In en, this message translates to:
+  /// **'Playlist Types'**
+  String get playlistTypes;
+
+  /// Filter checkbox label for video playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Video'**
+  String get playlistTypeVideo;
+
+  /// Filter checkbox label for audio/music playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Audio (Music)'**
+  String get playlistTypeAudio;
+
+  /// Filter checkbox label for audiobook playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Audiobook'**
+  String get playlistTypeAudiobook;
+
+  /// Filter checkbox label for book playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Book'**
+  String get playlistTypeBook;
+
+  /// Filter checkbox label for photo playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Photo'**
+  String get playlistTypePhoto;
+
+  /// Filter checkbox label for mixed media playlists
+  ///
+  /// In en, this message translates to:
+  /// **'Mixed'**
+  String get playlistTypeMixed;
+
+  /// Section header above video playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Video Playlists'**
+  String get videoPlaylistsSection;
+
+  /// Section header above audio playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Audio Playlists'**
+  String get audioPlaylistsSection;
+
+  /// Section header above audiobook playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Audiobook Playlists'**
+  String get audiobookPlaylistsSection;
+
+  /// Section header above book playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Book Playlists'**
+  String get bookPlaylistsSection;
+
+  /// Section header above photo playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Photo Playlists'**
+  String get photoPlaylistsSection;
+
+  /// Section header above mixed playlists when Group by Type is enabled
+  ///
+  /// In en, this message translates to:
+  /// **'Mixed Playlists'**
+  String get mixedPlaylistsSection;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -10249,4 +10249,49 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -10225,4 +10225,49 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -10314,4 +10314,49 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -10352,4 +10352,49 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -10223,4 +10223,49 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -10400,4 +10400,49 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10287,4 +10287,49 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -10304,4 +10304,49 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10240,4 +10240,49 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -10398,4 +10398,49 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -10407,4 +10407,49 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10159,6 +10159,51 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -10235,4 +10235,49 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -10364,6 +10364,51 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -10253,4 +10253,49 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -10181,4 +10181,49 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -10271,4 +10271,49 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -10376,4 +10376,49 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -10390,4 +10390,49 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -10102,4 +10102,49 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -10216,4 +10216,49 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -10469,4 +10469,49 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -10341,4 +10341,49 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -10245,4 +10245,49 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -10330,4 +10330,49 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9929,4 +9929,49 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -10291,4 +10291,49 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -10315,4 +10315,49 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9922,4 +9922,49 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -10311,4 +10311,49 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -10308,4 +10308,49 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -10323,4 +10323,49 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -10368,4 +10368,49 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -10265,4 +10265,49 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -10237,4 +10237,49 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10297,4 +10297,49 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -10204,4 +10204,49 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -10307,4 +10307,49 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -10330,6 +10330,51 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -10334,4 +10334,49 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -10324,4 +10324,49 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -10236,4 +10236,49 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -10316,4 +10316,49 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -10310,4 +10310,49 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -10345,4 +10345,49 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -10457,4 +10457,49 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10254,4 +10254,49 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -10329,4 +10329,49 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -10330,4 +10330,49 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -10316,4 +10316,49 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -10167,4 +10167,49 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -10360,4 +10360,49 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -10260,4 +10260,49 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -10281,4 +10281,49 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -10335,4 +10335,49 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -10248,4 +10248,49 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -9841,6 +9841,51 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get adminBackToSearch => 'Back to Search Criteria';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -32,7 +32,7 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
-  String get quickConnect => 'Quick Connect';
+  String get quickConnect => '快速连接';
 
   @override
   String get password => '密码';
@@ -1098,7 +1098,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String failedToDeleteItemWithError(String error) {
-    return 'Deletion operation failed with the following error: $error';
+    return '删除操作失败，错误信息如下：$error';
   }
 
   @override
@@ -1317,7 +1317,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get shuffle => '随机播放';
 
   @override
-  String get shuffleAll => 'Shuffle All';
+  String get shuffleAll => '随机播放全部';
 
   @override
   String get shuffleAllMusic => '随机播放所有音乐';
@@ -2076,7 +2076,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settings => '设置';
 
   @override
-  String get settingsSearchHint => 'Search settings';
+  String get settingsSearchHint => '搜索设置项';
 
   @override
   String get authentication => '身份验证';
@@ -2263,7 +2263,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get detailsBackgroundBlur => '详情页背景模糊';
 
   @override
-  String get detailsBackgroundOpacity => 'Details Background Opacity';
+  String get detailsBackgroundOpacity => '详情页背景不透明度';
 
   @override
   String pixelValue(int value) {
@@ -2340,41 +2340,39 @@ class AppLocalizationsZh extends AppLocalizations {
   String get osdLockButtonDescription => '显示锁定按钮，长按解锁前会阻止触摸输入';
 
   @override
-  String get osdButtons => 'Player Buttons';
+  String get osdButtons => '播放器按钮';
 
   @override
-  String get osdButtonsDescription => 'Choose which buttons the player shows';
+  String get osdButtonsDescription => '选择播放器显示的按钮';
 
   @override
   String get osdButtonsSectionDescription =>
-      'Playback controls are always shown. Everything below is up to you, and each kind of device keeps its own list.';
+      '播放控制按钮始终显示。其余项目可自定义，不同设备类型拥有独立配置。';
 
   @override
-  String get detailButtons => 'Action Buttons';
+  String get detailButtons => '操作按钮';
 
   @override
-  String get detailButtonsDescription =>
-      'Choose which buttons the details screen shows';
+  String get detailButtonsDescription => '选择详情页面显示的按钮';
 
   @override
   String get detailButtonsSectionDescription =>
-      'Play is always first and the locked buttons are always shown. Everything else is up to you, and each kind of device keeps its own list.';
+      '播放按钮固定置顶，锁定按钮始终可见。其余项目可自定义，不同设备类型拥有独立配置。';
 
   @override
-  String get moveUp => 'Move Up';
+  String get moveUp => '上移';
 
   @override
-  String get moveDown => 'Move Down';
+  String get moveDown => '下移';
 
   @override
-  String get buttonOrderHint =>
-      'Use the arrows to change the order. On a remote, left and right move the highlighted button. Switching one off drops it below the rest.';
+  String get buttonOrderHint => '使用箭头调整顺序。遥控器可通过左右方向键移动选中按钮；关闭按钮将自动后置。';
 
   @override
-  String get orientationLock => 'Orientation Lock';
+  String get orientationLock => '方向锁定';
 
   @override
-  String get fullscreen => 'Fullscreen';
+  String get fullscreen => '全屏';
 
   @override
   String get audioBehavior => '音频行为';
@@ -3011,8 +3009,7 @@ class AppLocalizationsZh extends AppLocalizations {
       '下载的媒体将保存到你设备上的 Downloads/Moonfin 中。这些文件将对其他应用可见，例如你的图库或音乐播放器。\n\n现有下载将保留在当前位置。';
 
   @override
-  String get transcodingTimeRemainingUnavailable =>
-      'Transcoding: Time Remaining Unavailable';
+  String get transcodingTimeRemainingUnavailable => '转码中：剩余时间未知';
 
   @override
   String get enable => '启用';
@@ -3243,11 +3240,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get enableTrailerAudio => '媒体栏预告片开启音效';
 
   @override
-  String get trailerCaptions => 'Trailer Captions';
+  String get trailerCaptions => '预告片字幕';
 
   @override
-  String get trailerCaptionsDescription =>
-      'Show captions on YouTube trailers in the media bar';
+  String get trailerCaptionsDescription => '在媒体栏的 YouTube 预告片中显示字幕';
 
   @override
   String get episodePreview => '剧集预览';
@@ -3337,11 +3333,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get fullScreenRowsDescription => '将首页行限制为每屏 1 行';
 
   @override
-  String get homeRowsPadding => 'Home Row Padding';
+  String get homeRowsPadding => '首页行内边距';
 
   @override
-  String get homeRowsPaddingDescription =>
-      'Customize padding between home rows';
+  String get homeRowsPaddingDescription => '自定义首页各行之间的内边距';
 
   @override
   String get perRowImageType => '每行图片类型';
@@ -3600,7 +3595,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seerrDiscoveryRows => 'Seerr 发现栏目';
 
   @override
-  String get yourWatchlist => 'Your Watchlist';
+  String get yourWatchlist => '我的观看清单';
 
   @override
   String get resetRowsToDefaults => '将栏目重置为默认值';
@@ -8113,62 +8108,58 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsOfflineDownloads => '离线下载';
 
   @override
-  String get useNativeEmulator => 'Native Emulation';
+  String get useNativeEmulator => '原生模拟';
 
   @override
-  String get useNativeEmulatorSubtitle =>
-      'Play games with native cores instead of the EmulatorJS web player';
+  String get useNativeEmulatorSubtitle => '使用原生内核运行游戏，而非 EmulatorJS 网页播放器';
 
   @override
-  String get emulatorCores => 'Emulator Cores';
+  String get emulatorCores => '模拟器内核';
 
   @override
-  String get emulatorCoresSubtitle => 'Download systems to play games natively';
+  String get emulatorCoresSubtitle => '下载游戏系统以原生方式运行游戏';
 
   @override
   String get emulatorCoresDescription =>
-      'Choose which systems to install. Cores are provided by the libretro project and let games run natively instead of in a browser view.';
+      '选择需要安装的游戏系统。内核由 libretro 项目提供，可脱离浏览器，以原生模式运行游戏。';
 
   @override
-  String get emulatorCoreDownloading => 'Downloading';
+  String get emulatorCoreDownloading => '正在下载';
 
   @override
-  String get emulatorCoreUnavailable => 'Not available for this device';
+  String get emulatorCoreUnavailable => '当前设备不支持';
 
   @override
-  String get emulatorCoreDownloadFailed =>
-      'Could not download the core. Check your connection and try again.';
+  String get emulatorCoreDownloadFailed => '内核下载失败，请检查网络连接后重试。';
 
   @override
-  String get downloadedGames => 'Downloaded Games';
+  String get downloadedGames => '已下载游戏';
 
   @override
-  String get downloadedGamesSubtitle => 'Free up space used by game files';
+  String get downloadedGamesSubtitle => '释放游戏文件占用的存储空间';
 
   @override
   String get downloadedGamesDescription =>
-      'Games are copied to this device before they play. Remove the ones you have finished to free up space. Saves are kept on the server and are not deleted.';
+      '游戏运行前会复制至本机。可删除已通关游戏释放空间，存档保存在服务器，不会被清除。';
 
   @override
-  String get downloadedGamesEmpty =>
-      'No games have been downloaded to this device yet.';
+  String get downloadedGamesEmpty => '暂未在本机下载任何游戏。';
 
   @override
   String downloadedGamesTotal(int count, String size) {
-    return '$count games, $size';
+    return '$count 款游戏，占用 $size';
   }
 
   @override
-  String get removeAllDownloadedGames => 'Remove All';
+  String get removeAllDownloadedGames => '全部移除';
 
   @override
   String removeDownloadedGameConfirm(String title) {
-    return 'Remove $title from this device? It will download again the next time you play it.';
+    return '是否从本机移除 $title？下次游玩时将会重新下载。';
   }
 
   @override
-  String get removeAllDownloadedGamesConfirm =>
-      'Remove all downloaded games from this device? They will download again the next time you play them.';
+  String get removeAllDownloadedGamesConfirm => '是否移除本机所有已下载游戏？下次游玩时将会重新下载。';
 
   @override
   String get settingsHigh => '高';
@@ -9797,46 +9788,46 @@ class AppLocalizationsZh extends AppLocalizations {
   String get imdbTopEnglishMovies => 'IMDb 高分英语电影';
 
   @override
-  String get addToWatchlist => 'Add to Watchlist';
+  String get addToWatchlist => '加入观看清单';
 
   @override
-  String get removeFromWatchlist => 'Remove from Watchlist';
+  String get removeFromWatchlist => '从观看清单移除';
 
   @override
-  String get watchlistUpdateFailed => 'Couldn\'t update watchlist';
+  String get watchlistUpdateFailed => '观看清单更新失败';
 
   @override
-  String get adminSearchParameters => 'Search Parameters';
+  String get adminSearchParameters => '搜索参数';
 
   @override
-  String get adminCurrentMetadata => 'Current Metadata';
+  String get adminCurrentMetadata => '当前元数据';
 
   @override
-  String get adminLabelYear => 'Year';
+  String get adminLabelYear => '年份';
 
   @override
-  String get adminLabelImdbId => 'IMDb Id';
+  String get adminLabelImdbId => 'IMDb编号';
 
   @override
-  String get adminLabelTmdbMovieId => 'TheMovieDb Movie Id';
+  String get adminLabelTmdbMovieId => 'TheMovieDb 影片编号';
 
   @override
-  String get adminLabelTmdbBoxSetId => 'TheMovieDb Box Set Id';
+  String get adminLabelTmdbBoxSetId => 'TheMovieDb 合集编号';
 
   @override
-  String get adminLabelTvdbBoxSetId => 'TheTVDB Box Set Id';
+  String get adminLabelTvdbBoxSetId => 'TheTVDB 合集编号';
 
   @override
-  String get adminLabelTvdbId => 'TheTVDB Numerical Id';
+  String get adminLabelTvdbId => 'TheTVDB 数字编号';
 
   @override
-  String get adminLabelTvdbSlug => 'TheTVDB Slug Movie Id';
+  String get adminLabelTvdbSlug => 'TheTVDB 别名标识';
 
   @override
-  String get adminReplaceImages => 'Replace existing images';
+  String get adminReplaceImages => '替换现有图片';
 
   @override
-  String get adminBackToSearch => 'Back to Search Criteria';
+  String get adminBackToSearch => '返回搜索条件';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9828,6 +9828,51 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get adminBackToSearch => '返回搜索条件';
+
+  @override
+  String get grouping => 'Grouping';
+
+  @override
+  String get groupByType => 'Group by Type';
+
+  @override
+  String get playlistTypes => 'Playlist Types';
+
+  @override
+  String get playlistTypeVideo => 'Video';
+
+  @override
+  String get playlistTypeAudio => 'Audio (Music)';
+
+  @override
+  String get playlistTypeAudiobook => 'Audiobook';
+
+  @override
+  String get playlistTypeBook => 'Book';
+
+  @override
+  String get playlistTypePhoto => 'Photo';
+
+  @override
+  String get playlistTypeMixed => 'Mixed';
+
+  @override
+  String get videoPlaylistsSection => 'Video Playlists';
+
+  @override
+  String get audioPlaylistsSection => 'Audio Playlists';
+
+  @override
+  String get audiobookPlaylistsSection => 'Audiobook Playlists';
+
+  @override
+  String get bookPlaylistsSection => 'Book Playlists';
+
+  @override
+  String get photoPlaylistsSection => 'Photo Playlists';
+
+  @override
+  String get mixedPlaylistsSection => 'Mixed Playlists';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1306,6 +1306,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
+  static final playlistsGroupByType = Preference(
+    key: 'pref_playlists_group_by_type',
+    defaultValue: true,
+  );
+
   static final showMediaDetailsOnLibraryPage = Preference(
     key: 'pref_show_media_details_on_library_page',
     defaultValue: true,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -850,13 +850,12 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           int globalIndexOffset = 0;
           groupedMap.forEach((categoryKey, categoryItems) {
             final categoryTitle = switch (categoryKey) {
-              'Video' => 'Video Playlists',
-              'Audio' => 'Audio Playlists',
-              'AudioBook' => 'Audiobook Playlists',
-              'Book' => 'Book Playlists',
-              'Game' => 'Game Playlists',
-              'Photo' => 'Photo Playlists',
-              _ => 'Mixed Playlists',
+              'Video' => l10n.videoPlaylistsSection,
+              'Audio' => l10n.audioPlaylistsSection,
+              'AudioBook' => l10n.audiobookPlaylistsSection,
+              'Book' => l10n.bookPlaylistsSection,
+              'Photo' => l10n.photoPlaylistsSection,
+              _ => l10n.mixedPlaylistsSection,
             };
 
             slivers.add(
@@ -1025,8 +1024,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                       Scrollable.ensureVisible(
                         cardContext,
                         alignment: 0.15,
-                        alignmentPolicy:
-                            ScrollPositionAlignmentPolicy.keepVisible,
                         duration: const Duration(milliseconds: 160),
                         curve: Curves.easeOutCubic,
                       ),
@@ -2150,7 +2147,7 @@ class _SettingsDialogState extends State<_SettingsDialog> {
               Padding(
                 padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
                 child: Text(
-                  'Grouping',
+                  l10n.grouping,
                   style: TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w500,
@@ -2159,7 +2156,7 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                 ),
               ),
               _DialogCheckboxTile(
-                label: 'Group by Type',
+                label: l10n.groupByType,
                 checked: vm.groupByType,
                 onTap: () => vm.setGroupByType(!vm.groupByType),
                 accent: _jellyfinBlue,
@@ -2169,7 +2166,7 @@ class _SettingsDialogState extends State<_SettingsDialog> {
               Padding(
                 padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
                 child: Text(
-                  'Playlist Types',
+                  l10n.playlistTypes,
                   style: TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w500,
@@ -2177,13 +2174,13 @@ class _SettingsDialogState extends State<_SettingsDialog> {
                   ),
                 ),
               ),
-              for (final typeOption in const [
-                ('Video', 'Video'),
-                ('Audio', 'Audio (Music)'),
-                ('AudioBook', 'Audiobook'),
-                ('Book', 'Book'),
-                ('Photo', 'Photo'),
-                ('Mixed', 'Mixed'),
+              for (final typeOption in [
+                ('Video', l10n.playlistTypeVideo),
+                ('Audio', l10n.playlistTypeAudio),
+                ('AudioBook', l10n.playlistTypeAudiobook),
+                ('Book', l10n.playlistTypeBook),
+                ('Photo', l10n.playlistTypePhoto),
+                ('Mixed', l10n.playlistTypeMixed),
               ])
                 _DialogCheckboxTile(
                   label: typeOption.$2,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1064,8 +1064,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       ),
       onTap: () => _onItemTap(item),
     );
-      },
-    );
   }
 
   String? _cardSubtitle(AggregatedItem item) {

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -989,80 +989,96 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required WatchedIndicatorBehavior watchedBehavior,
     required bool isMobile,
   }) {
-    return MediaCard(
-      title: item.name,
-      subtitle: _cardSubtitle(item),
-      imageUrl: _imageUrl(item),
-      width: double.infinity,
-      aspectRatio: itemAspectRatio,
-      isBanner: _vm.imageType == ImageType.banner,
-      focusColor: focusColor,
-      focusNode: getGridItemFocusNode(index),
-      cardFocusExpansion: _prefs.get(
-        UserPreferences.cardFocusExpansion,
-      ),
-      suppressFocusGlow: isNeon,
-      isPlayed: item.isPlayed,
-      isFavorite: item.isFavorite,
-      unplayedCount: item.unplayedItemCount,
-      playedPercentage: _displayPlayedPercentage(item),
-      watchedBehavior: watchedBehavior,
-      itemType: item.type,
-      onFocus: isMobile
-          ? null
-          : () {
-              _onItemFocused(item);
-              _scrollToGridRow(
-                index: index,
-                crossAxisCount: crossAxisCount,
-                cellHeight: cellWidth / childAspectRatio,
-                mainAxisSpacing: 8.0,
-              );
-            },
-      onHoverStart: isMobile ? null : () => _onItemFocused(item),
-      onHoverEnd: isMobile
-          ? null
-          : () => _vm.setFocusedItem(null),
-      onKeyEvent: (_, event) {
-        if (PlatformDetection.isTV &&
-            event.isActionable &&
-            event.logicalKey.isBackKey &&
-            _allLetterFocusNode.context != null) {
-          _allLetterFocusNode.requestFocus();
-          return KeyEventResult.handled;
-        }
-        if (event.isActionable && event.logicalKey.isRightKey) {
-          final isLastColumn =
-              (index % crossAxisCount) == crossAxisCount - 1;
-          final isLastItem = index == _vm.items.length - 1;
-          if (isLastColumn || isLastItem) {
+    return Builder(
+      builder: (cardContext) {
+        return MediaCard(
+          title: item.name,
+          subtitle: _cardSubtitle(item),
+          imageUrl: _imageUrl(item),
+          width: double.infinity,
+          aspectRatio: itemAspectRatio,
+          isBanner: _vm.imageType == ImageType.banner,
+          focusColor: focusColor,
+          focusNode: getGridItemFocusNode(index),
+          cardFocusExpansion: _prefs.get(
+            UserPreferences.cardFocusExpansion,
+          ),
+          suppressFocusGlow: isNeon,
+          isPlayed: item.isPlayed,
+          isFavorite: item.isFavorite,
+          unplayedCount: item.unplayedItemCount,
+          playedPercentage: _displayPlayedPercentage(item),
+          watchedBehavior: watchedBehavior,
+          itemType: item.type,
+          onFocus: isMobile
+              ? null
+              : () {
+                  _onItemFocused(item);
+                  _scrollToGridRow(
+                    index: index,
+                    crossAxisCount: crossAxisCount,
+                    cellHeight: cellWidth / childAspectRatio,
+                    mainAxisSpacing: 8.0,
+                  );
+                  if (cardContext.mounted) {
+                    unawaited(
+                      Scrollable.ensureVisible(
+                        cardContext,
+                        alignment: 0.15,
+                        alignmentPolicy:
+                            ScrollPositionAlignmentPolicy.keepVisible,
+                        duration: const Duration(milliseconds: 160),
+                        curve: Curves.easeOutCubic,
+                      ),
+                    );
+                  }
+                },
+          onHoverStart: isMobile ? null : () => _onItemFocused(item),
+          onHoverEnd: isMobile
+              ? null
+              : () => _vm.setFocusedItem(null),
+          onKeyEvent: (_, event) {
+            if (PlatformDetection.isTV &&
+                event.isActionable &&
+                event.logicalKey.isBackKey &&
+                _allLetterFocusNode.context != null) {
+              _allLetterFocusNode.requestFocus();
+              return KeyEventResult.handled;
+            }
+            if (event.isActionable && event.logicalKey.isRightKey) {
+              final isLastColumn =
+                  (index % crossAxisCount) == crossAxisCount - 1;
+              final isLastItem = index == _vm.items.length - 1;
+              if (isLastColumn || isLastItem) {
+                return KeyEventResult.handled;
+              }
+            }
+
+            if (!_vm.hasMore && !_vm.loadingMore) {
+              return KeyEventResult.ignored;
+            }
+            if (!event.isActionable || !event.logicalKey.isDownKey) {
+              return KeyEventResult.ignored;
+            }
+
+            final nextRowIndex = index + crossAxisCount;
+            final atBottomLoadedRow =
+                nextRowIndex >= _vm.items.length;
+            if (!atBottomLoadedRow) {
+              return KeyEventResult.ignored;
+            }
+
+            _vm.loadMore();
             return KeyEventResult.handled;
-          }
-        }
-
-        if (!_vm.hasMore && !_vm.loadingMore) {
-          return KeyEventResult.ignored;
-        }
-        if (!event.isActionable || !event.logicalKey.isDownKey) {
-          return KeyEventResult.ignored;
-        }
-
-        final nextRowIndex = index + crossAxisCount;
-        final atBottomLoadedRow =
-            nextRowIndex >= _vm.items.length;
-        if (!atBottomLoadedRow) {
-          return KeyEventResult.ignored;
-        }
-
-        _vm.loadMore();
-        return KeyEventResult.handled;
+          },
+          onLongPress: () => showContextMenu(
+            context,
+            item,
+            onChanged: () => setState(() {}),
+          ),
+          onTap: () => _onItemTap(item),
+        );
       },
-      onLongPress: () => showContextMenu(
-        context,
-        item,
-        onChanged: () => setState(() {}),
-      ),
-      onTap: () => _onItemTap(item),
     );
   }
 
@@ -1769,35 +1785,6 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                 onSurface: onSurface,
               ),
             ],
-            if (vm.isPlaylistBrowse) ...[
-              Divider(color: dividerColor),
-              _sectionHeader('Grouping', sectionColor),
-              _DialogCheckboxTile(
-                label: 'Group by Type',
-                checked: vm.groupByType,
-                onTap: () => vm.setGroupByType(!vm.groupByType),
-                accent: accent,
-                onSurface: onSurface,
-              ),
-              Divider(color: dividerColor),
-              _sectionHeader('Playlist Types', sectionColor),
-              for (final typeOption in const [
-                ('Video', 'Video'),
-                ('Audio', 'Audio (Music)'),
-                ('AudioBook', 'Audiobook'),
-                ('Book', 'Book'),
-                ('Game', 'Game'),
-                ('Photo', 'Photo'),
-                ('Mixed', 'Mixed'),
-              ])
-                _DialogCheckboxTile(
-                  label: typeOption.$2,
-                  checked: vm.playlistTypeFilters.contains(typeOption.$1),
-                  onTap: () => vm.togglePlaylistTypeFilter(typeOption.$1),
-                  accent: accent,
-                  onSurface: onSurface,
-                ),
-            ],
             if (!vm.isMusicBrowse) ...[
               Divider(color: dividerColor),
               _sectionHeader(
@@ -2157,6 +2144,54 @@ class _SettingsDialogState extends State<_SettingsDialog> {
               ),
               for (final size in PosterSize.values)
                 _posterSizeRadioTile(vm, size),
+            ],
+            if (vm.isPlaylistBrowse) ...[
+              Divider(color: dividerColor),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+                child: Text(
+                  'Grouping',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: sectionColor,
+                  ),
+                ),
+              ),
+              _DialogCheckboxTile(
+                label: 'Group by Type',
+                checked: vm.groupByType,
+                onTap: () => vm.setGroupByType(!vm.groupByType),
+                accent: _jellyfinBlue,
+                onSurface: onSurface,
+              ),
+              Divider(color: dividerColor),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 4),
+                child: Text(
+                  'Playlist Types',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                    color: sectionColor,
+                  ),
+                ),
+              ),
+              for (final typeOption in const [
+                ('Video', 'Video'),
+                ('Audio', 'Audio (Music)'),
+                ('AudioBook', 'Audiobook'),
+                ('Book', 'Book'),
+                ('Photo', 'Photo'),
+                ('Mixed', 'Mixed'),
+              ])
+                _DialogCheckboxTile(
+                  label: typeOption.$2,
+                  checked: vm.playlistTypeFilters.contains(typeOption.$1),
+                  onTap: () => vm.togglePlaylistTypeFilter(typeOption.$1),
+                  accent: _jellyfinBlue,
+                  onSurface: onSurface,
+                ),
             ],
           ],
         ),

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -844,11 +844,19 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final isNeon =
             ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
+        // Grouping and the type checkboxes both move cards around, so focus
+        // nodes key on a card's place in the full list to stay with it.
+        final gridItems = _vm.visiblePlaylists;
+        final indexInItems = _vm.isPlaylistBrowse
+            ? <String, int>{
+                for (var i = 0; i < _vm.items.length; i++) _vm.items[i].id: i,
+              }
+            : const <String, int>{};
+
         if (_vm.isPlaylistBrowse && _vm.groupByType) {
           final groupedMap = _vm.groupedPlaylists;
           final slivers = <Widget>[];
 
-          int globalIndexOffset = 0;
           groupedMap.forEach((categoryKey, categoryItems) {
             final categoryTitle = switch (categoryKey) {
               'Video' => l10n.videoPlaylistsSection,
@@ -875,7 +883,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
               ),
             );
 
-            final offsetForGroup = globalIndexOffset;
             slivers.add(
               SliverPadding(
                 padding: EdgeInsets.fromLTRB(gridPadding, 0, gridPadding, 16),
@@ -889,11 +896,12 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                   delegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final item = categoryItems[index];
-                      final globalIdx = offsetForGroup + index;
                       final itemAspectRatio = _itemAspectRatio(item);
                       return _buildGridCard(
                         item: item,
-                        index: globalIdx,
+                        index: indexInItems[item.id] ?? index,
+                        positionInSection: index,
+                        sectionCount: categoryItems.length,
                         crossAxisCount: crossAxisCount,
                         cellWidth: cellWidth,
                         childAspectRatio: childAspectRatio,
@@ -909,8 +917,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 ),
               ),
             );
-
-            globalIndexOffset += categoryItems.length;
           });
 
           if (_vm.loadingMore) {
@@ -945,11 +951,13 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                   childAspectRatio: childAspectRatio,
                 ),
                 delegate: SliverChildBuilderDelegate((context, index) {
-                  final item = _vm.items[index];
+                  final item = gridItems[index];
                   final itemAspectRatio = _itemAspectRatio(item);
                   return _buildGridCard(
                     item: item,
-                    index: index,
+                    index: indexInItems[item.id] ?? index,
+                    positionInSection: index,
+                    sectionCount: gridItems.length,
                     crossAxisCount: crossAxisCount,
                     cellWidth: cellWidth,
                     childAspectRatio: childAspectRatio,
@@ -959,7 +967,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     watchedBehavior: watchedBehavior,
                     isMobile: isMobile,
                   );
-                }, childCount: _vm.items.length),
+                }, childCount: gridItems.length),
               ),
             ),
             if (_vm.loadingMore)
@@ -977,9 +985,15 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     );
   }
 
+  /// [index] keys the focus node and is the card's place in the full item list,
+  /// so it stays put as more pages arrive. [positionInSection] and
+  /// [sectionCount] describe the grid it's drawn in, which is one category once
+  /// the playlists page groups by type.
   Widget _buildGridCard({
     required AggregatedItem item,
     required int index,
+    required int positionInSection,
+    required int sectionCount,
     required int crossAxisCount,
     required double cellWidth,
     required double childAspectRatio,
@@ -989,95 +1003,96 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required WatchedIndicatorBehavior watchedBehavior,
     required bool isMobile,
   }) {
-    return Builder(
-      builder: (cardContext) {
-        return MediaCard(
-          title: item.name,
-          subtitle: _cardSubtitle(item),
-          imageUrl: _imageUrl(item),
-          width: double.infinity,
-          aspectRatio: itemAspectRatio,
-          isBanner: _vm.imageType == ImageType.banner,
-          focusColor: focusColor,
-          focusNode: getGridItemFocusNode(index),
-          cardFocusExpansion: _prefs.get(
-            UserPreferences.cardFocusExpansion,
-          ),
-          suppressFocusGlow: isNeon,
-          isPlayed: item.isPlayed,
-          isFavorite: item.isFavorite,
-          unplayedCount: item.unplayedItemCount,
-          playedPercentage: _displayPlayedPercentage(item),
-          watchedBehavior: watchedBehavior,
-          itemType: item.type,
-          onFocus: isMobile
-              ? null
-              : () {
-                  _onItemFocused(item);
+    // Section headers throw off the uniform row maths in _scrollToGridRow, so a
+    // grouped card asks the viewport to reveal it and needs its own context.
+    // Every other grid keeps the row scrolling and skips the extra element.
+    final isGrouped = _vm.isPlaylistBrowse && _vm.groupByType;
+
+    Widget card(BuildContext? revealContext) {
+      return MediaCard(
+        title: item.name,
+        subtitle: _cardSubtitle(item),
+        imageUrl: _imageUrl(item),
+        width: double.infinity,
+        aspectRatio: itemAspectRatio,
+        isBanner: _vm.imageType == ImageType.banner,
+        focusColor: focusColor,
+        focusNode: getGridItemFocusNode(index),
+        cardFocusExpansion: _prefs.get(UserPreferences.cardFocusExpansion),
+        suppressFocusGlow: isNeon,
+        isPlayed: item.isPlayed,
+        isFavorite: item.isFavorite,
+        unplayedCount: item.unplayedItemCount,
+        playedPercentage: _displayPlayedPercentage(item),
+        watchedBehavior: watchedBehavior,
+        itemType: item.type,
+        onFocus: isMobile
+            ? null
+            : () {
+                _onItemFocused(item);
+                if (revealContext == null) {
                   _scrollToGridRow(
-                    index: index,
+                    index: positionInSection,
                     crossAxisCount: crossAxisCount,
                     cellHeight: cellWidth / childAspectRatio,
                     mainAxisSpacing: 8.0,
                   );
-                  if (cardContext.mounted) {
-                    unawaited(
-                      Scrollable.ensureVisible(
-                        cardContext,
-                        alignment: 0.15,
-                        duration: const Duration(milliseconds: 160),
-                        curve: Curves.easeOutCubic,
-                      ),
-                    );
-                  }
-                },
-          onHoverStart: isMobile ? null : () => _onItemFocused(item),
-          onHoverEnd: isMobile
-              ? null
-              : () => _vm.setFocusedItem(null),
-          onKeyEvent: (_, event) {
-            if (PlatformDetection.isTV &&
-                event.isActionable &&
-                event.logicalKey.isBackKey &&
-                _allLetterFocusNode.context != null) {
-              _allLetterFocusNode.requestFocus();
+                } else if (revealContext.mounted) {
+                  unawaited(
+                    Scrollable.ensureVisible(
+                      revealContext,
+                      alignment: 0.15,
+                      duration: const Duration(milliseconds: 160),
+                      curve: Curves.easeOutCubic,
+                    ),
+                  );
+                }
+              },
+        onHoverStart: isMobile ? null : () => _onItemFocused(item),
+        onHoverEnd: isMobile ? null : () => _vm.setFocusedItem(null),
+        onKeyEvent: (_, event) {
+          if (PlatformDetection.isTV &&
+              event.isActionable &&
+              event.logicalKey.isBackKey &&
+              _allLetterFocusNode.context != null) {
+            _allLetterFocusNode.requestFocus();
+            return KeyEventResult.handled;
+          }
+          if (event.isActionable && event.logicalKey.isRightKey) {
+            // Measured against the section the card sits in, so the end of a
+            // ragged last row holds focus instead of jumping to the next
+            // category's first card.
+            final isLastColumn =
+                (positionInSection % crossAxisCount) == crossAxisCount - 1;
+            final isLastInSection = positionInSection == sectionCount - 1;
+            if (isLastColumn || isLastInSection) {
               return KeyEventResult.handled;
             }
-            if (event.isActionable && event.logicalKey.isRightKey) {
-              final isLastColumn =
-                  (index % crossAxisCount) == crossAxisCount - 1;
-              final isLastItem = index == _vm.items.length - 1;
-              if (isLastColumn || isLastItem) {
-                return KeyEventResult.handled;
-              }
-            }
+          }
 
-            if (!_vm.hasMore && !_vm.loadingMore) {
-              return KeyEventResult.ignored;
-            }
-            if (!event.isActionable || !event.logicalKey.isDownKey) {
-              return KeyEventResult.ignored;
-            }
+          if (!_vm.hasMore && !_vm.loadingMore) {
+            return KeyEventResult.ignored;
+          }
+          if (!event.isActionable || !event.logicalKey.isDownKey) {
+            return KeyEventResult.ignored;
+          }
 
-            final nextRowIndex = index + crossAxisCount;
-            final atBottomLoadedRow =
-                nextRowIndex >= _vm.items.length;
-            if (!atBottomLoadedRow) {
-              return KeyEventResult.ignored;
-            }
+          final nextRowIndex = index + crossAxisCount;
+          final atBottomLoadedRow = nextRowIndex >= _vm.items.length;
+          if (!atBottomLoadedRow) {
+            return KeyEventResult.ignored;
+          }
 
-            _vm.loadMore();
-            return KeyEventResult.handled;
-          },
-          onLongPress: () => showContextMenu(
-            context,
-            item,
-            onChanged: () => setState(() {}),
-          ),
-          onTap: () => _onItemTap(item),
-        );
-      },
-    );
+          _vm.loadMore();
+          return KeyEventResult.handled;
+        },
+        onLongPress: () =>
+            showContextMenu(context, item, onChanged: () => setState(() {})),
+        onTap: () => _onItemTap(item),
+      );
+    }
+
+    return isGrouped ? Builder(builder: card) : card(null);
   }
 
   String? _cardSubtitle(AggregatedItem item) {

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -835,6 +835,103 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final textHeight = (_hasSubtitles ? 42.0 : 24.0) * desktopTextScale;
         final childAspectRatio = cellWidth / (cellWidth / ar + textHeight);
 
+        final focusColor = _vm.isFilterBrowse
+            ? ThemeRegistry.active.borders.focusBorder.color
+            : Color(
+                _prefs.get(UserPreferences.focusColor).colorValue,
+              );
+        final isNeon =
+            ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+
+        if (_vm.isPlaylistBrowse && _vm.groupByType) {
+          final groupedMap = _vm.groupedPlaylists;
+          final slivers = <Widget>[];
+
+          int globalIndexOffset = 0;
+          groupedMap.forEach((categoryKey, categoryItems) {
+            final categoryTitle = switch (categoryKey) {
+              'Video' => 'Video Playlists',
+              'Audio' => 'Audio Playlists',
+              'AudioBook' => 'Audiobook Playlists',
+              'Book' => 'Book Playlists',
+              'Game' => 'Game Playlists',
+              'Photo' => 'Photo Playlists',
+              _ => 'Mixed Playlists',
+            };
+
+            slivers.add(
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(gridPadding, 16, gridPadding, 8),
+                sliver: SliverToBoxAdapter(
+                  child: Text(
+                    categoryTitle,
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: AppColorScheme.onSurface,
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+            final offsetForGroup = globalIndexOffset;
+            slivers.add(
+              SliverPadding(
+                padding: EdgeInsets.fromLTRB(gridPadding, 0, gridPadding, 16),
+                sliver: SliverGrid(
+                  gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: crossAxisCount,
+                    mainAxisSpacing: 8,
+                    crossAxisSpacing: spacing,
+                    childAspectRatio: childAspectRatio,
+                  ),
+                  delegate: SliverChildBuilderDelegate(
+                    (context, index) {
+                      final item = categoryItems[index];
+                      final globalIdx = offsetForGroup + index;
+                      final itemAspectRatio = _itemAspectRatio(item);
+                      return _buildGridCard(
+                        item: item,
+                        index: globalIdx,
+                        crossAxisCount: crossAxisCount,
+                        cellWidth: cellWidth,
+                        childAspectRatio: childAspectRatio,
+                        itemAspectRatio: itemAspectRatio,
+                        focusColor: focusColor,
+                        isNeon: isNeon,
+                        watchedBehavior: watchedBehavior,
+                        isMobile: isMobile,
+                      );
+                    },
+                    childCount: categoryItems.length,
+                  ),
+                ),
+              ),
+            );
+
+            globalIndexOffset += categoryItems.length;
+          });
+
+          if (_vm.loadingMore) {
+            slivers.add(
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Center(
+                    child: CircularProgressIndicator(color: _jellyfinBlue),
+                  ),
+                ),
+              ),
+            );
+          }
+
+          return CustomScrollView(
+            controller: _scrollController,
+            slivers: slivers,
+          );
+        }
+
         return CustomScrollView(
           controller: _scrollController,
           slivers: [
@@ -850,93 +947,18 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 delegate: SliverChildBuilderDelegate((context, index) {
                   final item = _vm.items[index];
                   final itemAspectRatio = _itemAspectRatio(item);
-                  final focusColor = _vm.isFilterBrowse
-                      ? ThemeRegistry.active.borders.focusBorder.color
-                      : Color(
-                          _prefs.get(UserPreferences.focusColor).colorValue,
-                        );
-                  final isNeon =
-                      ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
-                  Widget card = MediaCard(
-                    title: item.name,
-                    subtitle: _cardSubtitle(item),
-                    imageUrl: _imageUrl(item),
-                    width: double.infinity,
-                    aspectRatio: itemAspectRatio,
-                    isBanner: _vm.imageType == ImageType.banner,
+                  return _buildGridCard(
+                    item: item,
+                    index: index,
+                    crossAxisCount: crossAxisCount,
+                    cellWidth: cellWidth,
+                    childAspectRatio: childAspectRatio,
+                    itemAspectRatio: itemAspectRatio,
                     focusColor: focusColor,
-                    focusNode: getGridItemFocusNode(index),
-                    cardFocusExpansion: _prefs.get(
-                      UserPreferences.cardFocusExpansion,
-                    ),
-                    suppressFocusGlow: isNeon,
-                    isPlayed: item.isPlayed,
-                    isFavorite: item.isFavorite,
-                    unplayedCount: item.unplayedItemCount,
-                    playedPercentage: _displayPlayedPercentage(item),
+                    isNeon: isNeon,
                     watchedBehavior: watchedBehavior,
-                    itemType: item.type,
-                    onFocus: isMobile
-                        ? null
-                        : () {
-                            _onItemFocused(item);
-                            _scrollToGridRow(
-                              index: index,
-                              crossAxisCount: crossAxisCount,
-                              cellHeight: cellWidth / childAspectRatio,
-                              mainAxisSpacing: 8.0,
-                            );
-                          },
-                    onHoverStart: isMobile ? null : () => _onItemFocused(item),
-                    onHoverEnd: isMobile
-                        ? null
-                        : () => _vm.setFocusedItem(null),
-                    onKeyEvent: (_, event) {
-                      // On TV, Back on a grid card sends focus up to the alpha
-                      // bar's All chip when it's shown. The next Back, now on
-                      // the bar, leaves the library as usual.
-                      if (PlatformDetection.isTV &&
-                          event.isActionable &&
-                          event.logicalKey.isBackKey &&
-                          _allLetterFocusNode.context != null) {
-                        _allLetterFocusNode.requestFocus();
-                        return KeyEventResult.handled;
-                      }
-                      if (event.isActionable && event.logicalKey.isRightKey) {
-                        final isLastColumn =
-                            (index % crossAxisCount) == crossAxisCount - 1;
-                        final isLastItem = index == _vm.items.length - 1;
-                        if (isLastColumn || isLastItem) {
-                          // Keep focus in the current grid row at the right edge.
-                          return KeyEventResult.handled;
-                        }
-                      }
-
-                      if (!_vm.hasMore && !_vm.loadingMore) {
-                        return KeyEventResult.ignored;
-                      }
-                      if (!event.isActionable || !event.logicalKey.isDownKey) {
-                        return KeyEventResult.ignored;
-                      }
-
-                      final nextRowIndex = index + crossAxisCount;
-                      final atBottomLoadedRow =
-                          nextRowIndex >= _vm.items.length;
-                      if (!atBottomLoadedRow) {
-                        return KeyEventResult.ignored;
-                      }
-
-                      _vm.loadMore();
-                      return KeyEventResult.handled;
-                    },
-                    onLongPress: () => showContextMenu(
-                      context,
-                      item,
-                      onChanged: () => setState(() {}),
-                    ),
-                    onTap: () => _onItemTap(item),
+                    isMobile: isMobile,
                   );
-                  return card;
                 }, childCount: _vm.items.length),
               ),
             ),
@@ -951,6 +973,97 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
               ),
           ],
         );
+      },
+    );
+  }
+
+  Widget _buildGridCard({
+    required AggregatedItem item,
+    required int index,
+    required int crossAxisCount,
+    required double cellWidth,
+    required double childAspectRatio,
+    required double itemAspectRatio,
+    required Color focusColor,
+    required bool isNeon,
+    required WatchedIndicatorBehavior watchedBehavior,
+    required bool isMobile,
+  }) {
+    return MediaCard(
+      title: item.name,
+      subtitle: _cardSubtitle(item),
+      imageUrl: _imageUrl(item),
+      width: double.infinity,
+      aspectRatio: itemAspectRatio,
+      isBanner: _vm.imageType == ImageType.banner,
+      focusColor: focusColor,
+      focusNode: getGridItemFocusNode(index),
+      cardFocusExpansion: _prefs.get(
+        UserPreferences.cardFocusExpansion,
+      ),
+      suppressFocusGlow: isNeon,
+      isPlayed: item.isPlayed,
+      isFavorite: item.isFavorite,
+      unplayedCount: item.unplayedItemCount,
+      playedPercentage: _displayPlayedPercentage(item),
+      watchedBehavior: watchedBehavior,
+      itemType: item.type,
+      onFocus: isMobile
+          ? null
+          : () {
+              _onItemFocused(item);
+              _scrollToGridRow(
+                index: index,
+                crossAxisCount: crossAxisCount,
+                cellHeight: cellWidth / childAspectRatio,
+                mainAxisSpacing: 8.0,
+              );
+            },
+      onHoverStart: isMobile ? null : () => _onItemFocused(item),
+      onHoverEnd: isMobile
+          ? null
+          : () => _vm.setFocusedItem(null),
+      onKeyEvent: (_, event) {
+        if (PlatformDetection.isTV &&
+            event.isActionable &&
+            event.logicalKey.isBackKey &&
+            _allLetterFocusNode.context != null) {
+          _allLetterFocusNode.requestFocus();
+          return KeyEventResult.handled;
+        }
+        if (event.isActionable && event.logicalKey.isRightKey) {
+          final isLastColumn =
+              (index % crossAxisCount) == crossAxisCount - 1;
+          final isLastItem = index == _vm.items.length - 1;
+          if (isLastColumn || isLastItem) {
+            return KeyEventResult.handled;
+          }
+        }
+
+        if (!_vm.hasMore && !_vm.loadingMore) {
+          return KeyEventResult.ignored;
+        }
+        if (!event.isActionable || !event.logicalKey.isDownKey) {
+          return KeyEventResult.ignored;
+        }
+
+        final nextRowIndex = index + crossAxisCount;
+        final atBottomLoadedRow =
+            nextRowIndex >= _vm.items.length;
+        if (!atBottomLoadedRow) {
+          return KeyEventResult.ignored;
+        }
+
+        _vm.loadMore();
+        return KeyEventResult.handled;
+      },
+      onLongPress: () => showContextMenu(
+        context,
+        item,
+        onChanged: () => setState(() {}),
+      ),
+      onTap: () => _onItemTap(item),
+    );
       },
     );
   }
@@ -1657,6 +1770,35 @@ class _FilterSortDialogState extends State<_FilterSortDialog> {
                 accent: accent,
                 onSurface: onSurface,
               ),
+            ],
+            if (vm.isPlaylistBrowse) ...[
+              Divider(color: dividerColor),
+              _sectionHeader('Grouping', sectionColor),
+              _DialogCheckboxTile(
+                label: 'Group by Type',
+                checked: vm.groupByType,
+                onTap: () => vm.setGroupByType(!vm.groupByType),
+                accent: accent,
+                onSurface: onSurface,
+              ),
+              Divider(color: dividerColor),
+              _sectionHeader('Playlist Types', sectionColor),
+              for (final typeOption in const [
+                ('Video', 'Video'),
+                ('Audio', 'Audio (Music)'),
+                ('AudioBook', 'Audiobook'),
+                ('Book', 'Book'),
+                ('Game', 'Game'),
+                ('Photo', 'Photo'),
+                ('Mixed', 'Mixed'),
+              ])
+                _DialogCheckboxTile(
+                  label: typeOption.$2,
+                  checked: vm.playlistTypeFilters.contains(typeOption.$1),
+                  onTap: () => vm.togglePlaylistTypeFilter(typeOption.$1),
+                  accent: accent,
+                  onSurface: onSurface,
+                ),
             ],
             if (!vm.isMusicBrowse) ...[
               Divider(color: dividerColor),

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -805,6 +805,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       );
     }
 
+    final l10n = AppLocalizations.of(context);
     final cardWidth = _cardWidth();
     const spacing = 12.0;
     final watchedBehavior = _prefs.get(

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -403,7 +403,7 @@ class EmbyItemsApi implements ItemsApi {
       '/Playlists/$playlistId/Items',
       queryParameters: {
         'Fields':
-            'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres',
+            'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
       },

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -383,7 +383,7 @@ class JellyfinItemsApi implements ItemsApi {
       '/Playlists/$playlistId/Items',
       queryParameters: {
         'Fields':
-            'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres',
+            'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
       },


### PR DESCRIPTION
# Pull Request

## Summary
Fixes non-video playlists not showing up under playlist libraries/tabs, adds Playlist Type category filtering and a "Group by Type" toggle to the Display Cog menu, and fixes missing chapter markers when playing videos launched from playlists.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #961 
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **API Chapter Hydration**: Added `Chapters`, `Overview`, `UserData`, and `MediaStreams` to the `Fields` parameter in `getPlaylistItems` (`/Playlists/$playlistId/Items`) in `jellyfin_items_api.dart` and `emby_items_api.dart`. This ensures chapter markers are fetched for items played from playlists.
- **Playlist Item Classification**: Implemented `resolveItemMediaType(raw)` in `playlist_utils.dart` to check concrete item `Type` (`Movie`, `Episode`, `MusicVideo`, `Video`, `AudioBook`, `Audio`, `Book`, `Photo`) before `MediaType`. This resolves Jellyfin metadata mismatches where video items (e.g., Music Videos) report `MediaType: 'Audio'`.
- **Display Cog Dialog & Localization**: Placed **Grouping** ("Group by Type") and **Playlist Types** category checkboxes (`Video`, `Audio (Music)`, `Audiobook`, `Book`, `Photo`, `Mixed`) in the Display Cog menu (`_SettingsDialog`) in `library_browse_screen.dart`. Added complete ARB localization keys to `app_en.arb` and `l10n`.
- **Viewport Scroll Focus**: Updated card focus handling in `library_browse_screen.dart` with `Scrollable.ensureVisible` on the card's `BuildContext` to guarantee focused cards stay 100% visible inside the viewport when navigating down grid rows or section groups.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the Playlists library view and verify that audio, audiobook, book, photo, and mixed playlists appear alongside video playlists.
2. Tap the Display Cog (settings icon) on the library header.
3. Toggle **Group by Type** on and off. Verify section headers (`Video Playlists`, `Audio Playlists`, etc.) appear when checked and disappear when unchecked.
4. Check/uncheck individual Playlist Types to filter playlist visibility.
5. Start a video item with chapters from a playlist and verify that chapter markers render correctly in the player OSD.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Old Playlists Page:
<img width="2516" height="1524" alt="2026-07-28_23-12-13_moonfin" src="https://github.com/user-attachments/assets/de1f65db-471c-4d75-b508-84b8519dbb3f" />

New Display Cog Items:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-21-16" src="https://github.com/user-attachments/assets/1210e53f-1390-4c84-9e53-6ca7af8ba73a" />

Example Alternate Categories:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-21-33" src="https://github.com/user-attachments/assets/660b89f4-7a1f-47d6-b3d0-8c5d89570c06" />

Ungrouped Playlist View:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-21-49" src="https://github.com/user-attachments/assets/03ebdb04-6357-4f24-8dca-32e22680391d" />

Filtering (No Video playlists)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-22-02" src="https://github.com/user-attachments/assets/d705dd12-d617-4fa4-ba3c-c66161ae3876" />

Audiobook Playlist Subpage:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-22-30" src="https://github.com/user-attachments/assets/b4bc3cea-4eba-4fb4-a3b8-26abc564c845" />

Chapters Working for Item Launched via Playlist:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-28_23-24-34" src="https://github.com/user-attachments/assets/f22016b6-05b0-40a3-ba85-54fb90289fe9" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
