### PR TITLE
add missing up navigation on medern details tab

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4659,6 +4659,7 @@ class _DetailsContainerState extends State<_DetailsContainer> with FocusStateMix
                   return KeyEventResult.handled;
                 }
               }
+              widget.onNavigateUp?.call();
               return KeyEventResult.handled;
             } else if (focused == widget.audioButtonFocusNode) {
               widget.focusNode?.requestFocus();


### PR DESCRIPTION
# Pull Request

## Summary
You couldn't go back up to the modern details page tabs once the media details panel had focus unless you pressed back. Now you can press up to go back up (makes sense)

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1027 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- call onNavigateUp in keyEvent upArrow for DetailsContainer
- call it after the scrollable sections tried to handle, so you can still scroll up within the scrollable, it only goes up to the tab if there is no more scrolling up possible
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Do to modern details page for any item, navigate to details tab
2. D-pad to go down
3. Scroll up/down within the panel (still works)
4. Scroll up past the top, focus now goes up to the tabs row as expected

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
