### PR TITLE
feat(androidtv) - Add Android TV launcher channels

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/PreviewChannelPublisher.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/PreviewChannelPublisher.kt
@@ -53,17 +53,21 @@ class PreviewChannelPublisher(private val context: Context) {
         // reinserting keeps each row current without touching other apps.
         deleteAllPrograms()
 
+        val incomingKeys = channels.mapNotNull { it["key"] as? String }.toSet()
+        cleanUpObsoleteChannels(incomingKeys)
+
         channels.forEachIndexed { index, channel ->
             val key = channel["key"] as? String ?: return@forEachIndexed
             val title = channel["title"] as? String ?: key
             @Suppress("UNCHECKED_CAST")
             val items = channel["items"] as? List<Map<String, Any?>> ?: emptyList()
-            if (items.isEmpty()) return@forEachIndexed
 
             // The launcher only lets an app auto add one row, so the first
             // channel is requested browsable and the rest are opt in.
             val channelId = getChannelId(key, title, default = index == 0)
                 ?: return@forEachIndexed
+
+            if (items.isEmpty()) return@forEachIndexed
 
             val values = items.mapNotNull { buildProgram(channelId, it)?.toContentValues() }
             if (values.isNotEmpty()) {
@@ -81,6 +85,52 @@ class PreviewChannelPublisher(private val context: Context) {
         )
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun cleanUpObsoleteChannels(incomingKeys: Set<String>) {
+        val store = context.getSharedPreferences("moonfin_tv_channels", Context.MODE_PRIVATE)
+        val projection = arrayOf(
+            TvContractCompat.Channels._ID,
+            TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID,
+            TvContractCompat.Channels.COLUMN_DISPLAY_NAME,
+        )
+
+        runCatching {
+            context.contentResolver.query(
+                TvContractCompat.Channels.CONTENT_URI, projection, null, null, null,
+            )?.use { cursor ->
+                val idIndex = cursor.getColumnIndex(TvContractCompat.Channels._ID)
+                val keyIndex = cursor.getColumnIndex(TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID)
+                val titleIndex = cursor.getColumnIndex(TvContractCompat.Channels.COLUMN_DISPLAY_NAME)
+
+                while (cursor.moveToNext()) {
+                    val id = if (idIndex != -1) cursor.getLong(idIndex) else -1L
+                    val key = if (keyIndex != -1) cursor.getString(keyIndex) else null
+                    val title = if (titleIndex != -1) cursor.getString(titleIndex) else null
+
+                    val isObsoleteKey = key != null && key !in incomingKeys
+                    val isOldUpcoming = key == "upcoming" || (title != null && title.contains("&"))
+
+                    if (id != -1L && (isObsoleteKey || isOldUpcoming)) {
+                        val channelUri = TvContractCompat.buildChannelUri(id)
+                        context.contentResolver.delete(channelUri, null, null)
+                        if (key != null) store.edit().remove(key).apply()
+                    }
+                }
+            }
+        }
+
+        val storedKeys = store.all.keys.toSet()
+        for (oldKey in storedKeys - incomingKeys) {
+            val oldUriStr = store.getString(oldKey, null)
+            if (oldUriStr != null) {
+                runCatching {
+                    context.contentResolver.delete(Uri.parse(oldUriStr), null, null)
+                }
+            }
+            store.edit().remove(oldKey).apply()
+        }
+    }
+
     /**
      * Returns the id of the channel stored under [key], creating it when it does
      * not exist yet. The uri is cached so a channel the user placed on the home
@@ -89,10 +139,15 @@ class PreviewChannelPublisher(private val context: Context) {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun getChannelId(key: String, title: String, default: Boolean): Long? {
         val store = context.getSharedPreferences("moonfin_tv_channels", Context.MODE_PRIVATE)
+        val appLinkIntent = Intent(context, MainActivity::class.java).apply {
+            setPackage(context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        }
         val settings = Channel.Builder()
             .setType(TvContractCompat.Channels.TYPE_PREVIEW)
             .setDisplayName(title)
-            .setAppLinkIntent(Intent(context, MainActivity::class.java))
+            .setInternalProviderId(key)
+            .setAppLinkIntent(appLinkIntent)
             .build()
 
         var uri: Uri? = null
@@ -126,9 +181,13 @@ class PreviewChannelPublisher(private val context: Context) {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun buildProgram(channelId: Long, item: Map<String, Any?>): PreviewProgram? {
         val id = item["id"] as? String ?: return null
+        val posterUriStr = item["posterUri"] as? String
+        if (posterUriStr.isNullOrEmpty()) return null
         val isMovie = (item["kind"] as? String) == "movie"
 
         val intent = Intent(context, MainActivity::class.java).apply {
+            setPackage(context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             putExtra(WatchNextPublisher.EXTRA_ITEM_ID, id)
             (item["serverId"] as? String)?.takeIf { it.isNotEmpty() }
                 ?.let { putExtra(WatchNextPublisher.EXTRA_SERVER_ID, it) }

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/PreviewChannelPublisher.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/PreviewChannelPublisher.kt
@@ -12,8 +12,8 @@ import androidx.tvprovider.media.tv.TvContractCompat
 import java.util.concurrent.Executors
 
 /**
- * Publishes the app-owned home screen channel rows (Latest Movies, Latest
- * Shows, Upcoming) as preview channels on the Android TV launcher. Data is
+ * Publishes the app-owned home screen channel rows (Next Up, Recently Added,
+ * Recently Released) as preview channels on the Android TV launcher. Data is
  * shaped in Dart and handed over the watch next method channel, so this class
  * only talks to the TvProvider. Deep link intents reuse the watch next extras
  * so a tapped tile resolves through the same handler.
@@ -56,18 +56,24 @@ class PreviewChannelPublisher(private val context: Context) {
         val incomingKeys = channels.mapNotNull { it["key"] as? String }.toSet()
         cleanUpObsoleteChannels(incomingKeys)
 
-        channels.forEachIndexed { index, channel ->
-            val key = channel["key"] as? String ?: return@forEachIndexed
+        var autoAddClaimed = false
+        channels.forEach { channel ->
+            val key = channel["key"] as? String ?: return@forEach
             val title = channel["title"] as? String ?: key
             @Suppress("UNCHECKED_CAST")
             val items = channel["items"] as? List<Map<String, Any?>> ?: emptyList()
 
             // The launcher only lets an app auto add one row, so the first
-            // channel is requested browsable and the rest are opt in.
-            val channelId = getChannelId(key, title, default = index == 0)
-                ?: return@forEachIndexed
+            // channel with something in it is requested browsable and the rest
+            // are opt in. An empty row would only park a blank strip up there.
+            val autoAdd = !autoAddClaimed && items.isNotEmpty()
+            val channelId = getChannelId(key, title, default = autoAdd)
+                ?: return@forEach
+            if (autoAdd) autoAddClaimed = true
 
-            if (items.isEmpty()) return@forEachIndexed
+            // Empty channels are still created so the user can find and turn
+            // them on in the launcher settings before they fill up.
+            if (items.isEmpty()) return@forEach
 
             val values = items.mapNotNull { buildProgram(channelId, it)?.toContentValues() }
             if (values.isNotEmpty()) {
@@ -85,13 +91,18 @@ class PreviewChannelPublisher(private val context: Context) {
         )
     }
 
+    /**
+     * Drops channels this build no longer publishes so a renamed or retired row
+     * does not linger on the home screen. The provider only hands an app its own
+     * channels, so this never reaches another app's rows.
+     */
     @RequiresApi(Build.VERSION_CODES.O)
     private fun cleanUpObsoleteChannels(incomingKeys: Set<String>) {
         val store = context.getSharedPreferences("moonfin_tv_channels", Context.MODE_PRIVATE)
+        val edits = store.edit()
         val projection = arrayOf(
             TvContractCompat.Channels._ID,
             TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID,
-            TvContractCompat.Channels.COLUMN_DISPLAY_NAME,
         )
 
         runCatching {
@@ -100,35 +111,33 @@ class PreviewChannelPublisher(private val context: Context) {
             )?.use { cursor ->
                 val idIndex = cursor.getColumnIndex(TvContractCompat.Channels._ID)
                 val keyIndex = cursor.getColumnIndex(TvContractCompat.Channels.COLUMN_INTERNAL_PROVIDER_ID)
-                val titleIndex = cursor.getColumnIndex(TvContractCompat.Channels.COLUMN_DISPLAY_NAME)
 
                 while (cursor.moveToNext()) {
                     val id = if (idIndex != -1) cursor.getLong(idIndex) else -1L
                     val key = if (keyIndex != -1) cursor.getString(keyIndex) else null
-                    val title = if (titleIndex != -1) cursor.getString(titleIndex) else null
 
-                    val isObsoleteKey = key != null && key !in incomingKeys
-                    val isOldUpcoming = key == "upcoming" || (title != null && title.contains("&"))
-
-                    if (id != -1L && (isObsoleteKey || isOldUpcoming)) {
+                    if (id != -1L && key != null && key !in incomingKeys) {
                         val channelUri = TvContractCompat.buildChannelUri(id)
                         context.contentResolver.delete(channelUri, null, null)
-                        if (key != null) store.edit().remove(key).apply()
+                        edits.remove(key)
                     }
                 }
             }
         }
 
-        val storedKeys = store.all.keys.toSet()
-        for (oldKey in storedKeys - incomingKeys) {
-            val oldUriStr = store.getString(oldKey, null)
-            if (oldUriStr != null) {
+        // Older channels have no key recorded on them, so they come back empty
+        // handed above and are matched here by the uri cached when they were
+        // created.
+        for (oldKey in store.all.keys - incomingKeys) {
+            store.getString(oldKey, null)?.let { oldUri ->
                 runCatching {
-                    context.contentResolver.delete(Uri.parse(oldUriStr), null, null)
+                    context.contentResolver.delete(Uri.parse(oldUri), null, null)
                 }
             }
-            store.edit().remove(oldKey).apply()
+            edits.remove(oldKey)
         }
+
+        edits.apply()
     }
 
     /**
@@ -181,9 +190,11 @@ class PreviewChannelPublisher(private val context: Context) {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun buildProgram(channelId: Long, item: Map<String, Any?>): PreviewProgram? {
         val id = item["id"] as? String ?: return null
+        // The tile is mostly artwork, so an item without a poster would show
+        // up as a placeholder.
         val posterUriStr = item["posterUri"] as? String
         if (posterUriStr.isNullOrEmpty()) return null
-        val isMovie = (item["kind"] as? String) == "movie"
+        val kind = item["kind"] as? String
 
         val intent = Intent(context, MainActivity::class.java).apply {
             setPackage(context.packageName)
@@ -196,21 +207,24 @@ class PreviewChannelPublisher(private val context: Context) {
         val builder = PreviewProgram.Builder()
             .setChannelId(channelId)
             .setType(
-                if (isMovie) TvContractCompat.PreviewPrograms.TYPE_MOVIE
-                else TvContractCompat.PreviewPrograms.TYPE_TV_EPISODE,
+                when (kind) {
+                    "episode" -> TvContractCompat.PreviewPrograms.TYPE_TV_EPISODE
+                    "series" -> TvContractCompat.PreviewPrograms.TYPE_TV_SERIES
+                    else -> TvContractCompat.PreviewPrograms.TYPE_MOVIE
+                },
             )
             .setPosterArtAspectRatio(
-                if (isMovie) TvContractCompat.PreviewPrograms.ASPECT_RATIO_MOVIE_POSTER
-                else TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9,
+                if (kind == "episode") TvContractCompat.PreviewPrograms.ASPECT_RATIO_16_9
+                else TvContractCompat.PreviewPrograms.ASPECT_RATIO_MOVIE_POSTER,
             )
             .setTitle(item["title"] as? String ?: "")
+            .setPosterArtUri(Uri.parse(posterUriStr))
             .setIntent(intent)
 
         (item["episodeTitle"] as? String)?.let { builder.setEpisodeTitle(it) }
         (item["seasonNumber"] as? Number)?.let { builder.setSeasonNumber(it.toInt()) }
         (item["episodeNumber"] as? Number)?.let { builder.setEpisodeNumber(it.toInt()) }
         (item["description"] as? String)?.let { builder.setDescription(it) }
-        (item["posterUri"] as? String)?.let { builder.setPosterArtUri(Uri.parse(it)) }
         (item["durationMs"] as? Number)?.let { builder.setDurationMillis(it.toInt()) }
 
         return builder.build()

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/WatchNextPublisher.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/WatchNextPublisher.kt
@@ -104,6 +104,8 @@ class WatchNextPublisher(private val context: Context) {
         val resumeMs = (item["resumePositionMs"] as? Number)?.toInt() ?: 0
 
         val intent = Intent(context, MainActivity::class.java).apply {
+            setPackage(context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             putExtra(EXTRA_ITEM_ID, id)
             (item["serverId"] as? String)?.takeIf { it.isNotEmpty() }
                 ?.let { putExtra(EXTRA_SERVER_ID, it) }

--- a/lib/background/watch_next_background.dart
+++ b/lib/background/watch_next_background.dart
@@ -48,7 +48,7 @@ Future<void> watchNextBackgroundMain() async {
       } catch (_) {}
 
       await CarArtwork.instance.ensureReady();
-      final items = WatchNextService.buildItems(rows, client.imageApi);
+      final items = WatchNextService.buildItems(rows, client);
       await CarArtwork.instance.persistHosts();
 
       if (items.isEmpty) {

--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -612,6 +612,8 @@ class OfflineItemsApi implements ItemsApi {
     String? fields,
     String? enableImageTypes,
     int? imageTypeLimit,
+    // The downloaded catalog is flat, so there is nothing to recurse into.
+    bool recursive = false,
   }) async {
     var scope = _scope(parentId, includeItemTypes: includeItemTypes);
     if (includeItemTypes != null && includeItemTypes.isNotEmpty) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -251,6 +251,9 @@ class RowDataSource {
       fields: _fields,
       enableImageTypes: _imageTypes,
       imageTypeLimit: _imageTypeLimit,
+      // No parent to scope to, so without recursion the server only offers
+      // the library folders themselves.
+      recursive: true,
     );
     return _parseItems(response, serverId);
   }

--- a/lib/data/services/tv_channels_service.dart
+++ b/lib/data/services/tv_channels_service.dart
@@ -10,35 +10,53 @@ import '../../playback/car_artwork.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/platform_detection.dart';
 import '../models/aggregated_item.dart';
+import '../repositories/user_views_repository.dart';
 import 'media_server_client_factory.dart';
 import 'row_data_source.dart';
 import 'watch_next_service.dart';
 
-/// Publishes the Android TV launcher channel rows (Latest Movies, Latest Shows,
-/// Upcoming). It reuses the watch next method channel, artwork wrapping, and
+/// Publishes the Android TV launcher channel rows (Next Up, Recent Films, New Episodes,
+/// Recently Added Media). It reuses the watch next method channel, artwork wrapping, and
 /// deep link plumbing, so the only new surface is the channel data itself.
 class TvChannelsService {
   static const _channel = MethodChannel('org.moonfin.androidtv/watch_next');
   static const _maxItems = 20;
+  static const _debounceDelay = Duration(seconds: 5);
+
+  Timer? _debounce;
+  String? _lastPublishedSignature;
 
   bool get _enabled => PlatformDetection.isAndroid && PlatformDetection.isTV;
+
+  void update() {
+    if (!_enabled) return;
+    _debounce?.cancel();
+    _debounce = Timer(_debounceDelay, () => unawaited(publish()));
+  }
 
   Future<void> publish() async {
     if (!_enabled) return;
     try {
       final client = GetIt.instance<MediaServerClient>();
       final channels = await buildChannels(client, serverId: _serverIdFor(client));
+      final signature = _signatureFor(channels);
+      if (signature == _lastPublishedSignature) return;
+
       if (channels.isEmpty) {
         await _channel.invokeMethod('clearChannels');
+        _lastPublishedSignature = signature;
         return;
       }
       await CarArtwork.instance.persistHosts();
       await _channel.invokeMethod('publishChannels', {'channels': channels});
+      _lastPublishedSignature = signature;
     } catch (_) {}
   }
 
   void clear() {
     if (!_enabled) return;
+    _debounce?.cancel();
+    _lastPublishedSignature = null;
     unawaited(_channel.invokeMethod('clearChannels').catchError((_) {}));
   }
 
@@ -52,6 +70,66 @@ class TvChannelsService {
     return client.baseUrl;
   }
 
+  static String _signatureFor(List<Map<String, dynamic>> channels) {
+    final buffer = StringBuffer();
+    for (final channel in channels) {
+      buffer.write(channel['key']);
+      final items = channel['items'] as List<Map<String, dynamic>>? ?? [];
+      for (final item in items) {
+        buffer
+          ..write('|')
+          ..write(item['id'] ?? '')
+          ..write(':')
+          ..write(item['posterUri'] ?? '');
+      }
+      buffer.write(';');
+    }
+    return buffer.toString();
+  }
+
+  static Future<List<AggregatedItem>> _loadRecentlyReleasedForCollection(
+    RowDataSource dataSource,
+    String serverId,
+    List<String> targetTypes,
+  ) async {
+    try {
+      final repo = GetIt.instance<UserViewsRepository>();
+      final views = await repo.getAllViewsIncludingHidden();
+      final matchingViews = views.where((v) {
+        final type = v.collectionType.toLowerCase();
+        if (targetTypes.contains('movies')) {
+          return type == 'movies';
+        }
+        if (targetTypes.contains('tvshows')) {
+          return type == 'tvshows' || type == 'shows';
+        }
+        return false;
+      }).toList();
+
+      if (matchingViews.isEmpty) {
+        return await dataSource.loadRecentlyReleasedByType(
+          serverId,
+          targetTypes.contains('movies') ? const ['Movie'] : const ['Series', 'Episode'],
+          limit: _maxItems,
+        );
+      }
+
+      final items = <AggregatedItem>[];
+      for (final view in matchingViews) {
+        final row = await dataSource.loadRecentlyReleased(
+          view.id,
+          view.name,
+          serverId,
+          view.collectionType.toLowerCase(),
+        );
+        items.addAll(row.items);
+      }
+      return items;
+    } catch (_) {
+      return <AggregatedItem>[];
+    }
+  }
+
   /// Fetches the launcher rows and shapes them into the native payload. Shared
   /// by the foreground trigger and the background refresh isolate, both of
   /// which run without a widget tree.
@@ -61,32 +139,42 @@ class TvChannelsService {
   }) async {
     final l10n = _localizations();
     final dataSource = RowDataSource(client);
+    final prefs = GetIt.instance<UserPreferences>();
 
     // The rows are independent, so fetch them together and warm the artwork
-    // cache while they are in flight.
+    // cache while they are in flight. Next Up is built first as the primary row.
     final fetches = Future.wait([
-      dataSource.loadLatestByType(serverId, const ['Movie'], limit: _maxItems),
-      dataSource.loadLatestByType(serverId, const ['Episode'], limit: _maxItems),
-      dataSource.loadRecentlyReleasedByType(
-        serverId,
-        const ['Movie', 'Episode'],
-        limit: _maxItems,
-      ),
+      dataSource
+          .loadNextUp(serverId)
+          .then((row) => prefs.filterNextUp(row.items))
+          .catchError((_) => <AggregatedItem>[]),
+      dataSource
+          .loadLatestByType(serverId, const ['Movie'], limit: _maxItems)
+          .catchError((_) => <AggregatedItem>[]),
+      dataSource
+          .loadLatestByType(serverId, const ['Series', 'Episode'], limit: _maxItems)
+          .catchError((_) => <AggregatedItem>[]),
+      _loadRecentlyReleasedForCollection(dataSource, serverId, const ['movies']),
+      _loadRecentlyReleasedForCollection(dataSource, serverId, const ['tvshows']),
     ]);
     await CarArtwork.instance.ensureReady();
     final results = await fetches;
 
     final defs = <(String, String, List<AggregatedItem>)>[
-      ('latest_movies', l10n.latestLibraryName(l10n.movies), results[0]),
-      ('latest_shows', l10n.latestLibraryName(l10n.tvShows), results[1]),
+      ('next_up', l10n.nextUp, results[0]),
+      ('latest_movies', l10n.latestLibraryName(l10n.movies), results[1]),
+      ('latest_shows', l10n.latestLibraryName(l10n.tvShows), results[2]),
       (
-        'upcoming',
-        l10n.recentlyReleasedLibraryName(l10n.moviesAndTvShows),
-        results[2],
+        'recently_released_movies',
+        l10n.recentlyReleasedLibraryName(l10n.movies),
+        results[3],
+      ),
+      (
+        'recently_released_shows',
+        l10n.recentlyReleasedLibraryName(l10n.tvShows),
+        results[4],
       ),
     ];
-
-    final imageApi = client.imageApi;
 
     final channels = <Map<String, dynamic>>[];
     for (final (key, title, sourceItems) in defs) {
@@ -96,15 +184,13 @@ class TvChannelsService {
         if (item.id.isEmpty || !seen.add(item.id)) continue;
         final payload = WatchNextService.buildProgramPayload(
           item,
-          imageApi,
+          client,
           index: items.length,
         );
         if (payload != null) items.add(payload);
         if (items.length >= _maxItems) break;
       }
-      if (items.isNotEmpty) {
-        channels.add({'key': key, 'title': title, 'items': items});
-      }
+      channels.add({'key': key, 'title': title, 'items': items});
     }
     return channels;
   }

--- a/lib/data/services/tv_channels_service.dart
+++ b/lib/data/services/tv_channels_service.dart
@@ -10,15 +10,41 @@ import '../../playback/car_artwork.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/platform_detection.dart';
 import '../models/aggregated_item.dart';
+import '../models/aggregated_library.dart';
 import '../repositories/user_views_repository.dart';
 import 'media_server_client_factory.dart';
 import 'row_data_source.dart';
 import 'watch_next_service.dart';
 
-/// Publishes the Android TV launcher channel rows (Next Up, Recent Films, New Episodes,
-/// Recently Added Media). It reuses the watch next method channel, artwork wrapping, and
-/// deep link plumbing, so the only new surface is the channel data itself.
+/// The two library kinds that get their own recently released launcher row.
+enum _ReleaseCollection {
+  movies(collectionTypes: ['movies'], itemTypes: ['Movie']),
+  tvShows(collectionTypes: ['tvshows', 'shows'], itemTypes: ['Series']);
+
+  const _ReleaseCollection({
+    required this.collectionTypes,
+    required this.itemTypes,
+  });
+
+  /// Library collection types that feed this row.
+  final List<String> collectionTypes;
+
+  /// Item types to ask for when the row can't be scoped to a library.
+  final List<String> itemTypes;
+}
+
+/// Publishes the Android TV launcher channel rows (Next Up, Recently Added
+/// Movies, Recently Added TV Shows, Recently Released Movies, Recently
+/// Released TV Shows). It reuses the watch next method channel, artwork
+/// wrapping, and deep link plumbing, so the only new surface is the channel
+/// data itself.
 class TvChannelsService {
+  // One instance app wide so signing out cancels the debounce the home screen
+  // scheduled, rather than leaving a publish to fire against a torn down client.
+  factory TvChannelsService() => _instance;
+  TvChannelsService._();
+  static final TvChannelsService _instance = TvChannelsService._();
+
   static const _channel = MethodChannel('org.moonfin.androidtv/watch_next');
   static const _maxItems = 20;
   static const _debounceDelay = Duration(seconds: 5);
@@ -87,46 +113,67 @@ class TvChannelsService {
     return buffer.toString();
   }
 
-  static Future<List<AggregatedItem>> _loadRecentlyReleasedForCollection(
+  /// Builds a recently released row for [collection] out of every library of
+  /// that kind. Falls back to the unscoped query when the libraries can't be
+  /// listed, which is what happens in the background isolate where the views
+  /// repository is not registered.
+  static Future<List<AggregatedItem>> _loadRecentlyReleased(
     RowDataSource dataSource,
     String serverId,
-    List<String> targetTypes,
+    _ReleaseCollection collection,
   ) async {
-    try {
-      final repo = GetIt.instance<UserViewsRepository>();
-      final views = await repo.getAllViewsIncludingHidden();
-      final matchingViews = views.where((v) {
-        final type = v.collectionType.toLowerCase();
-        if (targetTypes.contains('movies')) {
-          return type == 'movies';
-        }
-        if (targetTypes.contains('tvshows')) {
-          return type == 'tvshows' || type == 'shows';
-        }
-        return false;
-      }).toList();
-
-      if (matchingViews.isEmpty) {
+    final views = await _viewsFor(collection);
+    if (views.isEmpty) {
+      try {
         return await dataSource.loadRecentlyReleasedByType(
           serverId,
-          targetTypes.contains('movies') ? const ['Movie'] : const ['Series', 'Episode'],
+          collection.itemTypes,
           limit: _maxItems,
         );
+      } catch (_) {
+        return const [];
       }
+    }
 
-      final items = <AggregatedItem>[];
-      for (final view in matchingViews) {
-        final row = await dataSource.loadRecentlyReleased(
-          view.id,
-          view.name,
-          serverId,
-          view.collectionType.toLowerCase(),
+    final rows = await Future.wait([
+      for (final view in views)
+        dataSource
+            .loadRecentlyReleased(
+              view.id,
+              view.name,
+              serverId,
+              view.collectionType.toLowerCase(),
+            )
+            .then((row) => row.items)
+            .catchError((_) => <AggregatedItem>[]),
+    ]);
+
+    // Each library sorts on its own, so they are merged on release date before
+    // the row gets capped. Concatenating would let the first library fill the
+    // row and crowd the rest out.
+    final merged = rows.expand((items) => items).toList();
+    merged.sort((a, b) {
+      final left = a.premiereDate;
+      final right = b.premiereDate;
+      if (left == null) return right == null ? 0 : 1;
+      if (right == null) return -1;
+      return right.compareTo(left);
+    });
+    return merged;
+  }
+
+  static Future<List<AggregatedLibrary>> _viewsFor(
+    _ReleaseCollection collection,
+  ) async {
+    try {
+      final views = await GetIt.instance<UserViewsRepository>().getUserViews();
+      return views.where((v) {
+        return collection.collectionTypes.contains(
+          v.collectionType.toLowerCase(),
         );
-        items.addAll(row.items);
-      }
-      return items;
+      }).toList();
     } catch (_) {
-      return <AggregatedItem>[];
+      return const [];
     }
   }
 
@@ -154,8 +201,8 @@ class TvChannelsService {
       dataSource
           .loadLatestByType(serverId, const ['Series', 'Episode'], limit: _maxItems)
           .catchError((_) => <AggregatedItem>[]),
-      _loadRecentlyReleasedForCollection(dataSource, serverId, const ['movies']),
-      _loadRecentlyReleasedForCollection(dataSource, serverId, const ['tvshows']),
+      _loadRecentlyReleased(dataSource, serverId, _ReleaseCollection.movies),
+      _loadRecentlyReleased(dataSource, serverId, _ReleaseCollection.tvShows),
     ]);
     await CarArtwork.instance.ensureReady();
     final results = await fetches;

--- a/lib/data/services/watch_next_service.dart
+++ b/lib/data/services/watch_next_service.dart
@@ -114,8 +114,9 @@ class WatchNextService {
     return items;
   }
 
-  /// Shapes a movie or episode into the native program payload. Public so the
-  /// launcher channel rows reuse the same fields. Returns null for other types.
+  /// Shapes a movie, series or episode into the native program payload. Public
+  /// so the launcher channel rows reuse the same fields. Returns null for other
+  /// types.
   static Map<String, dynamic>? buildProgramPayload(
     AggregatedItem item,
     MediaServerClient client, {
@@ -148,7 +149,7 @@ class WatchNextService {
     return {
       'id': id,
       'serverId': serverId,
-      'kind': isEpisode ? 'episode' : 'movie',
+      'kind': isEpisode ? 'episode' : (isSeries ? 'series' : 'movie'),
       'title': isEpisode ? (item.seriesName ?? item.name) : item.name,
       if (isEpisode) 'episodeTitle': item.name,
       if (isEpisode && item.parentIndexNumber != null)

--- a/lib/data/services/watch_next_service.dart
+++ b/lib/data/services/watch_next_service.dart
@@ -53,8 +53,8 @@ class WatchNextService {
       if (signature == _lastPublishedSignature) return;
 
       await CarArtwork.instance.ensureReady();
-      final imageApi = GetIt.instance<MediaServerClient>().imageApi;
-      final items = buildItems(rows, imageApi);
+      final client = GetIt.instance<MediaServerClient>();
+      final items = buildItems(rows, client);
 
       if (items.isEmpty) {
         await _channel.invokeMethod('clear');
@@ -96,7 +96,7 @@ class WatchNextService {
 
   static List<Map<String, dynamic>> buildItems(
     List<HomeRow> rows,
-    ImageApi imageApi,
+    MediaServerClient client,
   ) {
     final seen = <String>{};
     final items = <Map<String, dynamic>>[];
@@ -105,7 +105,7 @@ class WatchNextService {
     )) {
       for (final item in row.items) {
         if (item.id.isEmpty || !seen.add(item.id)) continue;
-        final payload = buildProgramPayload(item, imageApi, index: items.length);
+        final payload = buildProgramPayload(item, client, index: items.length);
         if (payload != null) items.add(payload);
         if (items.length >= _maxItems) break;
       }
@@ -118,18 +118,20 @@ class WatchNextService {
   /// launcher channel rows reuse the same fields. Returns null for other types.
   static Map<String, dynamic>? buildProgramPayload(
     AggregatedItem item,
-    ImageApi imageApi, {
+    MediaServerClient client, {
     int index = 0,
   }) {
     final id = item.id;
     final isMovie = item.type == 'Movie';
     final isEpisode = item.type == 'Episode';
-    if (!isMovie && !isEpisode) return null;
+    final isSeries = item.type == 'Series';
+    if (!isMovie && !isEpisode && !isSeries) return null;
 
     final serverId = item.serverId;
+    final imageApi = client.imageApi;
 
     final poster = CarArtwork.instance
-        .wrap(isMovie ? _moviePoster(item, imageApi) : _episodePoster(item, imageApi))
+        .wrap(carAuthedImageUrl(client, isEpisode ? _episodePoster(item, imageApi) : _moviePoster(item, imageApi)))
         ?.toString();
 
     final resumeMs = item.playbackPositionTicks != null
@@ -146,7 +148,7 @@ class WatchNextService {
     return {
       'id': id,
       'serverId': serverId,
-      'kind': isMovie ? 'movie' : 'episode',
+      'kind': isEpisode ? 'episode' : 'movie',
       'title': isEpisode ? (item.seriesName ?? item.name) : item.name,
       if (isEpisode) 'episodeTitle': item.name,
       if (isEpisode && item.parentIndexNumber != null)

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -16,6 +16,7 @@ import '../../../data/services/connectivity_service.dart';
 import '../../../data/services/home_row_cache_store.dart';
 import '../../../data/services/row_data_source.dart';
 import '../../../data/services/topshelf_service.dart';
+import '../../../data/services/tv_channels_service.dart';
 import '../../../data/services/watch_next_service.dart';
 import '../../../data/viewmodels/media_bar_view_model.dart';
 import '../../../l10n/app_localizations.dart';
@@ -45,6 +46,7 @@ class HomeViewModel extends ChangeNotifier {
 
   final TopShelfService _topShelf = TopShelfService();
   final WatchNextService _watchNext = WatchNextService();
+  final TvChannelsService _tvChannels = TvChannelsService();
 
   List<HomeRow> _rows = [];
   List<HomeRow> get rows => _rows;
@@ -554,6 +556,7 @@ class HomeViewModel extends ChangeNotifier {
       unawaited(_cacheStore.write(_homeCacheKey(), _rows));
       _topShelf.update(_rows);
       _watchNext.update(_rows);
+      _tvChannels.update();
 
       if (showMergedResume) {
         unawaited(_loadResumeAndNextUpInBackground());
@@ -801,6 +804,7 @@ class HomeViewModel extends ChangeNotifier {
     }
     _topShelf.update(_rows);
     _watchNext.update(_rows);
+    _tvChannels.update();
   }
 
   /// Refetches the row with [rowId] and replaces it in place, or removes it when
@@ -1976,6 +1980,7 @@ class HomeViewModel extends ChangeNotifier {
     }
     notifyListeners();
     _watchNext.update(_rows);
+    _tvChannels.update();
   }
 
   static const _seerrEnrichConcurrency = 5;

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -79,6 +79,9 @@ abstract class ItemsApi {
     int? imageTypeLimit,
   });
 
+  /// Set [recursive] when there is no [parentId], or when [includeItemTypes]
+  /// narrows what comes back. A recursive parent query without a type filter
+  /// returns seasons and episodes alongside the series.
   Future<Map<String, dynamic>> getRecentlyReleasedItems({
     String? parentId,
     List<String>? includeItemTypes,
@@ -86,6 +89,7 @@ abstract class ItemsApi {
     String? fields,
     String? enableImageTypes,
     int? imageTypeLimit,
+    bool recursive = false,
   });
 
   Future<Map<String, dynamic>> getSeasons(String seriesId);

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -255,12 +255,13 @@ class EmbyItemsApi implements ItemsApi {
     String? fields,
     String? enableImageTypes,
     int? imageTypeLimit,
+    bool recursive = false,
   }) async {
     final response = await _dio.get(
       '/Items',
       queryParameters: {
         if (parentId != null) 'ParentId': parentId,
-        'Recursive': true,
+        if (recursive) 'Recursive': true,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
         if (limit != null) 'Limit': limit,

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -260,6 +260,7 @@ class EmbyItemsApi implements ItemsApi {
       '/Items',
       queryParameters: {
         if (parentId != null) 'ParentId': parentId,
+        'Recursive': true,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
         if (limit != null) 'Limit': limit,

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -250,6 +250,7 @@ class JellyfinItemsApi implements ItemsApi {
       '/Users/$userId/Items',
       queryParameters: {
         'ParentId': ?parentId,
+        'Recursive': true,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
         'Limit': ?limit,

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -244,13 +244,14 @@ class JellyfinItemsApi implements ItemsApi {
     String? fields,
     String? enableImageTypes,
     int? imageTypeLimit,
+    bool recursive = false,
   }) async {
     final userId = _getUserId();
     final response = await _dio.get(
       '/Users/$userId/Items',
       queryParameters: {
         'ParentId': ?parentId,
-        'Recursive': true,
+        if (recursive) 'Recursive': true,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
         'Limit': ?limit,


### PR DESCRIPTION
# Pull Request

## Summary
Implements Android TV launcher preview channels integration for Leanback and Projectivy launchers. Adds support for 4 additional Jellyfin/Emby channel types (**Next Up**, **Recently Added TV Shows**, **Recently Released Movies**, and **Recently Released TV Shows**) and fixes **Recently Added Movies** implementation. The rows also filter out hidden Next Up items, purges obsolete channels, and optimizes deep link intents with package scoping and `FLAG_ACTIVITY_SINGLE_TOP` to minimize cold-booting.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1002 
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Implemented `TvChannelsService.dart` publishing Next Up, Recently Added Movies, Recently Added TV Shows, Recently Released Movies, and Recently Released TV Shows launcher channels.
- Updated `WatchNextService.buildProgramPayload` to handle `Series` item types in addition to `Movie` and `Episode`.
- Added `'Recursive': true` parameter to `getRecentlyReleasedItems` in `jellyfin_items_api.dart` and `emby_items_api.dart`.
- Integrated `UserViewsRepository` in `TvChannelsService` to query library parent IDs for recently released channels.
- Applied `UserPreferences.filterNextUp(...)` in launcher channel payloads to respect user hidden series settings.
- Added `cleanUpObsoleteChannels` in `PreviewChannelPublisher.kt` to delete deprecated channels directly from `TvContractCompat.Channels.CONTENT_URI`.
- Added `setPackage(context.packageName)` and `FLAG_ACTIVITY_SINGLE_TOP` to launcher program intents in `PreviewChannelPublisher.kt` and `WatchNextPublisher.kt` to eliminate cold boots and package resolution delays.
- Filtered out items lacking poster artwork (`posterUri.isNullOrEmpty()`) in `PreviewChannelPublisher.kt` to prevent exclamation mark placeholder tiles.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code (but only implemented on Android TV)

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launched Android TV debug session
2. Opened Projectivy / Android TV launcher settings -> Channels -> **Moonfin Beta**.
3. Verified all 5 channels appear, populate with content, and respond instantly to deep link clicks.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-01_19-48-29" src="https://github.com/user-attachments/assets/a67f2a94-0ddd-4b1e-a6d8-efa8a03d25f4" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-01_19-48-42" src="https://github.com/user-attachments/assets/a6b43aef-d0fd-4c11-a8ae-a1b34db455a5" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
