### PR TITLE
feat-ui - Tidy up new Media Details page layout

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5140,6 +5140,14 @@
   "@networks": {
     "description": "Seerr row: networks"
   },
+  "tags": "Tags",
+  "@tags": {
+    "description": "Heading for the keyword tags a title is filed under"
+  },
+  "genresAndTags": "Genres and Tags",
+  "@genresAndTags": {
+    "description": "Button and dialog title for browsing a title's genres, networks and tags"
+  },
   "seerrDiscoveryRows": "Seerr Discovery Rows",
   "@seerrDiscoveryRows": {
     "description": "Subtitle shown under Seerr discovery home rows"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6874,6 +6874,18 @@ abstract class AppLocalizations {
   /// **'Networks'**
   String get networks;
 
+  /// Heading for the keyword tags a title is filed under
+  ///
+  /// In en, this message translates to:
+  /// **'Tags'**
+  String get tags;
+
+  /// Button and dialog title for browsing a title's genres, networks and tags
+  ///
+  /// In en, this message translates to:
+  /// **'Genres and Tags'**
+  String get genresAndTags;
+
   /// Subtitle shown under Seerr discovery home rows
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3792,6 +3792,12 @@ class AppLocalizationsAf extends AppLocalizations {
   String get networks => 'Netwerke';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-ontdekkingsrye';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3793,6 +3793,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get networks => 'الشبكات';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'صفوف استكشاف Seerr';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3807,6 +3807,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get networks => 'Сеткі';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Радкі агляду Seerr';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3807,6 +3807,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get networks => 'мрежи';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Редове за откриване в Seerr';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3778,6 +3778,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get networks => 'নেটওয়ার্ক';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr ডিসকভারি সারি';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3836,6 +3836,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get networks => 'Xarxes';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Fileres de descoberta Seerr';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3797,6 +3797,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get networks => 'sítě';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Objevovací řádky Seerr';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3812,6 +3812,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get networks => 'Rhwydweithiau';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Rhesi Darganfod Seerr';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3785,6 +3785,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get networks => 'Netværk';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-opdagelsesrækker';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3884,6 +3884,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get networks => 'Netzwerke';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-Entdeckungszeilen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3832,6 +3832,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get networks => 'Δίκτυα';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Σειρές ανακάλυψης Seerr';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3766,6 +3766,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get networks => 'Networks';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr Discovery Rows';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3784,6 +3784,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get networks => 'Retoj';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Malkovraj vicoj de Seerr';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3815,6 +3815,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get networks => 'Redes';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Filas de descubrimiento de Seerr';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3789,6 +3789,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get networks => 'Võrgud';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerri avastamisread';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3765,6 +3765,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get networks => 'شبکه ها';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'ردیف‌های کشف Seerr';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3801,6 +3801,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get networks => 'Verkot';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-löytörivit';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3837,6 +3837,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get networks => 'Diffuseurs';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Découvertes Seerr';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3830,6 +3830,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get networks => 'Redes';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Filas de descubrimento de Seerr';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3751,6 +3751,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get networks => 'רשתות';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'שורות גילוי של Seerr';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3777,6 +3777,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get networks => 'नेटवर्क';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr डिस्कवरी पंक्तियाँ';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3908,6 +3908,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get networks => 'mreže';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr redovi otkrivanja';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3815,6 +3815,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get networks => 'Tévéadók';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr felfedezési sorok';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3790,6 +3790,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get networks => 'Jaringan';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Baris Discovery Seerr';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3810,6 +3810,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get networks => 'Reti';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Righe Scoperta Seerr';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3702,6 +3702,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get networks => 'ネットワーク';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr のディスカバリー行';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3804,6 +3804,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get networks => 'Желілер';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr ашу жолдары';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3809,6 +3809,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get networks => 'ಜಾಲಗಳು';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr ಡಿಸ್ಕವರಿ ಸಾಲುಗಳು';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3695,6 +3695,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get networks => '네트워크';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr 둘러보기 행';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3806,6 +3806,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get networks => 'Tinklai';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr atradimų eilutės';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3804,6 +3804,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get networks => 'Tīkli';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr atklāšanas rindas';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3807,6 +3807,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get networks => 'Мрежи';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Редови за откривање во Seerr';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3812,6 +3812,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get networks => 'നെറ്റ്വർക്കുകൾ';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr ഡിസ്കവറി വരികൾ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3795,6 +3795,12 @@ class AppLocalizationsMn extends AppLocalizations {
   String get networks => 'Сүлжээ';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-ийн танилцах эгнээ';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3782,6 +3782,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get networks => 'Nettverk';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-oppdagelsesrader';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3802,6 +3802,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get networks => 'Netwerken';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-ontdekkingsrijen';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3775,6 +3775,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get networks => 'ਨੈੱਟਵਰਕ';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr ਖੋਜ ਕਤਾਰਾਂ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3793,6 +3793,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get networks => 'Sieci';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Wiersze odkrywania Seerr';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3808,6 +3808,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get networks => 'Emissoras';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Linhas de Descoberta do Seerr';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3815,6 +3815,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get networks => 'Rețele';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Rânduri de descoperire Seerr';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3818,6 +3818,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get networks => 'Сети';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Ряды подборок Seerr';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3787,6 +3787,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get networks => 'ජාල';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr සොයාගැනීමේ පේළි';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3810,6 +3810,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get networks => 'siete';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Objavovacie riadky Seerr';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3813,6 +3813,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get networks => 'Omrežja';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Vrstice za odkrivanje Seerr';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3818,6 +3818,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get networks => 'Rrjetet';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Rreshtat e zbulimit Seerr';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3907,6 +3907,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get networks => 'Мреже';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr редови откривања';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3791,6 +3791,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get networks => 'Nätverk';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr-upptäcktsrader';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3814,6 +3814,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get networks => 'Mitandao';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Safu za Ugunduzi za Seerr';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3816,6 +3816,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get networks => 'நெட்வொர்க்குகள்';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr கண்டுபிடிப்பு வரிசைகள்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3808,6 +3808,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get networks => 'నెట్‌వర్క్‌లు';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr డిస్కవరీ వరుసలు';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3759,6 +3759,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get networks => 'เครือข่าย';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'แถวสำรวจของ Seerr';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3821,6 +3821,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get networks => 'Mga network';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Mga Seerr Discovery Row';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3798,6 +3798,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get networks => 'Yayıncılar';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr Keşfet Satırları';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3794,6 +3794,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get networks => 'تور';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr بايقاش قۇرلىرى';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3812,6 +3812,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get networks => 'мережі';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Рядки відкриттів Seerr';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3793,6 +3793,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get networks => 'Mạng';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Hàng khám phá Seerr';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -3668,6 +3668,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get networks => '網路';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr 探索列表';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3659,6 +3659,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get networks => '电视网';
 
   @override
+  String get tags => 'Tags';
+
+  @override
+  String get genresAndTags => 'Genres and Tags';
+
+  @override
   String get seerrDiscoveryRows => 'Seerr 发现栏目';
 
   @override

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -479,7 +479,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   void initState() {
     super.initState();
     
-    final FocusOnKeyEventCallback leftToSidebarHandler = (node, event) {
+    KeyEventResult leftToSidebarHandler(FocusNode node, KeyEvent event) {
       if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowLeft) {
         final navbarPosition = widget.prefs.get(UserPreferences.navbarPosition);
         if (navbarPosition == NavbarPosition.left) {
@@ -491,7 +491,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
       }
       return KeyEventResult.ignored;
-    };
+    }
 
     _castFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _crewFirstFocusNode.onKeyEvent = leftToSidebarHandler;
@@ -512,6 +512,32 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     _moviesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _seriesFirstFocusNode.onKeyEvent = leftToSidebarHandler;
     _collectionFirstFocusNode.onKeyEvent = leftToSidebarHandler;
+
+    void attachAutoScroll(FocusNode node) {
+      node.addListener(() {
+        if (node.hasFocus && mounted) {
+          final ctx = node.context;
+          if (ctx != null) {
+            Scrollable.ensureVisible(
+              ctx,
+              duration: const Duration(milliseconds: 250),
+              alignment: 0.15,
+              curve: Curves.easeOutCubic,
+            );
+          }
+        }
+      });
+    }
+
+    attachAutoScroll(_seerrChipsFocusNode);
+    attachAutoScroll(_seerrRecommendationsFocusNode);
+    attachAutoScroll(_seerrSimilarFocusNode);
+    attachAutoScroll(_seerrBannerFocusNode);
+    attachAutoScroll(_castFirstFocusNode);
+    attachAutoScroll(_crewFirstFocusNode);
+    attachAutoScroll(_similarFirstFocusNode);
+    attachAutoScroll(_seasonsFirstFocusNode);
+    attachAutoScroll(_episodesFirstFocusNode);
 
     for (final cat in extraCategoriesOrder) {
       final node = FocusNode(debugLabel: 'modernFeatureFirst_$cat');
@@ -2311,7 +2337,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           for (var i = 0; i < sections.length; i++) ...[
-            if (i > 0) const SizedBox(height: 20),
+            if (i > 0) const SizedBox(height: 16),
             sections[i],
           ],
         ],
@@ -2476,7 +2502,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
         itemCount: collections.length,
-        separatorBuilder: (_, __) => const SizedBox(height: 32),
+        separatorBuilder: (_, _) => const SizedBox(height: 32),
         itemBuilder: (context, index) {
           final col = collections[index];
           final rowFocusNode = _collectionRowFocusNodeFor(col.id);
@@ -4035,7 +4061,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       addText(l10n.seasonCount(item.childCount!));
     }
     if (item.type == 'Season') {
-      final epCount = _vm.episodes.length > 0 ? _vm.episodes.length : (item.childCount ?? 0);
+      final epCount = _vm.episodes.isNotEmpty ? _vm.episodes.length : (item.childCount ?? 0);
       if (epCount > 0) {
         addText(l10n.episodeCount(epCount));
       }
@@ -4044,7 +4070,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final s = item.parentIndexNumber;
       final e = item.indexNumber;
       if (s != null && e != null) {
-        addText('S${s}:E$e');
+        addText('S$s:E$e');
       }
     }
     final status = item.status;

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -21,6 +21,7 @@ import '../../../../preference/preference_constants.dart';
 import '../../../../util/overview_text.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
+import '../../../../util/focus/focus_scroll.dart';
 import '../../../navigation/destinations.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/marquee_text.dart';
@@ -515,21 +516,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     void attachAutoScroll(FocusNode node) {
       node.addListener(() {
-        if (node.hasFocus && mounted) {
-          final ctx = node.context;
-          if (ctx != null) {
-            Scrollable.ensureVisible(
-              ctx,
-              duration: const Duration(milliseconds: 250),
-              alignment: 0.15,
-              curve: Curves.easeOutCubic,
-            );
-          }
+        final ctx = node.context;
+        if (node.hasFocus && mounted && ctx != null) {
+          scrollFocusIntoView(ctx);
         }
       });
     }
 
-    attachAutoScroll(_seerrChipsFocusNode);
+    // _seerrChipsFocusNode is left out on purpose. It lands on a
+    // SeerrBrowseChip, which scrolls itself, and two calls racing over the same
+    // viewport settle wherever the slower one happens to finish.
     attachAutoScroll(_seerrRecommendationsFocusNode);
     attachAutoScroll(_seerrSimilarFocusNode);
     attachAutoScroll(_seerrBannerFocusNode);

--- a/lib/ui/widgets/seerr/seerr_browse_chip.dart
+++ b/lib/ui/widgets/seerr/seerr_browse_chip.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../../../util/focus/focus_scroll.dart';
 import '../../mixins/focus_state_mixin.dart';
 
 /// A tappable pill for a genre, network or keyword, which leads into Seerr
@@ -48,13 +49,7 @@ class _SeerrBrowseChipState extends State<SeerrBrowseChip>
       focusNode: widget.focusNode,
       onFocusChange: (focused) {
         setFocused(focused);
-        if (focused && mounted) {
-          Scrollable.ensureVisible(
-            context,
-            duration: const Duration(milliseconds: 180),
-            alignment: 0.2,
-          );
-        }
+        if (focused && mounted) scrollFocusIntoView(context);
       },
       onKeyEvent: (node, event) {
         if (event is! KeyDownEvent && event is! KeyRepeatEvent) {

--- a/lib/ui/widgets/seerr/seerr_browse_chip.dart
+++ b/lib/ui/widgets/seerr/seerr_browse_chip.dart
@@ -46,7 +46,16 @@ class _SeerrBrowseChipState extends State<SeerrBrowseChip>
     final borderRadius = AppRadius.circular(999);
     return Focus(
       focusNode: widget.focusNode,
-      onFocusChange: setFocused,
+      onFocusChange: (focused) {
+        setFocused(focused);
+        if (focused && mounted) {
+          Scrollable.ensureVisible(
+            context,
+            duration: const Duration(milliseconds: 180),
+            alignment: 0.2,
+          );
+        }
+      },
       onKeyEvent: (node, event) {
         if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
           return KeyEventResult.ignored;

--- a/lib/ui/widgets/seerr/seerr_item_chips.dart
+++ b/lib/ui/widgets/seerr/seerr_item_chips.dart
@@ -1,16 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
-import '../../navigation/destinations.dart';
 import 'seerr_browse_chip.dart';
+import 'seerr_tags_dialog.dart';
 
 /// Seerr's genres, networks and keywords for a title, each leading into Seerr
 /// browse filtered by it.
-///
-/// Kept apart from the library's own genres, which lead into library browse.
-/// They look alike but land somewhere else, so folding them together would
-/// break one of the two.
 class SeerrItemChips extends StatelessWidget {
   final SeerrMediaDetailState state;
 
@@ -38,99 +33,17 @@ class SeerrItemChips extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mediaType = state.isTv ? 'tv' : 'movie';
+    if (!hasContent(state)) return const SizedBox.shrink();
 
-    void open(String id, String name, String filterType) => context.push(
-          Destinations.seerrBrowseWith(
-            filterId: id,
-            filterName: name,
-            mediaType: mediaType,
-            filterType: filterType,
-          ),
-        );
-
-    // Numbered across the whole block, so only the first and last chip hand
-    // off out of it.
-    final total =
-        state.genres.length + state.networks.length + state.keywords.length;
-    var index = 0;
-    SeerrBrowseChip chip({
-      required String label,
-      required VoidCallback onTap,
-      Color color = Colors.white12,
-      Color? borderColor,
-      Color labelColor = Colors.white,
-      bool dense = false,
-    }) {
-      final i = index++;
-      return SeerrBrowseChip(
-        label: label,
-        onTap: onTap,
-        color: color,
-        borderColor: borderColor,
-        labelColor: labelColor,
-        dense: dense,
-        focusNode: i == 0 ? firstFocusNode : null,
-        onNavigateUp: i == 0 ? onNavigateUp : null,
-        onNavigateDown: i == total - 1 ? onNavigateDown : null,
-      );
-    }
-
-    final rows = <Widget>[
-      if (state.genres.isNotEmpty)
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: [
-            for (final g in state.genres)
-              chip(
-                label: g.name,
-                onTap: () => open(g.id.toString(), g.name, 'genre'),
-              ),
-          ],
-        ),
-      if (state.networks.isNotEmpty)
-        Wrap(
-          spacing: 8,
-          runSpacing: 6,
-          children: [
-            for (final n in state.networks)
-              chip(
-                label: n.name,
-                color: Colors.transparent,
-                borderColor: Colors.white24,
-                labelColor: Colors.white70,
-                onTap: () => open(n.id.toString(), n.name, 'network'),
-              ),
-          ],
-        ),
-      if (state.keywords.isNotEmpty)
-        Wrap(
-          spacing: 6,
-          runSpacing: 6,
-          children: [
-            for (final k in state.keywords)
-              chip(
-                label: k.name,
-                color: Colors.white.withValues(alpha: 0.05),
-                labelColor: Colors.white60,
-                dense: true,
-                onTap: () => open(k.id.toString(), k.name, 'keyword'),
-              ),
-          ],
-        ),
-    ];
-    if (rows.isEmpty) return const SizedBox.shrink();
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (var i = 0; i < rows.length; i++) ...[
-          if (i > 0) const SizedBox(height: 10),
-          rows[i],
-        ],
-      ],
+    return SeerrBrowseChip(
+      label: 'Genre and Tag Search',
+      onTap: () => SeerrTagsDialog.show(context, state),
+      color: Colors.white.withValues(alpha: 0.1),
+      borderColor: Colors.white24,
+      labelColor: Colors.white.withValues(alpha: 0.9),
+      focusNode: firstFocusNode,
+      onNavigateUp: onNavigateUp,
+      onNavigateDown: onNavigateDown,
     );
   }
 }

--- a/lib/ui/widgets/seerr/seerr_item_chips.dart
+++ b/lib/ui/widgets/seerr/seerr_item_chips.dart
@@ -1,20 +1,22 @@
 import 'package:flutter/material.dart';
 
 import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
+import '../../../l10n/app_localizations.dart';
 import 'seerr_browse_chip.dart';
 import 'seerr_tags_dialog.dart';
 
-/// Seerr's genres, networks and keywords for a title, each leading into Seerr
-/// browse filtered by it.
+/// Opens Seerr's genres, networks and keywords for a title.
+///
+/// Kept apart from the library's own genres, which lead into library browse.
+/// They look alike but land somewhere else, so folding them together would
+/// break one of the two.
 class SeerrItemChips extends StatelessWidget {
   final SeerrMediaDetailState state;
 
-  /// Where a d-pad lands when it enters the block from above.
+  /// Where a d-pad lands when it enters from above.
   final FocusNode? firstFocusNode;
 
-  /// Called when up from the first chip or down from the last would leave the
-  /// block. Everything in between is left to the usual traversal, which walks
-  /// the wrapped rows by position.
+  /// Called when up or down would leave the button.
   final VoidCallback? onNavigateUp;
   final VoidCallback? onNavigateDown;
 
@@ -36,7 +38,7 @@ class SeerrItemChips extends StatelessWidget {
     if (!hasContent(state)) return const SizedBox.shrink();
 
     return SeerrBrowseChip(
-      label: 'Genre and Tag Search',
+      label: AppLocalizations.of(context).genresAndTags,
       onTap: () => SeerrTagsDialog.show(context, state),
       color: Colors.white.withValues(alpha: 0.1),
       borderColor: Colors.white24,

--- a/lib/ui/widgets/seerr/seerr_stats_card.dart
+++ b/lib/ui/widgets/seerr/seerr_stats_card.dart
@@ -12,6 +12,11 @@ String seerrFormatRuntime(int minutes) {
   return m > 0 ? '${h}h ${m}m' : '${h}h';
 }
 
+/// Facts sit side by side once the card is at least this wide, and stack below.
+const _kStatsGridBreakpoint = 540.0;
+
+const _kStatsPerLine = 3;
+
 /// The facts Seerr knows about a title that the library does not: its TMDB
 /// score, where production stands, and the money behind it.
 class SeerrStatsCard extends StatelessWidget {
@@ -75,124 +80,123 @@ class SeerrStatsCard extends StatelessWidget {
     if (rows.isEmpty) return const SizedBox.shrink();
 
     return LayoutBuilder(
-      builder: (context, constraints) {
-        final isWide = constraints.maxWidth >= 540;
+      builder: (context, constraints) =>
+          constraints.maxWidth >= _kStatsGridBreakpoint
+          ? _grid(rows)
+          : _stack(rows),
+    );
+  }
 
-        if (isWide) {
-          final gridRows = <List<_StatRow>>[];
-          for (var i = 0; i < rows.length; i += 3) {
-            gridRows.add(rows.sublist(i, (i + 3).clamp(0, rows.length)));
-          }
+  Widget _card({required Widget child, EdgeInsetsGeometry? padding}) {
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.06),
+        borderRadius: AppRadius.circular(10),
+        border: Border.fromBorderSide(ThemeRegistry.active.borders.cardBorder),
+      ),
+      padding: padding,
+      child: child,
+    );
+  }
 
-          return Container(
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.06),
-              borderRadius: AppRadius.circular(10),
-              border: Border.fromBorderSide(
-                ThemeRegistry.active.borders.cardBorder,
+  Widget _grid(List<_StatRow> rows) {
+    final lines = <List<_StatRow>>[
+      for (var i = 0; i < rows.length; i += _kStatsPerLine)
+        rows.sublist(i, (i + _kStatsPerLine).clamp(0, rows.length)),
+    ];
+
+    return _card(
+      padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
+      child: Column(
+        children: [
+          for (var r = 0; r < lines.length; r++) ...[
+            if (r > 0)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 10),
+                child: Divider(height: 1, thickness: 1, color: Colors.white10),
               ),
-            ),
-            padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
-            child: Column(
+            Row(
               children: [
-                for (var r = 0; r < gridRows.length; r++) ...[
-                  if (r > 0)
-                    const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 10),
-                      child: Divider(
-                        height: 1,
-                        thickness: 1,
-                        color: Colors.white10,
-                      ),
+                for (var c = 0; c < _kStatsPerLine; c++) ...[
+                  if (c > 0)
+                    Container(
+                      height: 32,
+                      width: 1,
+                      color: Colors.white10,
+                      margin: const EdgeInsets.symmetric(horizontal: 16),
                     ),
-                  Row(
-                    children: [
-                      for (var c = 0; c < 3; c++) ...[
-                        if (c > 0)
-                          Container(
-                            height: 32,
-                            width: 1,
-                            color: Colors.white10,
-                            margin: const EdgeInsets.symmetric(horizontal: 16),
-                          ),
-                        Expanded(
-                          child: c < gridRows[r].length
-                              ? Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      gridRows[r][c].label,
-                                      style: const TextStyle(
-                                        color: Colors.white60,
-                                        fontSize: 12,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 3),
-                                    Text(
-                                      gridRows[r][c].value,
-                                      style: const TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.bold,
-                                      ),
-                                    ),
-                                  ],
-                                )
-                              : const SizedBox.shrink(),
-                        ),
-                      ],
-                    ],
+                  // The last line is padded out so its facts keep the column
+                  // widths the lines above set.
+                  Expanded(
+                    child: c < lines[r].length
+                        ? _fact(lines[r][c])
+                        : const SizedBox.shrink(),
                   ),
                 ],
               ],
             ),
-          );
-        }
+          ],
+        ],
+      ),
+    );
+  }
 
-        return Container(
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.06),
-            borderRadius: AppRadius.circular(10),
-            border: Border.fromBorderSide(
-              ThemeRegistry.active.borders.cardBorder,
-            ),
+  Widget _fact(_StatRow row) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          row.label,
+          style: const TextStyle(
+            color: Colors.white60,
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
           ),
-          child: Column(
-            children: [
-              for (var i = 0; i < rows.length; i++) ...[
-                Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Text(
-                          rows[i].label,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
+        ),
+        const SizedBox(height: 3),
+        Text(
+          row.value,
+          style: const TextStyle(
+            color: Colors.white,
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _stack(List<_StatRow> rows) {
+    return _card(
+      child: Column(
+        children: [
+          for (var i = 0; i < rows.length; i++) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      rows[i].label,
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
                       ),
-                      Text(
-                        rows[i].value,
-                        style: const TextStyle(
-                          color: Colors.white70,
-                          fontSize: 14,
-                        ),
-                      ),
-                    ],
+                    ),
                   ),
-                ),
-                if (i < rows.length - 1)
-                  const Divider(height: 1, thickness: 1, color: Colors.white10),
-              ],
-            ],
-          ),
-        );
-      },
+                  Text(
+                    rows[i].value,
+                    style: const TextStyle(color: Colors.white70, fontSize: 14),
+                  ),
+                ],
+              ),
+            ),
+            if (i < rows.length - 1)
+              const Divider(height: 1, thickness: 1, color: Colors.white10),
+          ],
+        ],
+      ),
     );
   }
 

