### PR TITLE
feat-homerows - Add Playlist Order sorting for home screen playlist rows as they were meant to be

### DIFF
--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -814,7 +814,11 @@ class OfflineItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async =>
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async =>
       _envelope(const []);
 
   @override

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -531,7 +531,7 @@ class MultiServerRepository {
               final targetStartIndex = pageCount * _defaultLimit;
               _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
               final sortBy =
-                  prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ??
+                  prefs?.get(UserPreferences.playlistsRowSortBy).itemsApiSortValue ??
                   _defaultSortBy;
 
               final response = await session.client.itemsApi.getItems(
@@ -777,7 +777,7 @@ class MultiServerRepository {
           row.rowType == HomeRowType.audioPlaylists) {
         final sortBy = row.rowType == HomeRowType.audioPlaylists
             ? (prefs?.get(UserPreferences.audioRowsSortBy).apiValue ?? _defaultSortBy)
-            : (prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ?? _defaultSortBy);
+            : (prefs?.get(UserPreferences.playlistsRowSortBy).itemsApiSortValue ?? _defaultSortBy);
         if (sortBy == 'SortName') {
           uniqueCombined.sort((a, b) => a.name.compareTo(b.name));
         } else {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -601,6 +601,7 @@ class RowDataSource {
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
     bool usePlaylistOrder = false,
+    bool showEpisodes = false,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
@@ -618,13 +619,16 @@ class RowDataSource {
             startIndex: startIndex,
             limit: limit,
           );
-    return _buildRow(
+    final row = _buildRow(
       id: rowId,
       title: title,
       response: response,
       serverId: serverId,
       rowType: HomeRowType.playlists,
     );
+    if (!showEpisodes) return row;
+    final expanded = await _expandSeriesItems(row.items, serverId);
+    return row.copyWith(items: expanded);
   }
 
   Future<HomeRow> loadGenreRow(
@@ -1671,11 +1675,14 @@ class RowDataSource {
           );
         }
         try {
-          final sortPref = GetIt.instance.isRegistered<UserPreferences>()
+          final prefs = GetIt.instance.isRegistered<UserPreferences>()
               ? GetIt.instance<UserPreferences>()
-                  .get(UserPreferences.playlistsRowSortBy)
-              : LibrarySortBy.playlistOrder;
+              : null;
+          final sortPref = prefs?.get(UserPreferences.playlistsRowSortBy) ??
+              LibrarySortBy.playlistOrder;
           final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
+          final showEpisodes =
+              prefs?.get(UserPreferences.playlistsRowShowEpisodes) ?? false;
           final row = await loadPlaylistRow(
             serverId,
             playlistId: playlistId,
@@ -1684,6 +1691,7 @@ class RowDataSource {
             sortBy: usePlaylistOrder ? _defaultSortBy : sortPref.apiValue,
             sortOrder: _defaultSortOrder,
             usePlaylistOrder: usePlaylistOrder,
+            showEpisodes: showEpisodes,
           );
           return row;
         } catch (_) {
@@ -1778,6 +1786,54 @@ class RowDataSource {
       if (rating == null || rating.isEmpty) return true;
       return !blocked.contains(rating);
     }).toList();
+  }
+
+  /// Expands any [AggregatedItem] of type 'Series' in [items] by fetching its
+  /// episodes and inserting them in season/episode order at the series'
+  /// position. Non-series items (Movies, Episodes already in the list, etc.)
+  /// are kept as-is. Falls back to the series card on any fetch error.
+  Future<List<AggregatedItem>> _expandSeriesItems(
+    List<AggregatedItem> items,
+    String serverId,
+  ) async {
+    final result = <AggregatedItem>[];
+    for (final item in items) {
+      if (item.type != 'Series') {
+        result.add(item);
+        continue;
+      }
+      try {
+        final episodeData = await _client.itemsApi.getEpisodes(item.id);
+        final rawEpisodes = (episodeData['Items'] as List?) ?? [];
+        if (rawEpisodes.isEmpty) {
+          result.add(item);
+          continue;
+        }
+        final episodes = rawEpisodes
+            .whereType<Map<String, dynamic>>()
+            .map((data) => AggregatedItem(
+                  id: data['Id']?.toString() ?? '',
+                  serverId: serverId,
+                  rawData: data,
+                ))
+            .toList()
+          ..sort((a, b) {
+            // Season 0 = Specials — sort after all regular seasons.
+            int seasonKey(int s) => s == 0 ? 0x7FFFFFFF : s;
+            final aSeason = seasonKey(a.rawData['ParentIndexNumber'] as int? ?? 0);
+            final bSeason = seasonKey(b.rawData['ParentIndexNumber'] as int? ?? 0);
+            if (aSeason != bSeason) return aSeason.compareTo(bSeason);
+            final aEp = a.rawData['IndexNumber'] as int? ?? 0;
+            final bEp = b.rawData['IndexNumber'] as int? ?? 0;
+            return aEp.compareTo(bEp);
+          });
+        result.addAll(episodes);
+      } catch (_) {
+        // Fall back to series poster if episode fetch fails.
+        result.add(item);
+      }
+    }
+    return result;
   }
 
   Set<String> _blockedParentalRatings() {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -600,17 +600,24 @@ class RowDataSource {
     required String rowId,
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
+    bool usePlaylistOrder = false,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
-    final response = await _getItemsWithFallback(
-      parentId: playlistId,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      recursive: false,
-      startIndex: startIndex,
-      limit: limit,
-    );
+    final response = usePlaylistOrder
+        ? await _client.itemsApi.getPlaylistItems(
+            playlistId,
+            startIndex: startIndex,
+            limit: limit,
+          )
+        : await _getItemsWithFallback(
+            parentId: playlistId,
+            sortBy: sortBy,
+            sortOrder: sortOrder,
+            recursive: false,
+            startIndex: startIndex,
+            limit: limit,
+          );
     return _buildRow(
       id: rowId,
       title: title,
@@ -959,18 +966,25 @@ class RowDataSource {
         if (parsed != null &&
             parsed.source == HomeSectionPluginSource.playlists) {
           final playlistId = parsed.additionalData;
-          var sortBy = _defaultSortBy;
-          if (prefs != null) {
-            sortBy = prefs.get(UserPreferences.playlistsRowSortBy).apiValue;
+          final sortPref = prefs?.get(UserPreferences.playlistsRowSortBy) ??
+              LibrarySortBy.playlistOrder;
+          final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
+          if (usePlaylistOrder) {
+            response = await _client.itemsApi.getPlaylistItems(
+              playlistId,
+              startIndex: currentOffset,
+              limit: _defaultLimit,
+            );
+          } else {
+            response = await _getItemsWithFallback(
+              parentId: playlistId,
+              sortBy: sortPref.apiValue,
+              sortOrder: 'Ascending',
+              recursive: false,
+              startIndex: currentOffset,
+              limit: _defaultLimit,
+            );
           }
-          response = await _getItemsWithFallback(
-            parentId: playlistId,
-            sortBy: sortBy,
-            sortOrder: 'Ascending',
-            recursive: false,
-            startIndex: currentOffset,
-            limit: _defaultLimit,
-          );
         } else {
           final pageCount = (currentOffset / _defaultLimit).ceil();
           final startIndex = pageCount * _defaultLimit;
@@ -1657,19 +1671,19 @@ class RowDataSource {
           );
         }
         try {
-          var sortBy = _defaultSortBy;
-          if (GetIt.instance.isRegistered<UserPreferences>()) {
-            sortBy = GetIt.instance<UserPreferences>()
-                .get(UserPreferences.playlistsRowSortBy)
-                .apiValue;
-          }
+          final sortPref = GetIt.instance.isRegistered<UserPreferences>()
+              ? GetIt.instance<UserPreferences>()
+                  .get(UserPreferences.playlistsRowSortBy)
+              : LibrarySortBy.playlistOrder;
+          final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
           final row = await loadPlaylistRow(
             serverId,
             playlistId: playlistId,
             title: title,
             rowId: rowId,
-            sortBy: sortBy,
+            sortBy: usePlaylistOrder ? _defaultSortBy : sortPref.apiValue,
             sortOrder: _defaultSortOrder,
+            usePlaylistOrder: usePlaylistOrder,
           );
           return row;
         } catch (_) {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -367,6 +367,7 @@ enum HomeSectionType {
 }
 
 enum LibrarySortBy {
+  playlistOrder('', 'Playlist Order'),
   name('SortName', 'Name'),
   dateAdded('DateCreated', 'Date Added'),
   premiereDate('PremiereDate', 'Premiere Date'),
@@ -382,6 +383,14 @@ enum LibrarySortBy {
   const LibrarySortBy(this.apiValue, this.displayName);
   final String apiValue;
   final String displayName;
+
+  /// The sort value to pass to the Jellyfin/Emby /Items API.
+  ///
+  /// Some options (e.g. [playlistOrder]) use a dedicated endpoint and carry
+  /// an empty [apiValue]. Passing an empty string to the Items API produces
+  /// a malformed request, so this getter substitutes 'SortName' as a safe
+  /// fallback for any context that must use the Items API regardless.
+  String get itemsApiSortValue => apiValue.isEmpty ? 'SortName' : apiValue;
 }
 
 enum ChannelSortBy {

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1089,6 +1089,11 @@ class UserPreferences extends ChangeNotifier {
     values: LibrarySortBy.values,
   );
 
+  static final playlistsRowShowEpisodes = Preference(
+    key: 'pref_playlists_row_show_episodes',
+    defaultValue: false,
+  );
+
   static final audioRowsSortBy = EnumPreference(
     key: 'pref_audio_rows_sort_by',
     defaultValue: LibrarySortBy.name,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1085,7 +1085,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final playlistsRowSortBy = EnumPreference(
     key: 'pref_playlists_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.playlistOrder,
     values: LibrarySortBy.values,
   );
 

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -127,6 +127,11 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     _reloadHomeRows();
   }
 
+  void _onPlaylistsEpisodesChanged() {
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+  }
+
   void _onAudioSortChanged() {
     _pushPersonalizationSync();
     _reloadHomeRows();
@@ -470,6 +475,15 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                       icon: Icons.sort,
                       labelOf: (v) => v.displayName,
                       onChanged: _onPlaylistsSortChanged,
+                    ),
+                  if (showPlaylistsRows)
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.playlistsRowShowEpisodes,
+                      title: 'Show Individual Episodes',
+                      subtitle:
+                          'Expand TV shows to display each episode separately.',
+                      icon: Icons.video_library_outlined,
+                      onChanged: (_) => _onPlaylistsEpisodesChanged(),
                     ),
                 ],
               ),

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -131,7 +131,11 @@ abstract class ItemsApi {
     bool? isFavorite,
   });
 
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId);
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  });
 
   Future<Map<String, dynamic>> createPlaylist({
     required String name,

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -398,7 +398,11 @@ class EmbyItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async {
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async {
     final response = await _dio.get(
       '/Playlists/$playlistId/Items',
       queryParameters: {
@@ -406,6 +410,8 @@ class EmbyItemsApi implements ItemsApi {
             'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
+        'StartIndex': ?startIndex,
+        'Limit': ?limit,
       },
     );
     return response.data as Map<String, dynamic>;

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -378,7 +378,11 @@ class JellyfinItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async {
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async {
     final response = await _dio.get(
       '/Playlists/$playlistId/Items',
       queryParameters: {
@@ -386,6 +390,8 @@ class JellyfinItemsApi implements ItemsApi {
             'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
+        'StartIndex': ?startIndex,
+        'Limit': ?limit,
       },
     );
     return response.data as Map<String, dynamic>;


### PR DESCRIPTION
# Pull Request

## Summary
Add a new **Playlist Order** sort option for home screen playlist rows that preserves the natural ordering of a playlist, matching exactly what the user configured in the web interface. This is set as the new default for the playlist row sort preference, since it makes more sense than the other options. Previously, playlist rows always queried the generic `/Items?parentId=...` endpoint
sorted by `SortName`, which did not match the playlist's curated order. The fix routes Playlist Order requests through the dedicated `/Playlists/{id}/Items` endpoint, which Jellyfin returns in insertion order. Pagination is supported so lazy-loading works
correctly as the user scrolls through a long playlist mirroring what we do on the other rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #626 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add `LibrarySortBy.playlistOrder` enum value with an empty `apiValue` sentinel, signalling the data layer to use the dedicated playlist endpoint.
- Change the `playlistsRowSortBy` preference default from `name` to `playlistOrder`.
- Extend `getPlaylistItems` on **ItemsApi** (abstract), **JellyfinItemsApi**, **EmbyItemsApi**, and the **offline stub** to accept optional `startIndex` and `limit` parameters for paginated lazy-loading.
- Branch both the initial row load and the lazy-load paging path in **RowDataSource** to call `getPlaylistItems` (paginated) when `playlistOrder` is active, and fall back to the existing Items API path for all other sort options.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Add a playlist to the home screen as a row via Home Row Settings.
2. Confirm items appear in native playlist insertion order (matching the Jellyfin web UI).
3. Scroll to the end of a long playlist row and confirm lazy-loading fetches additional
   items in correct order.
4. Open Home Row Settings → Playlists → Sort and confirm the list shows: Playlist Order (selected by default)
5. Switch to Name sort and confirm items reorder alphabetically.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previously On Moonfin:
The Playlist:
<img width="1615" height="770" alt="2026-08-02_13-06-39_moonfin" src="https://github.com/user-attachments/assets/f646fff3-0f23-4a80-ad12-cc5cc3586f32" />

On the Homescreen (alpha ordering):
<img width="2110" height="680" alt="2026-08-02_13-06-28_moonfin" src="https://github.com/user-attachments/assets/c7113cb0-4af9-46ff-9839-3af75ca68874" />

Row Sort Options:
<img width="250" alt="2026-08-02_13-14-39_moonfin" src="https://github.com/user-attachments/assets/500774b7-208c-401c-934d-7d9530cdc0b5" />

### New Implementation:
New default sort option:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_13-50-06" src="https://github.com/user-attachments/assets/9477ebc6-c019-4cd0-8fe7-c7bee4bf80a2" />

On the main video playlist:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_13-51-11" src="https://github.com/user-attachments/assets/2f4163dc-0556-459b-bd1c-d62f266646e4" />

Applied to an Audiobook playlist:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_13-51-28" src="https://github.com/user-attachments/assets/803736c5-4b16-4ccc-bcac-e2b64267c2fe" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
