### PR TITLE
fix Keep season context when playing specials displayed inline in a seaon

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -95,6 +95,22 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   final String itemId;
 
+  /// The season the viewer was browsing when they opened this item. Only set
+  /// when it differs from the item's own season, which happens for a special
+  /// that DisplaySpecialsWithinSeasons lists inside a regular season.
+  final String? contextSeasonId;
+
+  String? _resolvedEpisodesSeasonId;
+
+  /// The season [episodes] was actually loaded from, so callers queue playback
+  /// and build links against the list that is on screen.
+  String? get effectiveSeasonId {
+    final item = _item;
+    if (item == null) return _resolvedEpisodesSeasonId ?? contextSeasonId;
+    if (item.type == 'Season') return itemId;
+    return _resolvedEpisodesSeasonId ?? contextSeasonId ?? item.seasonId;
+  }
+
   ItemDetailState _state = ItemDetailState.loading;
   ItemDetailState get state => _state;
 
@@ -349,6 +365,7 @@ class ItemDetailViewModel extends ChangeNotifier {
   ItemDetailViewModel({
     required this.itemId,
     String? serverId,
+    this.contextSeasonId,
     required MediaServerClient client,
     required ItemMutationRepository mutations,
     required MdbListRepository mdbListRepository,
@@ -632,14 +649,38 @@ class ItemDetailViewModel extends ChangeNotifier {
     final item = _item;
     if (item == null) return;
     final seriesId = item.seriesId ?? itemId;
+    final ownSeasonId = item.type == 'Season' ? itemId : item.seasonId;
+    final requestedSeasonId = item.type == 'Season'
+        ? itemId
+        : (contextSeasonId ?? item.seasonId);
     try {
-      final data = await _client.itemsApi.getEpisodes(
-        seriesId,
-        seasonId: item.type == 'Season' ? itemId : item.seasonId,
-        fields: _episodeOverviewFields,
-      );
-      final items = (data['Items'] as List?) ?? [];
-      _episodes = _mapItems(items);
+      Future<List<AggregatedItem>> episodesOf(String? seasonId) async {
+        final data = await _client.itemsApi.getEpisodes(
+          seriesId,
+          seasonId: seasonId,
+          fields: _episodeOverviewFields,
+        );
+        return _mapItems((data['Items'] as List?) ?? []);
+      }
+
+      var seasonId = requestedSeasonId;
+      var episodes = await episodesOf(seasonId);
+
+      // The browsed season only holds this item while the server inlines
+      // specials. A stale link, or an offline catalogue that files specials
+      // strictly under season 0, leaves it out — fall back to its own season
+      // rather than stranding the page on a list it does not appear in.
+      // Without a season to fall back to there is nothing better to ask for:
+      // a null season id would fetch every episode of the series.
+      if (ownSeasonId != null &&
+          seasonId != ownSeasonId &&
+          !episodes.any((e) => e.id == itemId)) {
+        seasonId = ownSeasonId;
+        episodes = await episodesOf(ownSeasonId);
+      }
+
+      _resolvedEpisodesSeasonId = seasonId;
+      _episodes = episodes;
       notifyListeners();
     } catch (_) {}
   }

--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -38,6 +38,7 @@ import '../../preference/user_preferences.dart';
 import '../../syncplay/syncplay_manager.dart';
 import '../../util/platform_detection.dart';
 import '../../util/episode_playability.dart';
+import '../../util/season_queue_context.dart';
 import '../../util/audio_track_logic.dart';
 import '../../util/subtitle_track_logic.dart';
 
@@ -116,31 +117,6 @@ int? _asInt(dynamic value) {
   return null;
 }
 
-bool _isSingleSeasonEpisodeQueue(
-  List<dynamic> queueItems, {
-  required String seriesId,
-  required String seasonId,
-  required int seasonNumber,
-}) {
-  if (queueItems.isEmpty) return false;
-
-  for (final item in queueItems) {
-    if (item is! AggregatedItem) return false;
-    if (!_isEpisodeQueueItem(item)) return false;
-    if (item.seriesId != seriesId) return false;
-
-    final itemSeasonId = item.seasonId;
-    if (itemSeasonId != null && itemSeasonId.isNotEmpty) {
-      if (itemSeasonId != seasonId) return false;
-      continue;
-    }
-
-    if (item.parentIndexNumber != seasonNumber) return false;
-  }
-
-  return true;
-}
-
 List<AggregatedItem> _mapServerItemsToAggregated(
   List<dynamic> items,
   String serverId,
@@ -158,48 +134,6 @@ List<AggregatedItem> _mapServerItemsToAggregated(
       .toList(growable: false);
 }
 
-List<AggregatedItem> _sortEpisodesForPlayback(List<AggregatedItem> episodes) {
-  final sorted = List<AggregatedItem>.from(episodes);
-  sorted.sort((a, b) {
-    final seasonCmp = (a.parentIndexNumber ?? 0).compareTo(
-      b.parentIndexNumber ?? 0,
-    );
-    if (seasonCmp != 0) return seasonCmp;
-    final episodeCmp = (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0);
-    if (episodeCmp != 0) return episodeCmp;
-    return a.id.compareTo(b.id);
-  });
-  return sorted;
-}
-
-bool _isSeasonFinale(
-  AggregatedItem completedItem,
-  List<AggregatedItem> seasonEpisodes,
-) {
-  if (seasonEpisodes.isEmpty) return false;
-
-  final completedId = completedItem.id;
-  if (seasonEpisodes.last.id == completedId) return true;
-
-  if (seasonEpisodes.any((episode) => episode.id == completedId)) {
-    return false;
-  }
-
-  final completedIndex = completedItem.indexNumber;
-  if (completedIndex == null) return false;
-
-  int? maxEpisodeIndex;
-  for (final episode in seasonEpisodes) {
-    final idx = episode.indexNumber;
-    if (idx == null) continue;
-    if (maxEpisodeIndex == null || idx > maxEpisodeIndex) {
-      maxEpisodeIndex = idx;
-    }
-  }
-
-  return maxEpisodeIndex != null && completedIndex >= maxEpisodeIndex;
-}
-
 Future<List<AggregatedItem>> _fetchSeasonEpisodes({
   required MediaServerClient client,
   required String serverId,
@@ -213,7 +147,7 @@ Future<List<AggregatedItem>> _fetchSeasonEpisodes({
   );
   final rawItems = (data['Items'] as List?) ?? const [];
   final episodes = _mapServerItemsToAggregated(rawItems, serverId);
-  return _sortEpisodesForPlayback(episodes);
+  return orderSeasonEpisodes(episodes);
 }
 
 Future<String?> _resolveNextSeasonId({
@@ -255,14 +189,24 @@ Future<List<dynamic>> _nextSeasonItemsProvider(
   if (!_isEpisodeQueueItem(completedItem)) return const <dynamic>[];
 
   final seriesId = completedItem.seriesId;
-  final seasonId = completedItem.seasonId;
-  final seasonNumber = completedItem.parentIndexNumber;
   if (seriesId == null || seriesId.isEmpty) return const <dynamic>[];
+
+  if (queueItems.any((item) => item is! AggregatedItem)) {
+    return const <dynamic>[];
+  }
+  final episodeQueue = queueItems.cast<AggregatedItem>();
+
+  // An inlined special carries the Specials season on itself, so the season to
+  // continue from is the one the rest of the queue is made of.
+  final queueSeason = resolveQueueSeason(episodeQueue);
+  final seasonId = queueSeason?.seasonId ?? completedItem.seasonId;
+  final seasonNumber =
+      queueSeason?.seasonNumber ?? completedItem.parentIndexNumber;
   if (seasonId == null || seasonId.isEmpty) return const <dynamic>[];
   if (seasonNumber == null) return const <dynamic>[];
 
-  if (!_isSingleSeasonEpisodeQueue(
-    queueItems,
+  if (!isSeasonScopedEpisodeQueue(
+    episodeQueue,
     seriesId: seriesId,
     seasonId: seasonId,
     seasonNumber: seasonNumber,
@@ -285,7 +229,7 @@ Future<List<dynamic>> _nextSeasonItemsProvider(
     return const <dynamic>[];
   }
 
-  if (!_isSeasonFinale(completedItem, currentSeasonEpisodes)) {
+  if (!isSeasonFinale(completedItem, currentSeasonEpisodes)) {
     return const <dynamic>[];
   }
 

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -380,11 +380,15 @@ final appRouter = GoRouter(
         final itemId = state.pathParameters['itemId']!;
         final serverId = state.uri.queryParameters['serverId'];
         final autoPlay = state.uri.queryParameters['autoPlay'] == 'true';
+        final contextSeasonId = state.uri.queryParameters['seasonContext'];
         return ItemDetailScreen(
-          key: ValueKey(itemId),
+          // The browsed season decides which episode list this screen loads, so
+          // a change of context has to remount rather than reuse the view model.
+          key: ValueKey('$itemId|${contextSeasonId ?? ''}'),
           itemId: itemId,
           serverId: serverId,
           autoPlay: autoPlay,
+          contextSeasonId: contextSeasonId,
         );
       },
       routes: [

--- a/lib/ui/navigation/destinations.dart
+++ b/lib/ui/navigation/destinations.dart
@@ -177,11 +177,23 @@ class Destinations {
       '/library/$libraryId/letters';
   static String librarySuggestionsOf(String libraryId) =>
       '/library/$libraryId/suggestions';
-  static String item(String itemId, {String? serverId, bool autoPlay = false}) {
+  /// [seasonContext] names the season the viewer was browsing, which is not
+  /// always the item's own season: a special inlined by
+  /// DisplaySpecialsWithinSeasons is listed under a regular season while still
+  /// living in Specials. Carrying it keeps the episode list and the play queue
+  /// on the season that was on screen.
+  static String item(
+    String itemId, {
+    String? serverId,
+    bool autoPlay = false,
+    String? seasonContext,
+  }) {
     final base = '/item/$itemId';
     final params = <String>[
       if (serverId != null) 'serverId=$serverId',
       if (autoPlay) 'autoPlay=true',
+      if (seasonContext != null && seasonContext.isNotEmpty)
+        'seasonContext=${Uri.encodeQueryComponent(seasonContext)}',
     ];
     return params.isEmpty ? base : '$base?${params.join('&')}';
   }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -84,6 +84,7 @@ import '../../../syncplay/syncplay_manager.dart';
 import '../../../util/audio_labels.dart';
 import '../../../util/download_utils.dart';
 import '../../../util/episode_playability.dart';
+import '../../../util/season_queue_context.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/language_matching.dart';
 import '../../../util/subtitle_track_logic.dart';
@@ -217,12 +218,17 @@ class ItemDetailScreen extends StatefulWidget {
   /// Only used to resolve an IMDb-keyed Seerr id by searching for it.
   final String? seerrTitle;
 
+  /// The season the viewer came from, when it is not this item's own season —
+  /// see [ItemDetailViewModel.contextSeasonId].
+  final String? contextSeasonId;
+
   const ItemDetailScreen({
     super.key,
     required this.itemId,
     this.serverId,
     this.autoPlay = false,
     this.seerrTitle,
+    this.contextSeasonId,
   });
 
   @override
@@ -268,6 +274,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     _viewModel = ItemDetailViewModel(
       itemId: widget.itemId,
       serverId: widget.serverId,
+      contextSeasonId: widget.contextSeasonId,
       client: client,
       mutations: GetIt.instance<ItemMutationRepository>(),
       mdbListRepository: GetIt.instance<MdbListRepository>(),
@@ -2073,6 +2080,7 @@ class _DetailContentState extends State<_DetailContent> {
         DetailNextUpCard(
           episode: viewModel.nextUp!,
           imageApi: viewModel.imageApi,
+          contextSeasonId: viewModel.effectiveSeasonId,
           focusNode: seriesNextUpFocusNode,
           onKeyEvent: (event) {
             if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
@@ -2253,6 +2261,7 @@ class _DetailContentState extends State<_DetailContent> {
               imageApi: viewModel.imageApi,
               onChanged: () => viewModel.load(),
               isActive: viewModel.nextUp?.id == ep.id,
+              contextSeasonId: item.id,
             ),
           ),
         ),
@@ -2374,6 +2383,7 @@ class _DetailContentState extends State<_DetailContent> {
               DetailNextUpCard(
                 episode: nextEpisode,
                 imageApi: viewModel.imageApi,
+                contextSeasonId: viewModel.effectiveSeasonId,
                 focusNode: nextEpisodeFocusNode,
                 onKeyEvent: (event) {
                   if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
@@ -2417,6 +2427,7 @@ class _DetailContentState extends State<_DetailContent> {
             currentEpisodeId: item.id,
             imageApi: viewModel.imageApi,
             onChanged: () => viewModel.load(),
+            contextSeasonId: viewModel.effectiveSeasonId,
             scrollController: _trackSectionScrollController(
               episodesFocusNode,
               ctrl,
@@ -5838,8 +5849,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if (!mounted) return;
 
       // Consume autoPlay from the current detail route so back navigation
-      // doesn't re-trigger playback.
-      context.replace(Destinations.item(item.id, serverId: item.serverId));
+      // doesn't re-trigger playback. The browsed season has to survive the
+      // rewrite, or the screen reloads against the item's own season.
+      context.replace(
+        Destinations.item(
+          item.id,
+          serverId: item.serverId,
+          seasonContext: viewModel.contextSeasonId,
+        ),
+      );
 
       final isPhoto = item.type == 'Photo';
       final ws = _computeWatchState(item);
@@ -7735,6 +7753,68 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         .toList();
   }
 
+  /// The playable season list that actually holds [target], as the season pages
+  /// display it.
+  ///
+  /// A special is filed under Specials but shown inside a regular season once
+  /// the library inlines it, and nothing on the item says which season claimed
+  /// it. So for a special, ask about the seasons of its neighbours in aired
+  /// order — the one that lists it is the one to queue. Regular episodes take
+  /// the first candidate, their own season, on the first request.
+  Future<List<AggregatedItem>> _seasonQueueContaining(
+    MediaServerClient client, {
+    required String seriesId,
+    required String serverId,
+    required AggregatedItem target,
+    required List<AggregatedItem> airedEpisodes,
+    required String fields,
+  }) async {
+    final candidates = <String>[];
+    void addCandidate(String? seasonId) {
+      if (seasonId == null || seasonId.isEmpty) return;
+      if (candidates.contains(seasonId)) return;
+      candidates.add(seasonId);
+    }
+
+    if (isSpecialEpisode(target)) {
+      final at = airedEpisodes.indexWhere((e) => e.id == target.id);
+      if (at >= 0) {
+        // Airs-before is the common case, so the season that follows leads.
+        for (var i = at + 1; i < airedEpisodes.length; i++) {
+          if (isSpecialEpisode(airedEpisodes[i])) continue;
+          addCandidate(airedEpisodes[i].seasonId);
+          break;
+        }
+        for (var i = at - 1; i >= 0; i--) {
+          if (isSpecialEpisode(airedEpisodes[i])) continue;
+          addCandidate(airedEpisodes[i].seasonId);
+          break;
+        }
+      }
+    }
+    addCandidate(target.seasonId);
+
+    for (final seasonId in candidates) {
+      try {
+        final seasonData = await client.itemsApi.getEpisodes(
+          seriesId,
+          seasonId: seasonId,
+          fields: fields,
+        );
+        final seasonEpisodes = _mapRawItemsForServer(
+          seasonData['Items'],
+          serverId,
+        );
+        if (!seasonEpisodes.any((e) => e.id == target.id)) continue;
+        final playable = seasonEpisodes
+            .where(isEligibleNextEpisodeCandidate)
+            .toList();
+        if (playable.isNotEmpty) return playable;
+      } catch (_) {}
+    }
+    return const <AggregatedItem>[];
+  }
+
   Future<List<AggregatedItem>> _truncateQueueIfImmediateNextUnplayable(
     List<AggregatedItem> queue, {
     required int startIndex,
@@ -7827,10 +7907,20 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           lastPlayedType == 'episode' &&
           lastPlayed.id != widget.itemId) {
         if (context.mounted) {
-          final currentSeasonId = viewModel.item?.seasonId;
-          if (lastPlayed.seasonId != null &&
-              lastPlayed.seasonId!.isNotEmpty &&
-              lastPlayed.seasonId != currentSeasonId) {
+          // An inlined special owns the Specials season while being listed in
+          // the one on screen, so membership of the loaded list — not the
+          // season id — decides whether playback left the season.
+          final browsedSeasonId = viewModel.effectiveSeasonId;
+          final stayedInSeason =
+              viewModel.episodes.any((e) => e.id == lastPlayed.id) ||
+              lastPlayed.seasonId == browsedSeasonId;
+          // A special's own season is Specials, which is never the season the
+          // viewer was moved into — rebuilding the stack under it would land
+          // them exactly where this whole change keeps them out of.
+          if (!stayedInSeason &&
+              !isSpecialEpisode(lastPlayed) &&
+              lastPlayed.seasonId != null &&
+              lastPlayed.seasonId!.isNotEmpty) {
             final router = GoRouter.of(context);
             router.pushReplacement(
               Destinations.item(
@@ -7845,7 +7935,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             });
           } else {
             context.pushReplacement(
-              Destinations.item(lastPlayed.id, serverId: lastPlayed.serverId),
+              Destinations.item(
+                lastPlayed.id,
+                serverId: lastPlayed.serverId,
+                seasonContext: seasonContextParam(
+                  contextSeasonId: browsedSeasonId,
+                  episodeSeasonId: lastPlayed.seasonId,
+                ),
+              ),
             );
           }
         }
@@ -7854,7 +7951,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           lastPlayedType == 'episode' &&
           lastPlayed.seasonId != null &&
           lastPlayed.seasonId!.isNotEmpty &&
-          lastPlayed.seasonId != widget.itemId) {
+          lastPlayed.seasonId != widget.itemId &&
+          // A special inlined into this season is displayed here, so finishing
+          // on one must not bounce the viewer over to the Specials season.
+          !viewModel.episodes.any((e) => e.id == lastPlayed.id)) {
         if (context.mounted) {
           context.pushReplacement(
             Destinations.item(
@@ -8021,27 +8121,17 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                   );
             }
 
-            final targetSeasonId = targetEpisode.seasonId;
-            var queueEpisodes = <AggregatedItem>[targetEpisode];
-            if (targetSeasonId != null && targetSeasonId.isNotEmpty) {
-              try {
-                final seasonData = await client.itemsApi.getEpisodes(
-                  item.id,
-                  seasonId: targetSeasonId,
-                  fields: episodeQueueFields,
-                );
-                final seasonEpisodes = _mapRawItemsForServer(
-                  seasonData['Items'],
-                  item.serverId,
-                );
-                final playableSeasonEpisodes = seasonEpisodes
-                    .where(isEligibleNextEpisodeCandidate)
-                    .toList();
-                if (playableSeasonEpisodes.isNotEmpty) {
-                  queueEpisodes = playableSeasonEpisodes;
-                }
-              } catch (_) {}
-            }
+            final playableSeasonEpisodes = await _seasonQueueContaining(
+              client,
+              seriesId: item.id,
+              serverId: item.serverId,
+              target: targetEpisode,
+              airedEpisodes: allEpisodes,
+              fields: episodeQueueFields,
+            );
+            final queueEpisodes = playableSeasonEpisodes.isNotEmpty
+                ? playableSeasonEpisodes
+                : <AggregatedItem>[targetEpisode];
 
             final startIndex = queueEpisodes.indexWhere(
               (e) => e.id == targetEpisode.id,
@@ -8156,7 +8246,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             var episodes = viewModel.episodes;
             if (episodes.isEmpty || !episodes.any((e) => e.id == item.id)) {
               final seriesId = item.seriesId;
-              final seasonId = item.seasonId;
+              // Matches the list on screen, which for an inlined special is the
+              // season being browsed rather than Specials.
+              final seasonId = viewModel.effectiveSeasonId ?? item.seasonId;
               if (seriesId != null && seriesId.isNotEmpty) {
                 try {
                   const episodeQueueFields = 'Overview,RunTimeTicks,UserData';
@@ -12387,6 +12479,10 @@ class _EpisodesRow extends StatelessWidget {
   final KeyEventResult Function(int index, KeyEvent event)? onItemKeyEvent;
   final VoidCallback? onChanged;
 
+  /// The season these episodes are listed under — see
+  /// [DetailEpisodeCard.contextSeasonId].
+  final String? contextSeasonId;
+
   const _EpisodesRow({
     required this.episodes,
     required this.currentEpisodeId,
@@ -12395,6 +12491,7 @@ class _EpisodesRow extends StatelessWidget {
     this.firstItemFocusNode,
     this.onItemKeyEvent,
     this.onChanged,
+    this.contextSeasonId,
   });
 
   @override
@@ -12434,6 +12531,7 @@ class _EpisodesRow extends StatelessWidget {
                 ? null
                 : (event) => onItemKeyEvent!(index, event),
             onChanged: onChanged,
+            contextSeasonId: contextSeasonId,
           );
         },
       ),
@@ -12450,6 +12548,10 @@ class _EpisodeListCard extends StatefulWidget {
   final KeyEventResult Function(KeyEvent event)? onKeyEvent;
   final VoidCallback? onChanged;
 
+  /// The season this card is listed under — see
+  /// [DetailEpisodeCard.contextSeasonId].
+  final String? contextSeasonId;
+
   const _EpisodeListCard({
     required this.episode,
     required this.isCurrent,
@@ -12458,6 +12560,7 @@ class _EpisodeListCard extends StatefulWidget {
     this.focusNode,
     this.onKeyEvent,
     this.onChanged,
+    this.contextSeasonId,
   });
 
   @override
@@ -12476,6 +12579,19 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
 
   void _handleLongPress() {
     showContextMenu(context, widget.episode, onChanged: widget.onChanged);
+  }
+
+  void _open() {
+    context.push(
+      Destinations.item(
+        widget.episode.id,
+        serverId: widget.episode.serverId,
+        seasonContext: seasonContextParam(
+          contextSeasonId: widget.contextSeasonId,
+          episodeSeasonId: widget.episode.seasonId,
+        ),
+      ),
+    );
   }
 
   @override
@@ -12510,8 +12626,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
           }
           final handlerResult = _selectKeyHandler.handleKeyEvent(
             event,
-            onTap: () =>
-                context.push(Destinations.item(ep.id, serverId: ep.serverId)),
+            onTap: _open,
             onLongPress: _handleLongPress,
           );
           if (handlerResult != KeyEventResult.ignored) {
@@ -12520,8 +12635,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
-          onTap: () =>
-              context.push(Destinations.item(ep.id, serverId: ep.serverId)),
+          onTap: _open,
           onLongPress: _handleLongPress,
           onSecondaryTap: _handleLongPress,
           child: Container(
@@ -12673,11 +12787,16 @@ class DetailNextUpCard extends StatefulWidget {
   final FocusNode? focusNode;
   final KeyEventResult Function(KeyEvent event)? onKeyEvent;
 
+  /// The season this card is listed under — see
+  /// [DetailEpisodeCard.contextSeasonId].
+  final String? contextSeasonId;
+
   const DetailNextUpCard({
     required this.episode,
     required this.imageApi,
     this.focusNode,
     this.onKeyEvent,
+    this.contextSeasonId,
   });
 
   @override
@@ -12686,6 +12805,19 @@ class DetailNextUpCard extends StatefulWidget {
 
 class DetailNextUpCardState extends State<DetailNextUpCard>
     with FocusStateMixin {
+  void _open() {
+    context.push(
+      Destinations.item(
+        widget.episode.id,
+        serverId: widget.episode.serverId,
+        seasonContext: seasonContextParam(
+          contextSeasonId: widget.contextSeasonId,
+          episodeSeasonId: widget.episode.seasonId,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final episode = widget.episode;
@@ -12719,17 +12851,13 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
             return customResult;
           }
           if (isActivateKey(event)) {
-            context.push(
-              Destinations.item(episode.id, serverId: episode.serverId),
-            );
+            _open();
             return KeyEventResult.handled;
           }
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
-          onTap: () => context.push(
-            Destinations.item(episode.id, serverId: episode.serverId),
-          ),
+          onTap: _open,
           child: AnimatedScale(
             scale: cardExpansion && showFocusBorder ? 1.02 : 1.0,
             duration: const Duration(milliseconds: 120),
@@ -12848,6 +12976,10 @@ class DetailEpisodeCard extends StatefulWidget {
   final FocusNode? focusNode;
   final FocusOnKeyEventCallback? onKeyEvent;
 
+  /// The season this card is listed under, forwarded so an inlined special
+  /// opens in the season the viewer is browsing instead of Specials.
+  final String? contextSeasonId;
+
   final bool isActive;
 
   const DetailEpisodeCard({
@@ -12856,6 +12988,7 @@ class DetailEpisodeCard extends StatefulWidget {
     this.onChanged,
     this.focusNode,
     this.onKeyEvent,
+    this.contextSeasonId,
     this.isActive = false,
   });
 
@@ -12875,6 +13008,19 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
 
   void _handleLongPress() {
     showContextMenu(context, widget.episode, onChanged: widget.onChanged);
+  }
+
+  void _open() {
+    context.push(
+      Destinations.item(
+        widget.episode.id,
+        serverId: widget.episode.serverId,
+        seasonContext: seasonContextParam(
+          contextSeasonId: widget.contextSeasonId,
+          episodeSeasonId: widget.episode.seasonId,
+        ),
+      ),
+    );
   }
 
   @override
@@ -12914,9 +13060,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
           }
           final handlerResult = _selectKeyHandler.handleKeyEvent(
             event,
-            onTap: () => context.push(
-              Destinations.item(episode.id, serverId: episode.serverId),
-            ),
+            onTap: _open,
             onLongPress: _handleLongPress,
           );
           if (handlerResult != KeyEventResult.ignored) {
@@ -12925,9 +13069,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
           return KeyEventResult.ignored;
         },
         child: GestureDetector(
-          onTap: () => context.push(
-            Destinations.item(episode.id, serverId: episode.serverId),
-          ),
+          onTap: _open,
           onLongPress: _handleLongPress,
           onSecondaryTap: _handleLongPress,
           child: AnimatedScale(

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -18,6 +18,7 @@ import '../../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../preference/user_preferences.dart';
 import '../../../../preference/preference_constants.dart';
+import '../../../../util/episode_playability.dart';
 import '../../../../util/overview_text.dart';
 import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
@@ -1300,6 +1301,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 imageApi: _vm.imageApi,
                 onChanged: () => _vm.load(),
                 isActive: _vm.episodes[i].id == nextUpId,
+                contextSeasonId: _vm.effectiveSeasonId,
                 focusNode: i == 0 ? _episodesFirstFocusNode : null,
                 onKeyEvent: i == 0
                     ? (node, event) {
@@ -4322,8 +4324,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         final manager = GetIt.instance<PlaybackManager>();
         final hasProgress = (episode!.playbackPosition?.inMilliseconds ?? 0) > 0 ||
                             (episode.playedPercentage ?? 0) > 0;
+        // On a season, follow the list as displayed so playback carries on
+        // through the season instead of stopping after this one item.
+        var queue = <AggregatedItem>[episode];
+        var startIndex = 0;
+        if (item.type == 'Season') {
+          final playable = _vm.episodes
+              .where((e) => e.id == episode!.id || isEligibleNextEpisodeCandidate(e))
+              .toList();
+          final at = playable.indexWhere((e) => e.id == episode!.id);
+          if (at >= 0) {
+            queue = playable;
+            startIndex = at;
+          }
+        }
         await manager.playItems(
-          [episode],
+          queue,
+          startIndex: startIndex,
           startPosition: hasProgress
               ? (episode.playbackPosition ?? Duration.zero)
               : Duration.zero,

--- a/lib/util/season_queue_context.dart
+++ b/lib/util/season_queue_context.dart
@@ -1,0 +1,140 @@
+import '../data/models/aggregated_item.dart';
+
+/// Servers file specials under season 0, but a special with AirsBefore/AirsAfter
+/// metadata is displayed — and played — inside another season once the library
+/// has DisplaySpecialsWithinSeasons on. Its own SeasonId therefore says nothing
+/// about which season's queue it belongs to.
+bool isSpecialEpisode(AggregatedItem item) => item.parentIndexNumber == 0;
+
+/// Prerolls are stitched into the queue alongside the episodes and say nothing
+/// about which season it represents.
+bool isPrerollQueueItem(AggregatedItem item) =>
+    item.rawData['__moonfinIsPreroll'] == true;
+
+bool _isEpisode(AggregatedItem item) =>
+    item.type?.trim().toLowerCase() == 'episode';
+
+/// The `seasonContext` a link should carry: nothing when the season is the
+/// episode's own, since that is what the item already resolves to.
+String? seasonContextParam({
+  required String? contextSeasonId,
+  required String? episodeSeasonId,
+}) {
+  if (contextSeasonId == null || contextSeasonId.isEmpty) return null;
+  if (contextSeasonId == episodeSeasonId) return null;
+  return contextSeasonId;
+}
+
+/// The season a queue actually represents, read off its first regular episode.
+/// Null when the queue holds nothing but specials, which is what playing from
+/// the Specials season itself produces.
+({String seasonId, int seasonNumber})? resolveQueueSeason(
+  List<AggregatedItem> queueItems,
+) {
+  for (final item in queueItems) {
+    if (isPrerollQueueItem(item)) continue;
+    if (!_isEpisode(item) || isSpecialEpisode(item)) continue;
+    final seasonId = item.seasonId;
+    final seasonNumber = item.parentIndexNumber;
+    if (seasonId == null || seasonId.isEmpty || seasonNumber == null) continue;
+    return (seasonId: seasonId, seasonNumber: seasonNumber);
+  }
+  return null;
+}
+
+/// Whether every item is an episode of this one season. Specials count as
+/// members wherever they are inlined, so a queue of [S2E1 … S2E13, special]
+/// still reads as season 2 and can roll over into season 3.
+bool isSeasonScopedEpisodeQueue(
+  List<AggregatedItem> queueItems, {
+  required String seriesId,
+  required String seasonId,
+  required int seasonNumber,
+}) {
+  if (queueItems.isEmpty) return false;
+
+  var sawEpisode = false;
+  for (final item in queueItems) {
+    if (isPrerollQueueItem(item)) continue;
+    if (!_isEpisode(item)) return false;
+    sawEpisode = true;
+    if (item.seriesId != seriesId) return false;
+    if (isSpecialEpisode(item)) continue;
+
+    final itemSeasonId = item.seasonId;
+    if (itemSeasonId != null && itemSeasonId.isNotEmpty) {
+      if (itemSeasonId != seasonId) return false;
+      continue;
+    }
+
+    if (item.parentIndexNumber != seasonNumber) return false;
+  }
+
+  return sawEpisode;
+}
+
+/// Ordering for a season-scoped episode list.
+///
+/// Where a special sits among regular episodes is the air order the server
+/// worked out from its AirsBefore/AirsAfter metadata, so a mixed list is left
+/// exactly as it arrived — sorting by season number would drag the special to
+/// the front, which is not where an airs-after one belongs. Every other list
+/// keeps the defensive sort, including the Specials season itself: specials
+/// with no placement carry nothing to preserve, and not every backend
+/// guarantees an order.
+List<AggregatedItem> orderSeasonEpisodes(List<AggregatedItem> episodes) {
+  final ordered = List<AggregatedItem>.from(episodes);
+  final inlinesSpecials =
+      ordered.any(isSpecialEpisode) &&
+      ordered.any((episode) => !isSpecialEpisode(episode));
+  if (inlinesSpecials) return ordered;
+
+  ordered.sort((a, b) {
+    final seasonCmp = (a.parentIndexNumber ?? 0).compareTo(
+      b.parentIndexNumber ?? 0,
+    );
+    if (seasonCmp != 0) return seasonCmp;
+    final episodeCmp = (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0);
+    if (episodeCmp != 0) return episodeCmp;
+    return a.id.compareTo(b.id);
+  });
+  return ordered;
+}
+
+/// Whether [completedItem] was the last thing this season had to play, which
+/// is what lets playback roll on into the next one.
+bool isSeasonFinale(
+  AggregatedItem completedItem,
+  List<AggregatedItem> seasonEpisodes,
+) {
+  if (seasonEpisodes.isEmpty) return false;
+
+  final completedId = completedItem.id;
+  if (seasonEpisodes.last.id == completedId) return true;
+
+  final completedAt = seasonEpisodes.indexWhere((e) => e.id == completedId);
+  if (completedAt >= 0) {
+    // Only a regular episode still to come holds the season open. A trailing
+    // special is an inlined extra, and the queue reached its end without it,
+    // so waiting on it would strand playback here instead of moving on.
+    return seasonEpisodes.skip(completedAt + 1).every(isSpecialEpisode);
+  }
+
+  // A special numbers itself against the Specials season, so its IndexNumber
+  // carries no meaning next to this season's episode numbers.
+  if (isSpecialEpisode(completedItem)) return false;
+
+  final completedIndex = completedItem.indexNumber;
+  if (completedIndex == null) return false;
+
+  int? maxEpisodeIndex;
+  for (final episode in seasonEpisodes) {
+    final idx = episode.indexNumber;
+    if (idx == null) continue;
+    if (maxEpisodeIndex == null || idx > maxEpisodeIndex) {
+      maxEpisodeIndex = idx;
+    }
+  }
+
+  return maxEpisodeIndex != null && completedIndex >= maxEpisodeIndex;
+}

--- a/test/ui/navigation/item_destination_test.dart
+++ b/test/ui/navigation/item_destination_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/navigation/destinations.dart';
+
+void main() {
+  group('Destinations.item', () {
+    test('stays bare without options', () {
+      expect(Destinations.item('abc'), '/item/abc');
+    });
+
+    test(
+      'carries the browsed season so an inlined special keeps its context',
+      () {
+        expect(
+          Destinations.item(
+            'special-id',
+            serverId: 's1',
+            seasonContext: 'season-1',
+          ),
+          '/item/special-id?serverId=s1&seasonContext=season-1',
+        );
+      },
+    );
+
+    test('omits an absent or empty season context', () {
+      expect(Destinations.item('abc', seasonContext: null), '/item/abc');
+      expect(Destinations.item('abc', seasonContext: ''), '/item/abc');
+    });
+
+    test('escapes a season context so it survives the query string', () {
+      final uri = Uri.parse(Destinations.item('abc', seasonContext: 'a b&c'));
+      expect(uri.queryParameters['seasonContext'], 'a b&c');
+    });
+  });
+}

--- a/test/util/season_queue_context_test.dart
+++ b/test/util/season_queue_context_test.dart
@@ -1,0 +1,301 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/util/season_queue_context.dart';
+
+const _seriesId = 'series-alpha';
+const _season1Id = 'season-1';
+const _season2Id = 'season-2';
+const _specialsId = 'season-specials';
+
+AggregatedItem _episode(
+  String id, {
+  String seriesId = _seriesId,
+  String? seasonId = _season1Id,
+  int seasonNumber = 1,
+  int? indexNumber,
+  String type = 'Episode',
+}) {
+  return AggregatedItem(
+    id: id,
+    serverId: 'server',
+    rawData: {
+      'Id': id,
+      'Type': type,
+      'SeriesId': seriesId,
+      'SeasonId': ?seasonId,
+      'ParentIndexNumber': seasonNumber,
+      'IndexNumber': ?indexNumber,
+    },
+  );
+}
+
+/// A special as the server hands it over: filed under Specials, displayed
+/// inside a regular season.
+AggregatedItem _special(String id, {int indexNumber = 1}) => _episode(
+  id,
+  seasonId: _specialsId,
+  seasonNumber: 0,
+  indexNumber: indexNumber,
+);
+
+AggregatedItem _preroll(String id) => AggregatedItem(
+  id: id,
+  serverId: 'server',
+  rawData: {'Id': id, 'Type': 'Trailer', '__moonfinIsPreroll': true},
+);
+
+void main() {
+  group('resolveQueueSeason', () {
+    test('reads season 1 from a queue an airs-before special leads', () {
+      final season = resolveQueueSeason([
+        _special('opening-special'),
+        _episode('s1e1', indexNumber: 1),
+        _episode('s1e2', indexNumber: 2),
+      ]);
+
+      expect(season?.seasonId, _season1Id);
+      expect(season?.seasonNumber, 1);
+    });
+
+    test('reads season 1 from a queue an airs-after special trails', () {
+      final season = resolveQueueSeason([
+        _episode('s1e1', indexNumber: 1),
+        _episode('s1e2', indexNumber: 2),
+        _special('season-1-finale-special'),
+      ]);
+
+      expect(season?.seasonId, _season1Id);
+      expect(season?.seasonNumber, 1);
+    });
+
+    test('returns null for a queue of nothing but specials', () {
+      expect(
+        resolveQueueSeason([_special('one'), _special('two', indexNumber: 2)]),
+        isNull,
+      );
+    });
+
+    test('ignores prerolls stitched into the queue', () {
+      final season = resolveQueueSeason([
+        _preroll('preroll'),
+        _episode('s2e1', seasonId: _season2Id, seasonNumber: 2, indexNumber: 1),
+      ]);
+
+      expect(season?.seasonId, _season2Id);
+      expect(season?.seasonNumber, 2);
+    });
+  });
+
+  group('isSeasonScopedEpisodeQueue', () {
+    bool scoped(
+      List<AggregatedItem> queue, {
+      String seasonId = _season1Id,
+      int seasonNumber = 1,
+    }) => isSeasonScopedEpisodeQueue(
+      queue,
+      seriesId: _seriesId,
+      seasonId: seasonId,
+      seasonNumber: seasonNumber,
+    );
+
+    test('accepts an inlined special as a member of the season', () {
+      expect(
+        scoped([_special('inlined-special'), _episode('s1e1', indexNumber: 1)]),
+        isTrue,
+      );
+      expect(
+        scoped([_episode('s1e1', indexNumber: 1), _special('inlined-special')]),
+        isTrue,
+      );
+    });
+
+    test('rejects a queue spanning two real seasons', () {
+      expect(
+        scoped([
+          _episode('s1e1', indexNumber: 1),
+          _episode(
+            's2e1',
+            seasonId: _season2Id,
+            seasonNumber: 2,
+            indexNumber: 1,
+          ),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('rejects another series and non-episodes', () {
+      expect(
+        scoped([_episode('other', seriesId: 'series-other', indexNumber: 1)]),
+        isFalse,
+      );
+      expect(
+        scoped([_episode('movie', type: 'Movie', indexNumber: 1)]),
+        isFalse,
+      );
+    });
+
+    test(
+      'falls back to the season number when the item carries no season id',
+      () {
+        expect(
+          scoped([_episode('s1e1', seasonId: null, indexNumber: 1)]),
+          isTrue,
+        );
+        expect(
+          scoped([
+            _episode('s3e1', seasonId: null, seasonNumber: 3, indexNumber: 1),
+          ]),
+          isFalse,
+        );
+      },
+    );
+
+    test('rejects an empty queue and one holding only prerolls', () {
+      expect(scoped([]), isFalse);
+      expect(scoped([_preroll('preroll')]), isFalse);
+    });
+  });
+
+  group('orderSeasonEpisodes', () {
+    test('sorts a scrambled season that holds no special', () {
+      final ordered = orderSeasonEpisodes([
+        _episode('s1e3', indexNumber: 3),
+        _episode('s1e1', indexNumber: 1),
+        _episode('s1e2', indexNumber: 2),
+      ]);
+
+      expect(ordered.map((e) => e.id), ['s1e1', 's1e2', 's1e3']);
+    });
+
+    test('leaves air order alone when a special trails the season', () {
+      final aired = [
+        _episode('s1e1', indexNumber: 1),
+        _episode('s1e2', indexNumber: 2),
+        _special('airs-after'),
+      ];
+
+      expect(orderSeasonEpisodes(aired).map((e) => e.id), [
+        's1e1',
+        's1e2',
+        'airs-after',
+      ]);
+    });
+
+    test('still sorts the Specials season, which inlines nothing', () {
+      final scrambled = [
+        _special('third', indexNumber: 3),
+        _special('first', indexNumber: 1),
+        _special('second', indexNumber: 2),
+      ];
+
+      expect(orderSeasonEpisodes(scrambled).map((e) => e.id), [
+        'first',
+        'second',
+        'third',
+      ]);
+    });
+
+    test('leaves air order alone when a special leads the season', () {
+      final aired = [_special('airs-before'), _episode('s1e1', indexNumber: 1)];
+
+      expect(orderSeasonEpisodes(aired).map((e) => e.id), [
+        'airs-before',
+        's1e1',
+      ]);
+    });
+  });
+
+  group('isSeasonFinale', () {
+    // The season as the server lists it once an airs-after special is inlined.
+    final airsAfterSeason = [
+      _episode('s1e1', indexNumber: 1),
+      _episode('s1e2', indexNumber: 2),
+      _special('airs-after'),
+    ];
+
+    test('a trailing special does not hold back the next season', () {
+      // The queue ran out on the last regular episode, so the special was
+      // never queued — waiting on it would strand playback here.
+      expect(isSeasonFinale(airsAfterSeason[1], airsAfterSeason), isTrue);
+    });
+
+    test('the trailing special itself finishes the season', () {
+      expect(isSeasonFinale(airsAfterSeason[2], airsAfterSeason), isTrue);
+    });
+
+    test('a mid-season episode does not finish the season', () {
+      expect(isSeasonFinale(airsAfterSeason[0], airsAfterSeason), isFalse);
+    });
+
+    test('a leading special never finishes the season', () {
+      final airsBeforeSeason = [
+        _special('airs-before'),
+        _episode('s1e1', indexNumber: 1),
+      ];
+
+      expect(isSeasonFinale(airsBeforeSeason[0], airsBeforeSeason), isFalse);
+      expect(isSeasonFinale(airsBeforeSeason[1], airsBeforeSeason), isTrue);
+    });
+
+    test('an absent special is not judged by its own numbering', () {
+      // Special #2 would otherwise read as past the season's last episode.
+      expect(
+        isSeasonFinale(_special('unlisted', indexNumber: 2), [
+          _episode('s1e1', indexNumber: 1),
+        ]),
+        isFalse,
+      );
+    });
+
+    test('an absent episode falls back to the highest episode number', () {
+      final season = [
+        _episode('s1e1', indexNumber: 1),
+        _episode('s1e2', indexNumber: 2),
+      ];
+
+      expect(isSeasonFinale(_episode('later', indexNumber: 3), season), isTrue);
+      expect(
+        isSeasonFinale(_episode('early', indexNumber: 1), season),
+        isFalse,
+      );
+    });
+
+    test('an empty season finishes nothing', () {
+      expect(isSeasonFinale(_episode('s1e1', indexNumber: 1), []), isFalse);
+    });
+  });
+
+  group('seasonContextParam', () {
+    test('is dropped when it matches the episode own season', () {
+      expect(
+        seasonContextParam(
+          contextSeasonId: _season1Id,
+          episodeSeasonId: _season1Id,
+        ),
+        isNull,
+      );
+    });
+
+    test('is dropped when there is no context', () {
+      expect(
+        seasonContextParam(contextSeasonId: null, episodeSeasonId: _season1Id),
+        isNull,
+      );
+      expect(
+        seasonContextParam(contextSeasonId: '', episodeSeasonId: _season1Id),
+        isNull,
+      );
+    });
+
+    test('is carried for a special listed outside its own season', () {
+      expect(
+        seasonContextParam(
+          contextSeasonId: _season1Id,
+          episodeSeasonId: _specialsId,
+        ),
+        _season1Id,
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
A special with `AirsBefore`/`AirsAfter` metadata is displayed inside a regular
season once the library has `DisplaySpecialsWithinSeasons` enabled, but the item
still carries Specials as its own `SeasonId`. Opening such a special from a
season reloaded the detail screen against Specials, and playing it queued the
Specials season rather than the run that was on screen.

This carries the browsed season through navigation and playback so an inlined
special stays in the season that actually lists it.

## Related Issues
- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Links carry the browsed season as a `seasonContext` query parameter, so the
  detail screen loads the list the viewer came from and falls back to the item's
  own season when that list does not contain it.
- Playback queues the season that actually lists the episode rather than the
  special's own `SeasonId`.
- A queue's season is resolved from its regular episodes instead of the completed
  item, so the rollover after an inlined special continues into the correct season.
- A season list mixing specials with regular episodes keeps the server's aired
  order; sorting by season number would drag a special to the front of the run it
  was placed in.
- Playing an episode from a season screen queues the rest of that season instead
  of stopping after the single item.
- New `lib/util/season_queue_context.dart` consolidates season/queue resolution
  that was previously duplicated in `playback_module.dart` (net −90 lines there).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Unit tests cover the season/queue resolution logic; the app was built and
launched on macOS to confirm the branch compiles and runs.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enable `DisplaySpecialsWithinSeasons` on a TV library whose series has a
   special with `AirsBefore`/`AirsAfter` metadata.
2. Open the season and confirm the special appears at its aired position (not
   pulled to the front of the season).
3. Open the special: the episode list shown must remain the browsed season, not
   Specials.
4. Play the special: playback must continue into the next episode of that season.
5. Play through to the season's last episode and confirm rollover moves into the
   next season.
6. Open a special from the Specials season directly and confirm it still behaves
   as part of Specials.

## Screenshots (if applicable)
N/A — no visual changes; behaviour only.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced