### PR TITLE
feat(seerr) - Allow Request More for continuing TV series with visual FLAIR

### DIFF
--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -125,6 +125,20 @@ class SeerrQualityStatus {
     return seasons;
   }
 
+  /// Season numbers that are either already available in the library (status 4 or 5)
+  /// or have active/approved requests, so their chips should be greyed out.
+  Set<int> get unavailableOrRequestedSeasons {
+    final seasons = Set<int>.from(requestedSeasons);
+    for (final s in seasonAvailability) {
+      final statusVal = (is4k ? s.status4k : s.status) ?? 0;
+      if (statusVal >= 4) {
+        seasons.add(s.seasonNumber);
+      }
+    }
+    return seasons;
+  }
+
+
   /// Season number to media status (2 pending, 3 processing, 4 partial,
   /// 5 available) for this quality track, so a series can show where it stands
   /// season by season rather than only as a whole.

--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -125,28 +125,24 @@ class SeerrQualityStatus {
     return seasons;
   }
 
-  /// Season numbers that are either already available in the library (status 4 or 5)
-  /// or have active/approved requests, so their chips should be greyed out.
-  Set<int> get unavailableOrRequestedSeasons {
-    final seasons = Set<int>.from(requestedSeasons);
-    for (final s in seasonAvailability) {
-      final statusVal = (is4k ? s.status4k : s.status) ?? 0;
-      if (statusVal >= 4) {
-        seasons.add(s.seasonNumber);
-      }
-    }
-    return seasons;
-  }
+  /// Seasons the library already holds for this track, fully or partially.
+  Set<int> get availableSeasons => {
+        for (final s in seasonAvailability)
+          if (((is4k ? s.status4k : s.status) ?? 0) >= 4) s.seasonNumber,
+      };
 
+  /// Seasons the request sheet may not offer: already in the library or
+  /// already spoken for by an open request.
+  Set<int> get unavailableOrRequestedSeasons =>
+      {...requestedSeasons, ...availableSeasons};
 
   /// Season number to media status (2 pending, 3 processing, 4 partial,
   /// 5 available) for this quality track, so a series can show where it stands
   /// season by season rather than only as a whole.
   ///
