### PR TITLE
feat-homerows - Add Collection row playlist order sort option

### DIFF
--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -814,7 +814,11 @@ class OfflineItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async =>
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async =>
       _envelope(const []);
 
   @override

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -531,7 +531,7 @@ class MultiServerRepository {
               final targetStartIndex = pageCount * _defaultLimit;
               _rowOffsets[cacheKey] = targetStartIndex + _defaultLimit;
               final sortBy =
-                  prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ??
+                  prefs?.get(UserPreferences.playlistsRowSortBy).itemsApiSortValue ??
                   _defaultSortBy;
 
               final response = await session.client.itemsApi.getItems(
@@ -646,7 +646,7 @@ class MultiServerRepository {
               return items;
             case HomeRowType.collections:
               final sortBy =
-                  prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
+                  prefs?.get(UserPreferences.collectionsRowSortBy).itemsApiSortValue ??
                   _defaultSortBy;
               _rowOffsets[cacheKey] = startIndex + _defaultLimit;
 
@@ -777,7 +777,7 @@ class MultiServerRepository {
           row.rowType == HomeRowType.audioPlaylists) {
         final sortBy = row.rowType == HomeRowType.audioPlaylists
             ? (prefs?.get(UserPreferences.audioRowsSortBy).apiValue ?? _defaultSortBy)
-            : (prefs?.get(UserPreferences.playlistsRowSortBy).apiValue ?? _defaultSortBy);
+            : (prefs?.get(UserPreferences.playlistsRowSortBy).itemsApiSortValue ?? _defaultSortBy);
         if (sortBy == 'SortName') {
           uniqueCombined.sort((a, b) => a.name.compareTo(b.name));
         } else {
@@ -790,28 +790,40 @@ class MultiServerRepository {
       }
       sortedCombined = uniqueCombined;
     } else {
-      final sortBy = switch (row.rowType) {
-        HomeRowType.favorites =>
-          prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ??
-              _defaultSortBy,
-        HomeRowType.collections =>
-          prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
-              _defaultSortBy,
-        HomeRowType.genres =>
-          prefs?.get(UserPreferences.genresRowSortBy).apiValue ??
-              _defaultSortBy,
-        HomeRowType.audioArtists ||
-        HomeRowType.audioAlbums =>
-          prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
-              _defaultSortBy,
-        _ => _defaultSortBy,
-      };
+      final collectionsSort = prefs?.get(UserPreferences.collectionsRowSortBy);
+      // For a specific pinned collection row using Playlist Order, preserve the
+      // server-returned insertion order — don't re-sort on the client side.
+      // The generic 'collections' all-BoxSets row (row.id == 'collections') has
+      // no parentId, so playlistOrder is never active for it.
+      final collectionsUsePlaylistOrder =
+          row.rowType == HomeRowType.collections &&
+          collectionsSort == LibrarySortBy.playlistOrder &&
+          row.id != 'collections';
+      if (collectionsUsePlaylistOrder) {
+        sortedCombined = uniqueCombined;
+      } else {
+        final sortBy = switch (row.rowType) {
+          HomeRowType.favorites =>
+            prefs?.get(UserPreferences.favoritesRowSortBy).apiValue ??
+                _defaultSortBy,
+          HomeRowType.collections =>
+            collectionsSort?.itemsApiSortValue ?? _defaultSortBy,
+          HomeRowType.genres =>
+            prefs?.get(UserPreferences.genresRowSortBy).apiValue ??
+                _defaultSortBy,
+          HomeRowType.audioArtists ||
+          HomeRowType.audioAlbums =>
+            prefs?.get(UserPreferences.audioRowsSortBy).apiValue ??
+                _defaultSortBy,
+          _ => _defaultSortBy,
+        };
 
-      sortedCombined = _sortAggregatedItems(
-        uniqueCombined,
-        sortBy: sortBy,
-        sortOrder: 'Ascending',
-      );
+        sortedCombined = _sortAggregatedItems(
+          uniqueCombined,
+          sortBy: sortBy,
+          sortOrder: 'Ascending',
+        );
+      }
     }
 
     final totalCount = sessions.fold<int>(0, (sum, session) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -24,6 +24,7 @@ import '../repositories/user_views_repository.dart';
 import '../../preference/seerr_preferences.dart';
 import '../viewmodels/seerr_discover_view_model.dart';
 import 'custom_external_lists_service.dart';
+import 'plugin_sync_service.dart';
 
 class RowDataSource {
   final MediaServerClient _client;
@@ -573,24 +574,54 @@ class RowDataSource {
     required String rowId,
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
+    bool usePlaylistOrder = false,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
+    // Fetch items without a forced sort when playlist order is requested so the
+    // server returns them in native linked-children order before we apply the
+    // plugin-stored custom ordering on top.
     final response = await _getItemsWithFallback(
       parentId: collectionId,
-      sortBy: sortBy,
+      sortBy: usePlaylistOrder ? null : sortBy,
       sortOrder: sortOrder,
       recursive: false,
       startIndex: startIndex,
       limit: limit,
     );
-    return _buildRow(
+    final row = _buildRow(
       id: rowId,
       title: title,
       response: response,
       serverId: serverId,
       rowType: HomeRowType.collections,
     );
+
+    if (!usePlaylistOrder) return row;
+
+    // Apply Moonbase plugin custom order (same logic as item_detail_view_model).
+    try {
+      final syncService = GetIt.instance<PluginSyncService>();
+      if (!syncService.pluginAvailable) return row;
+      final customOrder =
+          await syncService.fetchCustomCollectionOrder(_client, collectionId);
+      if (customOrder == null || customOrder.isEmpty) return row;
+      final orderMap = {
+        for (var i = 0; i < customOrder.length; i++) customOrder[i]: i,
+      };
+      final sorted = List<AggregatedItem>.from(row.items)
+        ..sort((a, b) {
+          final ai = orderMap[a.id];
+          final bi = orderMap[b.id];
+          if (ai == null && bi == null) return 0;
+          if (ai == null) return 1;
+          if (bi == null) return -1;
+          return ai.compareTo(bi);
+        });
+      return row.copyWith(items: sorted);
+    } catch (_) {
+      return row;
+    }
   }
 
   Future<HomeRow> loadPlaylistRow(
@@ -1017,9 +1048,8 @@ class RowDataSource {
           isFavorite: true,
         );
       case HomeRowType.collections:
-        final sortBy =
-            prefs?.get(UserPreferences.collectionsRowSortBy).apiValue ??
-            _defaultSortBy;
+        final sortPref = prefs?.get(UserPreferences.collectionsRowSortBy) ??
+            LibrarySortBy.playlistOrder;
         final parsed = _parseStableId(row.id);
         final parentId =
             (parsed != null &&
@@ -1029,10 +1059,17 @@ class RowDataSource {
         final includeItemTypes = row.id == 'collections'
             ? const ['BoxSet']
             : null;
+        // Playlist Order for a specific pinned collection: fetch without a
+        // server sort so the Items API returns items in native linked-children
+        // order. The custom plugin order is only applied at the initial load
+        // (loadCollectionRow); lazy-load pages simply append in server order.
+        final effectiveSortBy = (sortPref == LibrarySortBy.playlistOrder && parentId != null)
+            ? null
+            : sortPref.itemsApiSortValue;
         response = await _getItemsWithFallback(
           parentId: parentId,
           includeItemTypes: includeItemTypes,
-          sortBy: sortBy,
+          sortBy: effectiveSortBy,
           sortOrder: 'Ascending',
           recursive: true,
           startIndex: currentOffset,
@@ -1611,19 +1648,19 @@ class RowDataSource {
           );
         }
         try {
-          var sortBy = _defaultSortBy;
-          if (GetIt.instance.isRegistered<UserPreferences>()) {
-            sortBy = GetIt.instance<UserPreferences>()
-                .get(UserPreferences.collectionsRowSortBy)
-                .apiValue;
-          }
+          final sortPref = GetIt.instance.isRegistered<UserPreferences>()
+              ? GetIt.instance<UserPreferences>()
+                  .get(UserPreferences.collectionsRowSortBy)
+              : LibrarySortBy.playlistOrder;
+          final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
           final row = await loadCollectionRow(
             serverId,
             collectionId: collectionId,
             title: title,
             rowId: rowId,
-            sortBy: sortBy,
+            sortBy: usePlaylistOrder ? _defaultSortBy : sortPref.apiValue,
             sortOrder: _defaultSortOrder,
+            usePlaylistOrder: usePlaylistOrder,
           );
           return row;
         } catch (_) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -600,17 +600,24 @@ class RowDataSource {
     required String rowId,
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
+    bool usePlaylistOrder = false,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
-    final response = await _getItemsWithFallback(
-      parentId: playlistId,
-      sortBy: sortBy,
-      sortOrder: sortOrder,
-      recursive: false,
-      startIndex: startIndex,
-      limit: limit,
-    );
+    final response = usePlaylistOrder
+        ? await _client.itemsApi.getPlaylistItems(
+            playlistId,
+            startIndex: startIndex,
+            limit: limit,
+          )
+        : await _getItemsWithFallback(
+            parentId: playlistId,
+            sortBy: sortBy,
+            sortOrder: sortOrder,
+            recursive: false,
+            startIndex: startIndex,
+            limit: limit,
+          );
     return _buildRow(
       id: rowId,
       title: title,
@@ -959,18 +966,25 @@ class RowDataSource {
         if (parsed != null &&
             parsed.source == HomeSectionPluginSource.playlists) {
           final playlistId = parsed.additionalData;
-          var sortBy = _defaultSortBy;
-          if (prefs != null) {
-            sortBy = prefs.get(UserPreferences.playlistsRowSortBy).apiValue;
+          final sortPref = prefs?.get(UserPreferences.playlistsRowSortBy) ??
+              LibrarySortBy.playlistOrder;
+          final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
+          if (usePlaylistOrder) {
+            response = await _client.itemsApi.getPlaylistItems(
+              playlistId,
+              startIndex: currentOffset,
+              limit: _defaultLimit,
+            );
+          } else {
+            response = await _getItemsWithFallback(
+              parentId: playlistId,
+              sortBy: sortPref.apiValue,
+              sortOrder: 'Ascending',
+              recursive: false,
+              startIndex: currentOffset,
+              limit: _defaultLimit,
+            );
           }
-          response = await _getItemsWithFallback(
-            parentId: playlistId,
-            sortBy: sortBy,
-            sortOrder: 'Ascending',
-            recursive: false,
-            startIndex: currentOffset,
-            limit: _defaultLimit,
-          );
         } else {
           final pageCount = (currentOffset / _defaultLimit).ceil();
           final startIndex = pageCount * _defaultLimit;
@@ -1657,19 +1671,19 @@ class RowDataSource {
           );
         }
         try {
-          var sortBy = _defaultSortBy;
-          if (GetIt.instance.isRegistered<UserPreferences>()) {
-            sortBy = GetIt.instance<UserPreferences>()
-                .get(UserPreferences.playlistsRowSortBy)
-                .apiValue;
-          }
+          final sortPref = GetIt.instance.isRegistered<UserPreferences>()
+              ? GetIt.instance<UserPreferences>()
+                  .get(UserPreferences.playlistsRowSortBy)
+              : LibrarySortBy.playlistOrder;
+          final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
           final row = await loadPlaylistRow(
             serverId,
             playlistId: playlistId,
             title: title,
             rowId: rowId,
-            sortBy: sortBy,
+            sortBy: usePlaylistOrder ? _defaultSortBy : sortPref.apiValue,
             sortOrder: _defaultSortOrder,
+            usePlaylistOrder: usePlaylistOrder,
           );
           return row;
         } catch (_) {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -575,6 +575,7 @@ class RowDataSource {
     String sortBy = _defaultSortBy,
     String sortOrder = _defaultSortOrder,
     bool usePlaylistOrder = false,
+    bool showEpisodes = false,
     int startIndex = 0,
     int limit = _defaultLimit,
   }) async {
@@ -589,7 +590,7 @@ class RowDataSource {
       startIndex: startIndex,
       limit: limit,
     );
-    final row = _buildRow(
+    var row = _buildRow(
       id: rowId,
       title: title,
       response: response,
@@ -597,31 +598,35 @@ class RowDataSource {
       rowType: HomeRowType.collections,
     );
 
-    if (!usePlaylistOrder) return row;
-
-    // Apply Moonbase plugin custom order (same logic as item_detail_view_model).
-    try {
-      final syncService = GetIt.instance<PluginSyncService>();
-      if (!syncService.pluginAvailable) return row;
-      final customOrder =
-          await syncService.fetchCustomCollectionOrder(_client, collectionId);
-      if (customOrder == null || customOrder.isEmpty) return row;
-      final orderMap = {
-        for (var i = 0; i < customOrder.length; i++) customOrder[i]: i,
-      };
-      final sorted = List<AggregatedItem>.from(row.items)
-        ..sort((a, b) {
-          final ai = orderMap[a.id];
-          final bi = orderMap[b.id];
-          if (ai == null && bi == null) return 0;
-          if (ai == null) return 1;
-          if (bi == null) return -1;
-          return ai.compareTo(bi);
-        });
-      return row.copyWith(items: sorted);
-    } catch (_) {
-      return row;
+    if (usePlaylistOrder) {
+      // Apply Moonbase plugin custom order (same logic as item_detail_view_model).
+      try {
+        final syncService = GetIt.instance<PluginSyncService>();
+        if (syncService.pluginAvailable) {
+          final customOrder =
+              await syncService.fetchCustomCollectionOrder(_client, collectionId);
+          if (customOrder != null && customOrder.isNotEmpty) {
+            final orderMap = {
+              for (var i = 0; i < customOrder.length; i++) customOrder[i]: i,
+            };
+            final sorted = List<AggregatedItem>.from(row.items)
+              ..sort((a, b) {
+                final ai = orderMap[a.id];
+                final bi = orderMap[b.id];
+                if (ai == null && bi == null) return 0;
+                if (ai == null) return 1;
+                if (bi == null) return -1;
+                return ai.compareTo(bi);
+              });
+            row = row.copyWith(items: sorted);
+          }
+        }
+      } catch (_) {}
     }
+
+    if (!showEpisodes) return row;
+    final expanded = await _expandSeriesItems(row.items, serverId);
+    return row.copyWith(items: expanded);
   }
 
   Future<HomeRow> loadPlaylistRow(
@@ -1648,11 +1653,14 @@ class RowDataSource {
           );
         }
         try {
-          final sortPref = GetIt.instance.isRegistered<UserPreferences>()
+          final prefs = GetIt.instance.isRegistered<UserPreferences>()
               ? GetIt.instance<UserPreferences>()
-                  .get(UserPreferences.collectionsRowSortBy)
-              : LibrarySortBy.playlistOrder;
+              : null;
+          final sortPref = prefs?.get(UserPreferences.collectionsRowSortBy) ??
+              LibrarySortBy.playlistOrder;
           final usePlaylistOrder = sortPref == LibrarySortBy.playlistOrder;
+          final showEpisodes =
+              prefs?.get(UserPreferences.collectionsRowShowEpisodes) ?? false;
           final row = await loadCollectionRow(
             serverId,
             collectionId: collectionId,
@@ -1661,6 +1669,7 @@ class RowDataSource {
             sortBy: usePlaylistOrder ? _defaultSortBy : sortPref.apiValue,
             sortOrder: _defaultSortOrder,
             usePlaylistOrder: usePlaylistOrder,
+            showEpisodes: showEpisodes,
           );
           return row;
         } catch (_) {
@@ -1815,6 +1824,54 @@ class RowDataSource {
       if (rating == null || rating.isEmpty) return true;
       return !blocked.contains(rating);
     }).toList();
+  }
+
+  /// Expands any [AggregatedItem] of type 'Series' in [items] by fetching its
+  /// episodes and inserting them in season/episode order at the series'
+  /// position. Non-series items (Movies, Episodes already in the list, etc.)
+  /// are kept as-is. Falls back to the series card on any fetch error.
+  Future<List<AggregatedItem>> _expandSeriesItems(
+    List<AggregatedItem> items,
+    String serverId,
+  ) async {
+    final result = <AggregatedItem>[];
+    for (final item in items) {
+      if (item.type != 'Series') {
+        result.add(item);
+        continue;
+      }
+      try {
+        final episodeData = await _client.itemsApi.getEpisodes(item.id);
+        final rawEpisodes = (episodeData['Items'] as List?) ?? [];
+        if (rawEpisodes.isEmpty) {
+          result.add(item);
+          continue;
+        }
+        final episodes = rawEpisodes
+            .whereType<Map<String, dynamic>>()
+            .map((data) => AggregatedItem(
+                  id: data['Id']?.toString() ?? '',
+                  serverId: serverId,
+                  rawData: data,
+                ))
+            .toList()
+          ..sort((a, b) {
+            // Season 0 = Specials — sort after all regular seasons.
+            int seasonKey(int s) => s == 0 ? 0x7FFFFFFF : s;
+            final aSeason = seasonKey(a.rawData['ParentIndexNumber'] as int? ?? 0);
+            final bSeason = seasonKey(b.rawData['ParentIndexNumber'] as int? ?? 0);
+            if (aSeason != bSeason) return aSeason.compareTo(bSeason);
+            final aEp = a.rawData['IndexNumber'] as int? ?? 0;
+            final bEp = b.rawData['IndexNumber'] as int? ?? 0;
+            return aEp.compareTo(bEp);
+          });
+        result.addAll(episodes);
+      } catch (_) {
+        // Fall back to series poster if episode fetch fails.
+        result.add(item);
+      }
+    }
+    return result;
   }
 
   Set<String> _blockedParentalRatings() {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -383,6 +383,14 @@ enum LibrarySortBy {
   const LibrarySortBy(this.apiValue, this.displayName);
   final String apiValue;
   final String displayName;
+
+  /// The sort value to pass to the Jellyfin/Emby /Items API.
+  ///
+  /// Some options (e.g. [playlistOrder]) use a dedicated endpoint and carry
+  /// an empty [apiValue]. Passing an empty string to the Items API produces
+  /// a malformed request, so this getter substitutes 'SortName' as a safe
+  /// fallback for any context that must use the Items API regardless.
+  String get itemsApiSortValue => apiValue.isEmpty ? 'SortName' : apiValue;
 }
 
 enum ChannelSortBy {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -367,6 +367,7 @@ enum HomeSectionType {
 }
 
 enum LibrarySortBy {
+  playlistOrder('', 'Playlist Order'),
   name('SortName', 'Name'),
   dateAdded('DateCreated', 'Date Added'),
   premiereDate('PremiereDate', 'Premiere Date'),

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1077,6 +1077,11 @@ class UserPreferences extends ChangeNotifier {
     values: LibrarySortBy.values,
   );
 
+  static final collectionsRowShowEpisodes = Preference(
+    key: 'pref_collections_row_show_episodes',
+    defaultValue: false,
+  );
+
   static final genresRowSortBy = EnumPreference(
     key: 'pref_genres_row_sort_by',
     defaultValue: LibrarySortBy.name,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1085,7 +1085,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final playlistsRowSortBy = EnumPreference(
     key: 'pref_playlists_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.playlistOrder,
     values: LibrarySortBy.values,
   );
 

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1073,7 +1073,7 @@ class UserPreferences extends ChangeNotifier {
 
   static final collectionsRowSortBy = EnumPreference(
     key: 'pref_collections_row_sort_by',
-    defaultValue: LibrarySortBy.name,
+    defaultValue: LibrarySortBy.playlistOrder,
     values: LibrarySortBy.values,
   );
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -1053,7 +1053,7 @@ class HomeViewModel extends ChangeNotifier {
         .apiValue;
     final collectionsSortBy = _prefs
         .get(UserPreferences.collectionsRowSortBy)
-        .apiValue;
+        .itemsApiSortValue;
     final genresSortBy = _prefs.get(UserPreferences.genresRowSortBy).apiValue;
     final genresItemFilter = _prefs
         .get(UserPreferences.genresRowItemFilter)

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -100,6 +100,11 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
     _reloadHomeRows();
   }
 
+  void _onCollectionsEpisodesChanged() {
+    _pushPersonalizationSync();
+    _reloadHomeRows();
+  }
+
   void _onGenresSortChanged() {
     _pushPersonalizationSync();
     _reloadHomeRows();
@@ -395,6 +400,15 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                       icon: Icons.sort,
                       labelOf: (v) => v.displayName,
                       onChanged: _onCollectionsSortChanged,
+                    ),
+                  if (showCollectionsRows)
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.collectionsRowShowEpisodes,
+                      title: 'Show Individual Episodes',
+                      subtitle:
+                          'Expand TV shows to display each episode separately.',
+                      icon: Icons.video_library_outlined,
+                      onChanged: (_) => _onCollectionsEpisodesChanged(),
                     ),
                 ],
               ),

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -131,7 +131,11 @@ abstract class ItemsApi {
     bool? isFavorite,
   });
 
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId);
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  });
 
   Future<Map<String, dynamic>> createPlaylist({
     required String name,

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -398,7 +398,11 @@ class EmbyItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async {
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async {
     final response = await _dio.get(
       '/Playlists/$playlistId/Items',
       queryParameters: {
@@ -406,6 +410,8 @@ class EmbyItemsApi implements ItemsApi {
             'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
+        'StartIndex': ?startIndex,
+        'Limit': ?limit,
       },
     );
     return response.data as Map<String, dynamic>;

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -378,7 +378,11 @@ class JellyfinItemsApi implements ItemsApi {
   }
 
   @override
-  Future<Map<String, dynamic>> getPlaylistItems(String playlistId) async {
+  Future<Map<String, dynamic>> getPlaylistItems(
+    String playlistId, {
+    int? startIndex,
+    int? limit,
+  }) async {
     final response = await _dio.get(
       '/Playlists/$playlistId/Items',
       queryParameters: {
@@ -386,6 +390,8 @@ class JellyfinItemsApi implements ItemsApi {
             'BasicSyncInfo,PrimaryImageAspectRatio,RunTimeTicks,Artists,AlbumArtist,IndexNumber,MediaType,PlaylistItemId,BackdropImageTags,ParentBackdropImageTags,ParentBackdropItemId,SeriesName,ParentIndexNumber,Genres,Chapters,Overview,UserData,MediaStreams',
         'EnableImageTypes': 'Primary,Backdrop,Logo,Thumb',
         'ImageTypeLimit': 1,
+        'StartIndex': ?startIndex,
+        'Limit': ?limit,
       },
     );
     return response.data as Map<String, dynamic>;


### PR DESCRIPTION
# Pull Request

## Summary
Adds **Playlist Order** as a sort option for plugin-pinned collection rows on the home screen, restoring the Moonbase-stored custom drag-and-drop order the user has set on the collection detail page. The implementation mirrors the existing custom order logic in the collection detail view model: items are fetched via `/Items?parentId={collectionId}` with no forced sort,
then the ordered ID list stored at `GET /Moonfin/Collections/{id}/Order` is applied client-side. If no custom order has been saved the row falls back to server-default order gracefully. Note: this PR depends on the Playlists PR (which introduces `LibrarySortBy.playlistOrder` enum).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Add `itemsApiSortValue` getter to `LibrarySortBy` that substitutes `'SortName'` when  `apiValue` is empty, preventing malformed Items API requests when a sort option that uses a dedicated endpoint is used in a generic Items API context.
- Apply `itemsApiSortValue` at all `collectionsRowSortBy` and `playlistsRowSortBy` call sites in `RowDataSource`, `MultiServerRepository`, and `HomeViewModel` where the Items API is used.
- Add `usePlaylistOrder` flag to `loadCollectionRow`; when set, fetches items with `sortBy: null` then applies Moonbase custom order via `fetchCustomCollectionOrder`.
- Update `HomeRowType.collections` lazy-load paging path to pass `null` sortBy when `playlistOrder` is active, preserving server order without calling the Playlist endpoint.
- Change `collectionsRowSortBy` preference default to `playlistOrder`.
- The generic all-BoxSets Collections row is intentionally unaffected and continues to sort alphabetically.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Pin a specific collection (e.g. Alien Collection) as a home screen row via Home Row Settings.
2. Confirm items appear in the custom drag-and-drop order set on the collection detail page.
3. Confirm that if no custom order has been saved, the row loads without errors and shows items in server-default order.
4. Confirm the generic Collections row (showing all BoxSets) is unaffected and still sorts alphabetically by default.
5. Open Home Row Settings → Collections → Sort and confirm Playlist Order appears at the top of the full sort list and is selected by default.
6. Switch to Name sort and confirm items reorder alphabetically.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Original Collection Ordering

Aliens Collection (alpha ordering)
<img width="2492" height="723" alt="2026-08-02_14-35-40_moonfin" src="https://github.com/user-attachments/assets/bea06608-ebfe-4a41-a37e-f4edeeeb11bb" />

Aliens Collection in Moonfin (using our custom ordering)
<img width="1671" height="1344" alt="2026-08-02_14-47-20_moonfin" src="https://github.com/user-attachments/assets/ea18a48d-1842-4054-bc18-15e844a1014b" />

### New Sort Method:

Settings Menu:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_14-48-23" src="https://github.com/user-attachments/assets/5d1379f9-be58-4f2e-9806-9f25b526fadc" />

Applied to Aliens:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_15-07-51" src="https://github.com/user-attachments/assets/fd3c9f95-1dcc-494b-97de-c9b23ff6a84a" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_15-08-09" src="https://github.com/user-attachments/assets/867fe776-ee02-4d0a-bdaf-2fc7d9560a61" />

Applied to Evil Dead:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_15-09-31" src="https://github.com/user-attachments/assets/bd2cbdcd-9e8a-4bc7-861a-0988b63a8be4" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-02_15-10-34" src="https://github.com/user-attachments/assets/453617b4-a1b8-42a2-b2df-214a05a2a70b" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