--- a/lib/ui/widgets/seerr/seerr_stats_card.dart
+++ b/lib/ui/widgets/seerr/seerr_stats_card.dart
@@ -47,13 +47,9 @@ class SeerrStatsCard extends StatelessWidget {
         rows.add(_StatRow(l10n.firstAirDateLabel, dateLabel));
       }
     }
-    if (s.isTv) {
-      if (s.numberOfSeasons != null && s.numberOfSeasons! > 0) {
-        rows.add(_StatRow(l10n.seasonsLabel, s.numberOfSeasons.toString()));
-      }
-      if (s.numberOfEpisodes != null && s.numberOfEpisodes! > 0) {
-        rows.add(_StatRow(l10n.episodesLabel, s.numberOfEpisodes.toString()));
-      }
+
+    if (s.budget != null && s.budget! > 0) {
+      rows.add(_StatRow(l10n.budgetLabel, _formatMoneyFull(s.budget!)));
     }
     if (s.revenue != null && s.revenue! > 0) {
       rows.add(_StatRow(l10n.revenueLabel, _formatMoneyFull(s.revenue!)));
@@ -61,8 +57,14 @@ class SeerrStatsCard extends StatelessWidget {
     if (s.runtime != null && s.runtime! > 0) {
       rows.add(_StatRow(l10n.runtimeLabel, seerrFormatRuntime(s.runtime!)));
     }
-    if (s.budget != null && s.budget! > 0) {
-      rows.add(_StatRow(l10n.budgetLabel, _formatMoneyFull(s.budget!)));
+
+    if (s.isTv) {
+      if (s.numberOfSeasons != null && s.numberOfSeasons! > 0) {
+        rows.add(_StatRow(l10n.seasonsLabel, s.numberOfSeasons.toString()));
+      }
+      if (s.numberOfEpisodes != null && s.numberOfEpisodes! > 0) {
+        rows.add(_StatRow(l10n.episodesLabel, s.numberOfEpisodes.toString()));
+      }
     }
     return rows;
   }
@@ -72,41 +74,125 @@ class SeerrStatsCard extends StatelessWidget {
     final rows = _facts(state, AppLocalizations.of(context));
     if (rows.isEmpty) return const SizedBox.shrink();
 
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.06),
-        borderRadius: AppRadius.circular(10),
-        border: Border.fromBorderSide(ThemeRegistry.active.borders.cardBorder),
-      ),
-      child: Column(
-        children: [
-          for (var i = 0; i < rows.length; i++) ...[
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: Text(
-                      rows[i].label,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                  Text(
-                    rows[i].value,
-                    style: const TextStyle(color: Colors.white70, fontSize: 14),
-                  ),
-                ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth >= 540;
+
+        if (isWide) {
+          final gridRows = <List<_StatRow>>[];
+          for (var i = 0; i < rows.length; i += 3) {
+            gridRows.add(rows.sublist(i, (i + 3).clamp(0, rows.length)));
+          }
+
+          return Container(
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.06),
+              borderRadius: AppRadius.circular(10),
+              border: Border.fromBorderSide(
+                ThemeRegistry.active.borders.cardBorder,
               ),
             ),
-            if (i < rows.length - 1)
-              const Divider(height: 1, thickness: 1, color: Colors.white10),
-          ],
-        ],
-      ),
+            padding: const EdgeInsets.symmetric(vertical: 14, horizontal: 20),
+            child: Column(
+              children: [
+                for (var r = 0; r < gridRows.length; r++) ...[
+                  if (r > 0)
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 10),
+                      child: Divider(
+                        height: 1,
+                        thickness: 1,
+                        color: Colors.white10,
+                      ),
+                    ),
+                  Row(
+                    children: [
+                      for (var c = 0; c < 3; c++) ...[
+                        if (c > 0)
+                          Container(
+                            height: 32,
+                            width: 1,
+                            color: Colors.white10,
+                            margin: const EdgeInsets.symmetric(horizontal: 16),
+                          ),
+                        Expanded(
+                          child: c < gridRows[r].length
+                              ? Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      gridRows[r][c].label,
+                                      style: const TextStyle(
+                                        color: Colors.white60,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 3),
+                                    Text(
+                                      gridRows[r][c].value,
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                )
+                              : const SizedBox.shrink(),
+                        ),
+                      ],
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          );
+        }
+
+        return Container(
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.06),
+            borderRadius: AppRadius.circular(10),
+            border: Border.fromBorderSide(
+              ThemeRegistry.active.borders.cardBorder,
+            ),
+          ),
+          child: Column(
+            children: [
+              for (var i = 0; i < rows.length; i++) ...[
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          rows[i].label,
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                      Text(
+                        rows[i].value,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (i < rows.length - 1)
+                  const Divider(height: 1, thickness: 1, color: Colors.white10),
+              ],
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/lib/ui/widgets/seerr/seerr_tags_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_tags_dialog.dart
@@ -1,0 +1,281 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
+import '../../mixins/focus_state_mixin.dart';
+import '../../navigation/destinations.dart';
+import 'seerr_browse_chip.dart';
+
+/// Modal popup displaying all Genres, Networks, and Keywords for a title in a
+/// clean categorized dialog.
+class SeerrTagsDialog extends StatefulWidget {
+  final SeerrMediaDetailState state;
+
+  const SeerrTagsDialog({super.key, required this.state});
+
+  static Future<void> show(
+    BuildContext context,
+    SeerrMediaDetailState state,
+  ) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => SeerrTagsDialog(state: state),
+    );
+  }
+
+  @override
+  State<SeerrTagsDialog> createState() => _SeerrTagsDialogState();
+}
+
+class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
+  late final FocusNode _firstChipFocusNode = FocusNode(debugLabel: 'dialogFirstChip');
+
+  @override
+  void dispose() {
+    _firstChipFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mediaType = widget.state.isTv ? 'tv' : 'movie';
+
+    void open(String id, String name, String filterType) {
+      Navigator.of(context).pop();
+      context.push(
+        Destinations.seerrBrowseWith(
+          filterId: id,
+          filterName: name,
+          mediaType: mediaType,
+          filterType: filterType,
+        ),
+      );
+    }
+
+    var isFirstChip = true;
+
+    FocusNode? grabFirstChipFocusNode() {
+      if (isFirstChip) {
+        isFirstChip = false;
+        return _firstChipFocusNode;
+      }
+      return null;
+    }
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 36),
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 640, maxHeight: 520),
+        decoration: BoxDecoration(
+          color: AppColorScheme.surface.withValues(alpha: 0.94),
+          borderRadius: AppRadius.circular(16),
+          border: Border.fromBorderSide(
+            ThemeRegistry.active.borders.cardBorder,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.5),
+              blurRadius: 24,
+              spreadRadius: 4,
+            ),
+          ],
+        ),
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const Expanded(
+                  child: Text(
+                    'Keywords',
+                    style: TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+                _DialogCloseButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  onNavigateDown: () {
+                    if (_firstChipFocusNode.canRequestFocus) {
+                      _firstChipFocusNode.requestFocus();
+                    }
+                  },
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Flexible(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    if (widget.state.genres.isNotEmpty) ...[
+                      const Text(
+                        'Genres',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white70,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final g in widget.state.genres)
+                            SeerrBrowseChip(
+                              label: g.name,
+                              focusNode: grabFirstChipFocusNode(),
+                              onTap: () =>
+                                  open(g.id.toString(), g.name, 'genre'),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    if (widget.state.networks.isNotEmpty) ...[
+                      const Text(
+                        'Networks',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white70,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 8,
+                        children: [
+                          for (final n in widget.state.networks)
+                            SeerrBrowseChip(
+                              label: n.name,
+                              color: Colors.transparent,
+                              borderColor: Colors.white24,
+                              labelColor: Colors.white70,
+                              focusNode: grabFirstChipFocusNode(),
+                              onTap: () =>
+                                  open(n.id.toString(), n.name, 'network'),
+                            ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                    ],
+                    if (widget.state.keywords.isNotEmpty) ...[
+                      const Text(
+                        'Tags',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          color: Colors.white70,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 6,
+                        runSpacing: 6,
+                        children: [
+                          for (final k in widget.state.keywords)
+                            SeerrBrowseChip(
+                              label: k.name,
+                              color: Colors.white.withValues(alpha: 0.08),
+                              labelColor: Colors.white70,
+                              dense: true,
+                              focusNode: grabFirstChipFocusNode(),
+                              onTap: () =>
+                                  open(k.id.toString(), k.name, 'keyword'),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DialogCloseButton extends StatefulWidget {
+  final VoidCallback onPressed;
+  final VoidCallback? onNavigateDown;
+
+  const _DialogCloseButton({
+    required this.onPressed,
+    this.onNavigateDown,
+  });
+
+  @override
+  State<_DialogCloseButton> createState() => _DialogCloseButtonState();
+}
+
+class _DialogCloseButtonState extends State<_DialogCloseButton>
+    with FocusStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: setFocused,
+      onKeyEvent: (node, event) {
+        if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+          return KeyEventResult.ignored;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.select ||
+            event.logicalKey == LogicalKeyboardKey.enter ||
+            event.logicalKey == LogicalKeyboardKey.gameButtonA) {
+          widget.onPressed();
+          return KeyEventResult.handled;
+        }
+        if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+            widget.onNavigateDown != null) {
+          widget.onNavigateDown!();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setHovered(true),
+        onExit: (_) => setHovered(false),
+        child: GestureDetector(
+          onTap: widget.onPressed,
+          child: AnimatedScale(
+            scale: showFocusBorder ? 1.1 : 1.0,
+            duration: const Duration(milliseconds: 120),
+            child: Container(
+              width: 36,
+              height: 36,
+              decoration: BoxDecoration(
+                color: showFocusBorder
+                    ? focusColor.withValues(alpha: 0.2)
+                    : Colors.white.withValues(alpha: 0.08),
+                shape: BoxShape.circle,
+                border: Border.fromBorderSide(
+                  ThemeRegistry.active.borders.chipBorder.copyWith(
+                    color: showFocusBorder ? focusColor : Colors.transparent,
+                    width: showFocusBorder ? 2 : 1,
+                  ),
+                ),
+              ),
+              child: const Icon(
+                Icons.close,
+                size: 20,
+                color: Colors.white70,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/seerr/seerr_tags_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_tags_dialog.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
+import '../../../l10n/app_localizations.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../mixins/focus_state_mixin.dart';
 import '../../navigation/destinations.dart';
 import 'seerr_browse_chip.dart';
 
-/// Modal popup displaying all Genres, Networks, and Keywords for a title in a
-/// clean categorized dialog.
+/// The genres, networks and tags a title is filed under, each one a shortcut
+/// into browsing everything else filed the same way.
 class SeerrTagsDialog extends StatefulWidget {
   final SeerrMediaDetailState state;
 
@@ -30,7 +31,7 @@ class SeerrTagsDialog extends StatefulWidget {
 }
 
 class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
-  late final FocusNode _firstChipFocusNode = FocusNode(debugLabel: 'dialogFirstChip');
+  final FocusNode _firstChipFocusNode = FocusNode(debugLabel: 'dialogFirstChip');
 
   @override
   void dispose() {
@@ -38,8 +39,16 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
     super.dispose();
   }
 
+  /// Whichever section comes first owns the node, so Down off the close button
+  /// always lands somewhere.
+  bool get _hasFirstChip =>
+      widget.state.genres.isNotEmpty ||
+      widget.state.networks.isNotEmpty ||
+      widget.state.keywords.isNotEmpty;
+
   @override
   Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
     final mediaType = widget.state.isTv ? 'tv' : 'movie';
 
     void open(String id, String name, String filterType) {
@@ -54,14 +63,11 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
       );
     }
 
-    var isFirstChip = true;
-
-    FocusNode? grabFirstChipFocusNode() {
-      if (isFirstChip) {
-        isFirstChip = false;
-        return _firstChipFocusNode;
-      }
-      return null;
+    var claimed = false;
+    FocusNode? claimFirstChip() {
+      if (claimed) return null;
+      claimed = true;
+      return _firstChipFocusNode;
     }
 
     return Dialog(
@@ -90,10 +96,10 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
           children: [
             Row(
               children: [
-                const Expanded(
+                Expanded(
                   child: Text(
-                    'Keywords',
-                    style: TextStyle(
+                    l10n.genresAndTags,
+                    style: const TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
                       color: Colors.white,
@@ -101,12 +107,11 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
                   ),
                 ),
                 _DialogCloseButton(
+                  label: l10n.close,
                   onPressed: () => Navigator.of(context).pop(),
-                  onNavigateDown: () {
-                    if (_firstChipFocusNode.canRequestFocus) {
-                      _firstChipFocusNode.requestFocus();
-                    }
-                  },
+                  onNavigateDown: _hasFirstChip
+                      ? _firstChipFocusNode.requestFocus
+                      : null,
                 ),
               ],
             ),
@@ -116,86 +121,57 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    if (widget.state.genres.isNotEmpty) ...[
-                      const Text(
-                        'Genres',
-                        style: TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.white70,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: [
-                          for (final g in widget.state.genres)
-                            SeerrBrowseChip(
-                              label: g.name,
-                              focusNode: grabFirstChipFocusNode(),
-                              onTap: () =>
-                                  open(g.id.toString(), g.name, 'genre'),
+                    _section(
+                      title: l10n.genres,
+                      spacing: 8,
+                      chips: [
+                        for (final genre in widget.state.genres)
+                          SeerrBrowseChip(
+                            label: genre.name,
+                            focusNode: claimFirstChip(),
+                            onTap: () =>
+                                open(genre.id.toString(), genre.name, 'genre'),
+                          ),
+                      ],
+                    ),
+                    _section(
+                      title: l10n.networks,
+                      spacing: 8,
+                      chips: [
+                        for (final network in widget.state.networks)
+                          SeerrBrowseChip(
+                            label: network.name,
+                            color: Colors.transparent,
+                            borderColor: Colors.white24,
+                            labelColor: Colors.white70,
+                            focusNode: claimFirstChip(),
+                            onTap: () => open(
+                              network.id.toString(),
+                              network.name,
+                              'network',
                             ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                    if (widget.state.networks.isNotEmpty) ...[
-                      const Text(
-                        'Networks',
-                        style: TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.white70,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 8,
-                        runSpacing: 8,
-                        children: [
-                          for (final n in widget.state.networks)
-                            SeerrBrowseChip(
-                              label: n.name,
-                              color: Colors.transparent,
-                              borderColor: Colors.white24,
-                              labelColor: Colors.white70,
-                              focusNode: grabFirstChipFocusNode(),
-                              onTap: () =>
-                                  open(n.id.toString(), n.name, 'network'),
+                          ),
+                      ],
+                    ),
+                    _section(
+                      title: l10n.tags,
+                      spacing: 6,
+                      chips: [
+                        for (final keyword in widget.state.keywords)
+                          SeerrBrowseChip(
+                            label: keyword.name,
+                            color: Colors.white.withValues(alpha: 0.08),
+                            labelColor: Colors.white70,
+                            dense: true,
+                            focusNode: claimFirstChip(),
+                            onTap: () => open(
+                              keyword.id.toString(),
+                              keyword.name,
+                              'keyword',
                             ),
-                        ],
-                      ),
-                      const SizedBox(height: 16),
-                    ],
-                    if (widget.state.keywords.isNotEmpty) ...[
-                      const Text(
-                        'Tags',
-                        style: TextStyle(
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.white70,
-                        ),
-                      ),
-                      const SizedBox(height: 8),
-                      Wrap(
-                        spacing: 6,
-                        runSpacing: 6,
-                        children: [
-                          for (final k in widget.state.keywords)
-                            SeerrBrowseChip(
-                              label: k.name,
-                              color: Colors.white.withValues(alpha: 0.08),
-                              labelColor: Colors.white70,
-                              dense: true,
-                              focusNode: grabFirstChipFocusNode(),
-                              onTap: () =>
-                                  open(k.id.toString(), k.name, 'keyword'),
-                            ),
-                        ],
-                      ),
-                    ],
+                          ),
+                      ],
+                    ),
                   ],
                 ),
               ),
@@ -205,13 +181,41 @@ class _SeerrTagsDialogState extends State<SeerrTagsDialog> {
       ),
     );
   }
+
+  Widget _section({
+    required String title,
+    required double spacing,
+    required List<Widget> chips,
+  }) {
+    if (chips.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: Colors.white70,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Wrap(spacing: spacing, runSpacing: spacing, children: chips),
+        ],
+      ),
+    );
+  }
 }
 
 class _DialogCloseButton extends StatefulWidget {
+  final String label;
   final VoidCallback onPressed;
   final VoidCallback? onNavigateDown;
 
   const _DialogCloseButton({
+    required this.label,
     required this.onPressed,
     this.onNavigateDown,
   });
@@ -224,53 +228,60 @@ class _DialogCloseButtonState extends State<_DialogCloseButton>
     with FocusStateMixin {
   @override
   Widget build(BuildContext context) {
-    return Focus(
-      onFocusChange: setFocused,
-      onKeyEvent: (node, event) {
-        if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
-          return KeyEventResult.ignored;
-        }
-        if (event.logicalKey == LogicalKeyboardKey.select ||
-            event.logicalKey == LogicalKeyboardKey.enter ||
-            event.logicalKey == LogicalKeyboardKey.gameButtonA) {
-          widget.onPressed();
-          return KeyEventResult.handled;
-        }
-        if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
-            widget.onNavigateDown != null) {
-          widget.onNavigateDown!();
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
-      },
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        onEnter: (_) => setHovered(true),
-        onExit: (_) => setHovered(false),
-        child: GestureDetector(
-          onTap: widget.onPressed,
-          child: AnimatedScale(
-            scale: showFocusBorder ? 1.1 : 1.0,
-            duration: const Duration(milliseconds: 120),
-            child: Container(
-              width: 36,
-              height: 36,
-              decoration: BoxDecoration(
-                color: showFocusBorder
-                    ? focusColor.withValues(alpha: 0.2)
-                    : Colors.white.withValues(alpha: 0.08),
-                shape: BoxShape.circle,
-                border: Border.fromBorderSide(
-                  ThemeRegistry.active.borders.chipBorder.copyWith(
-                    color: showFocusBorder ? focusColor : Colors.transparent,
-                    width: showFocusBorder ? 2 : 1,
+    return Semantics(
+      container: true,
+      button: true,
+      label: widget.label,
+      child: Tooltip(
+        message: widget.label,
+        child: Focus(
+          onFocusChange: setFocused,
+          onKeyEvent: (node, event) {
+            if (isActivateKey(event)) {
+              widget.onPressed();
+              return KeyEventResult.handled;
+            }
+            final down = widget.onNavigateDown;
+            if (down != null &&
+                event.isActionable &&
+                event.logicalKey.isDownKey) {
+              down();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onEnter: (_) => setHovered(true),
+            onExit: (_) => setHovered(false),
+            child: GestureDetector(
+              onTap: widget.onPressed,
+              child: AnimatedScale(
+                scale: showFocusBorder ? 1.1 : 1.0,
+                duration: const Duration(milliseconds: 120),
+                child: Container(
+                  width: 36,
+                  height: 36,
+                  decoration: BoxDecoration(
+                    color: showFocusBorder
+                        ? focusColor.withValues(alpha: 0.2)
+                        : Colors.white.withValues(alpha: 0.08),
+                    shape: BoxShape.circle,
+                    border: Border.fromBorderSide(
+                      ThemeRegistry.active.borders.chipBorder.copyWith(
+                        color: showFocusBorder
+                            ? focusColor
+                            : Colors.transparent,
+                        width: showFocusBorder ? 2 : 1,
+                      ),
+                    ),
+                  ),
+                  child: const Icon(
+                    Icons.close,
+                    size: 20,
+                    color: Colors.white70,
                   ),
                 ),
-              ),
-              child: const Icon(
-                Icons.close,
-                size: 20,
-                color: Colors.white70,
               ),
             ),
           ),

--- a/lib/util/focus/focus_scroll.dart
+++ b/lib/util/focus/focus_scroll.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+/// Brings a newly focused widget into view, far enough from the top edge that
+/// whatever follows it is visible too. Shared so that moving a remote down a
+/// page reads as one motion rather than several differently timed ones.
+void scrollFocusIntoView(BuildContext context) {
+  Scrollable.ensureVisible(
+    context,
+    duration: const Duration(milliseconds: 250),
+    alignment: 0.15,
+    curve: Curves.easeOutCubic,
+  );
+}

--- a/test/ui/widgets/seerr/seerr_tags_dialog_test.dart
+++ b/test/ui/widgets/seerr/seerr_tags_dialog_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_api_models.dart';
+import 'package:moonfin/data/viewmodels/seerr_media_detail_view_model.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/ui/widgets/seerr/seerr_browse_chip.dart';
+import 'package:moonfin/ui/widgets/seerr/seerr_tags_dialog.dart';
+
+SeerrMediaDetailState _state({
+  List<SeerrGenre> genres = const [],
+  List<SeerrKeyword> keywords = const [],
+}) => SeerrMediaDetailState(
+  movie: SeerrMovieDetails(
+    id: 1,
+    title: 'Alien',
+    genres: genres,
+    keywords: keywords,
+  ),
+);
+
+Widget _app(Widget home) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: home,
+);
+
+void main() {
+  testWidgets('lists each section it has something to show for', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        SeerrTagsDialog(
+          state: _state(
+            genres: const [SeerrGenre(id: 1, name: 'Horror')],
+            keywords: const [SeerrKeyword(id: 2, name: 'space')],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Genres'), findsOneWidget);
+    expect(find.text('Horror'), findsOneWidget);
+    expect(find.text('Tags'), findsOneWidget);
+    expect(find.text('space'), findsOneWidget);
+
+    // This title has no networks, so that heading stays away rather than
+    // sitting above an empty row.
+    expect(find.text('Networks'), findsNothing);
+  });
+
+  testWidgets('gives the first chip a focus node so back out of the close '
+      'button lands somewhere', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        SeerrTagsDialog(
+          state: _state(
+            genres: const [
+              SeerrGenre(id: 1, name: 'Horror'),
+              SeerrGenre(id: 2, name: 'Sci-Fi'),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final chips = tester
+        .widgetList<SeerrBrowseChip>(find.byType(SeerrBrowseChip))
+        .toList();
+
+    expect(chips.first.focusNode, isNotNull);
+    expect(
+      chips.skip(1).every((chip) => chip.focusNode == null),
+      isTrue,
+      reason: 'only the first chip is the landing spot',
+    );
+  });
+
+  testWidgets('carries a label for the close button', (tester) async {
+    final semantics = tester.ensureSemantics();
+
+    await tester.pumpWidget(
+      _app(
+        SeerrTagsDialog(
+          state: _state(genres: const [SeerrGenre(id: 1, name: 'Horror')]),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Close'), findsAtLeastNWidgets(1));
+    semantics.dispose();
+  });
+
+  testWidgets('shows nothing but the header when the title has no tags', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(SeerrTagsDialog(state: _state())));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SeerrBrowseChip), findsNothing);
+    expect(find.text('Genres'), findsNothing);
+    expect(find.text('Genres and Tags'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Tidy up the unified Media Details page layout, D-pad focus viewport scrolling, and tag search dialog to eliminate wasted screen real estate across TV, Desktop, and Mobile platforms.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **seerr_stats_card.dart**: Formatted TMDB facts table into a responsive 2 rows x 3 columns grid on TV/Desktop landscape viewports (TMDB Score, Status, Release Date, Budget, Revenue, Runtime), eliminating wasted space while keeping a 1-column stack on mobile.
- **seerr_item_chips.dart**: Replaced sprawling inline chip wrap with a single compact **Genre and Tag Search** button located below the Seerr tab header.
- **seerr_tags_dialog.dart**: Created glassmorphic modal popup categorizing all Genres and Tags. Added focus border glow to the close button (X) and enabled D-pad DOWN navigation from X to the first chip.
- **seerr_browse_chip.dart**: Added `Scrollable.ensureVisible` focus callbacks so chip focus inside scrollable containers (like `SeerrTagsDialog`) automatically scrolls to keep focused tags centered.
- **modern_detail_content.dart**: Attached auto-scroll focus listeners across detail section nodes to keep D-pad focus continuously in view.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Windows or Android TV.
2. Navigate to any Movie or TV Show Media Details screen with Seerr metadata.
3. Verify the 2x3 grid table formats cleanly without wasted space.
4. Select **Genre and Tag Search** to open the **Keywords** popup dialog; verify close button (X) receives focus border and D-pad DOWN focuses the first chip.
5. Navigate D-pad DOWN through Recommendations and Similar rows; verify the viewport smoothly auto-scrolls.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Initial View
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-06_16-39-12" src="https://github.com/user-attachments/assets/408b7979-30a1-484e-b3a8-3b3b70102921" />

### Seerr Tab
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-06_16-43-40" src="https://github.com/user-attachments/assets/36b74750-bad5-4af5-8627-e9850e0ff0fd" />

### Pop-Up
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-06_16-43-58" src="https://github.com/user-attachments/assets/0f86d0f8-c543-454a-84fb-93fce062a866" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X ] No new warnings introduced
