### PR TITLE
bugfix-seerr - Fix Seerr search query URL encoding for spaces and apostrophes

### DIFF
--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -514,16 +514,24 @@ class SeerrHttpClient {
     int offset = 0,
   }) async {
     final page = (offset ~/ limit) + 1;
-    // Building the query through Dio rather than by hand, because
-    // Uri.encodeComponent leaves apostrophes as-is and Seerr rejects the
-    // request when a reserved character reaches it unencoded.
+    // Percent-encode query string explicitly using %20 for spaces and %27 for
+    // apostrophes. Passing query directly to Dio queryParameters uses
+    // x-www-form-urlencoded format (+ for spaces), which causes Seerr/TMDB
+    // to search for literal '+' characters and return 0 results.
+    final encodedQuery = Uri.encodeComponent(query)
+        .replaceAll("'", '%27')
+        .replaceAll('!', '%21')
+        .replaceAll('*', '%2A')
+        .replaceAll('(', '%28')
+        .replaceAll(')', '%29');
+
+    var url = '${_apiUrl('search')}?query=$encodedQuery&page=$page';
+    if (mediaType != null) {
+      url += '&type=${Uri.encodeComponent(mediaType)}';
+    }
+
     final response = await _dio.get(
-      _apiUrl('search'),
-      queryParameters: {
-        'query': query,
-        'page': page,
-        'type': ?mediaType,
-      },
+      url,
       options: _authOptions(),
     );
     _requireSuccess(response, 'search');


### PR DESCRIPTION
# Pull Request

## Summary
Fixes Seerr search query URL encoding so that searching queries with spaces (e.g. `evil dead` and `Matt's`) returns valid results from Seerr/TMDB alongside local search.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #933 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **SeerrHttpClient.search()** in **seerr_http_client.dart** to construct query strings with explicit percent-encoding (`%20` for spaces, `%27` for apostrophes).
- Resolved regression introduced in `ef85c6f9` where passing raw queries to Dio `queryParameters` converted spaces to `+` via `x-www-form-urlencoded` rules, causing Seerr/TMDB to search for literal `+` characters and return 0 results.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin search bar and type a multi-word query with spaces (e.g. `evil dead`).
2. Verify Seerr search tab returns valid result counts (e.g. 20 results) alongside local Jellyfin items.
3. Search for titles with apostrophes (e.g. `Matt's`): Verify search completes without HTTP 400 errors.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Sad Seerr:
<img width="1671" height="387" alt="2026-08-03_12-39-00_moonfin" src="https://github.com/user-attachments/assets/0b889f3b-8e07-46b9-88a6-eac6e108ce1c" />
<img width="736" height="282" alt="2026-08-03_12-39-17_moonfin" src="https://github.com/user-attachments/assets/f6ac790e-52c9-4930-88dd-3647119315f6" />

Happy Seerr:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-03_14-40-35" src="https://github.com/user-attachments/assets/4392152d-d0c9-42d5-91e6-6fcfa64e49e3" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-03_14-41-52" src="https://github.com/user-attachments/assets/9f5ddae5-3741-4532-ab49-6910921eefdf" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
