### PR TITLE
bugfix-subs - Harden cross-episode subtitle and audio stream persistence for TV series

### DIFF
--- a/lib/data/models/series_track_preference.dart
+++ b/lib/data/models/series_track_preference.dart
@@ -1,0 +1,61 @@
+import 'dart:convert';
+
+class SeriesTrackPreference {
+  final String language;
+  final String title;
+  final int relativeIndex;
+  final int? streamIndex;
+
+  const SeriesTrackPreference({
+    required this.language,
+    this.title = '',
+    this.relativeIndex = 0,
+    this.streamIndex,
+  });
+
+  static const empty = SeriesTrackPreference(language: '');
+  static const none = SeriesTrackPreference(language: 'none');
+
+  bool get isNone => language.toLowerCase() == 'none';
+  bool get isEmpty => language.isEmpty;
+  bool get isNotEmpty => language.isNotEmpty;
+
+  Map<String, dynamic> toJson() => {
+        'language': language,
+        'title': title,
+        'relativeIndex': relativeIndex,
+        if (streamIndex != null) 'streamIndex': streamIndex,
+      };
+
+  factory SeriesTrackPreference.fromJson(Map<String, dynamic> json) {
+    return SeriesTrackPreference(
+      language: json['language'] as String? ?? '',
+      title: json['title'] as String? ?? '',
+      relativeIndex: json['relativeIndex'] as int? ?? 0,
+      streamIndex: json['streamIndex'] as int?,
+    );
+  }
+
+  factory SeriesTrackPreference.fromRawString(String raw) {
+    final trimmed = raw.trim();
+    if (trimmed.isEmpty) return empty;
+    if (trimmed == 'none') return none;
+    if (trimmed.startsWith('{')) {
+      try {
+        final decoded = jsonDecode(trimmed) as Map<String, dynamic>;
+        return SeriesTrackPreference.fromJson(decoded);
+      } catch (_) {}
+    }
+    return SeriesTrackPreference(language: trimmed);
+  }
+
+  String toRawString() {
+    if (isEmpty) return '';
+    if (isNone) return 'none';
+    return jsonEncode(toJson());
+  }
+
+  @override
+  String toString() =>
+      'SeriesTrackPreference(language: $language, title: $title, relativeIndex: $relativeIndex, streamIndex: $streamIndex)';
+}

--- a/lib/data/models/series_track_preference.dart
+++ b/lib/data/models/series_track_preference.dart
@@ -4,27 +4,27 @@ class SeriesTrackPreference {
   final String language;
   final String title;
   final int relativeIndex;
-  final int? streamIndex;
 
   const SeriesTrackPreference({
     required this.language,
     this.title = '',
     this.relativeIndex = 0,
-    this.streamIndex,
   });
 
   static const empty = SeriesTrackPreference(language: '');
   static const none = SeriesTrackPreference(language: 'none');
 
   bool get isNone => language.toLowerCase() == 'none';
-  bool get isEmpty => language.isEmpty;
-  bool get isNotEmpty => language.isNotEmpty;
+
+  /// Nothing to match a track on. Plenty of tracks carry no language tag,
+  /// forced and SDH ones especially, so a title alone still counts.
+  bool get isEmpty => language.isEmpty && title.isEmpty;
+  bool get isNotEmpty => !isEmpty;
 
   Map<String, dynamic> toJson() => {
         'language': language,
         'title': title,
         'relativeIndex': relativeIndex,
-        if (streamIndex != null) 'streamIndex': streamIndex,
       };
 
   factory SeriesTrackPreference.fromJson(Map<String, dynamic> json) {
@@ -32,7 +32,6 @@ class SeriesTrackPreference {
       language: json['language'] as String? ?? '',
       title: json['title'] as String? ?? '',
       relativeIndex: json['relativeIndex'] as int? ?? 0,
-      streamIndex: json['streamIndex'] as int?,
     );
   }
 
@@ -57,5 +56,6 @@ class SeriesTrackPreference {
 
   @override
   String toString() =>
-      'SeriesTrackPreference(language: $language, title: $title, relativeIndex: $relativeIndex, streamIndex: $streamIndex)';
+      'SeriesTrackPreference(language: $language, title: $title, '
+      'relativeIndex: $relativeIndex)';
 }

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -7,7 +7,6 @@ import 'package:server_core/server_core.dart';
 import '../../data/models/aggregated_item.dart';
 import '../../data/models/series_track_preference.dart';
 import '../../data/repositories/offline_repository.dart';
-import '../../util/subtitle_track_logic.dart';
 import '../../data/services/audiobook_bookmarks_service.dart';
 import '../../data/services/audiobook_notes_service.dart';
 import '../../data/services/audiobook_resume_service.dart';
@@ -400,43 +399,57 @@ void registerPlaybackModule() {
   _getIt.registerSingleton<PlayerBackend>(initialBackend);
 
   final manager = PlaybackManager();
-  manager.onSubtitleTrackChanged = (itemId, index) {
-    _getIt<UserPreferences>().setItemSubtitleStreamIndex(itemId, index);
-    final currentItem = manager.queueService.currentItem;
-    if (currentItem is AggregatedItem &&
-        currentItem.seriesId != null &&
-        currentItem.seriesId!.isNotEmpty) {
-      final rawStreams = currentItem.rawData['MediaStreams'] as List? ?? [];
-      final maps = rawStreams
+
+  // The streams of one kind belonging to whatever is playing, or null when
+  // that isn't an episode and so has no series to remember a choice for.
+  ({String seriesId, List<Map<String, dynamic>> streams})? seriesStreams(
+    String kind,
+  ) {
+    final item = manager.queueService.currentItem;
+    if (item is! AggregatedItem) return null;
+    final seriesId = item.seriesId;
+    if (seriesId == null || seriesId.isEmpty) return null;
+    final raw = item.rawData['MediaStreams'] as List? ?? const [];
+    return (
+      seriesId: seriesId,
+      streams: raw
           .whereType<Map>()
           .map((e) => e.cast<String, dynamic>())
-          .where((s) => (s['Type'] as String?)?.toLowerCase() == 'subtitle')
-          .toList();
-      final pref = createSeriesTrackPreferenceFromStream(
-        streams: maps,
-        selectedIndex: index,
-      );
-      _getIt<UserPreferences>().setSeriesSubtitlePreference(currentItem.seriesId!, pref);
-    }
+          .where((s) => (s['Type'] as String?)?.toLowerCase() == kind)
+          .toList(),
+    );
+  }
+
+  manager.onSubtitleTrackChanged = (itemId, index) {
+    _getIt<UserPreferences>().setItemSubtitleStreamIndex(itemId, index);
   };
   manager.onAudioTrackChanged = (itemId, index) {
     _getIt<UserPreferences>().setItemAudioStreamIndex(itemId, index);
-    final currentItem = manager.queueService.currentItem;
-    if (currentItem is AggregatedItem &&
-        currentItem.seriesId != null &&
-        currentItem.seriesId!.isNotEmpty) {
-      final rawStreams = currentItem.rawData['MediaStreams'] as List? ?? [];
-      final maps = rawStreams
-          .whereType<Map>()
-          .map((e) => e.cast<String, dynamic>())
-          .where((s) => (s['Type'] as String?)?.toLowerCase() == 'audio')
-          .toList();
-      final pref = createSeriesTrackPreferenceFromStream(
-        streams: maps,
-        selectedIndex: index,
-      );
-      _getIt<UserPreferences>().setSeriesAudioPreference(currentItem.seriesId!, pref);
-    }
+  };
+
+  // This choice carries to the next episode, so it takes the selected signal
+  // rather than the changed ones above, which also fire without the viewer.
+  manager.onSubtitleTrackSelected = (itemId, index) {
+    final series = seriesStreams('subtitle');
+    if (series == null) return;
+    final pref = createSeriesTrackPreferenceFromStream(
+      streams: series.streams,
+      selectedIndex: index,
+    );
+    // A track the item doesn't list, an external one added mid playback say,
+    // leaves nothing to recognise it by later, so the last choice stays.
+    if (pref.isEmpty) return;
+    _getIt<UserPreferences>().setSeriesSubtitlePreference(series.seriesId, pref);
+  };
+  manager.onAudioTrackSelected = (itemId, index) {
+    final series = seriesStreams('audio');
+    if (series == null) return;
+    final pref = createSeriesTrackPreferenceFromStream(
+      streams: series.streams,
+      selectedIndex: index,
+    );
+    if (pref.isEmpty) return;
+    _getIt<UserPreferences>().setSeriesAudioPreference(series.seriesId, pref);
   };
 
   manager.setBackend(initialBackend);
@@ -614,17 +627,16 @@ void registerPlaybackModule() {
       seriesId = currentItem.seriesId;
     }
 
-    if (seriesId != null && seriesId.isNotEmpty) {
-      final seriesSubPref = prefs.getSeriesSubtitlePreference(seriesId);
-      if (seriesSubPref.isNone) {
-        return -1;
-      } else if (seriesSubPref.isNotEmpty) {
-        final matchedIndex = matchSeriesTrackIndex(
-          streams: subtitleStreams,
-          pref: seriesSubPref,
-        );
-        if (matchedIndex != null) return matchedIndex;
-      }
+    final seriesSubPref = seriesId != null && seriesId.isNotEmpty
+        ? prefs.getSeriesSubtitlePreference(seriesId)
+        : SeriesTrackPreference.empty;
+    if (seriesSubPref.isNone) return -1;
+    if (seriesSubPref.isNotEmpty) {
+      final matchedIndex = matchSeriesTrackIndex(
+        streams: subtitleStreams,
+        pref: seriesSubPref,
+      );
+      if (matchedIndex != null) return matchedIndex;
     }
 
     final effectiveAudioIndex = computeEffectiveAudioIndex(
@@ -650,15 +662,13 @@ void registerPlaybackModule() {
         : prefs.get(UserPreferences.subtitleMode);
 
     var preferredLanguage = manager.lastExplicitSubtitleLanguage;
-    if (preferredLanguage == null && seriesId != null && seriesId.isNotEmpty) {
-      final seriesLanguage = prefs.getSeriesSubtitleLanguage(seriesId);
-      if (seriesLanguage == 'none') {
-        return -1;
-      } else if (seriesLanguage.isNotEmpty) {
-        preferredLanguage = seriesLanguage;
-        if (subtitleMode == SubtitleMode.none) {
-          subtitleMode = SubtitleMode.always;
-        }
+    // No track in this episode carries the remembered one, so fall back to its
+    // language and make sure subtitles are on to show it. A remembered track
+    // with no language tag has nothing to fall back to.
+    if (preferredLanguage == null && seriesSubPref.language.isNotEmpty) {
+      preferredLanguage = seriesSubPref.language;
+      if (subtitleMode == SubtitleMode.none) {
+        subtitleMode = SubtitleMode.always;
       }
     }
 
@@ -667,7 +677,7 @@ void registerPlaybackModule() {
 
     return computeEffectiveSubtitleIndex(
       subtitleStreams: subtitleStreams,
-      selectedSubtitleIndex: explicitIndex,
+      selectedSubtitleIndex: null,
       activePlaybackSubtitleIndex: null,
       subtitleMode: subtitleMode,
       preferredLanguage: preferredLanguage,

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -5,7 +5,9 @@ import 'package:playback_emby/playback_emby.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../data/models/aggregated_item.dart';
+import '../../data/models/series_track_preference.dart';
 import '../../data/repositories/offline_repository.dart';
+import '../../util/subtitle_track_logic.dart';
 import '../../data/services/audiobook_bookmarks_service.dart';
 import '../../data/services/audiobook_notes_service.dart';
 import '../../data/services/audiobook_resume_service.dart';
@@ -400,9 +402,41 @@ void registerPlaybackModule() {
   final manager = PlaybackManager();
   manager.onSubtitleTrackChanged = (itemId, index) {
     _getIt<UserPreferences>().setItemSubtitleStreamIndex(itemId, index);
+    final currentItem = manager.queueService.currentItem;
+    if (currentItem is AggregatedItem &&
+        currentItem.seriesId != null &&
+        currentItem.seriesId!.isNotEmpty) {
+      final rawStreams = currentItem.rawData['MediaStreams'] as List? ?? [];
+      final maps = rawStreams
+          .whereType<Map>()
+          .map((e) => e.cast<String, dynamic>())
+          .where((s) => (s['Type'] as String?)?.toLowerCase() == 'subtitle')
+          .toList();
+      final pref = createSeriesTrackPreferenceFromStream(
+        streams: maps,
+        selectedIndex: index,
+      );
+      _getIt<UserPreferences>().setSeriesSubtitlePreference(currentItem.seriesId!, pref);
+    }
   };
   manager.onAudioTrackChanged = (itemId, index) {
     _getIt<UserPreferences>().setItemAudioStreamIndex(itemId, index);
+    final currentItem = manager.queueService.currentItem;
+    if (currentItem is AggregatedItem &&
+        currentItem.seriesId != null &&
+        currentItem.seriesId!.isNotEmpty) {
+      final rawStreams = currentItem.rawData['MediaStreams'] as List? ?? [];
+      final maps = rawStreams
+          .whereType<Map>()
+          .map((e) => e.cast<String, dynamic>())
+          .where((s) => (s['Type'] as String?)?.toLowerCase() == 'audio')
+          .toList();
+      final pref = createSeriesTrackPreferenceFromStream(
+        streams: maps,
+        selectedIndex: index,
+      );
+      _getIt<UserPreferences>().setSeriesAudioPreference(currentItem.seriesId!, pref);
+    }
   };
 
   manager.setBackend(initialBackend);
@@ -540,6 +574,22 @@ void registerPlaybackModule() {
   _getIt.registerSingleton<PlaybackArbiter>(audioArbiter);
   manager.setAudioArbiter(audioArbiter);
   manager.audioTrackSelector = (audioStreams, explicitIndex) {
+    if (explicitIndex != null) return explicitIndex;
+
+    final currentItem = manager.queueService.currentItem;
+    if (currentItem is AggregatedItem &&
+        currentItem.seriesId != null &&
+        currentItem.seriesId!.isNotEmpty) {
+      final seriesAudioPref = prefs.getSeriesAudioPreference(currentItem.seriesId!);
+      if (seriesAudioPref.isNotEmpty) {
+        final matchedIndex = matchSeriesTrackIndex(
+          streams: audioStreams,
+          pref: seriesAudioPref,
+        );
+        if (matchedIndex != null) return matchedIndex;
+      }
+    }
+
     final preferredAudioLanguage = manager.lastExplicitAudioLanguage ??
         (prefs.get(UserPreferences.defaultAudioLanguage) as String? ?? 'auto');
 
@@ -556,6 +606,27 @@ void registerPlaybackModule() {
   };
 
   manager.subtitleTrackSelector = (subtitleStreams, audioStreams, explicitIndex) {
+    if (explicitIndex != null) return explicitIndex;
+
+    final currentItem = manager.queueService.currentItem;
+    String? seriesId;
+    if (currentItem is AggregatedItem) {
+      seriesId = currentItem.seriesId;
+    }
+
+    if (seriesId != null && seriesId.isNotEmpty) {
+      final seriesSubPref = prefs.getSeriesSubtitlePreference(seriesId);
+      if (seriesSubPref.isNone) {
+        return -1;
+      } else if (seriesSubPref.isNotEmpty) {
+        final matchedIndex = matchSeriesTrackIndex(
+          streams: subtitleStreams,
+          pref: seriesSubPref,
+        );
+        if (matchedIndex != null) return matchedIndex;
+      }
+    }
+
     final effectiveAudioIndex = computeEffectiveAudioIndex(
       audioStreams: audioStreams,
       preferredAudioLanguage: manager.lastExplicitAudioLanguage ??
@@ -573,12 +644,6 @@ void registerPlaybackModule() {
       orElse: () => const <String, dynamic>{},
     );
     final activeAudioLanguage = activeAudioStream.isNotEmpty ? activeAudioStream['Language'] as String? : null;
-
-    final currentItem = manager.queueService.currentItem;
-    String? seriesId;
-    if (currentItem is AggregatedItem) {
-      seriesId = currentItem.seriesId;
-    }
 
     var subtitleMode = manager.lastExplicitSubtitleEnabled == false
         ? SubtitleMode.none

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -6,6 +6,7 @@ import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart' hide ImageType;
 
 import '../data/models/aggregated_item.dart';
+import '../data/models/series_track_preference.dart';
 import '../playback/audio_capability_profile.dart';
 import '../util/idiom/app_ui_idiom.dart';
 import '../util/insecure_certificates.dart';
@@ -2507,21 +2508,48 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: false,
   );
 
-  String getSeriesSubtitleLanguage(String seriesId) {
+  SeriesTrackPreference getSeriesSubtitlePreference(String seriesId) {
     final pref = Preference(
       key: 'pref_series_subtitle_lang_$seriesId',
       defaultValue: '',
     );
-    return _store.get(pref);
+    final raw = _store.get(pref);
+    return SeriesTrackPreference.fromRawString(raw);
+  }
+
+  Future<void> setSeriesSubtitlePreference(String seriesId, SeriesTrackPreference pref) async {
+    final key = Preference(
+      key: 'pref_series_subtitle_lang_$seriesId',
+      defaultValue: '',
+    );
+    await _store.set(key, pref.toRawString());
+    notifyListeners();
+  }
+
+  SeriesTrackPreference getSeriesAudioPreference(String seriesId) {
+    final pref = Preference(
+      key: 'pref_series_audio_lang_$seriesId',
+      defaultValue: '',
+    );
+    final raw = _store.get(pref);
+    return SeriesTrackPreference.fromRawString(raw);
+  }
+
+  Future<void> setSeriesAudioPreference(String seriesId, SeriesTrackPreference pref) async {
+    final key = Preference(
+      key: 'pref_series_audio_lang_$seriesId',
+      defaultValue: '',
+    );
+    await _store.set(key, pref.toRawString());
+    notifyListeners();
+  }
+
+  String getSeriesSubtitleLanguage(String seriesId) {
+    return getSeriesSubtitlePreference(seriesId).language;
   }
 
   Future<void> setSeriesSubtitleLanguage(String seriesId, String language) async {
-    final pref = Preference(
-      key: 'pref_series_subtitle_lang_$seriesId',
-      defaultValue: '',
-    );
-    await _store.set(pref, language);
-    notifyListeners();
+    await setSeriesSubtitlePreference(seriesId, SeriesTrackPreference(language: language));
   }
 
   int getItemSubtitleStreamIndex(String itemId) {

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -2544,14 +2544,6 @@ class UserPreferences extends ChangeNotifier {
     notifyListeners();
   }
 
-  String getSeriesSubtitleLanguage(String seriesId) {
-    return getSeriesSubtitlePreference(seriesId).language;
-  }
-
-  Future<void> setSeriesSubtitleLanguage(String seriesId, String language) async {
-    await setSeriesSubtitlePreference(seriesId, SeriesTrackPreference(language: language));
-  }
-
   int getItemSubtitleStreamIndex(String itemId) {
     final pref = Preference<int>(
       key: 'pref_item_subtitle_index_$itemId',

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -38,7 +38,6 @@ import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/preference_constants.dart';
-import '../../../util/subtitle_track_logic.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../ui/mixins/focus_state_mixin.dart';
@@ -6929,7 +6928,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       activeAudioLanguage = activeAudioStream['Language'] as String?;
     }
 
-    if (_selectedSubtitleIndex != null) return _selectedSubtitleIndex;
+    // Only for the item on screen. Callers naming a different episode want it
+    // resolved against that episode's own streams, where an index picked here
+    // means nothing.
+    if (item == null && _selectedSubtitleIndex != null) {
+      return _selectedSubtitleIndex;
+    }
 
     final targetItem = item ?? widget.viewModel.item;
     var preferredLanguage = prefs.get(UserPreferences.defaultSubtitleLanguage);

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -38,6 +38,7 @@ import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/preference_constants.dart';
+import '../../../util/subtitle_track_logic.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../preference/seerr_preferences.dart';
 import '../../../ui/mixins/focus_state_mixin.dart';
@@ -6928,6 +6929,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       activeAudioLanguage = activeAudioStream['Language'] as String?;
     }
 
+    if (_selectedSubtitleIndex != null) return _selectedSubtitleIndex;
+
     final targetItem = item ?? widget.viewModel.item;
     var preferredLanguage = prefs.get(UserPreferences.defaultSubtitleLanguage);
     var subtitleMode = prefs.get(UserPreferences.subtitleMode);
@@ -6935,14 +6938,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (targetItem != null) {
       final seriesId = targetItem.seriesId;
       if (seriesId != null && seriesId.isNotEmpty) {
-        final seriesLanguage = prefs.getSeriesSubtitleLanguage(seriesId);
-        if (seriesLanguage == 'none') {
+        final seriesSubPref = prefs.getSeriesSubtitlePreference(seriesId);
+        if (seriesSubPref.isNone) {
           return -1;
-        } else if (seriesLanguage.isNotEmpty) {
-          preferredLanguage = seriesLanguage;
-          if (subtitleMode == SubtitleMode.none) {
-            subtitleMode = SubtitleMode.always;
-          }
+        } else if (seriesSubPref.isNotEmpty) {
+          final matchedIndex = matchSeriesTrackIndex(
+            streams: subtitleStreams,
+            pref: seriesSubPref,
+          );
+          if (matchedIndex != null) return matchedIndex;
         }
       }
     }
@@ -8856,14 +8860,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if (streamIndex != null) {
         setState(() => _selectedSubtitleIndex = streamIndex);
         if (item.type == 'Episode' && item.seriesId != null) {
-          final selectedStream = streams.firstWhere(
-            (s) => s['Index'] == streamIndex,
-            orElse: () => <String, dynamic>{},
+          final pref = createSeriesTrackPreferenceFromStream(
+            streams: streams,
+            selectedIndex: streamIndex,
           );
-          final language = selectedStream.isEmpty
-              ? 'none'
-              : (selectedStream['Language'] as String? ?? '');
-          await prefs.setSeriesSubtitleLanguage(item.seriesId!, language);
+          await prefs.setSeriesSubtitlePreference(item.seriesId!, pref);
         }
       }
     }

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3590,7 +3590,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     if (!mounted || !_subtitleActive) return;
     final idx = _manager.subtitleStreamIndex;
     if (idx == null || idx < 0) return;
-    unawaited(_manager.changeSubtitleTrack(idx));
+    unawaited(_manager.changeSubtitleTrack(idx, userInitiated: false));
     if (_subtitleReapplyRetryScheduled || _state.duration > Duration.zero) {
       return;
     }
@@ -3603,7 +3603,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         }
         final retryIdx = _manager.subtitleStreamIndex;
         if (retryIdx == null || retryIdx < 0) return;
-        await _manager.changeSubtitleTrack(retryIdx);
+        await _manager.changeSubtitleTrack(retryIdx, userInitiated: false);
       }),
     );
   }

--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -1,4 +1,5 @@
 import 'dart:ui' as ui;
+import '../data/models/series_track_preference.dart';
 import '../preference/preference_constants.dart';
 import 'language_matching.dart';
 
@@ -319,4 +320,101 @@ int? mapSubtitleResultToStreamIndex(
     return displayStreams[streamPosition]['Index'] as int?;
   }
   return null;
+}
+
+int? matchSeriesTrackIndex({
+  required List<Map<String, dynamic>> streams,
+  required SeriesTrackPreference pref,
+}) {
+  if (pref.isEmpty) return null;
+  if (pref.isNone) return -1;
+
+  final matchingStreams = <Map<String, dynamic>>[];
+  for (final stream in streams) {
+    if (stream['Index'] == null) continue;
+    final lang = stream['Language'] as String? ?? '';
+    final normPref = normalizeLanguage(pref.language);
+    final iso3Pref = toIso3Language(normPref);
+
+    if (languageMatchesPreferred(lang, normPref, iso3Pref)) {
+      matchingStreams.add(stream);
+    }
+  }
+
+  if (matchingStreams.isEmpty) return null;
+
+  // 1. Try exact title match first (e.g., "Signs & Songs" or "SDH")
+  if (pref.title.trim().isNotEmpty) {
+    final targetTitle = pref.title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim().toLowerCase();
+    for (final stream in matchingStreams) {
+      final streamTitle = ((stream['Title'] ?? stream['DisplayTitle'] ?? stream['Name']) as String? ?? '')
+          .replaceAll(RegExp(r'^\d+\s*-\s*'), '')
+          .trim()
+          .toLowerCase();
+      if (streamTitle.isNotEmpty && streamTitle == targetTitle) {
+        return stream['Index'] as int?;
+      }
+    }
+  }
+
+  // 2. Try relative index match (N-th track of that language in container order)
+  if (pref.relativeIndex >= 0 && pref.relativeIndex < matchingStreams.length) {
+    return matchingStreams[pref.relativeIndex]['Index'] as int?;
+  }
+
+  // 3. Fallback to substring title match
+  if (pref.title.trim().isNotEmpty) {
+    final targetTitle = pref.title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim().toLowerCase();
+    for (final stream in matchingStreams) {
+      final streamTitle = ((stream['Title'] ?? stream['DisplayTitle'] ?? stream['Name']) as String? ?? '')
+          .replaceAll(RegExp(r'^\d+\s*-\s*'), '')
+          .trim()
+          .toLowerCase();
+      if (streamTitle.isNotEmpty &&
+          (streamTitle.contains(targetTitle) || targetTitle.contains(streamTitle))) {
+        return stream['Index'] as int?;
+      }
+    }
+  }
+
+  // 4. Fallback to first matching stream of that language
+  return matchingStreams.first['Index'] as int?;
+}
+
+SeriesTrackPreference createSeriesTrackPreferenceFromStream({
+  required List<Map<String, dynamic>> streams,
+  required int? selectedIndex,
+}) {
+  if (selectedIndex == null) return SeriesTrackPreference.empty;
+  if (selectedIndex == -1) return SeriesTrackPreference.none;
+
+  final selectedStream = streams.firstWhere(
+    (s) => s['Index'] == selectedIndex,
+    orElse: () => <String, dynamic>{},
+  );
+
+  if (selectedStream.isEmpty) return SeriesTrackPreference.empty;
+
+  final language = selectedStream['Language'] as String? ?? '';
+  String title = ((selectedStream['Title'] ?? selectedStream['DisplayTitle'] ?? selectedStream['Name']) as String? ?? '').trim();
+  title = title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim();
+
+  int relativeIndex = 0;
+  final normLang = normalizeLanguage(language);
+  final iso3Lang = toIso3Language(normLang);
+
+  for (final stream in streams) {
+    if (stream['Index'] == selectedIndex) break;
+    final l = stream['Language'] as String? ?? '';
+    if (languageMatchesPreferred(l, normLang, iso3Lang)) {
+      relativeIndex++;
+    }
+  }
+
+  return SeriesTrackPreference(
+    language: language,
+    title: title,
+    relativeIndex: relativeIndex,
+    streamIndex: selectedIndex,
+  );
 }

--- a/lib/util/subtitle_track_logic.dart
+++ b/lib/util/subtitle_track_logic.dart
@@ -322,6 +322,23 @@ int? mapSubtitleResultToStreamIndex(
   return null;
 }
 
+/// Leading track numbers vary between files, so they are dropped before two
+/// titles are compared.
+final _trackNumberPrefix = RegExp(r'^\d+\s*-\s*');
+
+String _normalizedTitle(String raw) =>
+    raw.replaceAll(_trackNumberPrefix, '').trim().toLowerCase();
+
+String _normalizedStreamTitle(Map<String, dynamic> stream) => _normalizedTitle(
+  (stream['Title'] ?? stream['DisplayTitle'] ?? stream['Name']) as String? ?? '',
+);
+
+/// The stream in [streams] that best answers a remembered choice, or null when
+/// none of them can be it.
+///
+/// The title comes first because it survives files listing their tracks in a
+/// different order, then the position among same-language tracks, then a looser
+/// title match for releases that word the same track slightly differently.
 int? matchSeriesTrackIndex({
   required List<Map<String, dynamic>> streams,
   required SeriesTrackPreference pref,
@@ -329,56 +346,59 @@ int? matchSeriesTrackIndex({
   if (pref.isEmpty) return null;
   if (pref.isNone) return -1;
 
-  final matchingStreams = <Map<String, dynamic>>[];
-  for (final stream in streams) {
-    if (stream['Index'] == null) continue;
-    final lang = stream['Language'] as String? ?? '';
-    final normPref = normalizeLanguage(pref.language);
-    final iso3Pref = toIso3Language(normPref);
+  final targetTitle = _normalizedTitle(pref.title);
 
-    if (languageMatchesPreferred(lang, normPref, iso3Pref)) {
-      matchingStreams.add(stream);
-    }
+  // An untagged track leaves only its title to go on. Falling back to position
+  // there would hand back some unrelated track, so it matches or it doesn't.
+  if (pref.language.isEmpty) {
+    final candidates = streams.where((s) => s['Index'] != null);
+    return _titleMatch(candidates, targetTitle, loose: false) ??
+        _titleMatch(candidates, targetTitle);
   }
 
+  final normPref = normalizeLanguage(pref.language);
+  final iso3Pref = toIso3Language(normPref);
+  final matchingStreams = streams
+      .where((s) => s['Index'] != null)
+      .where(
+        (s) => languageMatchesPreferred(
+          s['Language'] as String? ?? '',
+          normPref,
+          iso3Pref,
+        ),
+      )
+      .toList();
   if (matchingStreams.isEmpty) return null;
 
-  // 1. Try exact title match first (e.g., "Signs & Songs" or "SDH")
-  if (pref.title.trim().isNotEmpty) {
-    final targetTitle = pref.title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim().toLowerCase();
-    for (final stream in matchingStreams) {
-      final streamTitle = ((stream['Title'] ?? stream['DisplayTitle'] ?? stream['Name']) as String? ?? '')
-          .replaceAll(RegExp(r'^\d+\s*-\s*'), '')
-          .trim()
-          .toLowerCase();
-      if (streamTitle.isNotEmpty && streamTitle == targetTitle) {
-        return stream['Index'] as int?;
-      }
-    }
-  }
+  final exact = _titleMatch(matchingStreams, targetTitle, loose: false);
+  if (exact != null) return exact;
 
-  // 2. Try relative index match (N-th track of that language in container order)
   if (pref.relativeIndex >= 0 && pref.relativeIndex < matchingStreams.length) {
     return matchingStreams[pref.relativeIndex]['Index'] as int?;
   }
 
-  // 3. Fallback to substring title match
-  if (pref.title.trim().isNotEmpty) {
-    final targetTitle = pref.title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim().toLowerCase();
-    for (final stream in matchingStreams) {
-      final streamTitle = ((stream['Title'] ?? stream['DisplayTitle'] ?? stream['Name']) as String? ?? '')
-          .replaceAll(RegExp(r'^\d+\s*-\s*'), '')
-          .trim()
-          .toLowerCase();
-      if (streamTitle.isNotEmpty &&
-          (streamTitle.contains(targetTitle) || targetTitle.contains(streamTitle))) {
-        return stream['Index'] as int?;
-      }
-    }
-  }
+  return _titleMatch(matchingStreams, targetTitle) ??
+      matchingStreams.first['Index'] as int?;
+}
 
-  // 4. Fallback to first matching stream of that language
-  return matchingStreams.first['Index'] as int?;
+/// The first stream whose title reads as [targetTitle], or null. A [loose]
+/// match also accepts one title containing the other, for releases that word
+/// the same track slightly differently.
+int? _titleMatch(
+  Iterable<Map<String, dynamic>> streams,
+  String targetTitle, {
+  bool loose = true,
+}) {
+  if (targetTitle.isEmpty) return null;
+  for (final stream in streams) {
+    final streamTitle = _normalizedStreamTitle(stream);
+    if (streamTitle.isEmpty) continue;
+    final hit = loose
+        ? streamTitle.contains(targetTitle) || targetTitle.contains(streamTitle)
+        : streamTitle == targetTitle;
+    if (hit) return stream['Index'] as int?;
+  }
+  return null;
 }
 
 SeriesTrackPreference createSeriesTrackPreferenceFromStream({
@@ -396,8 +416,7 @@ SeriesTrackPreference createSeriesTrackPreferenceFromStream({
   if (selectedStream.isEmpty) return SeriesTrackPreference.empty;
 
   final language = selectedStream['Language'] as String? ?? '';
-  String title = ((selectedStream['Title'] ?? selectedStream['DisplayTitle'] ?? selectedStream['Name']) as String? ?? '').trim();
-  title = title.replaceAll(RegExp(r'^\d+\s*-\s*'), '').trim();
+  final title = _normalizedStreamTitle(selectedStream);
 
   int relativeIndex = 0;
   final normLang = normalizeLanguage(language);
@@ -415,6 +434,5 @@ SeriesTrackPreference createSeriesTrackPreferenceFromStream({
     language: language,
     title: title,
     relativeIndex: relativeIndex,
-    streamIndex: selectedIndex,
   );
 }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -123,6 +123,13 @@ class PlaybackManager implements AudioOwnable {
   void Function(String itemId, int? subtitleStreamIndex)? onSubtitleTrackChanged;
   void Function(String itemId, int? audioStreamIndex)? onAudioTrackChanged;
 
+  /// Fired only when the viewer picks a track, unlike the changed callbacks
+  /// above which also report the automatic pick for a new item and the reset
+  /// when one finishes. The index arrives raw, so -1 still reads as subtitles
+  /// off rather than as no choice at all.
+  void Function(String itemId, int subtitleStreamIndex)? onSubtitleTrackSelected;
+  void Function(String itemId, int audioStreamIndex)? onAudioTrackSelected;
+
   Stream<PlaybackBringupState> get bringupStateStream =>
       _bringupStateController.stream;
   Stream<void> get sessionEndedStream => _sessionEndedController.stream;
@@ -1770,7 +1777,10 @@ class PlaybackManager implements AudioOwnable {
     }
   }
 
-  Future<void> changeAudioTrack(int streamIndex) => _withProgressPaused(() async {
+  Future<void> changeAudioTrack(
+    int streamIndex, {
+    bool userInitiated = true,
+  }) => _withProgressPaused(() async {
     _audioStreamIndex = streamIndex;
     _audioSelectionExplicit = true;
 
@@ -1778,6 +1788,7 @@ class PlaybackManager implements AudioOwnable {
     if (currentItem != null) {
       final itemId = MediaStreamResolver.extractItemId(currentItem);
       onAudioTrackChanged?.call(itemId, streamIndex >= 0 ? streamIndex : null);
+      if (userInitiated) onAudioTrackSelected?.call(itemId, streamIndex);
     }
 
     final streams = _currentMediaStreams;
@@ -1953,10 +1964,19 @@ class PlaybackManager implements AudioOwnable {
     _subtitleRendererMode = SubtitleRendererMode.native;
   }
 
-  Future<void> changeSubtitleTrack(int streamIndex) =>
-      _withProgressPaused(() => _changeSubtitleTrackInner(streamIndex));
+  /// Pass `userInitiated: false` when reapplying the track already playing, so
+  /// it isn't mistaken for the viewer choosing it.
+  Future<void> changeSubtitleTrack(
+    int streamIndex, {
+    bool userInitiated = true,
+  }) => _withProgressPaused(
+    () => _changeSubtitleTrackInner(streamIndex, userInitiated: userInitiated),
+  );
 
-  Future<void> _changeSubtitleTrackInner(int streamIndex) async {
+  Future<void> _changeSubtitleTrackInner(
+    int streamIndex, {
+    bool userInitiated = true,
+  }) async {
     final previousSubtitleStreamIndex = _subtitleStreamIndex;
     final isBitmap = _isSubtitleBitmap(streamIndex);
     _subtitleStreamIndex = streamIndex;
@@ -1965,6 +1985,7 @@ class PlaybackManager implements AudioOwnable {
     if (currentItem != null) {
       final itemId = MediaStreamResolver.extractItemId(currentItem);
       onSubtitleTrackChanged?.call(itemId, streamIndex >= 0 ? streamIndex : null);
+      if (userInitiated) onSubtitleTrackSelected?.call(itemId, streamIndex);
     }
 
     _subtitleSelectionExplicit = streamIndex >= 0;
@@ -2069,6 +2090,15 @@ class PlaybackManager implements AudioOwnable {
     _subtitleStreamIndex = -1;
     _lastExplicitSubtitleEnabled = false;
     _lastExplicitSubtitleLanguage = null;
+
+    final currentItem = queueService.currentItem;
+    if (currentItem != null) {
+      onSubtitleTrackSelected?.call(
+        MediaStreamResolver.extractItemId(currentItem),
+        -1,
+      );
+    }
+
     await _resetSubtitleRendererMode();
     if (previousWasBurned || (!_isOfflinePlayback &&
         !(_backend?.supportsRuntimeTrackSelection ?? true))) {


### PR DESCRIPTION
# Pull Request

## Summary
We have logic to preserve user-selected tracks for audio and subtitle streams but it turns out they were only being logged if the changes were made prior to playback. This PR hardens the cross-episode track persistence for TV series so that subtitle and audio track selections—made either on the episode detail screen or during active video playback—persist across subsequent episodes of the same show.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Created **SeriesTrackPreference** data model storing language code, stream title/label, and relative stream index (**series_track_preference.dart**).
- Expanded **UserPreferences** to store rich subtitle and audio preferences per series ID (**user_preferences.dart**).
- Implemented 3-tier track matching (`matchSeriesTrackIndex`) prioritizing Language + Title match -> Language + Relative Index match -> Language Code fallback (**subtitle_track_logic.dart**).
- Updated in-player track change callbacks (`onSubtitleTrackChanged` and `onAudioTrackChanged`) to automatically persist show track preferences during playback (**playback_module.dart**).
- Fixed manual track selection priority in **item_detail_screen.dart** so direct clicks take immediate precedence over series preference lookups.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play Episode 1 of a series with multiple subtitle/audio tracks.
2. Change the subtitle or audio track either on the detail page or in-player.
3. Play Episode 2 of the same series: Verify that the matching track variant is selected automatically.
4. Relaunch Moonfin and play Episode 3: Verify track preference remains active across restarts.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Very unexciting series of screenshots showing how a user selected track (Chinese) overrides and is maintained across episodes:

<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-03_13-59-20" src="https://github.com/user-attachments/assets/01a8fda0-033c-4399-b975-cbac112619ed" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-03_13-59-38" src="https://github.com/user-attachments/assets/51a37119-ce48-4319-b678-fb7855a73ab0" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-03_13-59-50" src="https://github.com/user-attachments/assets/a5fcf81b-d7aa-4710-9e7f-6d02d489351c" />
## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
