### PR TITLE
rework padding adjustment logic for modern rows

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2453,14 +2453,14 @@ class _ContentRowsState extends State<_ContentRows>
     if (!fullScreenRows) {
       if (isRowsV2) {
         final customHeight = prefs.get(UserPreferences.modernHomeRowsPadding).toDouble();
-        if (!_isLibraryRow(row)) {
-          // Rows are pinned to this extent below, so a chosen height under
-          // the natural one clips the cards instead of tightening the gap.
-          totalHeight = customHeight > totalHeight ? customHeight : totalHeight;
-        } else {
-          final offset = (customHeight - 440.0).clamp(0.0, 120.0);
-          totalHeight += offset;
+        var offset = (customHeight - 400.0).clamp(-40.0, 200.0);
+        if (PlatformDetection.useMobileUi) {
+          totalHeight += 20.0;
+          offset = offset / 2.0;
+        } else if (_isLibraryRow(row)) {
+          totalHeight += 100.0;
         }
+        totalHeight += offset;
       } else if (_isLibraryRow(row)) {
         final classicPadding = prefs
             .get(UserPreferences.classicHomeRowsPadding)


### PR DESCRIPTION
# Pull Request

## Summary
Rework custom padding logic for modern home rows. This allows users to use the full range of the slider. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1000 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- instead of using the slider value as an absolute height (which was less than the card height in some cases), calculate an offset and grow the row height by that amount
- allows for negative offset for people who really want their rows as close as possible
- I made sure the default matches the spacing you get in stable

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Tested on mobile/desktop/android tv with various ui/poster scaling options
2.
3.

## Screenshots (if applicable)
TV:
Minimum: 
<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/4d9e1166-b9a2-4522-8139-2accafadf841" />

Default (middle):
<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/d3f78bcf-f831-4cb9-a7a8-8ab8ea0715d0" />

Maximum:
<img width="4000" height="3000" alt="image" src="https://github.com/user-attachments/assets/8c33fc70-8d5f-4ffc-86c2-7bdd942966ec" />

Mobile:
Minimum: 
<img width="1080" height="2340" alt="Screenshot_20260801_190931" src="https://github.com/user-attachments/assets/79a537af-0bf0-49eb-9fb2-c491b71ea590" />

Default (middle):
<img width="1080" height="2340" alt="Screenshot_20260801_191028" src="https://github.com/user-attachments/assets/f20ce6ce-85e9-4379-a90c-5a527ca230a5" />

Maximum:
<img width="1080" height="2340" alt="Screenshot_20260801_191047" src="https://github.com/user-attachments/assets/dfc9679c-99bc-4ed2-8815-1a606eecda93" />

Desktop (4k extra large):
Minimum:
<img width="2273" height="2095" alt="image" src="https://github.com/user-attachments/assets/f3184c19-b068-4c7d-8e4b-3139bf4515b8" />

Default (middle):
<img width="2273" height="2095" alt="image" src="https://github.com/user-attachments/assets/ff5268cc-d651-45fc-976a-80f120b431d4" />

Maximum:
<img width="2273" height="2095" alt="image" src="https://github.com/user-attachments/assets/0704f8e5-d464-4fb5-8a63-69720196c88b" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
