### PR TITLE
bugfix(playback) - Adjust gates for direct play/transcode stream resolution

### DIFF
--- a/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
+++ b/packages/playback_jellyfin/lib/src/jellyfin_media_stream_resolver.dart
@@ -393,36 +393,6 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       return (resolvedPath, method);
     }
 
-    final serverPlayMethod = source.defaultPlayMethod;
-    if (serverPlayMethod != null) {
-      if (serverPlayMethod == PlayMethod.directPlay && source.supportsDirectPlay) {
-        if (isAudio) {
-          return (
-            _buildDirectPlayAudioUrl(itemId, source),
-            StreamPlayMethod.directPlay,
-          );
-        }
-        return (
-          _client.playbackApi.getStreamUrl(itemId, mediaSourceId: source.id, liveStreamId: source.liveStreamId),
-          StreamPlayMethod.directPlay,
-        );
-      }
-      if (serverPlayMethod == PlayMethod.directStream && source.supportsDirectStream && source.directStreamUrl != null) {
-        var dsUrl = '${_client.baseUrl}${source.directStreamUrl}';
-        if (source.liveStreamId != null) {
-          dsUrl = '$dsUrl${dsUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
-        }
-        return (dsUrl, StreamPlayMethod.directStream);
-      }
-      if (serverPlayMethod == PlayMethod.transcode && source.supportsTranscoding && source.transcodingUrl != null) {
-        var tcUrl = '${_client.baseUrl}${source.transcodingUrl}';
-        if (source.liveStreamId != null) {
-          tcUrl = '$tcUrl${tcUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
-        }
-        return (tcUrl, StreamPlayMethod.transcode);
-      }
-    }
-
     const videoReEncodeReasons = <String>{
       'videocodecnotsupported',
       'videoprofilenotsupported',
@@ -449,14 +419,46 @@ class JellyfinMediaStreamResolver implements MediaStreamResolver {
       requiresVideoTranscode = true;
     }
 
-    if (source.supportsDirectPlay && isAudio) {
+    final allowDirectPlay = enableDirectPlay && !requiresVideoTranscode;
+
+    final serverPlayMethod = source.defaultPlayMethod;
+    if (serverPlayMethod != null) {
+      if (allowDirectPlay && serverPlayMethod == PlayMethod.directPlay && source.supportsDirectPlay) {
+        if (isAudio) {
+          return (
+            _buildDirectPlayAudioUrl(itemId, source),
+            StreamPlayMethod.directPlay,
+          );
+        }
+        return (
+          _client.playbackApi.getStreamUrl(itemId, mediaSourceId: source.id, liveStreamId: source.liveStreamId),
+          StreamPlayMethod.directPlay,
+        );
+      }
+      if (serverPlayMethod == PlayMethod.directStream && source.supportsDirectStream && source.directStreamUrl != null && !requiresVideoTranscode) {
+        var dsUrl = '${_client.baseUrl}${source.directStreamUrl}';
+        if (source.liveStreamId != null) {
+          dsUrl = '$dsUrl${dsUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
+        }
+        return (dsUrl, StreamPlayMethod.directStream);
+      }
+      if (serverPlayMethod == PlayMethod.transcode && source.supportsTranscoding && source.transcodingUrl != null) {
+        var tcUrl = '${_client.baseUrl}${source.transcodingUrl}';
+        if (source.liveStreamId != null) {
+          tcUrl = '$tcUrl${tcUrl.contains('?') ? '&' : '?'}LiveStreamId=${Uri.encodeComponent(source.liveStreamId!)}';
+        }
+        return (tcUrl, StreamPlayMethod.transcode);
+      }
+    }
+
+    if (allowDirectPlay && source.supportsDirectPlay && isAudio) {
       return (
         _buildDirectPlayAudioUrl(itemId, source),
         StreamPlayMethod.directPlay,
       );
     }
 
-    if (source.supportsDirectPlay) {
+    if (allowDirectPlay && source.supportsDirectPlay) {
       return (
         _client.playbackApi.getStreamUrl(itemId, mediaSourceId: source.id, liveStreamId: source.liveStreamId),
         StreamPlayMethod.directPlay,


### PR DESCRIPTION
# Pull Request

## Summary
Resolves an issue where media requiring a transcode (due to codec/bitrate constraints or explicit user quality overrides) was incorrectly forced into direct play by the media stream resolver.

## Related Issues
Link related issues or tickets separated by commas.

Vicky reported issue 2/3

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **jellyfin_media_stream_resolver.dart** to compute `requiresVideoTranscode` and define `allowDirectPlay = enableDirectPlay && !requiresVideoTranscode` prior to evaluating stream fallback methods.
- Gated all `directPlay` stream resolution checks in **jellyfin_media_stream_resolver.dart** with `allowDirectPlay`, ensuring that forced transcode requests and video re-encoding reasons route to `directStream` or `transcode` (`transcodingUrl`) instead of returning raw direct play URLs.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built and deployed on Android Shield with no issues but needs testing with appropriate hardware/files.
- [ ] Not tested (explain why):

### Test Steps
1. Play a video item and set an explicit bitrate limit (e.g. 720p 4Mbps).
2. Verify playback method is `transcode` and streams the lower bitrate transcode rather than attempting `directPlay`.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