-  /// Deliberately separate from [requestedSeasons], which answers the narrower
-  /// "may this season still be requested" question the request sheet asks.
-  /// Folding availability into that would quietly change which seasons a user
-  /// can tick.
+  /// Deliberately separate from [unavailableOrRequestedSeasons], which answers
+  /// the narrower "may this season still be requested" question the request
+  /// sheet asks.
   Map<int, int> get seasonStatus {
     final byNumber = <int, int>{};
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5630,6 +5630,11 @@
   "@allSeasons": {
     "description": "Checkbox label for selecting all seasons"
   },
+  "seriesContinuingFutureSeasonsMonitored": "Series Continuing · Future Seasons Monitored",
+  "@seriesContinuingFutureSeasonsMonitored": {
+    "description": "Status banner shown in Seerr request dialog for continuing series when currently aired seasons are in library"
+  },
+
   "advancedOptions": "Advanced Options",
   "@advancedOptions": {
     "description": "Expansion tile for advanced request options"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5630,11 +5630,10 @@
   "@allSeasons": {
     "description": "Checkbox label for selecting all seasons"
   },
-  "seriesContinuingFutureSeasonsMonitored": "Series Continuing · Future Seasons Monitored",
-  "@seriesContinuingFutureSeasonsMonitored": {
-    "description": "Status banner shown in Seerr request dialog for continuing series when currently aired seasons are in library"
+  "seerrSeriesContinuing": "Series Continuing · Future Seasons Can Be Requested",
+  "@seerrSeriesContinuing": {
+    "description": "Banner in the Seerr request dialog for a continuing series whose aired seasons are all in the library"
   },
-
   "advancedOptions": "Advanced Options",
   "@advancedOptions": {
     "description": "Expansion tile for advanced request options"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7474,11 +7474,11 @@ abstract class AppLocalizations {
   /// **'All Seasons'**
   String get allSeasons;
 
-  /// Status banner shown in Seerr request dialog for continuing series when currently aired seasons are in library
+  /// Banner in the Seerr request dialog for a continuing series whose aired seasons are all in the library
   ///
   /// In en, this message translates to:
-  /// **'Series Continuing · Future Seasons Monitored'**
-  String get seriesContinuingFutureSeasonsMonitored;
+  /// **'Series Continuing · Future Seasons Can Be Requested'**
+  String get seerrSeriesContinuing;
 
   /// Expansion tile for advanced request options
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7474,6 +7474,12 @@ abstract class AppLocalizations {
   /// **'All Seasons'**
   String get allSeasons;
 
+  /// Status banner shown in Seerr request dialog for continuing series when currently aired seasons are in library
+  ///
+  /// In en, this message translates to:
+  /// **'Series Continuing · Future Seasons Monitored'**
+  String get seriesContinuingFutureSeasonsMonitored;
+
   /// Expansion tile for advanced request options
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -4143,6 +4143,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get allSeasons => 'Alle Seisoene';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Gevorderde Opsies';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -4143,8 +4143,8 @@ class AppLocalizationsAf extends AppLocalizations {
   String get allSeasons => 'Alle Seisoene';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Gevorderde Opsies';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -4141,6 +4141,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get allSeasons => 'كل المواسم';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'خيارات متقدمة';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -4141,8 +4141,8 @@ class AppLocalizationsAr extends AppLocalizations {
   String get allSeasons => 'كل المواسم';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'خيارات متقدمة';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -4159,6 +4159,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get allSeasons => 'Усе сезоны';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Дадатковыя параметры';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -4159,8 +4159,8 @@ class AppLocalizationsBe extends AppLocalizations {
   String get allSeasons => 'Усе сезоны';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Дадатковыя параметры';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get allSeasons => 'Всички сезони';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Разширени опции';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4162,8 +4162,8 @@ class AppLocalizationsBg extends AppLocalizations {
   String get allSeasons => 'Всички сезони';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Разширени опции';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -4130,8 +4130,8 @@ class AppLocalizationsBn extends AppLocalizations {
   String get allSeasons => 'সব ঋতু';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'উন্নত বিকল্প';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -4130,6 +4130,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get allSeasons => 'সব ঋতু';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'উন্নত বিকল্প';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -4196,6 +4196,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get allSeasons => 'Totes les temporades';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opcions avançades';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -4196,8 +4196,8 @@ class AppLocalizationsCa extends AppLocalizations {
   String get allSeasons => 'Totes les temporades';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opcions avançades';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4150,8 +4150,8 @@ class AppLocalizationsCs extends AppLocalizations {
   String get allSeasons => 'Všechna roční období';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Pokročilé možnosti';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4150,6 +4150,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get allSeasons => 'Všechna roční období';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Pokročilé možnosti';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -4165,8 +4165,8 @@ class AppLocalizationsCy extends AppLocalizations {
   String get allSeasons => 'Pob Tymhorau';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Dewisiadau Uwch';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -4165,6 +4165,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get allSeasons => 'Pob Tymhorau';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Dewisiadau Uwch';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4137,8 +4137,8 @@ class AppLocalizationsDa extends AppLocalizations {
   String get allSeasons => 'Alle årstider';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Avancerede indstillinger';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4137,6 +4137,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get allSeasons => 'Alle årstider';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Avancerede indstillinger';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4242,8 +4242,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get allSeasons => 'Alle Staffeln';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Erweiterte Optionen';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4242,6 +4242,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get allSeasons => 'Alle Staffeln';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Erweiterte Optionen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4187,8 +4187,8 @@ class AppLocalizationsEl extends AppLocalizations {
   String get allSeasons => 'Όλες τις εποχές';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Προηγμένες Επιλογές';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4187,6 +4187,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get allSeasons => 'Όλες τις εποχές';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Προηγμένες Επιλογές';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4117,8 +4117,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get allSeasons => 'All Seasons';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Advanced Options';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4117,6 +4117,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get allSeasons => 'All Seasons';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Advanced Options';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -4136,8 +4136,8 @@ class AppLocalizationsEo extends AppLocalizations {
   String get allSeasons => 'Ĉiuj Sezonoj';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Altnivelaj Opcioj';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -4136,6 +4136,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get allSeasons => 'Ĉiuj Sezonoj';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Altnivelaj Opcioj';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4172,6 +4172,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get allSeasons => 'Todas las temporadas';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opciones avanzadas';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4172,8 +4172,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get allSeasons => 'Todas las temporadas';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opciones avanzadas';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4142,6 +4142,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get allSeasons => 'Kõik aastaajad';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Täpsemad suvandid';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4142,8 +4142,8 @@ class AppLocalizationsEt extends AppLocalizations {
   String get allSeasons => 'Kõik aastaajad';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Täpsemad suvandid';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -4117,6 +4117,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get allSeasons => 'تمام فصول';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'گزینه های پیشرفته';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -4117,8 +4117,8 @@ class AppLocalizationsFa extends AppLocalizations {
   String get allSeasons => 'تمام فصول';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'گزینه های پیشرفته';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4153,8 +4153,8 @@ class AppLocalizationsFi extends AppLocalizations {
   String get allSeasons => 'Kaikki vuodenajat';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Lisäasetukset';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4153,6 +4153,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get allSeasons => 'Kaikki vuodenajat';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Lisäasetukset';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4194,6 +4194,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get allSeasons => 'Toutes les saisons';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Options avancées';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4194,8 +4194,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get allSeasons => 'Toutes les saisons';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Options avancées';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -4187,8 +4187,8 @@ class AppLocalizationsGl extends AppLocalizations {
   String get allSeasons => 'Todas as estacións';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opcións avanzadas';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -4187,6 +4187,10 @@ class AppLocalizationsGl extends AppLocalizations {
   String get allSeasons => 'Todas as estacións';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opcións avanzadas';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -4094,8 +4094,8 @@ class AppLocalizationsHe extends AppLocalizations {
   String get allSeasons => 'כל העונות';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'אפשרויות מתקדמות';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -4094,6 +4094,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get allSeasons => 'כל העונות';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'אפשרויות מתקדמות';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -4129,8 +4129,8 @@ class AppLocalizationsHi extends AppLocalizations {
   String get allSeasons => 'सभी मौसम';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'उन्नत विकल्प';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -4129,6 +4129,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get allSeasons => 'सभी मौसम';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'उन्नत विकल्प';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4274,8 +4274,8 @@ class AppLocalizationsHr extends AppLocalizations {
   String get allSeasons => 'Sva godišnja doba';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Napredne opcije';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4274,6 +4274,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get allSeasons => 'Sva godišnja doba';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Napredne opcije';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4171,8 +4171,8 @@ class AppLocalizationsHu extends AppLocalizations {
   String get allSeasons => 'Minden évad';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Speciális beállítások';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4171,6 +4171,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get allSeasons => 'Minden évad';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Speciális beállítások';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -4142,6 +4142,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get allSeasons => 'Semua Musim';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opsi Lanjutan';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -4142,8 +4142,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get allSeasons => 'Semua Musim';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opsi Lanjutan';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4165,8 +4165,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get allSeasons => 'Tutte le Stagioni';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opzioni Avanzate';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4165,6 +4165,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get allSeasons => 'Tutte le Stagioni';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opzioni Avanzate';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -4038,8 +4038,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get allSeasons => 'オールシーズン';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => '詳細オプション';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -4038,6 +4038,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get allSeasons => 'オールシーズン';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => '詳細オプション';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -4157,6 +4157,10 @@ class AppLocalizationsKk extends AppLocalizations {
   String get allSeasons => 'Барлық маусымдар';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Қосымша опциялар';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -4157,8 +4157,8 @@ class AppLocalizationsKk extends AppLocalizations {
   String get allSeasons => 'Барлық маусымдар';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Қосымша опциялар';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get allSeasons => 'ಎಲ್ಲಾ ಋತುಗಳು';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'ಸುಧಾರಿತ ಆಯ್ಕೆಗಳು';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -4163,8 +4163,8 @@ class AppLocalizationsKn extends AppLocalizations {
   String get allSeasons => 'ಎಲ್ಲಾ ಋತುಗಳು';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'ಸುಧಾರಿತ ಆಯ್ಕೆಗಳು';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -4031,6 +4031,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get allSeasons => '올 시즌';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => '고급 옵션';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -4031,8 +4031,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get allSeasons => '올 시즌';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => '고급 옵션';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get allSeasons => 'Visi sezonai';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Išplėstinės parinktys';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4162,8 +4162,8 @@ class AppLocalizationsLt extends AppLocalizations {
   String get allSeasons => 'Visi sezonai';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Išplėstinės parinktys';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4160,8 +4160,8 @@ class AppLocalizationsLv extends AppLocalizations {
   String get allSeasons => 'Visas sezonas';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Papildu opcijas';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4160,6 +4160,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get allSeasons => 'Visas sezonas';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Papildu opcijas';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -4160,6 +4160,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get allSeasons => 'Сите годишни времиња';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Напредни опции';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -4160,8 +4160,8 @@ class AppLocalizationsMk extends AppLocalizations {
   String get allSeasons => 'Сите годишни времиња';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Напредни опции';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -4168,8 +4168,8 @@ class AppLocalizationsMl extends AppLocalizations {
   String get allSeasons => 'എല്ലാ സീസണുകളും';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'വിപുലമായ ഓപ്ഷനുകൾ';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -4168,6 +4168,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get allSeasons => 'എല്ലാ സീസണുകളും';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'വിപുലമായ ഓപ്ഷനുകൾ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -4150,6 +4150,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get allSeasons => 'Бүх улирал';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Нарийвчилсан сонголтууд';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -4150,8 +4150,8 @@ class AppLocalizationsMn extends AppLocalizations {
   String get allSeasons => 'Бүх улирал';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Нарийвчилсан сонголтууд';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4133,8 +4133,8 @@ class AppLocalizationsNb extends AppLocalizations {
   String get allSeasons => 'Alle årstider';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Avanserte alternativer';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4133,6 +4133,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get allSeasons => 'Alle årstider';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Avanserte alternativer';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4158,8 +4158,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get allSeasons => 'Alle seizoenen';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Geavanceerde opties';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4158,6 +4158,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get allSeasons => 'Alle seizoenen';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Geavanceerde opties';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -4126,8 +4126,8 @@ class AppLocalizationsPa extends AppLocalizations {
   String get allSeasons => 'ਸਾਰੇ ਸੀਜ਼ਨ';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'ਉੱਨਤ ਵਿਕਲਪ';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -4126,6 +4126,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get allSeasons => 'ਸਾਰੇ ਸੀਜ਼ਨ';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'ਉੱਨਤ ਵਿਕਲਪ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4148,8 +4148,8 @@ class AppLocalizationsPl extends AppLocalizations {
   String get allSeasons => 'Wszystkie sezony';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opcje zaawansowane';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4148,6 +4148,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get allSeasons => 'Wszystkie sezony';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opcje zaawansowane';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4164,6 +4164,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get allSeasons => 'Todas as Temporadas';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opções Avançadas';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4164,8 +4164,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get allSeasons => 'Todas as Temporadas';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opções Avançadas';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4173,8 +4173,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get allSeasons => 'Toate anotimpurile';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opțiuni avansate';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4173,6 +4173,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get allSeasons => 'Toate anotimpurile';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opțiuni avansate';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -4172,8 +4172,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get allSeasons => 'Все сезоны';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Дополнительные параметры';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -4172,6 +4172,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get allSeasons => 'Все сезоны';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Дополнительные параметры';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -4138,8 +4138,8 @@ class AppLocalizationsSi extends AppLocalizations {
   String get allSeasons => 'සියලුම වාර';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'උසස් විකල්ප';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -4138,6 +4138,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get allSeasons => 'සියලුම වාර';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'උසස් විකල්ප';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4163,6 +4163,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get allSeasons => 'Všetky ročné obdobia';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Rozšírené možnosti';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4163,8 +4163,8 @@ class AppLocalizationsSk extends AppLocalizations {
   String get allSeasons => 'Všetky ročné obdobia';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Rozšírené možnosti';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4166,8 +4166,8 @@ class AppLocalizationsSl extends AppLocalizations {
   String get allSeasons => 'Vsi letni časi';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Napredne možnosti';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4166,6 +4166,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get allSeasons => 'Vsi letni časi';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Napredne možnosti';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -4173,6 +4173,10 @@ class AppLocalizationsSq extends AppLocalizations {
   String get allSeasons => 'Të gjitha stinët';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Opsione të avancuara';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -4173,8 +4173,8 @@ class AppLocalizationsSq extends AppLocalizations {
   String get allSeasons => 'Të gjitha stinët';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Opsione të avancuara';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4275,6 +4275,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get allSeasons => 'Сва годишња доба';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Напредне опције';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4275,8 +4275,8 @@ class AppLocalizationsSr extends AppLocalizations {
   String get allSeasons => 'Сва годишња доба';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Напредне опције';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4141,6 +4141,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get allSeasons => 'Alla årstider';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Avancerade alternativ';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4141,8 +4141,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get allSeasons => 'Alla årstider';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Avancerade alternativ';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -4169,6 +4169,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get allSeasons => 'Misimu Yote';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Chaguzi za Juu';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -4169,8 +4169,8 @@ class AppLocalizationsSw extends AppLocalizations {
   String get allSeasons => 'Misimu Yote';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Chaguzi za Juu';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -4174,6 +4174,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get allSeasons => 'அனைத்து பருவங்களும்';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'மேம்பட்ட விருப்பங்கள்';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -4174,8 +4174,8 @@ class AppLocalizationsTa extends AppLocalizations {
   String get allSeasons => 'அனைத்து பருவங்களும்';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'மேம்பட்ட விருப்பங்கள்';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -4162,6 +4162,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get allSeasons => 'అన్ని సీజన్లు';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'అధునాతన ఎంపికలు';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -4162,8 +4162,8 @@ class AppLocalizationsTe extends AppLocalizations {
   String get allSeasons => 'అన్ని సీజన్లు';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'అధునాతన ఎంపికలు';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -4106,6 +4106,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get allSeasons => 'ทุกฤดูกาล';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'ตัวเลือกขั้นสูง';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -4106,8 +4106,8 @@ class AppLocalizationsTh extends AppLocalizations {
   String get allSeasons => 'ทุกฤดูกาล';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'ตัวเลือกขั้นสูง';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -4180,8 +4180,8 @@ class AppLocalizationsTl extends AppLocalizations {
   String get allSeasons => 'Lahat ng Panahon';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Mga Advanced na Opsyon';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -4180,6 +4180,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get allSeasons => 'Lahat ng Panahon';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Mga Advanced na Opsyon';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -4151,8 +4151,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get allSeasons => 'Tüm Sezonlar';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Gelişmiş Seçenekler';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -4151,6 +4151,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get allSeasons => 'Tüm Sezonlar';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Gelişmiş Seçenekler';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -4146,8 +4146,8 @@ class AppLocalizationsUg extends AppLocalizations {
   String get allSeasons => 'بارلىق پەسىللەر';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'ئالىي تاللانمىلار';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -4146,6 +4146,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get allSeasons => 'بارلىق پەسىللەر';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'ئالىي تاللانمىلار';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -4166,6 +4166,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get allSeasons => 'Всі сезони';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Додаткові параметри';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -4166,8 +4166,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get allSeasons => 'Всі сезони';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Додаткові параметри';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -4142,8 +4142,8 @@ class AppLocalizationsVi extends AppLocalizations {
   String get allSeasons => 'Tất cả các mùa';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => 'Tùy chọn nâng cao';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -4142,6 +4142,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get allSeasons => 'Tất cả các mùa';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => 'Tùy chọn nâng cao';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -4004,6 +4004,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get allSeasons => '所有季節';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => '進階選項';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -4004,8 +4004,8 @@ class AppLocalizationsYue extends AppLocalizations {
   String get allSeasons => '所有季節';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => '進階選項';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3985,8 +3985,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get allSeasons => '所有季';
 
   @override
-  String get seriesContinuingFutureSeasonsMonitored =>
-      'Series Continuing · Future Seasons Monitored';
+  String get seerrSeriesContinuing =>
+      'Series Continuing · Future Seasons Can Be Requested';
 
   @override
   String get advancedOptions => '高级选项';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3985,6 +3985,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get allSeasons => '所有季';
 
   @override
+  String get seriesContinuingFutureSeasonsMonitored =>
+      'Series Continuing · Future Seasons Monitored';
+
+  @override
   String get advancedOptions => '高级选项';
 
   @override

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -12354,13 +12354,13 @@ Widget? _seerrRequestButton(
   bool isPrimary = false,
   FocusNode? focusNode,
   bool autofocus = false,
-  String? itemStatus,
 }) {
   if (seerr == null) return null;
-  final statusStr = (seerr.state.tv?.status ?? itemStatus ?? '').toLowerCase();
-  final isContinuing = statusStr.isNotEmpty &&
-      statusStr != 'ended' &&
-      statusStr != 'canceled';
+  // A series counts as continuing until it has settled. An unknown status
+  // stays false, so a lookup that found nothing never opens the button.
+  final status = (seerr.state.tv?.status ?? '').toLowerCase();
+  final isContinuing =
+      status.isNotEmpty && status != 'ended' && status != 'canceled';
   final action = seerrRequestActionFor(
     seerr.state.quality(is4k: is4k),
     l10n,
@@ -12384,7 +12384,6 @@ Widget? _seerrRequestButton(
     ),
   );
 }
-
 
 /// Takes this track's open request back. Rides in the same arrangement slot
 /// as the track's request button, so an open request on a partially available

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -12354,12 +12354,19 @@ Widget? _seerrRequestButton(
   bool isPrimary = false,
   FocusNode? focusNode,
   bool autofocus = false,
+  String? itemStatus,
 }) {
   if (seerr == null) return null;
+  final statusStr = (seerr.state.tv?.status ?? itemStatus ?? '').toLowerCase();
+  final isContinuing = statusStr.isNotEmpty &&
+      statusStr != 'ended' &&
+      statusStr != 'canceled';
   final action = seerrRequestActionFor(
     seerr.state.quality(is4k: is4k),
     l10n,
     allowed: is4k ? seerr.canRequest4k : seerr.canRequest,
+    isTv: seerr.state.isTv,
+    isContinuing: isContinuing,
   );
   if (action.kind != SeerrRequestActionKind.request) return null;
   return _DetailActionButton(
@@ -12373,9 +12380,11 @@ Widget? _seerrRequestButton(
       vm: seerr,
       is4k: is4k,
       qualityToggle: qualityToggle,
+      isContinuing: isContinuing,
     ),
   );
 }
+
 
 /// Takes this track's open request back. Rides in the same arrangement slot
 /// as the track's request button, so an open request on a partially available

--- a/lib/ui/widgets/seerr/seerr_request_action.dart
+++ b/lib/ui/widgets/seerr/seerr_request_action.dart
@@ -24,6 +24,10 @@ class SeerrRequestAction {
 /// request still offers Request More rather than only reporting the request.
 /// Taking a request back is a separate control, from [seerrCancelLabelFor],
 /// so the two can sit side by side.
+///
+/// Full availability is only final for a movie or an ended series. A
+/// continuing series can always grow another season, so it keeps offering
+/// Request More even with every aired season in the library.
 SeerrRequestAction seerrRequestActionFor(
   SeerrQualityStatus q,
   AppLocalizations l10n, {
@@ -31,17 +35,19 @@ SeerrRequestAction seerrRequestActionFor(
   bool isTv = false,
   bool isContinuing = false,
 }) {
-  final isContinuingTv = isTv && isContinuing;
+  final continuingFullyAvailable = isTv && isContinuing && q.isFullyAvailable;
   final canShowRequest = allowed &&
-      (!q.isFullyAvailable || isContinuingTv) &&
-      (!q.hasExistingRequest || q.isPartiallyAvailable || isContinuingTv);
-  final hasOpenRequest =
-      q.activeRequests.isNotEmpty && (!q.isFullyAvailable || isContinuingTv);
+      (!q.isFullyAvailable || continuingFullyAvailable) &&
+      (!q.hasExistingRequest ||
+          q.isPartiallyAvailable ||
+          continuingFullyAvailable);
+  final hasOpenRequest = q.activeRequests.isNotEmpty &&
+      (!q.isFullyAvailable || continuingFullyAvailable);
 
   if (canShowRequest) {
     return SeerrRequestAction(
       SeerrRequestActionKind.request,
-      (q.isPartiallyAvailable || (q.isFullyAvailable && isContinuingTv))
+      q.isPartiallyAvailable || continuingFullyAvailable
           ? (q.is4k ? l10n.requestMore4k : l10n.requestMore)
           : (q.is4k ? l10n.request4k : l10n.request),
     );
@@ -54,7 +60,6 @@ SeerrRequestAction seerrRequestActionFor(
   }
   return SeerrRequestAction.none;
 }
-
 
 /// The label for taking this track's open request back, or null when there is
 /// nothing the viewer may cancel.

--- a/lib/ui/widgets/seerr/seerr_request_action.dart
+++ b/lib/ui/widgets/seerr/seerr_request_action.dart
@@ -28,16 +28,20 @@ SeerrRequestAction seerrRequestActionFor(
   SeerrQualityStatus q,
   AppLocalizations l10n, {
   required bool allowed,
+  bool isTv = false,
+  bool isContinuing = false,
 }) {
+  final isContinuingTv = isTv && isContinuing;
   final canShowRequest = allowed &&
-      !q.isFullyAvailable &&
-      (!q.hasExistingRequest || q.isPartiallyAvailable);
-  final hasOpenRequest = q.activeRequests.isNotEmpty && !q.isFullyAvailable;
+      (!q.isFullyAvailable || isContinuingTv) &&
+      (!q.hasExistingRequest || q.isPartiallyAvailable || isContinuingTv);
+  final hasOpenRequest =
+      q.activeRequests.isNotEmpty && (!q.isFullyAvailable || isContinuingTv);
 
   if (canShowRequest) {
     return SeerrRequestAction(
       SeerrRequestActionKind.request,
-      q.isPartiallyAvailable
+      (q.isPartiallyAvailable || (q.isFullyAvailable && isContinuingTv))
           ? (q.is4k ? l10n.requestMore4k : l10n.requestMore)
           : (q.is4k ? l10n.request4k : l10n.request),
     );
@@ -50,6 +54,7 @@ SeerrRequestAction seerrRequestActionFor(
   }
   return SeerrRequestAction.none;
 }
+
 
 /// The label for taking this track's open request back, or null when there is
 /// nothing the viewer may cancel.

--- a/lib/ui/widgets/seerr/seerr_request_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_request_dialog.dart
@@ -27,14 +27,13 @@ void showSeerrRequestDialog({
   required bool is4k,
   bool qualityToggle = false,
   int? season,
+  bool isContinuing = false,
 }) {
   final s = vm.state;
   final l10n = AppLocalizations.of(context);
   final type = s.isTv ? l10n.series : l10n.movie;
   showStyledPlayerDialog<void>(
     context,
-    // With a switch on the sheet the title stays neutral, since either track
-    // can end up being the one asked for. Without one it has to say which.
     title: is4k && !_hasQualityToggle(vm, qualityToggle)
         ? l10n.requestSeriesOrMovie4k(type)
         : l10n.requestSeriesOrMovie(type),
@@ -46,6 +45,7 @@ void showSeerrRequestDialog({
       seasons: s.tv?.seasons ?? const [],
       numberOfSeasons: s.numberOfSeasons ?? 0,
       season: season,
+      isContinuing: isContinuing,
     ),
   );
 }
@@ -59,6 +59,7 @@ class SeerrRequestDialog extends StatefulWidget {
   final bool qualityToggle;
   final List<SeerrSeason> seasons;
   final int numberOfSeasons;
+  final bool isContinuing;
 
   /// Opens with just this season ticked, for a viewer who asked for one rather
   /// than for the whole run.
@@ -73,11 +74,13 @@ class SeerrRequestDialog extends StatefulWidget {
     required this.seasons,
     required this.numberOfSeasons,
     this.season,
+    this.isContinuing = false,
   });
 
   @override
   State<SeerrRequestDialog> createState() => _SeerrRequestDialogState();
 }
+
 
 class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
   late bool _allSeasons = widget.season == null;
@@ -86,10 +89,11 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
   late final Set<int> _selectedSeasons = {?widget.season};
   late final SeerrAdvancedRequestController _advanced;
 
-  /// The seasons already spoken for belong to one track, so flipping the
-  /// switch redraws the chips against the track being asked for.
+  /// The seasons already available in the library or spoken for in requests,
+  /// so flipping the switch redraws the chips against the track being asked for.
   Set<int> get _requestedSeasons =>
-      widget.vm.state.quality(is4k: _is4k).requestedSeasons;
+      widget.vm.state.quality(is4k: _is4k).unavailableOrRequestedSeasons;
+
 
   @override
   void initState() {
@@ -195,6 +199,40 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
 
     final showToggle = _hasQualityToggle(widget.vm, widget.qualityToggle);
     final children = <Widget>[];
+    if (widget.isTv &&
+        widget.isContinuing &&
+        widget.vm.state.quality(is4k: _is4k).isFullyAvailable) {
+      children.add(
+        Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: const Color(0xFF10B981).withValues(alpha: 0.15),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(
+              color: const Color(0xFF10B981).withValues(alpha: 0.4),
+            ),
+          ),
+
+          child: const Row(
+            children: [
+              Icon(Icons.autorenew, color: Color(0xFF10B981), size: 20),
+              SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Series Continuing · Future Seasons Monitored',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     if (showToggle) {
       children.add(
         SeerrToggleRow(
@@ -208,6 +246,7 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
         ),
       );
     }
+
     if (widget.isTv) {
       children.add(const Divider(color: Colors.white12));
       children.add(_buildSeasonSelector(autofocusAll: !showToggle));
@@ -297,6 +336,7 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
                 return SeerrChoiceChip(
                   label: l10n.seasonChip(seasonNumber),
                   selected: selected,
+                  isAvailable: alreadyRequested,
                   onSelected: alreadyRequested
                       ? null
                       : (v) => setState(() {
@@ -307,6 +347,7 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
                           }
                         }),
                 );
+
               }).toList(),
             ),
           ),

--- a/lib/ui/widgets/seerr/seerr_request_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_request_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/viewmodels/seerr_media_detail_view_model.dart';
@@ -6,6 +7,7 @@ import '../../../l10n/app_localizations.dart';
 import 'seerr_advanced_request_options.dart';
 import 'seerr_quota_row.dart';
 import 'seerr_request_action.dart';
+import 'seerr_status_dot.dart';
 import 'seerr_tv_controls.dart';
 import '../track_selector_dialog.dart';
 
@@ -34,6 +36,8 @@ void showSeerrRequestDialog({
   final type = s.isTv ? l10n.series : l10n.movie;
   showStyledPlayerDialog<void>(
     context,
+    // With a switch on the sheet the title stays neutral, since either track
+    // can end up being the one asked for. Without one it has to say which.
     title: is4k && !_hasQualityToggle(vm, qualityToggle)
         ? l10n.requestSeriesOrMovie4k(type)
         : l10n.requestSeriesOrMovie(type),
@@ -81,7 +85,6 @@ class SeerrRequestDialog extends StatefulWidget {
   State<SeerrRequestDialog> createState() => _SeerrRequestDialogState();
 }
 
-
 class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
   late bool _allSeasons = widget.season == null;
   late bool _is4k = widget.is4k;
@@ -89,11 +92,9 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
   late final Set<int> _selectedSeasons = {?widget.season};
   late final SeerrAdvancedRequestController _advanced;
 
-  /// The seasons already available in the library or spoken for in requests,
-  /// so flipping the switch redraws the chips against the track being asked for.
-  Set<int> get _requestedSeasons =>
-      widget.vm.state.quality(is4k: _is4k).unavailableOrRequestedSeasons;
-
+  /// The track being asked for, so flipping the switch redraws the sheet
+  /// against the one the request will actually go out on.
+  SeerrQualityStatus get _quality => widget.vm.state.quality(is4k: _is4k);
 
   @override
   void initState() {
@@ -151,7 +152,8 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
     if (!widget.isTv) return 0;
     if (_allSeasons) {
       final total = _seasonNumbers.length;
-      return (total - _requestedSeasons.length).clamp(1, total);
+      return (total - _quality.unavailableOrRequestedSeasons.length)
+          .clamp(1, total);
     }
     return _selectedSeasons.length;
   }
@@ -199,28 +201,24 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
 
     final showToggle = _hasQualityToggle(widget.vm, widget.qualityToggle);
     final children = <Widget>[];
-    if (widget.isTv &&
-        widget.isContinuing &&
-        widget.vm.state.quality(is4k: _is4k).isFullyAvailable) {
+    if (widget.isTv && widget.isContinuing && _quality.isFullyAvailable) {
+      final green = seerrStatusColor(SeerrMediaStatus.available);
       children.add(
         Container(
           margin: const EdgeInsets.only(bottom: 12),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
-            color: const Color(0xFF10B981).withValues(alpha: 0.15),
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(
-              color: const Color(0xFF10B981).withValues(alpha: 0.4),
-            ),
+            color: green.withValues(alpha: 0.15),
+            borderRadius: AppRadius.circular(8),
+            border: Border.all(color: green.withValues(alpha: 0.4)),
           ),
-
           child: Row(
             children: [
-              const Icon(Icons.autorenew, color: Color(0xFF10B981), size: 20),
+              Icon(Icons.autorenew, color: green, size: 20),
               const SizedBox(width: 10),
               Expanded(
                 child: Text(
-                  l10n.seriesContinuingFutureSeasonsMonitored,
+                  l10n.seerrSeriesContinuing,
                   style: const TextStyle(
                     color: Colors.white,
                     fontSize: 13,
@@ -230,7 +228,6 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
               ),
             ],
           ),
-
         ),
       );
     }
@@ -247,7 +244,6 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
         ),
       );
     }
-
     if (widget.isTv) {
       children.add(const Divider(color: Colors.white12));
       children.add(_buildSeasonSelector(autofocusAll: !showToggle));
@@ -311,7 +307,9 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
   Widget _buildSeasonSelector({bool autofocusAll = false}) {
     final l10n = AppLocalizations.of(context);
     final seasonNumbers = _seasonNumbers;
-    final requested = _requestedSeasons;
+    final quality = _quality;
+    final unselectable = quality.unavailableOrRequestedSeasons;
+    final available = quality.availableSeasons;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -332,13 +330,13 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
               spacing: 8,
               runSpacing: 8,
               children: seasonNumbers.map((seasonNumber) {
-                final alreadyRequested = requested.contains(seasonNumber);
+                final taken = unselectable.contains(seasonNumber);
                 final selected = _selectedSeasons.contains(seasonNumber);
                 return SeerrChoiceChip(
                   label: l10n.seasonChip(seasonNumber),
                   selected: selected,
-                  isAvailable: alreadyRequested,
-                  onSelected: alreadyRequested
+                  isAvailable: available.contains(seasonNumber),
+                  onSelected: taken
                       ? null
                       : (v) => setState(() {
                           if (v) {
@@ -348,12 +346,10 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
                           }
                         }),
                 );
-
               }).toList(),
             ),
           ),
       ],
     );
   }
-
 }

--- a/lib/ui/widgets/seerr/seerr_request_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_request_dialog.dart
@@ -214,14 +214,14 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
             ),
           ),
 
-          child: const Row(
+          child: Row(
             children: [
-              Icon(Icons.autorenew, color: Color(0xFF10B981), size: 20),
-              SizedBox(width: 10),
+              const Icon(Icons.autorenew, color: Color(0xFF10B981), size: 20),
+              const SizedBox(width: 10),
               Expanded(
                 child: Text(
-                  'Series Continuing · Future Seasons Monitored',
-                  style: TextStyle(
+                  l10n.seriesContinuingFutureSeasonsMonitored,
+                  style: const TextStyle(
                     color: Colors.white,
                     fontSize: 13,
                     fontWeight: FontWeight.w500,
@@ -230,6 +230,7 @@ class _SeerrRequestDialogState extends State<SeerrRequestDialog> {
               ),
             ],
           ),
+
         ),
       );
     }

--- a/lib/ui/widgets/seerr/seerr_tv_controls.dart
+++ b/lib/ui/widgets/seerr/seerr_tv_controls.dart
@@ -126,12 +126,14 @@ class SeerrChoiceChip extends StatelessWidget {
   final String label;
   final bool selected;
   final ValueChanged<bool>? onSelected;
+  final bool isAvailable;
 
   const SeerrChoiceChip({
     super.key,
     required this.label,
     required this.selected,
     required this.onSelected,
+    this.isAvailable = false,
   });
 
   @override
@@ -145,16 +147,29 @@ class SeerrChoiceChip extends StatelessWidget {
             : Colors.white.withValues(alpha: enabled ? 0.08 : 0.04),
         borderRadius: AppRadius.circular(999),
       ),
-      child: Text(
-        label,
-        style: TextStyle(
-          fontSize: 13,
-          color: !enabled
-              ? Colors.white38
-              : selected
-                  ? Colors.white
-                  : Colors.white70,
-        ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isAvailable) ...[
+            const Icon(
+              Icons.check_circle,
+              size: 14,
+              color: Color(0xFF10B981),
+            ),
+            const SizedBox(width: 6),
+          ],
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              color: !enabled
+                  ? Colors.white38
+                  : selected
+                      ? Colors.white
+                      : Colors.white70,
+            ),
+          ),
+        ],
       ),
     );
 
@@ -168,6 +183,7 @@ class SeerrChoiceChip extends StatelessWidget {
     );
   }
 }
+
 
 /// A dialog action button (Cancel / primary submit) that works with d-pad.
 class SeerrDialogButton extends StatelessWidget {

--- a/lib/ui/widgets/seerr/seerr_tv_controls.dart
+++ b/lib/ui/widgets/seerr/seerr_tv_controls.dart
@@ -3,6 +3,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../focus/focusable_wrapper.dart';
 import '../track_selector_dialog.dart';
+import 'seerr_status_dot.dart';
 
 // D-pad friendly form controls for the Seerr request and issue dialogs. Plain
 // Material toggles, chips, and dropdowns don't react to the remote's select
@@ -126,6 +127,9 @@ class SeerrChoiceChip extends StatelessWidget {
   final String label;
   final bool selected;
   final ValueChanged<bool>? onSelected;
+
+  /// Marks a season the library already holds with a check, so a disabled
+  /// chip can say why it is off the table.
   final bool isAvailable;
 
   const SeerrChoiceChip({
@@ -151,10 +155,10 @@ class SeerrChoiceChip extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           if (isAvailable) ...[
-            const Icon(
+            Icon(
               Icons.check_circle,
               size: 14,
-              color: Color(0xFF10B981),
+              color: seerrStatusColor(SeerrMediaStatus.available),
             ),
             const SizedBox(width: 6),
           ],
@@ -183,7 +187,6 @@ class SeerrChoiceChip extends StatelessWidget {
     );
   }
 }
-
 
 /// A dialog action button (Cancel / primary submit) that works with d-pad.
 class SeerrDialogButton extends StatelessWidget {

--- a/test/data/viewmodels/seerr_quality_status_test.dart
+++ b/test/data/viewmodels/seerr_quality_status_test.dart
@@ -106,6 +106,28 @@ void main() {
       expect(uhd.requestedSeasons, {1});
     });
 
+    test('unavailableOrRequestedSeasons includes seasons available in library',
+        () {
+      final info = SeerrMediaInfo(
+        seasons: const [
+          SeerrSeasonAvailability(seasonNumber: 3, status: 5),
+        ],
+        requests: [
+          _request(id: 1, status: SeerrRequest.statusApproved, seasons: [2]),
+        ],
+      );
+      final hd = SeerrQualityStatus.of(
+        is4k: false,
+        mediaInfo: info,
+        canManageRequests: false,
+        currentUserId: null,
+      );
+
+      expect(hd.requestedSeasons, {2});
+      expect(hd.unavailableOrRequestedSeasons, {2, 3});
+    });
+
+
     test('declined and failed requests are not active and free their seasons',
         () {
       final info = SeerrMediaInfo(

--- a/test/data/viewmodels/seerr_quality_status_test.dart
+++ b/test/data/viewmodels/seerr_quality_status_test.dart
@@ -124,9 +124,9 @@ void main() {
       );
 
       expect(hd.requestedSeasons, {2});
+      expect(hd.availableSeasons, {3});
       expect(hd.unavailableOrRequestedSeasons, {2, 3});
     });
-
 
     test('declined and failed requests are not active and free their seasons',
         () {

--- a/test/ui/widgets/seerr/seerr_request_action_test.dart
+++ b/test/ui/widgets/seerr/seerr_request_action_test.dart
@@ -85,7 +85,21 @@ void main() {
       final action = seerrRequestActionFor(q, _l10n, allowed: true);
       expect(action.label, _l10n.requestMore4k);
     });
+
+    test('a fully available continuing TV series still offers request more', () {
+      final q = _track(status: 5);
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        isContinuing: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.request);
+      expect(action.label, _l10n.requestMore);
+    });
   });
+
 
   group('seerrCancelLabelFor', () {
     test('offers a viewer their own pending request back', () {

--- a/test/ui/widgets/seerr/seerr_request_action_test.dart
+++ b/test/ui/widgets/seerr/seerr_request_action_test.dart
@@ -98,8 +98,34 @@ void main() {
       expect(action.kind, SeerrRequestActionKind.request);
       expect(action.label, _l10n.requestMore);
     });
-  });
 
+    test('a fully available ended series has nothing left to offer', () {
+      final q = _track(status: 5);
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        isContinuing: false,
+      );
+      expect(action.kind, SeerrRequestActionKind.none);
+    });
+
+    test('a continuing series still processing reads requested', () {
+      final q = _track(
+        status: 3,
+        requests: [_request(status: SeerrRequest.statusApproved)],
+      );
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        isContinuing: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.requested);
+    });
+  });
 
   group('seerrCancelLabelFor', () {
     test('offers a viewer their own pending request back', () {


### PR DESCRIPTION
# Pull Request

## Summary
Enhances Seerr request interactions for TV series by keeping the **Request More** button active for continuing/returning series (e.g., *Alien Earth*, *From*) even when currently aired seasons are fully available in the library. Additionally, adds a continuing series status banner and a green checkmark indicator to available season choice chips in the request dialog.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **seerr_request_action.dart**: Updated `seerrRequestActionFor` to accept `isTv` and `isContinuing` flags, ensuring that continuing/returning TV series do not suppress the `Request More` button when all current seasons are available.
- **seerr_request_dialog.dart**: Added a continuing series status banner (**Series Continuing · Future Seasons Monitored**) and updated season selection to display a green checkmark icon (**Icons.check_circle**) for seasons already in the library while disabling their chips.
- **seerr_media_detail_view_model.dart**: Added `unavailableOrRequestedSeasons` getter to `SeerrQualityStatus` combining library-available seasons with active requests.
- **seerr_tv_controls.dart**: Added `isAvailable` icon support to `SeerrChoiceChip`.
- **item_detail_screen.dart**: Passed `isContinuing` series status to `_seerrRequestButton` and request dialog.
- **Unit Tests**: Added unit tests in **seerr_request_action_test.dart** and **seerr_quality_status_test.dart**.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Run `flutter test test/ui/widgets/seerr/seerr_request_action_test.dart` and `flutter test test/data/viewmodels/seerr_quality_status_test.dart`.
2. Open item detail for a continuing TV series with Season 1 available in library (*Alien Earth*).
3. Verify `Request More` button is visible and active.
4. Click `Request More` and verify the continuing series status banner and green checkmark on Season 1 choice chip.


## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-07_18-27-22" src="https://github.com/user-attachments/assets/3950c712-a795-4583-be5a-16154cb8f5f9" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-07_18-28-02" src="https://github.com/user-attachments/assets/f753fc1d-af14-4fba-8470-9be50416482d" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-07_18-28-31" src="https://github.com/user-attachments/assets/486a654c-def2-4072-a838-47102dbe2a20" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
