### PR TITLE
Fix(windows) the library grid not loading all items on large windows

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -36,7 +36,7 @@ Color get _jellyfinBlue => AppColorScheme.accent;
 const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 
-const _loadMoreExtent = 400.0;
+const _kLoadMoreExtent = 400.0;
 
 /// Grouped rows run tighter than the flat grid so a row of posters and its
 /// category heading both fit.
@@ -185,14 +185,14 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   /// Whether the scroll view has settled metrics and is within
-  /// [_loadMoreExtent] of its end.
+  /// [_kLoadMoreExtent] of its end.
   bool get _nearGridEnd {
     // Two grids briefly share the controller while one is swapped out.
     if (_scrollController.positions.length != 1) return false;
     final pos = _scrollController.position;
-    // The dimensions extentAfter reads.
+    // extentAfter reads both of these, and throws before they are set.
     if (!pos.hasPixels || !pos.hasContentDimensions) return false;
-    return pos.extentAfter < _loadMoreExtent;
+    return pos.extentAfter < _kLoadMoreExtent;
   }
 
   void _onScroll() {
@@ -1327,6 +1327,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        _scheduleViewportFillCheck();
         final isMobile = _isCompact(context);
         final horizPadding = isMobile ? 16.0 : _horizontalPadding;
         final vertPadding = isMobile ? 12.0 : 20.0;

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -36,6 +36,8 @@ Color get _jellyfinBlue => AppColorScheme.accent;
 const _horizontalPadding = 60.0;
 const _kCompactBreakpoint = 600.0;
 
+const _loadMoreExtent = 400.0;
+
 /// Grouped rows run tighter than the flat grid so a row of posters and its
 /// category heading both fit.
 const _kGroupedRowCardScale = 0.88;
@@ -152,6 +154,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (length != _lastGridItemsLength || firstId != _lastGridFirstItemId) {
       _lastGridItemsLength = length;
       _lastGridFirstItemId = firstId;
+      // A reload can land on the count the fill stopped at, which would read
+      // as a page that added nothing.
+      _lastFillItemCount = -1;
       gridContentVersion++;
       cleanupGridFocusNodes(length);
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -179,12 +184,47 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     _hasSubtitlesCache = null;
   }
 
-  void _onScroll() {
-    if (!_scrollController.hasClients) return;
+  /// Whether the scroll view has settled metrics and is within
+  /// [_loadMoreExtent] of its end.
+  bool get _nearGridEnd {
+    // Two grids briefly share the controller while one is swapped out.
+    if (_scrollController.positions.length != 1) return false;
     final pos = _scrollController.position;
-    if (pos.pixels > pos.maxScrollExtent - 400) {
-      _vm.loadMore();
-    }
+    // The dimensions extentAfter reads.
+    if (!pos.hasPixels || !pos.hasContentDimensions) return false;
+    return pos.extentAfter < _loadMoreExtent;
+  }
+
+  void _onScroll() {
+    if (_nearGridEnd) _vm.loadMore();
+  }
+
+  bool _fillCheckScheduled = false;
+  int _lastFillItemCount = -1;
+
+  /// A wide window lays out more columns, so a whole page of cards can fit
+  /// without overflowing the viewport. Nothing scrolls then, [_onScroll] never
+  /// fires, and paging stalls until the window is made smaller again. Top the
+  /// grid up after layout instead, until it overflows or the library runs out.
+  void _scheduleViewportFillCheck() {
+    // Every path that can page again notifies and rebuilds, which re-runs the
+    // builder, so skipping here never latches the fill off for good.
+    if (_fillCheckScheduled || _vm.loadingMore || !_vm.hasMore) return;
+    _fillCheckScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _fillCheckScheduled = false;
+      _maybeFillViewport();
+    });
+  }
+
+  void _maybeFillViewport() {
+    if (!mounted || !_nearGridEnd) return;
+    // Top up once per delivered page. A page still in flight, or one that
+    // rendered nothing new, leaves the count where it was and ends the fill.
+    final count = _vm.items.length;
+    if (count == _lastFillItemCount) return;
+    _lastFillItemCount = count;
+    _vm.loadMore();
   }
 
   void _scrollToGridRow({
@@ -898,6 +938,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
     return LayoutBuilder(
       builder: (context, constraints) {
+        _scheduleViewportFillCheck();
         final l10n = AppLocalizations.of(context);
         final isMobile = _isCompact(context);
         final gridPadding = isMobile ? 16.0 : _horizontalPadding;


### PR DESCRIPTION
# Pull Request

## Summary
On a large desktop window the Movies / TV Shows library grid stops loading items
partway through. Shrinking the window makes loading resume, which is what made
this look intermittent.

Paging was only ever triggered by the scroll listener. A wide window lays out up
to 20 columns, so the 75-item first page can fit entirely inside the viewport —
nothing overflows, `maxScrollExtent` stays 0, no scroll event fires, and the next
page is never requested. Making the window smaller pushes the content back into
overflow, so scrolling becomes possible and paging appears to fix itself.

This adds a post-layout check that tops the grid up until the content actually
overflows or the library runs out.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Added a post-frame viewport-fill check that pages until the grid overflows its viewport or `hasMore` is false, run from the grid's `LayoutBuilder` so resizing the window re-checks too.
- Extracted the "within 400px of the end" test into `_nearGridEnd`, shared by the scroll listener and the fill check so the two cannot drift apart.
- Guarded on `hasPixels` / `hasContentDimensions` — the metrics `extentAfter` actually reads — and on a single attached scroll position.
- Skipped scheduling while a page is in flight or once the library is fully loaded, so a finished grid stops queueing per-frame callbacks.
- Ended the fill when a delivered page adds no new rows, so a random sort returning already-shown items cannot spin against the server.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Reported on Windows, but the fix is in shared Dart — any platform with a viewport wide enough to fit a full page is affected.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin maximized on a wide or ultrawide display.
2. Browse a Movies or TV Shows library with more than ~75 items.
3. Confirm the grid keeps loading past the first page without resizing the
   window, and that scrolling still pages normally once content overflows.

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced