### PR TITLE
bugfix-externalrows - Add lazy loading to Seerr discovery rows on Home page

### DIFF
--- a/lib/data/repositories/seerr_repository.dart
+++ b/lib/data/repositories/seerr_repository.dart
@@ -411,12 +411,13 @@ class SeerrRepository {
         ),
       );
 
-  Future<SeerrDiscoverPage> getUpcomingMovies() => _withClient(
-    (c) async => SeerrDiscoverPage.fromJson(await c.getUpcomingMovies()),
+  Future<SeerrDiscoverPage> getUpcomingMovies({int page = 1}) => _withClient(
+    (c) async =>
+        SeerrDiscoverPage.fromJson(await c.getUpcomingMovies(page: page)),
   );
 
-  Future<SeerrDiscoverPage> getUpcomingTv() => _withClient(
-    (c) async => SeerrDiscoverPage.fromJson(await c.getUpcomingTv()),
+  Future<SeerrDiscoverPage> getUpcomingTv({int page = 1}) => _withClient(
+    (c) async => SeerrDiscoverPage.fromJson(await c.getUpcomingTv(page: page)),
   );
 
   Future<SeerrDiscoverPage> getWatchlist({int page = 1}) => _withClient(

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -402,18 +402,20 @@ class SeerrHttpClient {
     return response.data as Map<String, dynamic>;
   }
 
-  Future<Map<String, dynamic>> getUpcomingMovies() async {
+  Future<Map<String, dynamic>> getUpcomingMovies({int page = 1}) async {
     final response = await _dio.get(
       _apiUrl('discover/movies/upcoming'),
+      queryParameters: {'page': page},
       options: _authOptions(),
     );
     _requireSuccess(response, 'getUpcomingMovies');
     return response.data as Map<String, dynamic>;
   }
 
-  Future<Map<String, dynamic>> getUpcomingTv() async {
+  Future<Map<String, dynamic>> getUpcomingTv({int page = 1}) async {
     final response = await _dio.get(
       _apiUrl('discover/tv/upcoming'),
+      queryParameters: {'page': page},
       options: _authOptions(),
     );
     _requireSuccess(response, 'getUpcomingTv');

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -471,9 +471,9 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       case SeerrRowType.popularSeries:
         return _repo.getTrendingTv(limit: limit, offset: offset);
       case SeerrRowType.upcomingMovies:
-        return _repo.getUpcomingMovies();
+        return _repo.getUpcomingMovies(page: page);
       case SeerrRowType.upcomingSeries:
-        return _repo.getUpcomingTv();
+        return _repo.getUpcomingTv(page: page);
       case SeerrRowType.yourWatchlist:
         return _repo.getWatchlist(page: page);
       default:

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4314,7 +4314,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     final subtitle = _rowSubtitle(row, l10n);
     final hasSubtitle = subtitle != null && subtitle.isNotEmpty;
-    return _buildTitledRow(
+    final rowWidget = _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
       subtitle: subtitle,
@@ -4711,6 +4711,21 @@ class _ContentRowsState extends State<_ContentRows>
         },
       ),
     );
+
+    if (row.id.startsWith('seerr_')) {
+      return NotificationListener<ScrollNotification>(
+        onNotification: (notification) {
+          if (notification is ScrollUpdateNotification &&
+              notification.metrics.extentAfter < 300) {
+            widget.viewModel.loadMoreSeerrRow(row.id);
+          }
+          return false;
+        },
+        child: rowWidget,
+      );
+    }
+
+    return rowWidget;
   }
 
   Widget _buildV2ExtendedSection(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4314,7 +4314,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     final subtitle = _rowSubtitle(row, l10n);
     final hasSubtitle = subtitle != null && subtitle.isNotEmpty;
-    final rowWidget = _buildTitledRow(
+    return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
       subtitle: subtitle,
@@ -4711,21 +4711,6 @@ class _ContentRowsState extends State<_ContentRows>
         },
       ),
     );
-
-    if (row.id.startsWith('seerr_')) {
-      return NotificationListener<ScrollNotification>(
-        onNotification: (notification) {
-          if (notification is ScrollUpdateNotification &&
-              notification.metrics.extentAfter < 300) {
-            widget.viewModel.loadMoreSeerrRow(row.id);
-          }
-          return false;
-        },
-        child: rowWidget,
-      );
-    }
-
-    return rowWidget;
   }
 
   Widget _buildV2ExtendedSection(

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -838,6 +838,12 @@ class HomeViewModel extends ChangeNotifier {
 
     _inFlightPagingRowIds.add(row.id);
     try {
+      final seerrType = _seerrRowTypeForId(row.id);
+      if (seerrType != null) {
+        await _loadMoreSeerrRow(rowIndex, seerrType);
+        return;
+      }
+
       final int currentOffset = _rowOffsets[row.id] ?? row.items.length;
       final (List<AggregatedItem> items, int totalCount) result;
       if (_multiServerEnabled && !row.id.startsWith('pluginDynamic:')) {
@@ -1973,9 +1979,11 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   static const _seerrEnrichConcurrency = 5;
+  static const _seerrRowIdPrefix = 'seerr_';
+
+  /// Last page fetched per Seerr row. Seerr counts in pages where the rest of
+  /// the home rows count in items, so this can't share `_rowOffsets`.
   final Map<String, int> _seerrRowPages = {};
-  final Map<String, bool> _seerrRowLoadingMore = {};
-  final Map<String, bool> _seerrRowHasMore = {};
 
   Future<List<HomeRow>> _loadSeerrRow(
     SeerrRowType type,
@@ -1990,13 +1998,11 @@ class HomeViewModel extends ChangeNotifier {
         return [];
       }
 
-      _seerrRowPages[rowId] = 1;
-      _seerrRowHasMore[rowId] = true;
-
       final blockNsfw = seerrPrefs.blockNsfw;
       final limit = seerrPrefs.fetchLimit.limit;
 
       List<SeerrDiscoverItem> rawItems = [];
+      var hasMorePages = false;
 
       if (type == SeerrRowType.movieGenres) {
         final genres = await repo.getGenreSliderMovies();
@@ -2062,30 +2068,11 @@ class HomeViewModel extends ChangeNotifier {
           requestedBy: user.canViewAllRequests ? null : user.id,
           limit: limit,
         );
-        final mapped = response.results.where((r) => r.media != null).map((r) {
-          final media = r.media!;
-          return SeerrDiscoverItem(
-            id: media.tmdbId ?? media.id,
-            title: media.title ?? media.name,
-            name: media.name ?? media.title,
-            overview: media.overview,
-            releaseDate: media.releaseDate,
-            firstAirDate: media.firstAirDate,
-            mediaType: r.type,
-            posterPath: media.posterPath,
-            backdropPath: media.backdropPath,
-            mediaInfo: SeerrMediaInfo(
-              id: media.id,
-              tmdbId: media.tmdbId,
-              status: media.status,
-            ),
-          );
-        }).toList();
-        rawItems = (await mapBounded(
-          mapped,
-          _seerrEnrichConcurrency,
-          (item) => _enrichSeerrItem(repo, item),
-        )).whereType<SeerrDiscoverItem>().toList();
+        rawItems = await _enrichSeerrItems(
+          repo,
+          _seerrItemsFromRequests(response.results),
+        );
+        hasMorePages = (response.pageInfo?.pages ?? 1) > 1;
       } else if (type == SeerrRowType.recentlyAdded) {
         final media = await repo.getRecentlyAdded(limit: limit);
         final mapped = media
@@ -2108,270 +2095,208 @@ class HomeViewModel extends ChangeNotifier {
               ),
             )
             .toList();
-        rawItems = (await mapBounded(
-          mapped,
-          _seerrEnrichConcurrency,
-          (item) => _enrichSeerrItem(repo, item),
-        )).whereType<SeerrDiscoverItem>().toList();
-      } else if (type == SeerrRowType.yourWatchlist) {
-        final page = await _loadSeerrPage(repo, type, 1);
-        if (page != null) {
-          rawItems = (await mapBounded(
-            page.results,
-            _seerrEnrichConcurrency,
-            (item) => _enrichSeerrItem(repo, item),
-          )).whereType<SeerrDiscoverItem>().toList();
-          if (1 >= page.totalPages) {
-            _seerrRowHasMore[rowId] = false;
-          }
-        }
+        rawItems = await _enrichSeerrItems(repo, mapped);
       } else {
-        final page = await _loadSeerrPage(repo, type, 1);
+        final page = await _loadSeerrPage(repo, type, page: 1, limit: limit);
         if (page != null) {
-          rawItems = page.results;
-          if (1 >= page.totalPages) {
-            _seerrRowHasMore[rowId] = false;
-          }
+          rawItems = type == SeerrRowType.yourWatchlist
+              ? await _enrichSeerrItems(repo, page.results)
+              : page.results;
+          hasMorePages = page.totalPages > 1;
         }
       }
 
-      final filtered = rawItems.where((item) {
-        if (type != SeerrRowType.recentlyAdded &&
-            type != SeerrRowType.recentRequests &&
-            type != SeerrRowType.yourWatchlist) {
-          if (item.isAvailable || item.isBlacklisted) return false;
-        }
-        if (blockNsfw) {
-          if (item.adult) return false;
-          final text = '${item.displayTitle} ${item.overview ?? ''}';
-          if (SeerrDiscoverViewModel.nsfwPatterns.any(
-            (p) => p.hasMatch(text),
-          )) {
-            return false;
-          }
-        }
-        return true;
-      }).toList();
+      final items = _seerrAggregatedItems(rawItems, type, blockNsfw);
+      _seerrRowPages[rowId] = 1;
 
-      final aggregatedItems = filtered.map((item) {
-        return AggregatedItem(
-          id: item.id.toString(),
-          serverId: 'seerr',
-          rawData: {
-            'Name': item.displayTitle,
-            'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
-            'Overview': item.overview ?? '',
-            'PosterPath': item.posterPath ?? '',
-            'BackdropPath': item.backdropPath ?? '',
-            'ProductionYear': _extractYear(
-              item.releaseDate ?? item.firstAirDate,
-            ),
-            'SeerrMediaType': item.mediaType,
-            'SeerrStatus': item.mediaInfo?.status,
-          },
-        );
-      }).toList();
-
-      return [_seerrRow(rowId, title, aggregatedItems)];
+      // Paging keys off `hasMore`, so a row with further pages has to claim a
+      // total above what it holds. The real total is no help because the
+      // filtering above drops items the count still includes.
+      return [
+        _seerrRow(
+          rowId,
+          title,
+          items,
+          totalCount: hasMorePages ? items.length + 1 : items.length,
+        ),
+      ];
     } catch (e) {
       debugPrint('[SeerrHomeRow] Failed to load Seerr row $type: $e');
       return [];
     }
   }
 
-  Future<void> loadMoreSeerrRow(String rowId) async {
-    if (_seerrRowLoadingMore[rowId] == true) return;
-    if (_seerrRowHasMore[rowId] == false) return;
+  /// Appends the next Seerr page to [rowIndex]. Called from [loadMoreForRow],
+  /// which owns the in-flight guard and the `hasMore` check.
+  Future<void> _loadMoreSeerrRow(int rowIndex, SeerrRowType type) async {
+    final row = _rows[rowIndex];
+    final repo = await GetIt.instance.getAsync<SeerrRepository>();
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    await repo.ensureInitialized();
+    if (!repo.isAvailable) return;
 
-    final type = _seerrRowTypeForId(rowId);
-    if (type == null) return;
-    if (type == SeerrRowType.movieGenres ||
-        type == SeerrRowType.seriesGenres ||
-        type == SeerrRowType.networks ||
-        type == SeerrRowType.studios) {
-      return;
+    final limit = seerrPrefs.fetchLimit.limit;
+    final nextPage = (_seerrRowPages[row.id] ?? 1) + 1;
+
+    // Assume this is the last page until a response says otherwise, so a row
+    // without a paged endpoint stops asking rather than retrying forever.
+    var rawItems = const <SeerrDiscoverItem>[];
+    var exhausted = true;
+
+    if (type == SeerrRowType.recentRequests) {
+      final user = await repo.getCurrentUser();
+      final response = await repo.getRequests(
+        requestedBy: user.canViewAllRequests ? null : user.id,
+        limit: limit,
+        offset: (nextPage - 1) * limit,
+      );
+      rawItems = await _enrichSeerrItems(
+        repo,
+        _seerrItemsFromRequests(response.results),
+      );
+      exhausted = nextPage >= (response.pageInfo?.pages ?? nextPage);
+    } else {
+      final page = await _loadSeerrPage(
+        repo,
+        type,
+        page: nextPage,
+        limit: limit,
+      );
+      if (page != null) {
+        rawItems = type == SeerrRowType.yourWatchlist
+            ? await _enrichSeerrItems(repo, page.results)
+            : page.results;
+        exhausted = nextPage >= page.totalPages;
+      }
     }
 
-    _seerrRowLoadingMore[rowId] = true;
+    // Advance even when the page contributed nothing. Availability filtering can
+    // empty a whole page, and holding the pointer back would refetch that same
+    // page on every scroll instead of moving on.
+    _seerrRowPages[row.id] = nextPage;
 
-    try {
-      final repo = await GetIt.instance.getAsync<SeerrRepository>();
-      final seerrPrefs = GetIt.instance<SeerrPreferences>();
-      await repo.ensureInitialized();
-      if (!repo.isAvailable) {
-        _seerrRowLoadingMore[rowId] = false;
-        return;
-      }
+    final existingIds = row.items.map((item) => item.id).toSet();
+    final items = [
+      ...row.items,
+      ..._seerrAggregatedItems(
+        rawItems,
+        type,
+        seerrPrefs.blockNsfw,
+      ).where((item) => !existingIds.contains(item.id)),
+    ];
 
-      final currentPage = _seerrRowPages[rowId] ?? 1;
-      final nextPage = currentPage + 1;
-      final limit = seerrPrefs.fetchLimit.limit;
-      final blockNsfw = seerrPrefs.blockNsfw;
+    _rows = List.of(_rows);
+    _rows[rowIndex] = row.copyWith(
+      items: items,
+      totalCount: exhausted ? items.length : items.length + 1,
+    );
+    notifyListeners();
+  }
 
-      List<SeerrDiscoverItem> rawItems = [];
+  /// Row ids are the prefix followed by the type's serialized name, so deriving
+  /// the type keeps this in step as row types come and go.
+  SeerrRowType? _seerrRowTypeForId(String rowId) {
+    if (!rowId.startsWith(_seerrRowIdPrefix)) return null;
+    final name = rowId.substring(_seerrRowIdPrefix.length);
+    for (final type in SeerrRowType.values) {
+      if (type.serializedName == name) return type;
+    }
+    return null;
+  }
 
-      if (type == SeerrRowType.recentRequests) {
-        final user = await repo.getCurrentUser();
-        final response = await repo.getRequests(
-          requestedBy: user.canViewAllRequests ? null : user.id,
-          limit: limit,
-          offset: (nextPage - 1) * limit,
-        );
-        final mapped = response.results.where((r) => r.media != null).map((r) {
-          final media = r.media!;
-          return SeerrDiscoverItem(
-            id: media.tmdbId ?? media.id,
-            title: media.title ?? media.name,
-            name: media.name ?? media.title,
-            overview: media.overview,
-            releaseDate: media.releaseDate,
-            firstAirDate: media.firstAirDate,
-            mediaType: r.type,
-            posterPath: media.posterPath,
-            backdropPath: media.backdropPath,
-            mediaInfo: SeerrMediaInfo(
-              id: media.id,
-              tmdbId: media.tmdbId,
-              status: media.status,
-            ),
-          );
-        }).toList();
-        rawItems = (await mapBounded(
-          mapped,
-          _seerrEnrichConcurrency,
-          (item) => _enrichSeerrItem(repo, item),
-        )).whereType<SeerrDiscoverItem>().toList();
-      } else if (type == SeerrRowType.recentlyAdded) {
-        _seerrRowHasMore[rowId] = false;
-        _seerrRowLoadingMore[rowId] = false;
-        return;
-      } else if (type == SeerrRowType.yourWatchlist) {
-        final page = await repo.getWatchlist(page: nextPage);
-        rawItems = (await mapBounded(
-          page.results,
-          _seerrEnrichConcurrency,
-          (item) => _enrichSeerrItem(repo, item),
-        )).whereType<SeerrDiscoverItem>().toList();
-        if (nextPage >= page.totalPages) {
-          _seerrRowHasMore[rowId] = false;
-        }
-      } else {
-        final page = await _loadSeerrPage(repo, type, nextPage);
-        if (page != null) {
-          rawItems = page.results;
-          if (nextPage >= page.totalPages) {
-            _seerrRowHasMore[rowId] = false;
-          }
-        } else {
-          _seerrRowHasMore[rowId] = false;
-        }
-      }
+  Future<List<SeerrDiscoverItem>> _enrichSeerrItems(
+    SeerrRepository repo,
+    List<SeerrDiscoverItem> items,
+  ) async =>
+      (await mapBounded(
+        items,
+        _seerrEnrichConcurrency,
+        (item) => _enrichSeerrItem(repo, item),
+      )).whereType<SeerrDiscoverItem>().toList();
 
-      if (rawItems.isEmpty) {
-        _seerrRowHasMore[rowId] = false;
-        _seerrRowLoadingMore[rowId] = false;
-        return;
-      }
+  List<SeerrDiscoverItem> _seerrItemsFromRequests(List<SeerrRequest> requests) {
+    return requests.where((r) => r.media != null).map((r) {
+      final media = r.media!;
+      return SeerrDiscoverItem(
+        id: media.tmdbId ?? media.id,
+        title: media.title ?? media.name,
+        name: media.name ?? media.title,
+        overview: media.overview,
+        releaseDate: media.releaseDate,
+        firstAirDate: media.firstAirDate,
+        mediaType: r.type,
+        posterPath: media.posterPath,
+        backdropPath: media.backdropPath,
+        mediaInfo: SeerrMediaInfo(
+          id: media.id,
+          tmdbId: media.tmdbId,
+          status: media.status,
+        ),
+      );
+    }).toList();
+  }
 
-      final filtered = rawItems.where((item) {
-        if (type != SeerrRowType.recentlyAdded &&
-            type != SeerrRowType.recentRequests &&
-            type != SeerrRowType.yourWatchlist) {
-          if (item.isAvailable || item.isBlacklisted) return false;
-        }
-        if (blockNsfw) {
-          if (item.adult) return false;
-          final text = '${item.displayTitle} ${item.overview ?? ''}';
-          if (SeerrDiscoverViewModel.nsfwPatterns.any(
-            (p) => p.hasMatch(text),
-          )) {
+  List<AggregatedItem> _seerrAggregatedItems(
+    List<SeerrDiscoverItem> rawItems,
+    SeerrRowType type,
+    bool blockNsfw,
+  ) {
+    // The request, watchlist and recently added rows are meant to show media the
+    // user already has, so only the discovery rows hide what is available.
+    final hidesAvailable =
+        type != SeerrRowType.recentlyAdded &&
+        type != SeerrRowType.recentRequests &&
+        type != SeerrRowType.yourWatchlist;
+
+    return rawItems
+        .where((item) {
+          if (hidesAvailable && (item.isAvailable || item.isBlacklisted)) {
             return false;
           }
-        }
-        return true;
-      }).toList();
-
-      final newAggregated = filtered.map((item) {
-        return AggregatedItem(
-          id: item.id.toString(),
-          serverId: 'seerr',
-          rawData: {
-            'Name': item.displayTitle,
-            'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
-            'Overview': item.overview ?? '',
-            'PosterPath': item.posterPath ?? '',
-            'BackdropPath': item.backdropPath ?? '',
-            'ProductionYear': _extractYear(
-              item.releaseDate ?? item.firstAirDate,
-            ),
-            'SeerrMediaType': item.mediaType,
-            'SeerrStatus': item.mediaInfo?.status,
-          },
-        );
-      }).toList();
-
-      if (newAggregated.isNotEmpty) {
-        final rowIndex = _rows.indexWhere((r) => r.id == rowId);
-        if (rowIndex != -1) {
-          final currentRow = _rows[rowIndex];
-          final existingIds = currentRow.items.map((i) => i.id).toSet();
-          final uniqueNew =
-              newAggregated.where((i) => !existingIds.contains(i.id)).toList();
-
-          if (uniqueNew.isNotEmpty) {
-            final updatedRow = currentRow.copyWith(
-              items: [...currentRow.items, ...uniqueNew],
-            );
-            _rows[rowIndex] = updatedRow;
-            _seerrRowPages[rowId] = nextPage;
-            notifyListeners();
+          if (blockNsfw) {
+            if (item.adult) return false;
+            final text = '${item.displayTitle} ${item.overview ?? ''}';
+            if (SeerrDiscoverViewModel.nsfwPatterns.any(
+              (p) => p.hasMatch(text),
+            )) {
+              return false;
+            }
           }
-        }
-      }
-    } catch (e) {
-      debugPrint('[SeerrHomeRow] Failed to load more for $rowId: $e');
-    } finally {
-      _seerrRowLoadingMore[rowId] = false;
-    }
+          return true;
+        })
+        .map(
+          (item) => AggregatedItem(
+            id: item.id.toString(),
+            serverId: 'seerr',
+            rawData: {
+              'Name': item.displayTitle,
+              'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
+              'Overview': item.overview ?? '',
+              'PosterPath': item.posterPath ?? '',
+              'BackdropPath': item.backdropPath ?? '',
+              'ProductionYear': _extractYear(
+                item.releaseDate ?? item.firstAirDate,
+              ),
+              'SeerrMediaType': item.mediaType,
+              'SeerrStatus': item.mediaInfo?.status,
+            },
+          ),
+        )
+        .toList();
   }
 
-  SeerrRowType? _seerrRowTypeForId(String rowId) {
-    switch (rowId) {
-      case 'seerr_recent_requests':
-        return SeerrRowType.recentRequests;
-      case 'seerr_watchlist':
-        return SeerrRowType.yourWatchlist;
-      case 'seerr_recently_added':
-        return SeerrRowType.recentlyAdded;
-      case 'seerr_popular_movies':
-        return SeerrRowType.popularMovies;
-      case 'seerr_upcoming_movies':
-        return SeerrRowType.upcomingMovies;
-      case 'seerr_popular_series':
-        return SeerrRowType.popularSeries;
-      case 'seerr_upcoming_series':
-        return SeerrRowType.upcomingSeries;
-      case 'seerr_trending':
-        return SeerrRowType.trending;
-      case 'seerr_movie_genres':
-        return SeerrRowType.movieGenres;
-      case 'seerr_studios':
-        return SeerrRowType.studios;
-      case 'seerr_series_genres':
-        return SeerrRowType.seriesGenres;
-      case 'seerr_networks':
-        return SeerrRowType.networks;
-      default:
-        return null;
-    }
-  }
-
-  HomeRow _seerrRow(String rowId, String title, List<AggregatedItem> items) {
+  HomeRow _seerrRow(
+    String rowId,
+    String title,
+    List<AggregatedItem> items, {
+    int totalCount = 0,
+  }) {
     return HomeRow(
       id: rowId,
       title: title,
       rowType: HomeRowType.pluginDynamic,
       items: items,
+      totalCount: totalCount,
     );
   }
 
@@ -2401,11 +2326,10 @@ class HomeViewModel extends ChangeNotifier {
 
   Future<SeerrDiscoverPage?> _loadSeerrPage(
     SeerrRepository repo,
-    SeerrRowType type,
-    int page,
-  ) async {
-    final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final limit = seerrPrefs.fetchLimit.limit;
+    SeerrRowType type, {
+    required int page,
+    required int limit,
+  }) async {
     final offset = (page - 1) * limit;
     switch (type) {
       case SeerrRowType.yourWatchlist:
@@ -2417,9 +2341,9 @@ class HomeViewModel extends ChangeNotifier {
       case SeerrRowType.popularSeries:
         return repo.getTrendingTv(limit: limit, offset: offset);
       case SeerrRowType.upcomingMovies:
-        return repo.getUpcomingMovies();
+        return repo.getUpcomingMovies(page: page);
       case SeerrRowType.upcomingSeries:
-        return repo.getUpcomingTv();
+        return repo.getUpcomingTv(page: page);
       default:
         return null;
     }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -1973,6 +1973,9 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   static const _seerrEnrichConcurrency = 5;
+  final Map<String, int> _seerrRowPages = {};
+  final Map<String, bool> _seerrRowLoadingMore = {};
+  final Map<String, bool> _seerrRowHasMore = {};
 
   Future<List<HomeRow>> _loadSeerrRow(
     SeerrRowType type,
@@ -1986,6 +1989,9 @@ class HomeViewModel extends ChangeNotifier {
       if (!repo.isAvailable) {
         return [];
       }
+
+      _seerrRowPages[rowId] = 1;
+      _seerrRowHasMore[rowId] = true;
 
       final blockNsfw = seerrPrefs.blockNsfw;
       final limit = seerrPrefs.fetchLimit.limit;
@@ -2108,18 +2114,24 @@ class HomeViewModel extends ChangeNotifier {
           (item) => _enrichSeerrItem(repo, item),
         )).whereType<SeerrDiscoverItem>().toList();
       } else if (type == SeerrRowType.yourWatchlist) {
-        final page = await _loadSeerrPage(repo, type, limit);
+        final page = await _loadSeerrPage(repo, type, 1);
         if (page != null) {
           rawItems = (await mapBounded(
             page.results,
             _seerrEnrichConcurrency,
             (item) => _enrichSeerrItem(repo, item),
           )).whereType<SeerrDiscoverItem>().toList();
+          if (1 >= page.totalPages) {
+            _seerrRowHasMore[rowId] = false;
+          }
         }
       } else {
-        final page = await _loadSeerrPage(repo, type, limit);
+        final page = await _loadSeerrPage(repo, type, 1);
         if (page != null) {
           rawItems = page.results;
+          if (1 >= page.totalPages) {
+            _seerrRowHasMore[rowId] = false;
+          }
         }
       }
 
@@ -2167,6 +2179,193 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  Future<void> loadMoreSeerrRow(String rowId) async {
+    if (_seerrRowLoadingMore[rowId] == true) return;
+    if (_seerrRowHasMore[rowId] == false) return;
+
+    final type = _seerrRowTypeForId(rowId);
+    if (type == null) return;
+    if (type == SeerrRowType.movieGenres ||
+        type == SeerrRowType.seriesGenres ||
+        type == SeerrRowType.networks ||
+        type == SeerrRowType.studios) {
+      return;
+    }
+
+    _seerrRowLoadingMore[rowId] = true;
+
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      final seerrPrefs = GetIt.instance<SeerrPreferences>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) {
+        _seerrRowLoadingMore[rowId] = false;
+        return;
+      }
+
+      final currentPage = _seerrRowPages[rowId] ?? 1;
+      final nextPage = currentPage + 1;
+      final limit = seerrPrefs.fetchLimit.limit;
+      final blockNsfw = seerrPrefs.blockNsfw;
+
+      List<SeerrDiscoverItem> rawItems = [];
+
+      if (type == SeerrRowType.recentRequests) {
+        final user = await repo.getCurrentUser();
+        final response = await repo.getRequests(
+          requestedBy: user.canViewAllRequests ? null : user.id,
+          limit: limit,
+          offset: (nextPage - 1) * limit,
+        );
+        final mapped = response.results.where((r) => r.media != null).map((r) {
+          final media = r.media!;
+          return SeerrDiscoverItem(
+            id: media.tmdbId ?? media.id,
+            title: media.title ?? media.name,
+            name: media.name ?? media.title,
+            overview: media.overview,
+            releaseDate: media.releaseDate,
+            firstAirDate: media.firstAirDate,
+            mediaType: r.type,
+            posterPath: media.posterPath,
+            backdropPath: media.backdropPath,
+            mediaInfo: SeerrMediaInfo(
+              id: media.id,
+              tmdbId: media.tmdbId,
+              status: media.status,
+            ),
+          );
+        }).toList();
+        rawItems = (await mapBounded(
+          mapped,
+          _seerrEnrichConcurrency,
+          (item) => _enrichSeerrItem(repo, item),
+        )).whereType<SeerrDiscoverItem>().toList();
+      } else if (type == SeerrRowType.recentlyAdded) {
+        _seerrRowHasMore[rowId] = false;
+        _seerrRowLoadingMore[rowId] = false;
+        return;
+      } else if (type == SeerrRowType.yourWatchlist) {
+        final page = await repo.getWatchlist(page: nextPage);
+        rawItems = (await mapBounded(
+          page.results,
+          _seerrEnrichConcurrency,
+          (item) => _enrichSeerrItem(repo, item),
+        )).whereType<SeerrDiscoverItem>().toList();
+        if (nextPage >= page.totalPages) {
+          _seerrRowHasMore[rowId] = false;
+        }
+      } else {
+        final page = await _loadSeerrPage(repo, type, nextPage);
+        if (page != null) {
+          rawItems = page.results;
+          if (nextPage >= page.totalPages) {
+            _seerrRowHasMore[rowId] = false;
+          }
+        } else {
+          _seerrRowHasMore[rowId] = false;
+        }
+      }
+
+      if (rawItems.isEmpty) {
+        _seerrRowHasMore[rowId] = false;
+        _seerrRowLoadingMore[rowId] = false;
+        return;
+      }
+
+      final filtered = rawItems.where((item) {
+        if (type != SeerrRowType.recentlyAdded &&
+            type != SeerrRowType.recentRequests &&
+            type != SeerrRowType.yourWatchlist) {
+          if (item.isAvailable || item.isBlacklisted) return false;
+        }
+        if (blockNsfw) {
+          if (item.adult) return false;
+          final text = '${item.displayTitle} ${item.overview ?? ''}';
+          if (SeerrDiscoverViewModel.nsfwPatterns.any(
+            (p) => p.hasMatch(text),
+          )) {
+            return false;
+          }
+        }
+        return true;
+      }).toList();
+
+      final newAggregated = filtered.map((item) {
+        return AggregatedItem(
+          id: item.id.toString(),
+          serverId: 'seerr',
+          rawData: {
+            'Name': item.displayTitle,
+            'Type': item.mediaType == 'tv' ? 'Series' : 'Movie',
+            'Overview': item.overview ?? '',
+            'PosterPath': item.posterPath ?? '',
+            'BackdropPath': item.backdropPath ?? '',
+            'ProductionYear': _extractYear(
+              item.releaseDate ?? item.firstAirDate,
+            ),
+            'SeerrMediaType': item.mediaType,
+            'SeerrStatus': item.mediaInfo?.status,
+          },
+        );
+      }).toList();
+
+      if (newAggregated.isNotEmpty) {
+        final rowIndex = _rows.indexWhere((r) => r.id == rowId);
+        if (rowIndex != -1) {
+          final currentRow = _rows[rowIndex];
+          final existingIds = currentRow.items.map((i) => i.id).toSet();
+          final uniqueNew =
+              newAggregated.where((i) => !existingIds.contains(i.id)).toList();
+
+          if (uniqueNew.isNotEmpty) {
+            final updatedRow = currentRow.copyWith(
+              items: [...currentRow.items, ...uniqueNew],
+            );
+            _rows[rowIndex] = updatedRow;
+            _seerrRowPages[rowId] = nextPage;
+            notifyListeners();
+          }
+        }
+      }
+    } catch (e) {
+      debugPrint('[SeerrHomeRow] Failed to load more for $rowId: $e');
+    } finally {
+      _seerrRowLoadingMore[rowId] = false;
+    }
+  }
+
+  SeerrRowType? _seerrRowTypeForId(String rowId) {
+    switch (rowId) {
+      case 'seerr_recent_requests':
+        return SeerrRowType.recentRequests;
+      case 'seerr_watchlist':
+        return SeerrRowType.yourWatchlist;
+      case 'seerr_recently_added':
+        return SeerrRowType.recentlyAdded;
+      case 'seerr_popular_movies':
+        return SeerrRowType.popularMovies;
+      case 'seerr_upcoming_movies':
+        return SeerrRowType.upcomingMovies;
+      case 'seerr_popular_series':
+        return SeerrRowType.popularSeries;
+      case 'seerr_upcoming_series':
+        return SeerrRowType.upcomingSeries;
+      case 'seerr_trending':
+        return SeerrRowType.trending;
+      case 'seerr_movie_genres':
+        return SeerrRowType.movieGenres;
+      case 'seerr_studios':
+        return SeerrRowType.studios;
+      case 'seerr_series_genres':
+        return SeerrRowType.seriesGenres;
+      case 'seerr_networks':
+        return SeerrRowType.networks;
+      default:
+        return null;
+    }
+  }
+
   HomeRow _seerrRow(String rowId, String title, List<AggregatedItem> items) {
     return HomeRow(
       id: rowId,
@@ -2203,17 +2402,20 @@ class HomeViewModel extends ChangeNotifier {
   Future<SeerrDiscoverPage?> _loadSeerrPage(
     SeerrRepository repo,
     SeerrRowType type,
-    int limit,
+    int page,
   ) async {
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    final limit = seerrPrefs.fetchLimit.limit;
+    final offset = (page - 1) * limit;
     switch (type) {
       case SeerrRowType.yourWatchlist:
-        return repo.getWatchlist(page: 1);
+        return repo.getWatchlist(page: page);
       case SeerrRowType.trending:
-        return repo.getTrending(limit: limit, offset: 0);
+        return repo.getTrending(limit: limit, offset: offset);
       case SeerrRowType.popularMovies:
-        return repo.getTrendingMovies(limit: limit, offset: 0);
+        return repo.getTrendingMovies(limit: limit, offset: offset);
       case SeerrRowType.popularSeries:
-        return repo.getTrendingTv(limit: limit, offset: 0);
+        return repo.getTrendingTv(limit: limit, offset: offset);
       case SeerrRowType.upcomingMovies:
         return repo.getUpcomingMovies();
       case SeerrRowType.upcomingSeries:


### PR DESCRIPTION
# Pull Request

## Summary
Adds horizontal scroll pagination and lazy loading to Seerr discovery rows configured on the Home screen (seerr_recent_requests, seerr_watchlist, seerr_trending, seerr_popular_movies, seerr_upcoming_movies, seerr_popular_series, seerr_upcoming_series), matching the pagination behavior of the dedicated Seerr Discovery screen.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- home_view_model.dart: Added per-row pagination tracking (`_seerrRowPages`, `_seerrRowLoadingMore`, `_seerrRowHasMore`) for Seerr home section types, updated `_loadSeerrPage` to support passing target page index, and implemented `loadMoreSeerrRow(String rowId)` to fetch, filter, enrich, and append subsequent pages of items.
- home_screen.dart: Wrapped `_buildTitledRow` in a `NotificationListener<ScrollNotification>` for Seerr rows (`seerr_*`), triggering `loadMoreSeerrRow` when horizontal scrolling reaches within 300px of the right edge.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Deployed and tested on Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Configure Seerr discovery rows (e.g. Trending, Popular Movies) under External Lists > External Home row configurations.
2. Open the Home screen and scroll right horizontally on any Seerr row.
3. Verify items beyond the initial batch are dynamically loaded and appended as you approach the end of the row.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Original Seerr List Initial View:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-29_16-20-33" src="https://github.com/user-attachments/assets/e612e7b6-9da7-432f-85b4-0620a43c7709" />

Original Seerr List at 15 Items:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-29_16-24-33" src="https://github.com/user-attachments/assets/30a33427-8064-4dde-b08e-a2172c3c5841" />

New Seerr list... doesn't do that :)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
