### PR TITLE
bugfix(macos): Fix macOS crash on playback start caused by FFmpeg symbol collision

### DIFF
--- a/macos/Runner/Configs/Debug.xcconfig
+++ b/macos/Runner/Configs/Debug.xcconfig
@@ -1,2 +1,8 @@
 #include "../../Flutter/Flutter-Debug.xcconfig"
 #include "Warnings.xcconfig"
+
+// AetherEngine (static, FFmpeg 8 / Libav*) and media_kit (FFmpeg 6 / Av*) export the
+// same symbol names. The Lib* frameworks must precede the Pods -framework flags so
+// AetherEngine's calls bind to the FFmpeg ABI it was compiled against; otherwise
+// load() segfaults in av_dict_get (FFmpeg 6 resolving FFmpeg 8 struct layouts).
+OTHER_LDFLAGS = -framework Libavutil -framework Libavcodec -framework Libavformat -framework Libswresample -framework Libswscale -framework Libavfilter -framework Libdav1d $(inherited)

--- a/macos/Runner/Configs/Release.xcconfig
+++ b/macos/Runner/Configs/Release.xcconfig
@@ -1,2 +1,8 @@
 #include "../../Flutter/Flutter-Release.xcconfig"
 #include "Warnings.xcconfig"
+
+// AetherEngine (static, FFmpeg 8 / Libav*) and media_kit (FFmpeg 6 / Av*) export the
+// same symbol names. The Lib* frameworks must precede the Pods -framework flags so
+// AetherEngine's calls bind to the FFmpeg ABI it was compiled against; otherwise
+// load() segfaults in av_dict_get (FFmpeg 6 resolving FFmpeg 8 struct layouts).
+OTHER_LDFLAGS = -framework Libavutil -framework Libavcodec -framework Libavformat -framework Libswresample -framework Libswscale -framework Libavfilter -framework Libdav1d $(inherited)


### PR DESCRIPTION
# Pull Request

## Summary
Fixes a crash on macOS where playback would segfault as soon as the player
loaded media. AetherEngine (statically linked against FFmpeg 8, `Libav*`
frameworks) and media_kit (FFmpeg 6, `Av*` frameworks) export the same symbol
names, and the dynamic linker could resolve AetherEngine's FFmpeg calls
against media_kit's FFmpeg 6 — so `load()` crashed in `av_dict_get` when
FFmpeg 6 code walked FFmpeg 8 struct layouts.

This PR adds `OTHER_LDFLAGS` to the Debug and Release xcconfigs so the
`Libav*` frameworks are listed before the Pods `-framework` flags, ensuring
AetherEngine binds to the FFmpeg ABI it was compiled against.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Added `OTHER_LDFLAGS` to `macos/Runner/Configs/Debug.xcconfig` ordering the `Libav*` frameworks ahead of the inherited Pods flags
- Same change in `macos/Runner/Configs/Release.xcconfig`

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build and run the macOS app (Debug and Release).
2. Start playback of any media item.
3. Before this fix: immediate segfault in `av_dict_get` during `load()`. After: playback starts and runs normally.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
