### PR TITLE
bugfix-collections - Add lazy loading for large collections

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -162,28 +162,32 @@ class ItemDetailViewModel extends ChangeNotifier {
   bool _collectionHasMore = false;
   bool _collectionLoadingMore = false;
 
-  // --- Playlist flat-ID index (Phase 1) ---
-  //
-  // Phase 1 fetches all BoxSet top-level items + episode IDs with minimal
-  // fields to build a lightweight ordered list of IDs.  Full item data is
-  // fetched lazily in Phase 3.
+  // --- Playlist index ---
 
-  /// True while the flat ID index is being built.  The Playlist area shows a
-  /// spinner during this phase.
+  /// How much of a collection the index scan will walk. Past this the playlist
+  /// tab covers the head rather than the whole thing.
+  static const _indexScanLimit = 2000;
+
+  /// How many series are asked for their episodes at once during the scan.
+  static const _indexScanBatchSize = 8;
+
+  /// True while the index is being built. The playlist area shows a spinner.
   bool _playlistIndexBuilding = false;
   bool get playlistIndexBuilding => _playlistIndexBuilding;
 
-  /// Lightweight metadata entries used for re-sorting index without fetching full items.
+  /// The id and sort keys of every playable item, kept so the order can change
+  /// without fetching anything again. Null until the collection is scanned.
   List<_PlaylistItemIndexEntry>? _playlistIndexEntries;
 
-  /// Flat ordered list of movie/episode IDs for the play queue.
-  /// Null until Phase 1 completes.  After that, Phase 3 pages through it.
-  /// When a plugin-saved custom order exists (Strategy B), this is
-  /// initialised directly from that order.  Otherwise built by sorting all
-  /// movies + episodes by release date (Strategy A).
+  /// Ids in the order the playlist currently shows, which pages are read from.
   List<String>? _flattenedIds;
 
-  // --- Playlist page loading (Phase 3) ---
+  /// Ids in the order the user arranged them, either dragged here or saved on
+  /// the server. Kept apart from [_flattenedIds] so switching to another sort
+  /// and back doesn't lose it.
+  List<String>? _customOrderIds;
+
+  // --- Playlist page loading ---
   static const _playlistPageSize = 50;
   int _playlistFetchedCount = 0;
   bool _playlistHasMore = false;
@@ -249,8 +253,6 @@ class ItemDetailViewModel extends ChangeNotifier {
   CollectionSortOption _collectionSort = CollectionSortOption.releaseAscending;
   CollectionSortOption get collectionSort => _collectionSort;
 
-  List<AggregatedItem> _customPlaylistItems = const [];
-
   String? _parentCollectionName;
   String? get parentCollectionName => _parentCollectionName;
 
@@ -300,6 +302,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     _parentCollectionName = null;
     _parentCollections = const [];
     _flattenedIds = null;
+    _customOrderIds = null;
     _playlistIndexEntries = null;
     _collectionFetchedCount = 0;
     _collectionTotalCount = 0;
@@ -310,7 +313,6 @@ class ItemDetailViewModel extends ChangeNotifier {
     _playlistHasMore = false;
     _playlistLoadingMore = false;
     _playlistItems = const [];
-    _customPlaylistItems = const [];
     notifyListeners();
 
     try {
@@ -696,13 +698,33 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
   }
 
-  void setCollectionSort(CollectionSortOption option) {
+  /// Reorders the whole index and starts the list again from the top.
+  ///
+  /// Only a slice of the collection is loaded, so re-sorting what is on screen
+  /// would leave it holding one ordering while later pages arrive in another.
+  Future<void> setCollectionSort(CollectionSortOption option) async {
+    if (_collectionSort == option) return;
     _collectionSort = option;
-    _sortPlaylistIndex();
-    _applyCollectionSort();
+    // A saved order arrives ready to use, so the scan is only worth paying for
+    // when the sort actually needs the keys.
+    if (option != CollectionSortOption.custom) {
+      await _ensurePlaylistIndexEntries();
+    }
+    _rebuildFlattenedIds();
+    _resetPlaylistPaging();
+    notifyListeners();
+    await loadMorePlaylistItems();
   }
 
-  void _sortPlaylistIndex() {
+  /// Points [_flattenedIds] at the active sort. Every option lands here, so the
+  /// index and the pages fetched from it can never describe different orders.
+  void _rebuildFlattenedIds() {
+    if (_collectionSort == CollectionSortOption.custom) {
+      final custom = _customOrderIds;
+      // Copied, so a later drag can't edit the saved order underneath itself.
+      if (custom != null) _flattenedIds = List<String>.from(custom);
+      return;
+    }
     final entries = _playlistIndexEntries;
     if (entries == null || entries.isEmpty) return;
     switch (_collectionSort) {
@@ -710,42 +732,23 @@ class ItemDetailViewModel extends ChangeNotifier {
         entries.sort(
           (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
         );
-        _flattenedIds = entries.map((e) => e.id).toList();
-        break;
       case CollectionSortOption.releaseAscending:
         entries.sort(_PlaylistItemIndexEntry.compareReleaseAscending);
-        _flattenedIds = entries.map((e) => e.id).toList();
-        break;
       case CollectionSortOption.releaseDescending:
         entries.sort(
           (a, b) => _PlaylistItemIndexEntry.compareReleaseAscending(b, a),
         );
-        _flattenedIds = entries.map((e) => e.id).toList();
-        break;
       case CollectionSortOption.custom:
-        break;
+        return;
     }
+    _flattenedIds = entries.map((e) => e.id).toList();
   }
 
-  void _applyCollectionSort() {
-    switch (_collectionSort) {
-      case CollectionSortOption.alphabetical:
-        _playlistItems = List<AggregatedItem>.from(_playlistItems)
-          ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
-        break;
-      case CollectionSortOption.releaseAscending:
-        _playlistItems = List<AggregatedItem>.from(_playlistItems)
-          ..sort(_releaseSortAscending);
-        break;
-      case CollectionSortOption.releaseDescending:
-        _playlistItems = List<AggregatedItem>.from(_playlistItems)
-          ..sort((a, b) => _releaseSortAscending(b, a));
-        break;
-      case CollectionSortOption.custom:
-        _playlistItems = List<AggregatedItem>.from(_customPlaylistItems);
-        break;
-    }
-    notifyListeners();
+  /// Drops the loaded pages so the next fetch starts at the head of the index.
+  void _resetPlaylistPaging() {
+    _playlistItems = const [];
+    _playlistFetchedCount = 0;
+    _playlistHasMore = _flattenedIds?.isNotEmpty ?? false;
   }
 
   Future<void> reorderCollectionPlaylistItem(int oldIndex, int newIndex) async {
@@ -756,27 +759,29 @@ class ItemDetailViewModel extends ChangeNotifier {
     final item = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, item);
     _playlistItems = reordered;
-    _customPlaylistItems = reordered;
     _collectionSort = CollectionSortOption.custom;
 
-    // Keep the flat ID index in sync so that any subsequent lazy-load pages
-    // respect the new order.  If not all items are loaded yet, unloaded IDs
-    // remain at the end in their previous order.
-    if (_flattenedIds != null) {
-      final reorderedIds = reordered.map((i) => i.id).toList();
-      final unloaded = _flattenedIds!.length > reorderedIds.length
-          ? _flattenedIds!.sublist(reorderedIds.length)
-          : const <String>[];
-      _flattenedIds = [...reorderedIds, ...unloaded];
+    // The loaded items take the head of the index in their new order and the
+    // rest keep theirs. Matching on id rather than position holds up even when
+    // a page came back short because the server had dropped one of them.
+    final ids = _flattenedIds;
+    if (ids != null) {
+      final loadedIds = reordered.map((i) => i.id).toList();
+      final loaded = loadedIds.toSet();
+      final merged = [...loadedIds, ...ids.where((id) => !loaded.contains(id))];
+      _flattenedIds = merged;
+      _customOrderIds = List<String>.from(merged);
     }
 
     notifyListeners();
 
     try {
       final syncService = GetIt.instance<PluginSyncService>();
-      if (syncService.pluginAvailable && _flattenedIds != null) {
-        // Send the complete _flattenedIds list so server custom order is NOT truncated!
-        await syncService.saveCustomCollectionOrder(_client, itemId, _flattenedIds!);
+      final order = _customOrderIds;
+      if (syncService.pluginAvailable && order != null) {
+        // The whole order goes up, otherwise the server forgets where the items
+        // that haven't been paged in yet belong.
+        await syncService.saveCustomCollectionOrder(_client, itemId, order);
       }
     } catch (_) {}
   }
@@ -804,29 +809,25 @@ class ItemDetailViewModel extends ChangeNotifier {
     final total = data['TotalRecordCount'] as int?;
     if (total != null) _collectionTotalCount = total;
     _collectionFetchedCount += newItems.length;
-    _collectionHasMore = _collectionFetchedCount < _collectionTotalCount;
+    // A server that leaves the total out would otherwise strand the grid on its
+    // first page, so a full page is taken to mean there is more behind it.
+    _collectionHasMore = total != null
+        ? _collectionFetchedCount < _collectionTotalCount
+        : newItems.length == _collectionPageSize;
     _collectionItems = [..._collectionItems, ...newItems];
     notifyListeners();
   }
 
-  // ---------------------------------------------------------------------------
-  // Phase 1 — flat ID index build
-  // ---------------------------------------------------------------------------
-
-  /// Builds [_flattenedIds]: a lightweight ordered list of every playable item
-  /// ID in the BoxSet (movies + individual episodes in release-date order, or
-  /// the plugin's saved custom order when Strategy B is active).
-  ///
-  /// Only IDs are retained after this phase; the full [AggregatedItem] objects
-  /// used for sorting are discarded immediately, keeping memory usage minimal
-  /// even for collections with thousands of episodes.
+  /// Puts [_flattenedIds] in place, either from a saved order or by scanning
+  /// the collection, then starts the first page.
   Future<void> _buildPlaylistIndex() async {
     _playlistIndexBuilding = true;
     notifyListeners();
 
     try {
-      // Strategy B: plugin has a saved custom order — use it directly as the
-      // flat ID list (it already stores movie + episode IDs in story order).
+      // A saved order already lists movie and episode ids in story order, so it
+      // can stand in for the index and skip enumerating the collection. The
+      // entries only get built if the user later picks a different sort.
       final syncService = GetIt.instance<PluginSyncService>();
       if (syncService.pluginAvailable) {
         try {
@@ -835,37 +836,64 @@ class ItemDetailViewModel extends ChangeNotifier {
             itemId,
           );
           if (customOrder != null && customOrder.isNotEmpty) {
-            _flattenedIds = customOrder;
+            _customOrderIds = customOrder;
+            _flattenedIds = List<String>.from(customOrder);
             _collectionSort = CollectionSortOption.custom;
           }
         } catch (_) {}
       }
 
-      // Strategy A: no custom order — build by release date.
       if (_flattenedIds == null) {
-        // Fetch ALL top-level BoxSet items with minimal fields (just IDs +
-        // dates needed for sorting).  No limit; we only keep IDs.
-        final allData = await _client.itemsApi.getItems(
-          parentId: itemId,
-          fields: 'BasicSyncInfo',
+        await _ensurePlaylistIndexEntries();
+        _collectionSort = CollectionSortOption.releaseAscending;
+        _rebuildFlattenedIds();
+      }
+
+      _resetPlaylistPaging();
+    } catch (_) {}
+
+    _playlistIndexBuilding = false;
+    notifyListeners();
+
+    await loadMorePlaylistItems();
+  }
+
+  /// Walks the collection once to build [_playlistIndexEntries], the id and
+  /// sort key of every playable item in it. Does nothing if they already exist.
+  ///
+  /// Only the keys are kept. The items themselves are read a page at a time by
+  /// [_fetchPlaylistPage], so a collection of any size settles at a few KB.
+  Future<void> _ensurePlaylistIndexEntries() async {
+    if (_playlistIndexEntries != null) return;
+    try {
+      final allData = await _client.itemsApi.getItems(
+        parentId: itemId,
+        limit: _indexScanLimit,
+        fields: 'BasicSyncInfo',
+      );
+      final allTopLevel = _mapItems((allData['Items'] as List?) ?? []);
+
+      final seriesItems = allTopLevel.where((i) => i.type == 'Series').toList();
+      final flat = allTopLevel
+          .where(
+            (i) =>
+                i.type == 'Movie' ||
+                i.type == 'Audio' ||
+                i.type == 'Video' ||
+                i.type == 'MusicVideo',
+          )
+          .toList();
+
+      // A batch at a time. One request per series all at once would open as
+      // many sockets as the collection has shows.
+      for (var i = 0; i < seriesItems.length; i += _indexScanBatchSize) {
+        final end = i + _indexScanBatchSize;
+        final batch = seriesItems.sublist(
+          i,
+          end < seriesItems.length ? end : seriesItems.length,
         );
-        final allTopLevel = _mapItems((allData['Items'] as List?) ?? []);
-
-        final seriesItems =
-            allTopLevel.where((i) => i.type == 'Series').toList();
-        final nonSeriesItems = allTopLevel
-            .where(
-              (i) =>
-                  i.type == 'Movie' ||
-                  i.type == 'Audio' ||
-                  i.type == 'Video' ||
-                  i.type == 'MusicVideo',
-            )
-            .toList();
-
-        // Expand every series to its individual episodes.  Run in parallel.
         final episodeLists = await Future.wait(
-          seriesItems.map((series) async {
+          batch.map((series) async {
             try {
               final epData = await _client.itemsApi.getEpisodes(series.id);
               return _mapItems((epData['Items'] as List?) ?? []);
@@ -874,50 +902,28 @@ class ItemDetailViewModel extends ChangeNotifier {
             }
           }),
         );
-
-        final flat = <AggregatedItem>[...nonSeriesItems];
         for (final episodes in episodeLists) {
           flat.addAll(episodes);
         }
-        // Build lightweight index entries for memory-efficient re-sorting.
-        final entries = flat
-            .map(
-              (i) => _PlaylistItemIndexEntry(
-                id: i.id,
-                name: i.name,
-                premiereDate: i.premiereDate,
-                productionYear: i.productionYear,
-              ),
-            )
-            .toList();
-
-        // Sort movies + episodes together by release date (ascending).
-        entries.sort(_PlaylistItemIndexEntry.compareReleaseAscending);
-
-        _playlistIndexEntries = entries;
-        _flattenedIds = entries.map((e) => e.id).toList();
-        _collectionSort = CollectionSortOption.releaseAscending;
       }
 
-      _playlistHasMore = (_flattenedIds?.isNotEmpty) ?? false;
+      _playlistIndexEntries = flat
+          .map(
+            (i) => _PlaylistItemIndexEntry(
+              id: i.id,
+              name: i.name,
+              premiereDate: i.premiereDate,
+              productionYear: i.productionYear,
+            ),
+          )
+          .toList();
     } catch (_) {}
-
-    _playlistIndexBuilding = false;
-    notifyListeners();
-
-    // Kick off the first playlist page now that the index is ready.
-    if ((_flattenedIds?.isNotEmpty) ?? false) {
-      await _fetchPlaylistPage();
-    }
   }
 
-  // ---------------------------------------------------------------------------
-  // Phase 3 — playlist page loading
-  // ---------------------------------------------------------------------------
-
-  /// Fetches the next batch of full item data from [_flattenedIds] and appends
-  /// it to [_playlistItems].  Re-sorts each batch to match the index order
-  /// (the server returns items by-ID in arbitrary order).
+  /// Reads the next run of ids into [_playlistItems].
+  ///
+  /// Progress is counted in index positions rather than items returned, so an
+  /// id the server no longer knows about can't stall the list.
   Future<void> _fetchPlaylistPage() async {
     final ids = _flattenedIds;
     if (ids == null || _playlistFetchedCount >= ids.length) return;
@@ -934,60 +940,41 @@ class ItemDetailViewModel extends ChangeNotifier {
     );
     final items = _mapItems((data['Items'] as List?) ?? []);
 
-    // Re-sort to match the flattenedIds order.
-    final orderMap = {
-      for (var i = 0; i < batch.length; i++) batch[i]: i,
-    };
+    // The by-id endpoint answers in whatever order it likes.
+    final orderMap = {for (var i = 0; i < batch.length; i++) batch[i]: i};
     items.sort(
-      (a, b) => (orderMap[a.id] ?? 0).compareTo(orderMap[b.id] ?? 0),
+      (a, b) => (orderMap[a.id] ?? batch.length)
+          .compareTo(orderMap[b.id] ?? batch.length),
     );
 
     _playlistFetchedCount += batch.length;
     _playlistHasMore = _playlistFetchedCount < ids.length;
 
-    final combined = [..._playlistItems, ...items];
-    _playlistItems = combined;
-    _customPlaylistItems = List<AggregatedItem>.from(combined);
+    _playlistItems = [..._playlistItems, ...items];
 
     _resolveNextUp();
     notifyListeners();
   }
 
-  /// Resolves the Next Up item from the current [_playlistItems].
+  /// Picks the first unwatched item, or the first item once the whole
+  /// collection has been watched.
+  ///
+  /// Only the loaded head is visible here, so a watched head with pages still
+  /// to come is left alone. Wrapping to the start then would point at item one
+  /// while the next unseen one is further down.
   void _resolveNextUp() {
     if (_playlistItems.isEmpty) {
       _nextUp = null;
       return;
     }
-    final playedAll = _playlistItems.every(
-      (item) => item.rawData['UserData']?['Played'] == true,
-    );
-    if (playedAll) {
+    final unwatched = _playlistItems
+        .where((item) => item.rawData['UserData']?['Played'] != true)
+        .firstOrNull;
+    if (unwatched != null) {
+      _nextUp = unwatched;
+    } else if (!_playlistHasMore) {
       _nextUp = _playlistItems.first;
-    } else {
-      _nextUp = _playlistItems.firstWhere(
-        (item) => item.rawData['UserData']?['Played'] != true,
-        orElse: () => _playlistItems.first,
-      );
     }
-  }
-
-  /// Release-ascending sort comparator used for Strategy A playlist ordering.
-  static int _releaseSortAscending(AggregatedItem a, AggregatedItem b) {
-    final aDate =
-        a.premiereDate ??
-        (a.productionYear != null ? DateTime(a.productionYear!) : null);
-    final bDate =
-        b.premiereDate ??
-        (b.productionYear != null ? DateTime(b.productionYear!) : null);
-    if (aDate == null && bDate == null) {
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-    }
-    if (aDate == null) return 1;
-    if (bDate == null) return -1;
-    final byDate = aDate.compareTo(bDate);
-    if (byDate != 0) return byDate;
-    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
   }
 
   /// Called by the UI scroll listener to load the next grid page.

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -23,6 +23,42 @@ enum CollectionSortOption {
   custom,
 }
 
+/// Lightweight metadata entry used to build and re-sort the flat playlist index
+/// without holding full [AggregatedItem] objects in memory.
+class _PlaylistItemIndexEntry {
+  final String id;
+  final String name;
+  final DateTime? premiereDate;
+  final int? productionYear;
+
+  const _PlaylistItemIndexEntry({
+    required this.id,
+    required this.name,
+    this.premiereDate,
+    this.productionYear,
+  });
+
+  static int compareReleaseAscending(
+    _PlaylistItemIndexEntry a,
+    _PlaylistItemIndexEntry b,
+  ) {
+    final aDate =
+        a.premiereDate ??
+        (a.productionYear != null ? DateTime(a.productionYear!) : null);
+    final bDate =
+        b.premiereDate ??
+        (b.productionYear != null ? DateTime(b.productionYear!) : null);
+    if (aDate == null && bDate == null) {
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    }
+    if (aDate == null) return 1;
+    if (bDate == null) return -1;
+    final byDate = aDate.compareTo(bDate);
+    if (byDate != 0) return byDate;
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  }
+}
+
 enum ItemDetailState { loading, ready, error }
 
 /// Why a delete request failed.
@@ -116,6 +152,44 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   List<AggregatedItem> _collectionItems = const [];
   List<AggregatedItem> get collectionItems => _collectionItems;
+
+  // --- Collection grid pagination state ---
+  static const _collectionPageSize = 50;
+
+  /// Items fetched so far for the grid (startIndex).
+  int _collectionFetchedCount = 0;
+  int _collectionTotalCount = 0;
+  bool _collectionHasMore = false;
+  bool _collectionLoadingMore = false;
+
+  // --- Playlist flat-ID index (Phase 1) ---
+  //
+  // Phase 1 fetches all BoxSet top-level items + episode IDs with minimal
+  // fields to build a lightweight ordered list of IDs.  Full item data is
+  // fetched lazily in Phase 3.
+
+  /// True while the flat ID index is being built.  The Playlist area shows a
+  /// spinner during this phase.
+  bool _playlistIndexBuilding = false;
+  bool get playlistIndexBuilding => _playlistIndexBuilding;
+
+  /// Lightweight metadata entries used for re-sorting index without fetching full items.
+  List<_PlaylistItemIndexEntry>? _playlistIndexEntries;
+
+  /// Flat ordered list of movie/episode IDs for the play queue.
+  /// Null until Phase 1 completes.  After that, Phase 3 pages through it.
+  /// When a plugin-saved custom order exists (Strategy B), this is
+  /// initialised directly from that order.  Otherwise built by sorting all
+  /// movies + episodes by release date (Strategy A).
+  List<String>? _flattenedIds;
+
+  // --- Playlist page loading (Phase 3) ---
+  static const _playlistPageSize = 50;
+  int _playlistFetchedCount = 0;
+  bool _playlistHasMore = false;
+  bool _playlistLoadingMore = false;
+
+  bool get playlistLoadingMore => _playlistLoadingMore;
 
   // Cached BoxSet cast/crew, rebuilt only when _collectionItems changes.
   List<AggregatedItem>? _boxSetPeopleSource;
@@ -225,6 +299,18 @@ class ItemDetailViewModel extends ChangeNotifier {
     _parentCollectionItems = const [];
     _parentCollectionName = null;
     _parentCollections = const [];
+    _flattenedIds = null;
+    _playlistIndexEntries = null;
+    _collectionFetchedCount = 0;
+    _collectionTotalCount = 0;
+    _collectionHasMore = false;
+    _collectionLoadingMore = false;
+    _playlistIndexBuilding = false;
+    _playlistFetchedCount = 0;
+    _playlistHasMore = false;
+    _playlistLoadingMore = false;
+    _playlistItems = const [];
+    _customPlaylistItems = const [];
     notifyListeners();
 
     try {
@@ -346,7 +432,8 @@ class ItemDetailViewModel extends ChangeNotifier {
     } else if (type == 'Audio') {
       futures.add(_loadLyrics());
     } else if (type == 'BoxSet') {
-      futures.add(_loadCollectionItems());
+      futures.add(_loadCollectionItems()); // grid — Phase 2, starts immediately
+      futures.add(_buildPlaylistIndex());  // playlist — Phase 1, runs concurrently
     } else if (type == 'MusicVideo' ||
         type == 'Movie' ||
         type == 'Trailer' ||
@@ -611,27 +698,36 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   void setCollectionSort(CollectionSortOption option) {
     _collectionSort = option;
+    _sortPlaylistIndex();
     _applyCollectionSort();
   }
 
-  void _applyCollectionSort() {
-    int releaseSortAscending(AggregatedItem a, AggregatedItem b) {
-      final aDate =
-          a.premiereDate ??
-          (a.productionYear != null ? DateTime(a.productionYear!) : null);
-      final bDate =
-          b.premiereDate ??
-          (b.productionYear != null ? DateTime(b.productionYear!) : null);
-      if (aDate == null && bDate == null) {
-        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-      }
-      if (aDate == null) return 1;
-      if (bDate == null) return -1;
-      final byDate = aDate.compareTo(bDate);
-      if (byDate != 0) return byDate;
-      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  void _sortPlaylistIndex() {
+    final entries = _playlistIndexEntries;
+    if (entries == null || entries.isEmpty) return;
+    switch (_collectionSort) {
+      case CollectionSortOption.alphabetical:
+        entries.sort(
+          (a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+        );
+        _flattenedIds = entries.map((e) => e.id).toList();
+        break;
+      case CollectionSortOption.releaseAscending:
+        entries.sort(_PlaylistItemIndexEntry.compareReleaseAscending);
+        _flattenedIds = entries.map((e) => e.id).toList();
+        break;
+      case CollectionSortOption.releaseDescending:
+        entries.sort(
+          (a, b) => _PlaylistItemIndexEntry.compareReleaseAscending(b, a),
+        );
+        _flattenedIds = entries.map((e) => e.id).toList();
+        break;
+      case CollectionSortOption.custom:
+        break;
     }
+  }
 
+  void _applyCollectionSort() {
     switch (_collectionSort) {
       case CollectionSortOption.alphabetical:
         _playlistItems = List<AggregatedItem>.from(_playlistItems)
@@ -639,11 +735,11 @@ class ItemDetailViewModel extends ChangeNotifier {
         break;
       case CollectionSortOption.releaseAscending:
         _playlistItems = List<AggregatedItem>.from(_playlistItems)
-          ..sort(releaseSortAscending);
+          ..sort(_releaseSortAscending);
         break;
       case CollectionSortOption.releaseDescending:
         _playlistItems = List<AggregatedItem>.from(_playlistItems)
-          ..sort((a, b) => releaseSortAscending(b, a));
+          ..sort((a, b) => _releaseSortAscending(b, a));
         break;
       case CollectionSortOption.custom:
         _playlistItems = List<AggregatedItem>.from(_customPlaylistItems);
@@ -655,139 +751,283 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> reorderCollectionPlaylistItem(int oldIndex, int newIndex) async {
     if (oldIndex < 0 || oldIndex >= _playlistItems.length) return;
     if (newIndex < 0 || newIndex >= _playlistItems.length) return;
-    
+
     final reordered = List<AggregatedItem>.from(_playlistItems);
     final item = reordered.removeAt(oldIndex);
     reordered.insert(newIndex, item);
     _playlistItems = reordered;
     _customPlaylistItems = reordered;
     _collectionSort = CollectionSortOption.custom;
+
+    // Keep the flat ID index in sync so that any subsequent lazy-load pages
+    // respect the new order.  If not all items are loaded yet, unloaded IDs
+    // remain at the end in their previous order.
+    if (_flattenedIds != null) {
+      final reorderedIds = reordered.map((i) => i.id).toList();
+      final unloaded = _flattenedIds!.length > reorderedIds.length
+          ? _flattenedIds!.sublist(reorderedIds.length)
+          : const <String>[];
+      _flattenedIds = [...reorderedIds, ...unloaded];
+    }
+
     notifyListeners();
 
     try {
       final syncService = GetIt.instance<PluginSyncService>();
-      if (syncService.pluginAvailable) {
-        final itemIds = reordered.map((i) => i.id).toList();
-        await syncService.saveCustomCollectionOrder(_client, itemId, itemIds);
+      if (syncService.pluginAvailable && _flattenedIds != null) {
+        // Send the complete _flattenedIds list so server custom order is NOT truncated!
+        await syncService.saveCustomCollectionOrder(_client, itemId, _flattenedIds!);
       }
     } catch (_) {}
   }
 
+  /// Fetches the first page of grid items.
   Future<void> _loadCollectionItems() async {
     try {
-      // No sortBy: keep the collection's native order instead of forcing alphabetical s
-      final data = await _client.itemsApi.getItems(
-        parentId: itemId,
-        fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
-      );
-      final items = (data['Items'] as List?) ?? [];
-      _collectionItems = _mapItems(items);
-      // Render the Movies/Shows/Cast tabs as soon as the top-level items are in.
-      // The per-series episode fetch below only feeds the flattened Playlist tab
-      // and Next Up, so it should not block the collection from showing.
-      notifyListeners();
+      await _fetchCollectionPage();
+    } catch (_) {}
+  }
 
-      // Fetch each series' episodes in parallel. The list is release sorted
-      // below, so fetch order does not affect the result.
-      final list = <AggregatedItem>[];
-      final seriesChildren = <AggregatedItem>[];
-      for (final item in _collectionItems) {
-        if (item.type == 'Series') {
-          seriesChildren.add(item);
-        } else if (item.type == 'Movie' ||
-            item.type == 'Audio' ||
-            item.type == 'Video' ||
-            item.type == 'MusicVideo') {
-          list.add(item);
-        }
-      }
-      final episodeLists = await Future.wait(
-        seriesChildren.map((series) async {
-          try {
-            final epData = await _client.itemsApi.getEpisodes(series.id);
-            return _mapItems((epData['Items'] as List?) ?? []);
-          } catch (_) {
-            return const <AggregatedItem>[];
-          }
-        }),
-      );
-      for (final episodes in episodeLists) {
-        list.addAll(episodes);
-      }
-      
-      // Default to release order (ascending) sorting
-      int releaseSortAscending(AggregatedItem a, AggregatedItem b) {
-        final aDate =
-            a.premiereDate ??
-            (a.productionYear != null ? DateTime(a.productionYear!) : null);
-        final bDate =
-            b.premiereDate ??
-            (b.productionYear != null ? DateTime(b.productionYear!) : null);
-        if (aDate == null && bDate == null) {
-          return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-        }
-        if (aDate == null) return 1;
-        if (bDate == null) return -1;
-        final byDate = aDate.compareTo(bDate);
-        if (byDate != 0) return byDate;
-        return a.name.toLowerCase().compareTo(b.name.toLowerCase());
-      }
-      
-      list.sort(releaseSortAscending);
-      
-      _playlistItems = list;
-      _customPlaylistItems = List<AggregatedItem>.from(list);
-      _collectionSort = CollectionSortOption.releaseAscending;
+  /// Fetches the next page of BoxSet top-level items for the **grid**.
+  ///
+  /// Grid and playlist are now independent.  This method only updates
+  /// [_collectionItems]; playlist content is managed by [_buildPlaylistIndex]
+  /// and [_fetchPlaylistPage].
+  Future<void> _fetchCollectionPage() async {
+    final data = await _client.itemsApi.getItems(
+      parentId: itemId,
+      startIndex: _collectionFetchedCount,
+      limit: _collectionPageSize,
+      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
+    );
+    final newItems = _mapItems((data['Items'] as List?) ?? []);
+    final total = data['TotalRecordCount'] as int?;
+    if (total != null) _collectionTotalCount = total;
+    _collectionFetchedCount += newItems.length;
+    _collectionHasMore = _collectionFetchedCount < _collectionTotalCount;
+    _collectionItems = [..._collectionItems, ...newItems];
+    notifyListeners();
+  }
 
-      try {
-        final syncService = GetIt.instance<PluginSyncService>();
-        if (syncService.pluginAvailable) {
-          final customOrder = await syncService.fetchCustomCollectionOrder(_client, itemId);
+  // ---------------------------------------------------------------------------
+  // Phase 1 — flat ID index build
+  // ---------------------------------------------------------------------------
+
+  /// Builds [_flattenedIds]: a lightweight ordered list of every playable item
+  /// ID in the BoxSet (movies + individual episodes in release-date order, or
+  /// the plugin's saved custom order when Strategy B is active).
+  ///
+  /// Only IDs are retained after this phase; the full [AggregatedItem] objects
+  /// used for sorting are discarded immediately, keeping memory usage minimal
+  /// even for collections with thousands of episodes.
+  Future<void> _buildPlaylistIndex() async {
+    _playlistIndexBuilding = true;
+    notifyListeners();
+
+    try {
+      // Strategy B: plugin has a saved custom order — use it directly as the
+      // flat ID list (it already stores movie + episode IDs in story order).
+      final syncService = GetIt.instance<PluginSyncService>();
+      if (syncService.pluginAvailable) {
+        try {
+          final customOrder = await syncService.fetchCustomCollectionOrder(
+            _client,
+            itemId,
+          );
           if (customOrder != null && customOrder.isNotEmpty) {
-            final orderMap = {for (var i = 0; i < customOrder.length; i++) customOrder[i]: i};
-            list.sort((a, b) {
-              final aIndex = orderMap[a.id];
-              final bIndex = orderMap[b.id];
-              if (aIndex == null && bIndex == null) return releaseSortAscending(a, b);
-              if (aIndex == null) return 1;
-              if (bIndex == null) return -1;
-              return aIndex.compareTo(bIndex);
-            });
-            _playlistItems = list;
-            _customPlaylistItems = List<AggregatedItem>.from(list);
+            _flattenedIds = customOrder;
             _collectionSort = CollectionSortOption.custom;
           }
-        }
-      } catch (_) {}
-      
-      // Resolve Next Up item
-      if (_playlistItems.isNotEmpty) {
-        final playedAll = _playlistItems.every((item) => item.rawData['UserData']?['Played'] == true);
-        if (playedAll) {
-          _nextUp = _playlistItems.first;
-        } else {
-          _nextUp = _playlistItems.firstWhere(
-            (item) => item.rawData['UserData']?['Played'] != true,
-            orElse: () => _playlistItems.first,
-          );
-        }
-      } else {
-        _nextUp = null;
+        } catch (_) {}
       }
-      
-      notifyListeners();
+
+      // Strategy A: no custom order — build by release date.
+      if (_flattenedIds == null) {
+        // Fetch ALL top-level BoxSet items with minimal fields (just IDs +
+        // dates needed for sorting).  No limit; we only keep IDs.
+        final allData = await _client.itemsApi.getItems(
+          parentId: itemId,
+          fields: 'BasicSyncInfo',
+        );
+        final allTopLevel = _mapItems((allData['Items'] as List?) ?? []);
+
+        final seriesItems =
+            allTopLevel.where((i) => i.type == 'Series').toList();
+        final nonSeriesItems = allTopLevel
+            .where(
+              (i) =>
+                  i.type == 'Movie' ||
+                  i.type == 'Audio' ||
+                  i.type == 'Video' ||
+                  i.type == 'MusicVideo',
+            )
+            .toList();
+
+        // Expand every series to its individual episodes.  Run in parallel.
+        final episodeLists = await Future.wait(
+          seriesItems.map((series) async {
+            try {
+              final epData = await _client.itemsApi.getEpisodes(series.id);
+              return _mapItems((epData['Items'] as List?) ?? []);
+            } catch (_) {
+              return const <AggregatedItem>[];
+            }
+          }),
+        );
+
+        final flat = <AggregatedItem>[...nonSeriesItems];
+        for (final episodes in episodeLists) {
+          flat.addAll(episodes);
+        }
+        // Build lightweight index entries for memory-efficient re-sorting.
+        final entries = flat
+            .map(
+              (i) => _PlaylistItemIndexEntry(
+                id: i.id,
+                name: i.name,
+                premiereDate: i.premiereDate,
+                productionYear: i.productionYear,
+              ),
+            )
+            .toList();
+
+        // Sort movies + episodes together by release date (ascending).
+        entries.sort(_PlaylistItemIndexEntry.compareReleaseAscending);
+
+        _playlistIndexEntries = entries;
+        _flattenedIds = entries.map((e) => e.id).toList();
+        _collectionSort = CollectionSortOption.releaseAscending;
+      }
+
+      _playlistHasMore = (_flattenedIds?.isNotEmpty) ?? false;
     } catch (_) {}
+
+    _playlistIndexBuilding = false;
+    notifyListeners();
+
+    // Kick off the first playlist page now that the index is ready.
+    if ((_flattenedIds?.isNotEmpty) ?? false) {
+      await _fetchPlaylistPage();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase 3 — playlist page loading
+  // ---------------------------------------------------------------------------
+
+  /// Fetches the next batch of full item data from [_flattenedIds] and appends
+  /// it to [_playlistItems].  Re-sorts each batch to match the index order
+  /// (the server returns items by-ID in arbitrary order).
+  Future<void> _fetchPlaylistPage() async {
+    final ids = _flattenedIds;
+    if (ids == null || _playlistFetchedCount >= ids.length) return;
+
+    final end = (_playlistFetchedCount + _playlistPageSize).clamp(
+      0,
+      ids.length,
+    );
+    final batch = ids.sublist(_playlistFetchedCount, end);
+
+    final data = await _client.itemsApi.getItems(
+      ids: batch,
+      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
+    );
+    final items = _mapItems((data['Items'] as List?) ?? []);
+
+    // Re-sort to match the flattenedIds order.
+    final orderMap = {
+      for (var i = 0; i < batch.length; i++) batch[i]: i,
+    };
+    items.sort(
+      (a, b) => (orderMap[a.id] ?? 0).compareTo(orderMap[b.id] ?? 0),
+    );
+
+    _playlistFetchedCount += batch.length;
+    _playlistHasMore = _playlistFetchedCount < ids.length;
+
+    final combined = [..._playlistItems, ...items];
+    _playlistItems = combined;
+    _customPlaylistItems = List<AggregatedItem>.from(combined);
+
+    _resolveNextUp();
+    notifyListeners();
+  }
+
+  /// Resolves the Next Up item from the current [_playlistItems].
+  void _resolveNextUp() {
+    if (_playlistItems.isEmpty) {
+      _nextUp = null;
+      return;
+    }
+    final playedAll = _playlistItems.every(
+      (item) => item.rawData['UserData']?['Played'] == true,
+    );
+    if (playedAll) {
+      _nextUp = _playlistItems.first;
+    } else {
+      _nextUp = _playlistItems.firstWhere(
+        (item) => item.rawData['UserData']?['Played'] != true,
+        orElse: () => _playlistItems.first,
+      );
+    }
+  }
+
+  /// Release-ascending sort comparator used for Strategy A playlist ordering.
+  static int _releaseSortAscending(AggregatedItem a, AggregatedItem b) {
+    final aDate =
+        a.premiereDate ??
+        (a.productionYear != null ? DateTime(a.productionYear!) : null);
+    final bDate =
+        b.premiereDate ??
+        (b.productionYear != null ? DateTime(b.productionYear!) : null);
+    if (aDate == null && bDate == null) {
+      return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+    }
+    if (aDate == null) return 1;
+    if (bDate == null) return -1;
+    final byDate = aDate.compareTo(bDate);
+    if (byDate != 0) return byDate;
+    return a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  }
+
+  /// Called by the UI scroll listener to load the next grid page.
+  Future<void> loadMoreCollectionItems() async {
+    if (_collectionLoadingMore || !_collectionHasMore) return;
+    _collectionLoadingMore = true;
+    notifyListeners();
+    try {
+      await _fetchCollectionPage();
+    } catch (_) {}
+    _collectionLoadingMore = false;
+    notifyListeners();
+  }
+
+  /// Called by the UI scroll listener to load the next playlist page.
+  Future<void> loadMorePlaylistItems() async {
+    if (_playlistLoadingMore || !_playlistHasMore || _playlistIndexBuilding) {
+      return;
+    }
+    _playlistLoadingMore = true;
+    notifyListeners();
+    try {
+      await _fetchPlaylistPage();
+    } catch (_) {}
+    _playlistLoadingMore = false;
+    notifyListeners();
   }
 
   Future<void> _loadParentCollection() async {
     final item = _item;
     if (item == null) {
+      _parentCollectionItems = const [];
+      _parentCollectionName = null;
+      _parentCollections = const [];
+      notifyListeners();
       return;
     }
 
     try {
       final Map<String, String> boxSetIds = {};
-
       final ancestors = await _client.itemsApi.getAncestors(item.id);
       for (final ancestor in ancestors) {
         if (ancestor['Type'] == 'BoxSet') {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -159,6 +159,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
   late final ScrollController _scrollController = ScrollController();
+
+  // Tracks the maxScrollExtent at which we last triggered a BoxSet page load.
+  // Each unique extent can only fire one load; programmatic scroll events from
+  // content reflow after a page lands won't re-trigger until the user has
+  // actually scrolled into a new extent region.
+  double _boxSetLastTriggerMaxExtent = -1;
   String? _seriesLogoTag;
   String? _seriesLogoId;
   bool _showNavbarState = true;
@@ -546,6 +552,21 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   void _onScroll() {
     if (!mounted) return;
+
+    // Lazy-load more grid and playlist items when scrolled near the bottom of
+    // a BoxSet.  The maxScrollExtent guard prevents layout-reflow events from
+    // chaining loads without user-initiated scrolling.
+    if (_vm.item?.type == 'BoxSet' && _scrollController.hasClients) {
+      final pos = _scrollController.position;
+      final maxExtent = pos.maxScrollExtent;
+      if (pos.pixels > maxExtent - 400 &&
+          maxExtent > _boxSetLastTriggerMaxExtent) {
+        _boxSetLastTriggerMaxExtent = maxExtent;
+        _vm.loadMoreCollectionItems();
+        _vm.loadMorePlaylistItems();
+      }
+    }
+
     if (PlatformDetection.isTV) return;
     final scrolledDown = _scrollController.offset > 50.0;
     if (scrolledDown && _showNavbarState) {
@@ -559,6 +580,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   void _onViewModelChanged() {
     if (mounted) {
+      if (_vm.state == ItemDetailState.loading || _vm.playlistItems.isEmpty) {
+        _boxSetLastTriggerMaxExtent = -1;
+      }
       setState(() {});
       _loadSeriesLogo();
       _loadStudioLogos();
@@ -946,10 +970,25 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         });
 
         return [
-          if (_vm.playlistItems.isNotEmpty)
+          if (moviesList.isNotEmpty)
+            _ModernTab(l10n.movies, (context, item) => _mediaGrid(context, moviesList, firstFocusNode: _moviesFirstFocusNode)),
+          if (seriesList.isNotEmpty)
+            _ModernTab(l10n.series, (context, item) => _mediaGrid(context, seriesList, firstFocusNode: _seriesFirstFocusNode)),
+          if (hasCast) _ModernTab(l10n.castMembers, _boxSetCastTab),
+          if (hasCrew) _ModernTab(l10n.crewSection, _boxSetCrewTab),
+          if (hasStudios) studios,
+          // Show the Playlist tab while the index is building (spinner) OR
+          // once items are available (the list). Placed last so simple
+          // movie-only collections land on Movies by default.
+          if (_vm.playlistItems.isNotEmpty || _vm.playlistIndexBuilding)
             _ModernTab(
               l10n.playlist,
               (context, item) {
+                // Phase 1: flat ID index still building — show full spinner.
+                if (_vm.playlistIndexBuilding) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
                 final listWidget = DetailTrackList(
                   tracks: _vm.playlistItems,
                   imageApi: _vm.imageApi,
@@ -1012,6 +1051,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                             ),
                           ),
                           listWidget,
+                          // Phase 3: page loading footer spinner.
+                          if (_vm.playlistLoadingMore)
+                            const Padding(
+                              padding: EdgeInsets.symmetric(vertical: 16),
+                              child: Center(child: CircularProgressIndicator()),
+                            ),
                         ],
                       ),
                     ),
@@ -1019,14 +1064,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 );
               },
             ),
-          if (moviesList.isNotEmpty)
-            _ModernTab(l10n.movies, (context, item) => _mediaGrid(context, moviesList, firstFocusNode: _moviesFirstFocusNode)),
-          if (seriesList.isNotEmpty)
-            _ModernTab(l10n.series, (context, item) => _mediaGrid(context, seriesList, firstFocusNode: _seriesFirstFocusNode)),
-          if (hasCast) _ModernTab(l10n.castMembers, _boxSetCastTab),
-          if (hasCrew) _ModernTab(l10n.crewSection, _boxSetCrewTab),
-          if (hasStudios) studios,
         ];
+
       default:
         return [
           if (hasCast) cast,
@@ -4495,6 +4534,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             tabBar: tabBarWidget,
             tabContent: tabContent,
             topInset: topInset,
+            scrollController: _scrollController,
           );
   }
 }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -160,10 +160,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
   late final ScrollController _scrollController = ScrollController();
 
-  // Tracks the maxScrollExtent at which we last triggered a BoxSet page load.
-  // Each unique extent can only fire one load; programmatic scroll events from
-  // content reflow after a page lands won't re-trigger until the user has
-  // actually scrolled into a new extent region.
+  // The scroll extent the last collection page was asked for at. A page landing
+  // grows the extent, so holding the previous one stops the notifications that
+  // arrive during that reflow from asking for the same page again.
   double _boxSetLastTriggerMaxExtent = -1;
   String? _seriesLogoTag;
   String? _seriesLogoId;
@@ -553,9 +552,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   void _onScroll() {
     if (!mounted) return;
 
-    // Lazy-load more grid and playlist items when scrolled near the bottom of
-    // a BoxSet.  The maxScrollExtent guard prevents layout-reflow events from
-    // chaining loads without user-initiated scrolling.
+    // Ahead of the isTV return below, so a D-pad walk down a collection pulls
+    // the next page the same way a touch scroll does.
     if (_vm.item?.type == 'BoxSet' && _scrollController.hasClients) {
       final pos = _scrollController.position;
       final maxExtent = pos.maxScrollExtent;
@@ -580,7 +578,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   void _onViewModelChanged() {
     if (mounted) {
-      if (_vm.state == ItemDetailState.loading || _vm.playlistItems.isEmpty) {
+      // A new collection, or one whose list restarted after a sort change,
+      // needs the trigger to fire again from wherever the scroll now sits.
+      if (_vm.item?.type == 'BoxSet' &&
+          (_vm.state == ItemDetailState.loading || _vm.playlistItems.isEmpty)) {
         _boxSetLastTriggerMaxExtent = -1;
       }
       setState(() {});

--- a/lib/ui/screens/detail/modern/modern_portrait_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_portrait_layout.dart
@@ -10,6 +10,7 @@ class ModernPortraitLayout extends StatelessWidget {
   final Widget tabBar;
   final Widget tabContent;
   final double topInset;
+  final ScrollController? scrollController;
 
   const ModernPortraitLayout({
     super.key,
@@ -19,6 +20,7 @@ class ModernPortraitLayout extends StatelessWidget {
     required this.tabContent,
     required this.topInset,
     this.upNext,
+    this.scrollController,
   });
 
   @override
@@ -36,6 +38,7 @@ class ModernPortraitLayout extends StatelessWidget {
         ),
         SafeArea(
           child: SingleChildScrollView(
+            controller: scrollController,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [


### PR DESCRIPTION
# Pull Request

## Summary
Collections with thousands of items were causing OOM crashes and UI stutter on low-memory devices (Fire Stick, Google TV, budget mobile devices). This PR adds two-phase lazy loading to the BoxSet detail screen (Modern Details only).

**Phase 1** builds a lightweight flat ID index once at load time: all BoxSet top-level items are fetched with minimal fields, and every series is expanded to individual episode IDs in season/episode order. The full objects are discarded immediately, leaving only a lightweight index of a few KB even for a 1,000-episode collection.

**Phase 2 (grid)** pages BoxSet top-level items (movies + series tiles) in 50-item batches via `startIndex` pagination, driven by a scroll listener.

**Phase 3 (playlist)** pages the flat ID list in 50-item batches, fetching full item data via `getItems(ids: batch)`. Movies and episodes appear in story order in the Playlist tab; the play queue is complete once all pages load.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

### `item_detail_view_model.dart`
- Add grid pagination state: `_collectionFetchedCount`, `_collectionTotalCount`, `_collectionHasMore`, `_collectionLoadingMore`; all reset on `load()`.
- Add playlist index state: `_playlistIndexBuilding`, `_flattenedIds`, and `_playlistIndexEntries` (`_PlaylistItemIndexEntry`); reset on `load()`.
- Add playlist page state: `_playlistFetchedCount`, `_playlistHasMore`, `_playlistLoadingMore` (50 items per batch); reset on `load()`.
- `_loadSecondary()` for BoxSet spawns `_loadCollectionItems()` and `_buildPlaylistIndex()` concurrently via `Future.wait`.
- `_loadCollectionItems()` / `_fetchCollectionPage()` are grid-only; they no longer touch `_playlistItems`.
- New `_buildPlaylistIndex()`: Phase 1. Checks plugin for saved custom order (Strategy B); if none, fetches all top-level items + all episode IDs in parallel (Strategy A), sorts by release date, stores lightweight index entries and `_flattenedIds`. Kicks off `_fetchPlaylistPage()` when done.
- New `_fetchPlaylistPage()`: Slices the next 50 IDs from `_flattenedIds`, fetches full data, re-sorts to preserve index order, appends to `_playlistItems`.
- Public `loadMoreCollectionItems()` and `loadMorePlaylistItems()` with independent in-flight guards.
- `setCollectionSort()` re-sorts `_playlistIndexEntries` and updates `_flattenedIds` so future lazy-loaded pages match the active sort option (Alphabetical, Release Ascending, Release Descending).
- `reorderCollectionPlaylistItem()` syncs `_flattenedIds` and passes `_flattenedIds!` to `saveCustomCollectionOrder()` so server-side custom order for unloaded items is preserved.

### `modern_detail_content.dart` (Modern Details only)
- Add `_boxSetLastTriggerMaxExtent` field with reset on view model state load to prevent stale scroll limits.
- `_onScroll()` calls `loadMoreCollectionItems()` and `loadMorePlaylistItems()` before the `isTV` early-return so scroll triggers fire on both mobile touch and TV D-pad navigation.
- Moved Playlist tab to the end of the tab bar (`Movies → Series → Cast → Crew → Studios → Playlist`) so collections land on Movies by default.
- Playlist tab shows a full-screen `CircularProgressIndicator` during Phase 1, and a footer spinner during Phase 3 batch fetches.

### `modern_portrait_layout.dart`
- Passed `scrollController: scrollController` to `SingleChildScrollView` so portrait mode on mobile touch screens fires scroll triggers properly.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open any BoxSet collection detail screen.
2. Scroll to the bottom — a `CircularProgressIndicator` should briefly appear and the next 100 items load.
3. Confirm collections with a mix of movies and series (e.g. a franchise collection containing a TV show) still show all episodes in the Playlist tab.
4. Confirm collections with a custom drag-and-drop sort order retain that order across page loads.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
