### PR TITLE
fix(library) - Do The Alphabet Dance

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -490,20 +490,20 @@ class LibraryBrowseViewModel extends ChangeNotifier {
 
     while (!hasPrefix() && hasMore) {
       final beforeCount = _items.length;
-      await loadMore();
+      await loadMore(pageSizeOverride: 300);
       if (_items.length == beforeCount) break;
     }
     return hasPrefix();
   }
 
-  Future<void> loadMore() async {
+  Future<void> loadMore({int? pageSizeOverride}) async {
     if (_loadingMore || !hasMore) return;
     _loadingMore = true;
     notifyListeners();
 
     final previouslyFetched = _fetchedCount;
     try {
-      await _fetchPage(_fetchedCount);
+      await _fetchPage(_fetchedCount, pageSizeOverride: pageSizeOverride);
       // Stop on a page the server had nothing left for, not on one that only
       // repeated what is already shown, which a random sort does by chance.
       if (_fetchedCount <= previouslyFetched) {
@@ -516,8 +516,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _fetchPage(int startIndex) async {
-    final pageSize = startIndex == 0 ? _firstPageSize : _pageSize;
+  Future<void> _fetchPage(int startIndex, {int? pageSizeOverride}) async {
+    final pageSize = pageSizeOverride ?? (startIndex == 0 ? _firstPageSize : _pageSize);
     final filters = <String>[];
     if (_playedFilter == PlayedStatusFilter.watched) {
       filters.add('IsPlayed');

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -303,21 +303,37 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       final targetIndex = _indexOfLetter(letter);
       if (targetIndex < 0) return;
 
+      double targetOffset = 0.0;
       if (_isSongsBrowse) {
-        _scrollController.jumpTo(targetIndex * _kSongRowHeight);
+        targetOffset = targetIndex * _kSongRowHeight;
       } else {
         final geometry = _gridGeometry;
         if (geometry == null) return;
         final line = targetIndex ~/ geometry.perLine;
-        _scrollController.jumpTo(
-          (geometry.leadingPad +
-                  line * (geometry.lineExtent + geometry.lineSpacing))
-              .clamp(0.0, _scrollController.position.maxScrollExtent),
-        );
+        targetOffset = geometry.leadingPad +
+            line * (geometry.lineExtent + geometry.lineSpacing);
       }
 
-      await WidgetsBinding.instance.endOfFrame;
-      if (!mounted) return;
+      // Slivers in a CustomScrollView compute maxScrollExtent lazily as children are laid out.
+      // Jumping to a line deeper than currently built children gets clamped to the current maxExtent.
+      // Loop jumps over frame boundaries until the layout expands to reach targetOffset or true scroll bottom.
+      for (int i = 0; i < 5; i++) {
+        if (!mounted || !_scrollController.hasClients) break;
+        final currentMax = _scrollController.position.maxScrollExtent;
+        final destination = targetOffset.clamp(0.0, currentMax);
+        _scrollController.jumpTo(destination);
+
+        await WidgetsBinding.instance.endOfFrame;
+        if (!mounted || !_scrollController.hasClients) break;
+
+        final currentPixels = _scrollController.position.pixels;
+        final newMax = _scrollController.position.maxScrollExtent;
+        if ((currentPixels - targetOffset).abs() < 2.0 ||
+            (destination >= currentMax && currentMax == newMax)) {
+          break;
+        }
+      }
+
       if (PlatformDetection.isTV) {
         getGridItemFocusNode(targetIndex).requestFocus();
       }

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -287,10 +287,17 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   bool _isJumpingToLetter = false;
+  int _letterJumpGeneration = 0;
 
   /// Scrolls the first item whose sort name starts with [letter] to the
   /// leading edge, loading pages first if it hasn't arrived yet.
   Future<void> _jumpToLetter(String letter) async {
+    // Scrubbing along the alphabet bar starts a jump per letter, and an older
+    // one would keep re-asserting its own offset against the newest, so each
+    // jump checks in after every await and bows out once superseded.
+    final generation = ++_letterJumpGeneration;
+    bool stillCurrent() => mounted && generation == _letterJumpGeneration;
+
     _vm.setLetterFilter(letter);
     if (!mounted) return;
     setState(() => _isJumpingToLetter = true);
@@ -298,7 +305,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     try {
       await _vm.ensureItemsLoadedForPrefix(letter);
       await WidgetsBinding.instance.endOfFrame;
-      if (!mounted || !_scrollController.hasClients) return;
+      if (!stillCurrent() || !_scrollController.hasClients) return;
 
       final targetIndex = _indexOfLetter(letter);
       if (targetIndex < 0) return;
@@ -314,17 +321,18 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             line * (geometry.lineExtent + geometry.lineSpacing);
       }
 
-      // Slivers in a CustomScrollView compute maxScrollExtent lazily as children are laid out.
-      // Jumping to a line deeper than currently built children gets clamped to the current maxExtent.
-      // Loop jumps over frame boundaries until the layout expands to reach targetOffset or true scroll bottom.
+      // Slivers report maxScrollExtent lazily as children are laid out, so a
+      // jump deeper than the built children clamps short. Re-jump across
+      // frame boundaries until the layout reaches the target or the true
+      // scroll bottom.
       for (int i = 0; i < 5; i++) {
-        if (!mounted || !_scrollController.hasClients) break;
         final currentMax = _scrollController.position.maxScrollExtent;
         final destination = targetOffset.clamp(0.0, currentMax);
         _scrollController.jumpTo(destination);
 
         await WidgetsBinding.instance.endOfFrame;
-        if (!mounted || !_scrollController.hasClients) break;
+        if (!stillCurrent()) return;
+        if (!_scrollController.hasClients) break;
 
         final currentPixels = _scrollController.position.pixels;
         final newMax = _scrollController.position.maxScrollExtent;
@@ -338,7 +346,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         getGridItemFocusNode(targetIndex).requestFocus();
       }
     } finally {
-      if (mounted) setState(() => _isJumpingToLetter = false);
+      // A superseded jump leaves the flag for the jump that replaced it.
+      if (stillCurrent()) setState(() => _isJumpingToLetter = false);
     }
   }
 


### PR DESCRIPTION
# Pull Request

## Summary
Resolves the two-press requirement when performing an alphabetical quick jump in library screens, and optimizes cold-start letter scanning performance by chunking prefix page fetches.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **library_browse_screen.dart**: Implemented a multi-frame scroll convergence loop in `_jumpToLetter` to iteratively jump and settle frame layouts until `targetOffset` is reached, ensuring `maxScrollExtent` lazy sliver expansion completes in 1-3 frames before requesting item focus.
- **library_browse_view_model.dart**: Added optional `pageSizeOverride` parameter to `loadMore` and `_fetchPage`, and configured `ensureItemsLoadedForPrefix` to fetch in 300-item page chunks instead of 48-item pages during letter scans (reducing cold-start prefix scan times from ~30s to <1.5s).


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open any library screen (Movies, TV Shows, Audio, etc.) with a large number of items.
2. Select any letter on the Alphabet quick jump bar.
3. Verify that the grid scrolls directly to the target letter row and focuses the first item in **1 single press**.
4. Verify on a fresh install / cold boot that jumping to letters far down the alphabet (e.g. T, W, Z) completes in ~1 second instead of waiting ~30 seconds for 48-item serial page loads.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/a826e301-1a99-4061-93fa-c2ae2ddf9649

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
