### PR TITLE
bugfix-externalrows - Fix calendar cache invalidation loop and external backdrops

### DIFF
--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -87,7 +87,12 @@ class BackgroundService {
       }
     }
 
-    if (urls.isEmpty) {
+    // External rows carry artwork as a URL or a TMDB path rather than as
+    // Jellyfin image tags. Network and studio tiles are left out because their
+    // artwork is a duotone logo, which washes out behind the library.
+    final filterType = item.rawData['FilterType'];
+    final isLogoTile = filterType == 'network' || filterType == 'studio';
+    if (urls.isEmpty && !isLogoTile) {
       final backdropPath = item.rawData['BackdropPath'] as String?;
       if (backdropPath != null && backdropPath.isNotEmpty) {
         if (backdropPath.startsWith('http')) {

--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -87,6 +87,17 @@ class BackgroundService {
       }
     }
 
+    if (urls.isEmpty) {
+      final backdropPath = item.rawData['BackdropPath'] as String?;
+      if (backdropPath != null && backdropPath.isNotEmpty) {
+        if (backdropPath.startsWith('http')) {
+          urls.add(backdropPath);
+        } else if (backdropPath.startsWith('/')) {
+          urls.add('https://image.tmdb.org/t/p/w1280$backdropPath');
+        }
+      }
+    }
+
     // Albums, artists, and tracks carry no backdrop art, so fall back to their
     // cover blurred behind the library rather than clearing to nothing.
     if (urls.isEmpty && _audioTypes.contains(item.type)) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5100,7 +5100,7 @@ class _ContentRowsState extends State<_ContentRows>
   void _fetchBackdropIfNeeded(AggregatedItem item) async {
     if (item.serverId != 'seerr') return;
     final backdrop = item.rawData['BackdropPath'] as String?;
-    if (backdrop != null && backdrop.startsWith('/')) return;
+    if (backdrop != null && (backdrop.startsWith('/') || backdrop.startsWith('http'))) return;
     if (_dynamicBackdrops.containsKey(item.id)) return;
     if (!_fetchingBackdrops.add(item.id)) return;
 
@@ -5172,6 +5172,9 @@ class _ContentRowsState extends State<_ContentRows>
       final backdrop = item.rawData['BackdropPath'] as String?;
       if (backdrop != null && backdrop.startsWith('/')) {
         return _seerrTmdbImageUrl(backdrop, 1280);
+      }
+      if (backdrop != null && backdrop.startsWith('http')) {
+        return backdrop;
       }
       return _seerrTmdbImageUrl(item.rawData['PosterPath'] as String?, 300);
     }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5097,10 +5097,14 @@ class _ContentRowsState extends State<_ContentRows>
     return _resolvePrimaryImageUrl(item, imageApi, maxWidth: maxW);
   }
 
+  /// Whether a stored path already points at artwork. External rows hold either
+  /// a TMDB path or a full URL, and both mean there is nothing to look up.
+  static bool _hasSeerrBackdrop(String? path) =>
+      path != null && (path.startsWith('/') || path.startsWith('http'));
+
   void _fetchBackdropIfNeeded(AggregatedItem item) async {
     if (item.serverId != 'seerr') return;
-    final backdrop = item.rawData['BackdropPath'] as String?;
-    if (backdrop != null && (backdrop.startsWith('/') || backdrop.startsWith('http'))) return;
+    if (_hasSeerrBackdrop(item.rawData['BackdropPath'] as String?)) return;
     if (_dynamicBackdrops.containsKey(item.id)) return;
     if (!_fetchingBackdrops.add(item.id)) return;
 
@@ -5170,11 +5174,8 @@ class _ContentRowsState extends State<_ContentRows>
         return _seerrTmdbImageUrl(dynamicBackdrop, 1280);
       }
       final backdrop = item.rawData['BackdropPath'] as String?;
-      if (backdrop != null && backdrop.startsWith('/')) {
+      if (_hasSeerrBackdrop(backdrop)) {
         return _seerrTmdbImageUrl(backdrop, 1280);
-      }
-      if (backdrop != null && backdrop.startsWith('http')) {
-        return backdrop;
       }
       return _seerrTmdbImageUrl(item.rawData['PosterPath'] as String?, 300);
     }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -2643,6 +2643,13 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  /// Entries written before CacheVerV2 have a different shape, so the marker on
+  /// its own decides staleness. Artwork fields are deliberately not checked,
+  /// because an entry whose poster is genuinely missing is still valid and
+  /// refetching it only writes the same empty value back.
+  static bool _isStaleCalendarCache(List<AggregatedItem> items) =>
+      items.any((x) => !x.rawData.containsKey('CacheVerV2'));
+
   Future<List<AggregatedItem>> _loadRadarrCalendarFromCache() async {
     try {
       final dir = await getApplicationSupportDirectory();
@@ -2651,8 +2658,7 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || !x.rawData.containsKey('PosterPath') || !x.rawData.containsKey('CacheVerV2'));
-        if (hasOldCache) {
+        if (_isStaleCalendarCache(items)) {
           debugPrint('[RadarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
           try {
             await file.delete();
@@ -2686,8 +2692,7 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || !x.rawData.containsKey('PosterPath') || !x.rawData.containsKey('CacheVerV2'));
-        if (hasOldCache) {
+        if (_isStaleCalendarCache(items)) {
           debugPrint('[SonarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
           try {
             await file.delete();

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -2651,9 +2651,12 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '' || !x.rawData.containsKey('CacheVerV2'));
+        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || !x.rawData.containsKey('PosterPath') || !x.rawData.containsKey('CacheVerV2'));
         if (hasOldCache) {
           debugPrint('[RadarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
+          try {
+            await file.delete();
+          } catch (_) {}
           return const [];
         }
         return items;
@@ -2683,9 +2686,12 @@ class HomeViewModel extends ChangeNotifier {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
         final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
-        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || x.rawData['PosterPath'] == '' || !x.rawData.containsKey('CacheVerV2'));
+        final hasOldCache = items.any((x) => !x.rawData.containsKey('CalendarDate') || !x.rawData.containsKey('PosterPath') || !x.rawData.containsKey('CacheVerV2'));
         if (hasOldCache) {
           debugPrint('[SonarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
+          try {
+            await file.delete();
+          } catch (_) {}
           return const [];
         }
         return items;


### PR DESCRIPTION
# Pull Request

## Summary
If a Calendar entry from Radarr or Sonarr doesn't have a poster, it triggers a perpetual console log spam of  `[SonarrCalendarCache] Old cache detected...`. This PR fixes this edgecase by correcting poster path key checks and deleting invalid cache files immediately. Also adds backdrop URL resolution to `BackgroundService` for external rows (Calendar, Letterboxd, Seerr) and eliminates redundant search calls that caused `HTTP 400` errors.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `home_view_model.dart`: Replaced `x.rawData['PosterPath'] == ''` with `!x.rawData.containsKey('PosterPath')` in `_loadRadarrCalendarFromCache()` and `_loadSonarrCalendarFromCache()` so valid calendar items without poster artwork do not trigger false invalidation loops. Added `await file.delete()` upon invalidation to clear stale cache files from disk immediately.
- `background_service.dart`: Added fallback for `item.rawData['BackdropPath']` in `setBackground()` so external rows (Sonarr, Radarr, Letterboxd, Seerr) properly load high-resolution backdrop wallpapers when hovered or focused.
- `home_screen.dart`: Updated `_fetchBackdropIfNeeded` to skip redundant search calls if `BackdropPath` starts with `http`/`https`, eliminating unnecessary `HTTP 400` console errors. Updated `_resolveV2FocusedImageUrl` to return full `http`/`https` backdrop URLs for focused cards.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed - Tested on Android TV
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin client and observe console logs on Home screen startup.
2. Confirm `[SonarrCalendarCache] Old cache detected...` log spam has completely ceased.
3. Focus/hover items across Calendar, Letterboxd, and Seerr rows on the Home screen.
4. Verify backdrop wallpapers render cleanly behind the hero/background.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

My console when testing https://github.com/Moonfin-Client/Moonfin-Core/pull/981 :
<img width="1863" height="1044" alt="2026-07-29_16-23-48_WindowsTerminal" src="https://github.com/user-attachments/assets/79ae64e5-fbd2-47ea-9290-3d55b845a9b8" />

Log after this PR (so fresh, so clean):
<img width="2345" height="1222" alt="2026-07-29_16-45-31_WindowsTerminal" src="https://github.com/user-attachments/assets/4f340f03-a915-4b29-aaf4-cb9d393d5ecb" />

External rows now have backdrops (if enabled):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-29_16-44-40" src="https://github.com/user-attachments/assets/d190142d-5cbc-43a4-84d1-2192f7a1450f" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-07-29_16-45-17" src="https://github.com/user-attachments/assets/4fe1a6a8-f4f6-499f-8a9d-577d4e709daa" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
