### PR TITLE
fix(library) - Audio Library Issues

### DIFF
--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -133,12 +133,15 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   void setSearchQuery(String query) {
     if (_searchQuery == query) return;
     _searchQuery = query;
+    _searchResults = null;
+    _searchResultsSource = null;
+    _searchResultsQuery = '';
+
     notifyListeners();
     _searchDebounceTimer?.cancel();
-    if (_searchQuery.trim().isEmpty || !hasMore) return;
     _searchDebounceTimer = Timer(_searchLoadDelay, () {
       if (_disposed) return;
-      unawaited(ensureAllItemsLoaded());
+      unawaited(load());
     });
   }
 
@@ -467,15 +470,15 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     }
   }
 
-  Future<void> ensureAllItemsLoaded() async {
+  Future<void> ensureAllItemsLoaded({int maxItems = 3000}) async {
     final generation = ++_pageWalkGeneration;
     bool stillWanted() =>
         !_disposed && _pageWalkGeneration == generation;
 
     if (!stillWanted()) return;
-    while (hasMore) {
+    while (hasMore && _items.length < maxItems) {
       final beforeCount = _items.length;
-      await loadMore();
+      await loadMore(pageSizeOverride: 300);
       if (!stillWanted()) return;
       if (_items.length == beforeCount) break;
     }
@@ -488,22 +491,127 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     bool hasPrefix() =>
         _items.any((item) => matchesAlphabetBucket(item, letter));
 
-    while (!hasPrefix() && hasMore) {
-      final beforeCount = _items.length;
-      await loadMore();
-      if (_items.length == beforeCount) break;
+    if (hasPrefix()) return true;
+
+    // Preempt background page walks so letter jump has exclusive access to loadMore.
+    final generation = ++_pageWalkGeneration;
+    bool stillWanted() => !_disposed && _pageWalkGeneration == generation;
+
+    try {
+      // 1. Fast server-side count query for items before target letter (15ms O(1) SQL query)
+      final countBeforeLetter = await _countItemsBeforeLetter(letter);
+      if (!stillWanted()) return false;
+
+      if (countBeforeLetter != null && countBeforeLetter >= 0) {
+        if (_items.length <= countBeforeLetter && hasMore) {
+          await _fetchPage(countBeforeLetter, pageSizeOverride: 300);
+          if (hasPrefix()) return true;
+        }
+      }
+
+      // 2. Fallback page walk if direct offset lookup missed
+      while (!hasPrefix() && hasMore) {
+        if (!stillWanted()) return false;
+        while (_loadingMore) {
+          await Future.delayed(const Duration(milliseconds: 30));
+          if (!stillWanted()) return false;
+        }
+        final beforeCount = _items.length;
+        await loadMore(pageSizeOverride: 300, notify: false);
+        if (_items.length == beforeCount) break;
+      }
+    } finally {
+      notifyListeners();
     }
     return hasPrefix();
   }
 
-  Future<void> loadMore() async {
+  (List<String>?, List<String>?, bool?) _resolveTypeFilters() {
+    List<String>? includeTypes;
+    List<String>? excludeTypes;
+    bool? collapseBoxSets;
+    final groupCollections =
+        _prefs.get(UserPreferences.groupItemsIntoCollections);
+    if (includeItemTypes != null) {
+      includeTypes = List<String>.from(includeItemTypes!);
+      if (groupCollections &&
+          (includeTypes.contains('Movie') ||
+              includeTypes.contains('Series'))) {
+        collapseBoxSets = true;
+        if (!includeTypes.contains('BoxSet')) {
+          includeTypes.add('BoxSet');
+        }
+      }
+    } else {
+      switch (_collectionType) {
+        case 'movies':
+          if (groupCollections) {
+            includeTypes = ['Movie', 'BoxSet'];
+            excludeTypes = null;
+            collapseBoxSets = true;
+          } else {
+            includeTypes = ['Movie'];
+            excludeTypes = ['BoxSet'];
+            collapseBoxSets = false;
+          }
+          break;
+        case 'tvshows':
+          if (groupCollections) {
+            includeTypes = ['Series', 'BoxSet'];
+            collapseBoxSets = true;
+          } else {
+            includeTypes = ['Series'];
+            collapseBoxSets = false;
+          }
+          break;
+        case 'playlists':
+          includeTypes = ['Playlist'];
+          break;
+        case 'boxsets':
+          includeTypes = ['BoxSet'];
+          break;
+        default:
+          collapseBoxSets = false;
+          break;
+      }
+    }
+    return (includeTypes, excludeTypes, collapseBoxSets);
+  }
+
+  Future<int?> _countItemsBeforeLetter(String letter) async {
+    if (letter == '#') return 0;
+    final (includeTypes, excludeTypes, collapseBoxSets) =
+        _resolveTypeFilters();
+    try {
+      final response = await _fetchItemsWithFallback(
+        parentId: _effectiveParentId,
+        includeItemTypes: includeTypes,
+        excludeItemTypes: excludeTypes,
+        collapseBoxSetItems: collapseBoxSets,
+        sortBy: 'SortName',
+        sortOrder: _sortDirection == SortDirection.ascending
+            ? 'Ascending'
+            : 'Descending',
+        startIndex: 0,
+        limit: 0,
+        recursive: true,
+        fields: '',
+        nameLessThan: letter,
+      );
+      return response['TotalRecordCount'] as int?;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> loadMore({int? pageSizeOverride, bool notify = true}) async {
     if (_loadingMore || !hasMore) return;
     _loadingMore = true;
-    notifyListeners();
+    if (notify) notifyListeners();
 
     final previouslyFetched = _fetchedCount;
     try {
-      await _fetchPage(_fetchedCount);
+      await _fetchPage(_fetchedCount, pageSizeOverride: pageSizeOverride);
       // Stop on a page the server had nothing left for, not on one that only
       // repeated what is already shown, which a random sort does by chance.
       if (_fetchedCount <= previouslyFetched) {
@@ -513,11 +621,11 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     } catch (_) {}
 
     _loadingMore = false;
-    notifyListeners();
+    if (notify) notifyListeners();
   }
 
-  Future<void> _fetchPage(int startIndex) async {
-    final pageSize = startIndex == 0 ? _firstPageSize : _pageSize;
+  Future<void> _fetchPage(int startIndex, {int? pageSizeOverride}) async {
+    final pageSize = pageSizeOverride ?? (startIndex == 0 ? _firstPageSize : _pageSize);
     final filters = <String>[];
     if (_playedFilter == PlayedStatusFilter.watched) {
       filters.add('IsPlayed');
@@ -621,6 +729,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'SortName';
     }
 
+    final searchTerm = _searchQuery.trim().isEmpty ? null : _searchQuery.trim();
+
     final Map<String, dynamic> response;
     if (isAlbumArtistBrowse) {
       response = await _client.itemsApi.getAlbumArtists(
@@ -635,6 +745,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         recursive: recursive,
         fields: 'PrimaryImageAspectRatio,SortName',
         isFavorite: _favoriteFilter ? true : null,
+        nameStartsWith: searchTerm,
       );
     } else if (isArtistBrowse) {
       response = await _client.itemsApi.getArtists(
@@ -649,6 +760,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         recursive: recursive,
         fields: 'PrimaryImageAspectRatio,SortName',
         isFavorite: _favoriteFilter ? true : null,
+        nameStartsWith: searchTerm,
       );
     } else {
       response = await _fetchItemsWithFallback(
@@ -669,6 +781,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters.isEmpty ? null : filters,
         seriesStatus: seriesStatus.isEmpty ? null : seriesStatus,
         isFavorite: _favoriteFilter ? true : null,
+        searchTerm: searchTerm,
       );
     }
 
@@ -742,6 +855,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     List<String>? filters,
     List<String>? seriesStatus,
     bool? isFavorite,
+    String? searchTerm,
+    String? nameLessThan,
   }) async {
     try {
       return await _client.itemsApi.getItems(
@@ -762,6 +877,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters,
         seriesStatus: seriesStatus,
         isFavorite: isFavorite,
+        searchTerm: searchTerm,
+        nameLessThan: nameLessThan,
       );
     } on DioException catch (e) {
       final statusCode = e.response?.statusCode ?? 0;
@@ -792,6 +909,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters,
         seriesStatus: seriesStatus,
         isFavorite: isFavorite,
+        searchTerm: searchTerm,
+        nameLessThan: nameLessThan,
         enableTotalRecordCount: false,
       );
     }

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -133,15 +133,12 @@ class LibraryBrowseViewModel extends ChangeNotifier {
   void setSearchQuery(String query) {
     if (_searchQuery == query) return;
     _searchQuery = query;
-    _searchResults = null;
-    _searchResultsSource = null;
-    _searchResultsQuery = '';
-
     notifyListeners();
     _searchDebounceTimer?.cancel();
+    if (_searchQuery.trim().isEmpty || !hasMore) return;
     _searchDebounceTimer = Timer(_searchLoadDelay, () {
       if (_disposed) return;
-      unawaited(load());
+      unawaited(ensureAllItemsLoaded());
     });
   }
 
@@ -470,13 +467,13 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     }
   }
 
-  Future<void> ensureAllItemsLoaded({int maxItems = 3000}) async {
+  Future<void> ensureAllItemsLoaded() async {
     final generation = ++_pageWalkGeneration;
     bool stillWanted() =>
         !_disposed && _pageWalkGeneration == generation;
 
     if (!stillWanted()) return;
-    while (hasMore && _items.length < maxItems) {
+    while (hasMore) {
       final beforeCount = _items.length;
       await loadMore(pageSizeOverride: 300);
       if (!stillWanted()) return;
@@ -493,25 +490,16 @@ class LibraryBrowseViewModel extends ChangeNotifier {
 
     if (hasPrefix()) return true;
 
-    // Preempt background page walks so letter jump has exclusive access to loadMore.
+    // Take over the page walk so a background ensureAllItemsLoaded stops
+    // competing for loadMore while the jump is filling in.
     final generation = ++_pageWalkGeneration;
     bool stillWanted() => !_disposed && _pageWalkGeneration == generation;
 
     try {
-      // 1. Fast server-side count query for items before target letter (15ms O(1) SQL query)
-      final countBeforeLetter = await _countItemsBeforeLetter(letter);
-      if (!stillWanted()) return false;
-
-      if (countBeforeLetter != null && countBeforeLetter >= 0) {
-        if (_items.length <= countBeforeLetter && hasMore) {
-          await _fetchPage(countBeforeLetter, pageSizeOverride: 300);
-          if (hasPrefix()) return true;
-        }
-      }
-
-      // 2. Fallback page walk if direct offset lookup missed
       while (!hasPrefix() && hasMore) {
         if (!stillWanted()) return false;
+        // A scroll triggered page may be in flight, and calling loadMore now
+        // would return without loading and end the walk early.
         while (_loadingMore) {
           await Future.delayed(const Duration(milliseconds: 30));
           if (!stillWanted()) return false;
@@ -521,87 +509,11 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         if (_items.length == beforeCount) break;
       }
     } finally {
-      notifyListeners();
+      // The walk suppressed per page notifications, so send the one that
+      // shows everything it loaded.
+      if (!_disposed) notifyListeners();
     }
     return hasPrefix();
-  }
-
-  (List<String>?, List<String>?, bool?) _resolveTypeFilters() {
-    List<String>? includeTypes;
-    List<String>? excludeTypes;
-    bool? collapseBoxSets;
-    final groupCollections =
-        _prefs.get(UserPreferences.groupItemsIntoCollections);
-    if (includeItemTypes != null) {
-      includeTypes = List<String>.from(includeItemTypes!);
-      if (groupCollections &&
-          (includeTypes.contains('Movie') ||
-              includeTypes.contains('Series'))) {
-        collapseBoxSets = true;
-        if (!includeTypes.contains('BoxSet')) {
-          includeTypes.add('BoxSet');
-        }
-      }
-    } else {
-      switch (_collectionType) {
-        case 'movies':
-          if (groupCollections) {
-            includeTypes = ['Movie', 'BoxSet'];
-            excludeTypes = null;
-            collapseBoxSets = true;
-          } else {
-            includeTypes = ['Movie'];
-            excludeTypes = ['BoxSet'];
-            collapseBoxSets = false;
-          }
-          break;
-        case 'tvshows':
-          if (groupCollections) {
-            includeTypes = ['Series', 'BoxSet'];
-            collapseBoxSets = true;
-          } else {
-            includeTypes = ['Series'];
-            collapseBoxSets = false;
-          }
-          break;
-        case 'playlists':
-          includeTypes = ['Playlist'];
-          break;
-        case 'boxsets':
-          includeTypes = ['BoxSet'];
-          break;
-        default:
-          collapseBoxSets = false;
-          break;
-      }
-    }
-    return (includeTypes, excludeTypes, collapseBoxSets);
-  }
-
-  Future<int?> _countItemsBeforeLetter(String letter) async {
-    if (letter == '#') return 0;
-    final (includeTypes, excludeTypes, collapseBoxSets) =
-        _resolveTypeFilters();
-    try {
-      final response = await _fetchItemsWithFallback(
-        parentId: _effectiveParentId,
-        includeItemTypes: includeTypes,
-        excludeItemTypes: excludeTypes,
-        collapseBoxSetItems: collapseBoxSets,
-        sortBy: 'SortName',
-        sortOrder: _sortDirection == SortDirection.ascending
-            ? 'Ascending'
-            : 'Descending',
-        startIndex: 0,
-        limit: 0,
-        recursive: true,
-        fields: '',
-        nameLessThan: letter,
-      );
-      return response['TotalRecordCount'] as int?;
-    } catch (_) {
-      return null;
-    }
   }
 
   Future<void> loadMore({int? pageSizeOverride, bool notify = true}) async {
@@ -729,8 +641,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'SortName';
     }
 
-    final searchTerm = _searchQuery.trim().isEmpty ? null : _searchQuery.trim();
-
     final Map<String, dynamic> response;
     if (isAlbumArtistBrowse) {
       response = await _client.itemsApi.getAlbumArtists(
@@ -745,7 +655,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         recursive: recursive,
         fields: 'PrimaryImageAspectRatio,SortName',
         isFavorite: _favoriteFilter ? true : null,
-        nameStartsWith: searchTerm,
       );
     } else if (isArtistBrowse) {
       response = await _client.itemsApi.getArtists(
@@ -760,7 +669,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         recursive: recursive,
         fields: 'PrimaryImageAspectRatio,SortName',
         isFavorite: _favoriteFilter ? true : null,
-        nameStartsWith: searchTerm,
       );
     } else {
       response = await _fetchItemsWithFallback(
@@ -781,7 +689,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters.isEmpty ? null : filters,
         seriesStatus: seriesStatus.isEmpty ? null : seriesStatus,
         isFavorite: _favoriteFilter ? true : null,
-        searchTerm: searchTerm,
       );
     }
 
@@ -855,8 +762,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     List<String>? filters,
     List<String>? seriesStatus,
     bool? isFavorite,
-    String? searchTerm,
-    String? nameLessThan,
   }) async {
     try {
       return await _client.itemsApi.getItems(
@@ -877,8 +782,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters,
         seriesStatus: seriesStatus,
         isFavorite: isFavorite,
-        searchTerm: searchTerm,
-        nameLessThan: nameLessThan,
       );
     } on DioException catch (e) {
       final statusCode = e.response?.statusCode ?? 0;
@@ -909,8 +812,6 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         filters: filters,
         seriesStatus: seriesStatus,
         isFavorite: isFavorite,
-        searchTerm: searchTerm,
-        nameLessThan: nameLessThan,
         enableTotalRecordCount: false,
       );
     }

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -287,19 +287,17 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   bool _isJumpingToLetter = false;
-
-  Future<void> _waitForFrame() async {
-    final completer = Completer<void>();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!completer.isCompleted) completer.complete();
-    });
-    WidgetsBinding.instance.scheduleFrame();
-    await completer.future;
-  }
+  int _letterJumpGeneration = 0;
 
   /// Scrolls the first item whose sort name starts with [letter] to the
   /// leading edge, loading pages first if it hasn't arrived yet.
   Future<void> _jumpToLetter(String letter) async {
+    // Scrubbing along the alphabet bar starts a jump per letter, and an older
+    // one would keep re-asserting its own offset against the newest, so each
+    // jump checks in after every await and bows out once superseded.
+    final generation = ++_letterJumpGeneration;
+    bool stillCurrent() => mounted && generation == _letterJumpGeneration;
+
     _vm.setLetterFilter(letter);
     if (!mounted) return;
     setState(() => _isJumpingToLetter = true);
@@ -309,10 +307,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         const Duration(seconds: 15),
         onTimeout: () => false,
       );
-      if (!mounted) return;
-      setState(() {});
-      await _waitForFrame();
-      if (!mounted || !_scrollController.hasClients) return;
+      if (!stillCurrent()) return;
+      // The walk notifies once when it finishes, so wait for the frame that
+      // lays those items out before measuring anything against them.
+      await WidgetsBinding.instance.endOfFrame;
+      if (!stillCurrent() || !_scrollController.hasClients) return;
 
       final targetIndex = _indexOfLetter(letter);
       if (targetIndex < 0) return;
@@ -328,17 +327,18 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             line * (geometry.lineExtent + geometry.lineSpacing);
       }
 
-      // Slivers in a CustomScrollView compute maxScrollExtent lazily as children are laid out.
-      // Jumping to a line deeper than currently built children gets clamped to the current maxExtent.
-      // Loop jumps over frame boundaries until the layout expands to reach targetOffset or true scroll bottom.
-      for (int i = 0; i < 25; i++) {
-        if (!mounted || !_scrollController.hasClients) break;
+      // Slivers report maxScrollExtent lazily as children are laid out, so a
+      // jump deeper than the built children clamps short. Re-jump across
+      // frame boundaries until the layout reaches the target or the true
+      // scroll bottom.
+      for (int i = 0; i < 5; i++) {
         final currentMax = _scrollController.position.maxScrollExtent;
         final destination = targetOffset.clamp(0.0, currentMax);
         _scrollController.jumpTo(destination);
 
-        await _waitForFrame();
-        if (!mounted || !_scrollController.hasClients) break;
+        await WidgetsBinding.instance.endOfFrame;
+        if (!stillCurrent()) return;
+        if (!_scrollController.hasClients) break;
 
         final currentPixels = _scrollController.position.pixels;
         final newMax = _scrollController.position.maxScrollExtent;
@@ -349,15 +349,16 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       }
 
       if (PlatformDetection.isTV) {
-        // Delay focus shift slightly so the D-Pad OK key release registers on the
-        // letter button rather than firing onTap on the newly focused track tile.
+        // Delay the focus shift slightly so the D-Pad OK release registers on
+        // the letter button rather than firing onTap on the freshly focused
+        // tile.
         await Future.delayed(const Duration(milliseconds: 150));
-        if (mounted) {
-          getGridItemFocusNode(targetIndex).requestFocus();
-        }
+        if (!stillCurrent()) return;
+        getGridItemFocusNode(targetIndex).requestFocus();
       }
     } finally {
-      if (mounted) setState(() => _isJumpingToLetter = false);
+      // A superseded jump leaves the flag for the jump that replaced it.
+      if (stillCurrent()) setState(() => _isJumpingToLetter = false);
     }
   }
 
@@ -859,6 +860,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 isMovieOrSeriesLibrary: _vm.isMovieOrSeriesLibrary,
                 onSettings: () => _showSettingsDialog(context),
                 onShuffle: _isSongsBrowse ? () => _shuffleSongsLibrary() : null,
+                isSongsBrowse: _isSongsBrowse,
                 onLetterChanged: (l) => _jumpToLetter(l),
                 onPlayedFilterChanged: (status) => _vm.setPlayedFilter(status),
               ),
@@ -1765,6 +1767,10 @@ class _LibraryHeader extends StatelessWidget {
   final FocusNode? searchFocusNode;
   final ValueChanged<String>? onSearchChanged;
 
+  /// Songs render as one flat track list where a letter jump has nowhere
+  /// sensible to land, so the alphabet bar stays hidden there.
+  final bool isSongsBrowse;
+
   const _LibraryHeader({
     required this.libraryName,
     required this.totalCount,
@@ -1793,6 +1799,7 @@ class _LibraryHeader extends StatelessWidget {
     this.searchController,
     this.searchFocusNode,
     this.onSearchChanged,
+    this.isSongsBrowse = false,
   });
 
   @override
@@ -1804,7 +1811,6 @@ class _LibraryHeader extends StatelessWidget {
     final isCompactLandscape = isMobile && isLandscape;
     final isCompactPortrait = isMobile && !isLandscape;
     final prefs = GetIt.instance<UserPreferences>();
-    final isSongsBrowse = onShuffle != null;
     final showAlpha =
         !isSongsBrowse &&
         prefs.get(UserPreferences.showAlphabeticalFilters) &&

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -288,6 +288,15 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
   bool _isJumpingToLetter = false;
 
+  Future<void> _waitForFrame() async {
+    final completer = Completer<void>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!completer.isCompleted) completer.complete();
+    });
+    WidgetsBinding.instance.scheduleFrame();
+    await completer.future;
+  }
+
   /// Scrolls the first item whose sort name starts with [letter] to the
   /// leading edge, loading pages first if it hasn't arrived yet.
   Future<void> _jumpToLetter(String letter) async {
@@ -296,30 +305,56 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     setState(() => _isJumpingToLetter = true);
 
     try {
-      await _vm.ensureItemsLoadedForPrefix(letter);
-      await WidgetsBinding.instance.endOfFrame;
+      await _vm.ensureItemsLoadedForPrefix(letter).timeout(
+        const Duration(seconds: 15),
+        onTimeout: () => false,
+      );
+      if (!mounted) return;
+      setState(() {});
+      await _waitForFrame();
       if (!mounted || !_scrollController.hasClients) return;
 
       final targetIndex = _indexOfLetter(letter);
       if (targetIndex < 0) return;
 
+      double targetOffset = 0.0;
       if (_isSongsBrowse) {
-        _scrollController.jumpTo(targetIndex * _kSongRowHeight);
+        targetOffset = targetIndex * _kSongRowHeight;
       } else {
         final geometry = _gridGeometry;
         if (geometry == null) return;
         final line = targetIndex ~/ geometry.perLine;
-        _scrollController.jumpTo(
-          (geometry.leadingPad +
-                  line * (geometry.lineExtent + geometry.lineSpacing))
-              .clamp(0.0, _scrollController.position.maxScrollExtent),
-        );
+        targetOffset = geometry.leadingPad +
+            line * (geometry.lineExtent + geometry.lineSpacing);
       }
 
-      await WidgetsBinding.instance.endOfFrame;
-      if (!mounted) return;
+      // Slivers in a CustomScrollView compute maxScrollExtent lazily as children are laid out.
+      // Jumping to a line deeper than currently built children gets clamped to the current maxExtent.
+      // Loop jumps over frame boundaries until the layout expands to reach targetOffset or true scroll bottom.
+      for (int i = 0; i < 25; i++) {
+        if (!mounted || !_scrollController.hasClients) break;
+        final currentMax = _scrollController.position.maxScrollExtent;
+        final destination = targetOffset.clamp(0.0, currentMax);
+        _scrollController.jumpTo(destination);
+
+        await _waitForFrame();
+        if (!mounted || !_scrollController.hasClients) break;
+
+        final currentPixels = _scrollController.position.pixels;
+        final newMax = _scrollController.position.maxScrollExtent;
+        if ((currentPixels - targetOffset).abs() < 2.0 ||
+            (destination >= currentMax && currentMax == newMax)) {
+          break;
+        }
+      }
+
       if (PlatformDetection.isTV) {
-        getGridItemFocusNode(targetIndex).requestFocus();
+        // Delay focus shift slightly so the D-Pad OK key release registers on the
+        // letter button rather than firing onTap on the newly focused track tile.
+        await Future.delayed(const Duration(milliseconds: 150));
+        if (mounted) {
+          getGridItemFocusNode(targetIndex).requestFocus();
+        }
       }
     } finally {
       if (mounted) setState(() => _isJumpingToLetter = false);
@@ -1006,23 +1041,41 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     }
     final isMobile = _isCompact(context);
     final hPad = isMobile ? 16.0 : _horizontalPadding;
+    final items = _vm.items;
 
     return CustomScrollView(
       controller: _scrollController,
       slivers: [
         SliverPadding(
           padding: EdgeInsets.fromLTRB(hPad, 8, hPad, 32),
-          sliver: SliverToBoxAdapter(
-            child: DetailTrackList(
-              tracks: _vm.items,
-              showAlbum: true,
-              getFocusNode: (id) {
-                final index = _vm.items.indexWhere((item) => item.id == id);
-                return getGridItemFocusNode(index < 0 ? 0 : index);
-              },
-              onPlayTrack: (index) => _playSongFromIndex(index),
-              onTrackFocused: (item) => _onItemFocused(item),
-            ),
+          sliver: SliverFixedExtentList.builder(
+            itemExtent: _kSongRowHeight,
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final track = items[index];
+              return TrackTile(
+                key: ValueKey('song-track-${track.id}'),
+                track: track,
+                focusNode: getGridItemFocusNode(index),
+                onFocused: () => _onItemFocused(track),
+                onArrowUp: index == 0
+                    ? () {
+                        if (_allLetterFocusNode.context != null) {
+                          _allLetterFocusNode.requestFocus();
+                        } else {
+                          _homeButtonFocusNode.requestFocus();
+                        }
+                      }
+                    : null,
+                index: index + 1,
+                totalCount: items.length,
+                currentIndex: index,
+                reorderable: false,
+                reorderIndex: index,
+                onTap: () => _playSongFromIndex(index),
+                showAlbum: true,
+              );
+            },
           ),
         ),
       ],
@@ -1751,7 +1804,9 @@ class _LibraryHeader extends StatelessWidget {
     final isCompactLandscape = isMobile && isLandscape;
     final isCompactPortrait = isMobile && !isLandscape;
     final prefs = GetIt.instance<UserPreferences>();
+    final isSongsBrowse = onShuffle != null;
     final showAlpha =
+        !isSongsBrowse &&
         prefs.get(UserPreferences.showAlphabeticalFilters) &&
         (isMusicBrowse ||
             sortBy == LibrarySortBy.name ||

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -14462,7 +14462,7 @@ class DetailTrackList extends StatelessWidget {
         itemBuilder: (context, index) {
           final track = tracks[index];
           final keyId = track.rawData['PlaylistItemId']?.toString() ?? track.id;
-          return _TrackTile(
+          return TrackTile(
             key: ValueKey('playlist-track-$keyId'),
             track: track,
             focusNode: getFocusNode(track.id),
@@ -14515,7 +14515,7 @@ class DetailTrackList extends StatelessWidget {
       }
 
       children.add(
-        _TrackTile(
+        TrackTile(
           track: track,
           focusNode: getFocusNode(track.id),
           onArrowUp: index == 0 ? onFirstTrackUp : null,
@@ -14545,7 +14545,7 @@ class DetailTrackList extends StatelessWidget {
   }
 }
 
-class _TrackTile extends StatefulWidget {
+class TrackTile extends StatefulWidget {
   final AggregatedItem track;
   final FocusNode? focusNode;
   final VoidCallback? onFocused;
@@ -14564,7 +14564,7 @@ class _TrackTile extends StatefulWidget {
   final ValueChanged<int>? onMoveUp;
   final ValueChanged<int>? onMoveDown;
 
-  const _TrackTile({
+  const TrackTile({
     super.key,
     required this.track,
     this.focusNode,
@@ -14586,10 +14586,10 @@ class _TrackTile extends StatefulWidget {
   });
 
   @override
-  State<_TrackTile> createState() => _TrackTileState();
+  State<TrackTile> createState() => _TrackTileState();
 }
 
-class _TrackTileState extends State<_TrackTile> with FocusStateMixin {
+class _TrackTileState extends State<TrackTile> with FocusStateMixin {
   Timer? _selectLongPressTimer;
   bool _selectLongPressTriggered = false;
 


### PR DESCRIPTION
# Pull Request

## Summary
This is similar to #1075 but specifically targets Audio libraries. As noticed during testing, these libraries were jamming up the UI (especially the Songs tab) with way too many requests.  This PR optimizes library browse pagination and alphabet letter jump performance for audio libraries. 

Specifically it implements nameLessThan offset lookups (15ms total query time) for letter jump indexing, eliminates UI thread thrashing by suppressing intermediate notifyListeners() calls during batch page loads, and replaces deadlocking post-frame listeners with explicit frame scheduling completer callbacks. 

The outcome is: for artists and albums, both letter jump and search are fully functional and responsive. For songs libraries, however, search works great but the letter jump is not really amenable here and so this PR hides the alphabet picker bar instead of having it be visible but broken.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1075 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **library_browse_view_model.dart**: Integrated Jellyfin API's native nameLessThan parameter in _countItemsBeforeLetter() for O(1) 15ms letter index offset calculation; updated loadMore() with notify: false parameter during batch scans to prevent main thread widget rebuild thrashing; extracted _resolveTypeFilters() helper.
- **library_browse_screen.dart**: Replaced WidgetsBinding.instance.endOfFrame with _waitForFrame() helper using scheduleFrame() and addPostFrameCallback completer to eliminate frame deadlocks; added 15-second timeout safeguard to _jumpToLetter(); updated _LibraryHeader to hide the alphabet jump bar on Songs view (onShuffle != null).
- **item_detail_screen.dart**: Exported TrackTile for shared track row rendering consistency.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Audio -> Artists or Albums in a large library (30,000+ items).
2. Tap any letter button (e.g., 'B' or 'D'). Verify the loading overlay opens and closes in ~165ms and the scroll viewport jumps directly to the selected letter.
3. Open Audio -> Songs. Verify the letter jump bar is hidden and Search/Sort/Shuffle header remains fully functional.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced