### PR TITLE
bugfix(playback) - Prevent false direct play of H264 10-bit media

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/MediaCodecCapabilities.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/MediaCodecCapabilities.kt
@@ -147,12 +147,8 @@ object MediaCodecCapabilities {
         val supportsDvP8 = supportsDolbyVisionProfile(DolbyVisionProfiles.profile8, codecInfos)
 
         val supportsAvc = hasCodecForMime(MediaFormat.MIMETYPE_VIDEO_AVC, codecInfos)
-        val supportsAvcHigh10 = hasDecoder(
-            MediaFormat.MIMETYPE_VIDEO_AVC,
-            CodecProfileLevel.AVCProfileHigh10,
-            CodecProfileLevel.AVCLevel4,
-            codecInfos,
-        )
+        // Android TV hardware decoders do not support 10-bit H264 (AVC High 10) decoding.
+        val supportsAvcHigh10 = false
         val avcMainLevel = getAvcLevel(CodecProfileLevel.AVCProfileMain, codecInfos)
         val avcHigh10Level = getAvcLevel(CodecProfileLevel.AVCProfileHigh10, codecInfos)
 

--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -1177,6 +1177,11 @@ class DeviceProfileBuilder {
               property: 'VideoProfile',
               value: 'high 10',
             ),
+            _condition(
+              condition: 'LessThanEqual',
+              property: 'VideoBitDepth',
+              value: '8',
+            ),
           ],
         ),
       );

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -12,7 +12,6 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 import 'server_transcode_capabilities.dart';


### PR DESCRIPTION
# Pull Request

## Summary
Resolves an issue where 10-bit H264 (Hi10P) video titles were falsely direct-played on Android TV devices due to misleading framework driver codec capability reports, causing playback to fail or output a black screen.

## Related Issues
Link related issues or tickets separated by commas.

Vicky reported issue 3/3

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Overrode `supportsAvcHigh10 = false` in **MediaCodecCapabilities.kt** on Android TV to correct misleading Android framework MediaCodec API reports.
- Added `VideoBitDepth <= 8` condition under `!supportsAvcHigh10` for `h264` in **device_profile_builder.dart**, ensuring Jellyfin server automatically transcodes 10-bit H264 media to standard 8-bit H264 or HEVC for smooth playback.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built and deployed on Android Shield with no issues but needs testing with appropriate hardware/files.
- [ ] Not tested (explain why):

### Test Steps
1. Play an H264 10-bit (Hi10P) video title on an Android TV device.
2. Verify playback method is `transcode` and streams cleanly without black screen or hardware decoder crashes.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
