### PR TITLE
bugfix(playback) - Allow direct play for DoVi 8.1 with HDR10+ metadata on Profile 8 Devices

### DIFF
--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -1448,12 +1448,13 @@ class DeviceProfileBuilder {
       // bitstream, so it only needs a transcode when the client can't render
       // HEVC HDR10.
       unsupportedRangeTypesHevc.add('DOVI_INVALID');
-      if (!supportsHevcHdr10Plus) {
-        unsupportedRangeTypesHevc.add('HDR10_PLUS');
-      }
     }
 
-    if (knownHevcDoviHdr10PlusBug) {
+    if (!supportsHevcHdr10Plus) {
+      unsupportedRangeTypesHevc.add('HDR10_PLUS');
+    }
+
+    if (knownHevcDoviHdr10PlusBug && !supportsDvProfile8) {
       unsupportedRangeTypesHevc.add('DOVI_WITH_HDR10_PLUS');
       unsupportedRangeTypesHevc.add('DOVI_WITH_ELHDR10_PLUS');
     }

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -12,7 +12,6 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 import 'server_transcode_capabilities.dart';


### PR DESCRIPTION
# Pull Request

## Summary
Resolves unnecessary server video transcoding on Dolby Vision Profile 8.1 titles containing secondary HDR10+ metadata (`DOVI_WITH_HDR10_PLUS`), and un-nests the standalone `HDR10_PLUS` capability check in Jellyfin device profile generation.

## Related Issues
Link related issues or tickets separated by commas.

Vicky reported issue 1/3

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Un-nested `if (!supportsHevcHdr10Plus)` out of the `if (!supportsHevcHdr10)` block in **device_profile_builder.dart** so standalone `HDR10_PLUS` range capabilities are evaluated independently.
- Updated `knownHevcDoviHdr10PlusBug` handling in **device_profile_builder.dart** to allow direct play of `DOVI_WITH_HDR10_PLUS` when **supportsDvProfile8** is true, enabling hardware with Dolby Vision Profile 8 decoding to play Profile 8.1 titles natively using Dolby Vision RPU metadata without triggering a server re-encode.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built and deploy on Android Shield with no issues but needs testing with appropriate hardware/files.
- [ ] Not tested (explain why):

### Test Steps
1. Play a Dolby Vision Profile 8.1 title containing HDR10+ dynamic metadata (`DOVI_WITH_HDR10_PLUS`) on an Android TV device.
2. Verify playback method is `directPlay` with native Dolby Vision HDR output rather than triggering a server transcode.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
