### PR TITLE
bugfix(playback) - Adjust EAC3 Passthrough Logic

### DIFF
--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -921,11 +921,8 @@ class DeviceProfileBuilder {
     Set<AudioPassthroughToggle> explicitPassthroughToggles =
         const <AudioPassthroughToggle>{},
   }) {
-    if (audioOutputMode == AudioOutputMode.avrPassthrough &&
-        _isPassthroughControlledAudioCodec(codec) &&
-        (capabilityProfile.isAvReceiverRoute ||
-            _isPassthroughSetByHand(codec, explicitPassthroughToggles))) {
-      return _isAudioCodecPassthroughEnabled(
+    if (_isPassthroughControlledAudioCodec(codec)) {
+      final passthroughAllowed = _isAudioCodecPassthroughEnabled(
         codec: codec,
         ac3PassthroughEnabled: ac3PassthroughEnabled,
         eac3PassthroughEnabled: eac3PassthroughEnabled,
@@ -936,6 +933,12 @@ class DeviceProfileBuilder {
         trueHdPassthroughEnabled: trueHdPassthroughEnabled,
         trueHdAtmosPassthroughEnabled: trueHdAtmosPassthroughEnabled,
       );
+      if (!passthroughAllowed) {
+        // If passthrough for this codec was explicitly disabled by the user or
+        // route, do not advertise it as allowed, forcing the server to re-encode
+        // the audio stream to AAC/PCM during video transcoding.
+        return false;
+      }
     }
 
     if (universalAudioDecode) {
@@ -971,48 +974,6 @@ class DeviceProfileBuilder {
           trueHdPassthroughEnabled: trueHdPassthroughEnabled,
           trueHdAtmosPassthroughEnabled: trueHdAtmosPassthroughEnabled,
         );
-  }
-
-  /// Whether the user set any of the toggles this codec answers to by hand.
-  ///
-  /// A detected profile in AVR mode always reports an AV receiver route, so the
-  /// route side of the gate only ever fails when the hardware probe found
-  /// nothing. There is no detected capability left to follow in that state, and
-  /// falling through would hand the receiver a codec the user switched off, so
-  /// a hand-set toggle keeps governing. Reusing the enabled-check over which
-  /// toggles are set answers which ones the codec reads.
-  static bool _isPassthroughSetByHand(
-    String codec,
-    Set<AudioPassthroughToggle> explicitToggles,
-  ) {
-    if (explicitToggles.isEmpty) return false;
-    return _isAudioCodecPassthroughEnabled(
-      codec: codec,
-      ac3PassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.ac3,
-      ),
-      eac3PassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.eac3,
-      ),
-      eac3JocPassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.eac3Joc,
-      ),
-      dtsCorePassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.dtsCore,
-      ),
-      dtsHdPassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.dtsHd,
-      ),
-      dtsXPassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.dtsX,
-      ),
-      trueHdPassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.trueHd,
-      ),
-      trueHdAtmosPassthroughEnabled: explicitToggles.contains(
-        AudioPassthroughToggle.trueHdAtmos,
-      ),
-    );
   }
 
   static bool _isPassthroughControlledAudioCodec(String codec) {

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -553,10 +553,23 @@ class Media3PlayerBackend extends PlayerBackend {
         _prefs.get(UserPreferences.tunnelingFallbackDisabled) ||
         tunnelingDisabledByUser;
 
-    await _ensureActivityStarted();
+    final selectedAudioCodec = payload['audioCodec']?.toString().toLowerCase();
+    final isLosslessAudio = selectedAudioCodec == 'truehd' ||
+        selectedAudioCodec == 'mlp' ||
+        selectedAudioCodec == 'dts-hd' ||
+        selectedAudioCodec == 'dtshd';
+    final isNonPassthroughAc3Audio =
+        (selectedAudioCodec == 'eac3' || selectedAudioCodec == 'ac3') &&
+        !_prefs.resolveEac3PassthroughEnabled();
+    final hasActiveLosslessPassthrough =
+        _prefs.resolveTrueHdPassthroughEnabled() ||
+        _prefs.resolveTrueHdAtmosPassthroughEnabled();
+    final preferFfmpeg = _prefs.get(UserPreferences.preferExoPlayerFfmpeg) ||
+        isNonPassthroughAc3Audio ||
+        (isLosslessAudio && !hasActiveLosslessPassthrough);
 
     await _invoke<void>('setDecoderPreferences', {
-      'preferFfmpeg': _prefs.get(UserPreferences.preferExoPlayerFfmpeg),
+      'preferFfmpeg': preferFfmpeg,
       'tunnelingDisabled': _sessionTunnelingDisabled,
       'mapDolbyVisionProfile7ToHevc': mapDolbyVisionProfile7ToHevc,
       'allowExternalAudioEffects': _prefs.get(

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -12,7 +12,6 @@ import 'package:playback_core/playback_core.dart';
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
 import '../util/platform_detection.dart';
-import 'audio_capability_profile.dart';
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
 import 'server_transcode_capabilities.dart';


### PR DESCRIPTION
# Pull Request

## Summary
Resolves an issue where disabling EAC3 passthrough in settings still allowed raw EAC3 audio tracks to be bitstreamed/passthrough'd during video transcoding sessions.

## Related Issues
Link related issues or tickets separated by commas.

Vicky bonus round (4/3)

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated `_isAudioCodecAllowed` in **device_profile_builder.dart** to evaluate `_isAudioCodecPassthroughEnabled` for passthrough-controlled codecs (such as AC3 and EAC3), omitting them from Jellyfin's `allowedAudioCodecs` when passthrough is disabled in settings to force server audio transcoding to AAC/PCM during video transcoding.
- Updated `setDecoderPreferences` in **media3_player_backend.dart** to set `preferFfmpeg = true` when playing AC3/EAC3 audio streams with disabled passthrough, routing audio to Media3's FFmpeg extension for software PCM downmixing.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Built and deployed on Android Shield with no issues but needs testing with appropriate hardware/files.
- [ ] Not tested (explain why):

### Test Steps
1. Disable EAC3 passthrough in *Settings > Playback > Audio*.
2. Play an EAC3 item with forced video transcoding.
3. Verify Jellyfin server transcodes audio to AAC/TS and Media3 outputs PCM audio without raw EAC3 passthrough.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
