### PR TITLE
bugfix-offlinemedia - Fix for offline downloading via reverse proxy

### DIFF
--- a/lib/data/services/background_download_coordinator.dart
+++ b/lib/data/services/background_download_coordinator.dart
@@ -66,7 +66,7 @@ class BackgroundDownloadCoordinator {
     FileDownloader().configureNotificationForGroup(
       mediaGroup,
       running: const TaskNotification('Downloading', '{displayName}'),
-      complete: const TaskNotification('Download complete', '{displayName}'),
+      complete: null,
       error: const TaskNotification('Download failed', '{displayName}'),
       progressBar: true,
       groupNotificationId: 'moonfinMediaDownloads',

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -579,6 +579,9 @@ class DownloadService extends ChangeNotifier {
     required Directory dir,
     required String fileName,
   }) async {
+    // Both engines finish here, so this is the one place a batch can be counted.
+    _completedCount++;
+
     Future<void> runBestEffort(Future<void> task, Duration timeout) async {
       try {
         await task.timeout(timeout);
@@ -609,8 +612,9 @@ class DownloadService extends ChangeNotifier {
       );
     }
 
-    if (!_usesPluginNotifications &&
-        (_totalQueued <= 1 || _completedCount >= _totalQueued)) {
+    // The plugin no longer posts its own, so this is the completion notice on
+    // every platform. Held back to the last of a batch so a season reports once.
+    if (_totalQueued <= 1 || _completedCount >= _totalQueued) {
       await runBestEffort(
         _notificationService.showComplete(
           itemName: item.name,
@@ -915,7 +919,6 @@ class DownloadService extends ChangeNotifier {
       serverId: row.serverId,
       rawData: _offlineRepo.rowToRawData(row),
     );
-    unawaited(_notificationService.showComplete(itemName: item.name));
     unawaited(
       _runPostCompletionTasks(
         item: item,
@@ -1006,6 +1009,14 @@ class DownloadService extends ChangeNotifier {
     DioException error,
   ) {
     if (error.type == DioExceptionType.cancel) {
+      return false;
+    }
+
+    // A 5xx came from the server itself, so the alternate endpoint reaches the
+    // same failure a round trip later. The proxy trouble this fallback is for
+    // arrives with no status at all.
+    final status = error.response?.statusCode;
+    if (status != null && status >= 500) {
       return false;
     }
 
@@ -1687,7 +1698,6 @@ class DownloadService extends ChangeNotifier {
         isComplete: true,
         quality: quality,
       );
-      _completedCount++;
       notifyListeners();
 
       unawaited(

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -915,6 +915,7 @@ class DownloadService extends ChangeNotifier {
       serverId: row.serverId,
       rawData: _offlineRepo.rowToRawData(row),
     );
+    unawaited(_notificationService.showComplete(itemName: item.name));
     unawaited(
       _runPostCompletionTasks(
         item: item,
@@ -1004,8 +1005,7 @@ class DownloadService extends ChangeNotifier {
     DownloadQuality quality,
     DioException error,
   ) {
-    final status = error.response?.statusCode;
-    if (status != 401 && status != 403 && status != 404) {
+    if (error.type == DioExceptionType.cancel) {
       return false;
     }
 


### PR DESCRIPTION
# Pull Request

## Summary
Fixes intermittent 0% download hangs and false "Download complete" notifications caused by premature native background notifications and HTTP 302 redirect header stripping on reverse proxies.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Set **complete: null** in **background_download_coordinator.dart** notification configuration to suppress native notifications before file validation.
- Dispatch system completion notifications via **DownloadNotificationService** in **download_service.dart** only after **_validateDownloadedFile** verifies file length and container signature on disk.
- Expanded **_shouldRetryWithFallback** in **download_service.dart** to retry direct static endpoints (**_buildDirectItemFileUrl**) on general network/redirect failures.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed -- Downloads still work for my set-up, but should be tested by user who reported the reverse proxy issue
- [ ] Not tested (explain why):

### Test Steps
1. Initiate media download on physical Android device over server connection.
2. Verify progress bar updates continuously and completion notification displays only after file validation completes.
3. Verify downloaded media file is present and plays offline cleanly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
