### PR TITLE
Keep the Media3 target buffer below the app heap

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -523,6 +523,11 @@ class Media3VideoView(
         private const val EXTERNAL_SUBTITLE_ID_BASE = 10000
         private const val STREAMING_MAX_BUFFER_MS = 120_000
         private const val MAX_TARGET_BUFFER_BYTES = 384L * 1024 * 1024
+        // Fraction of the app heap the sample buffer may occupy. A third leaves
+        // room for decoder buffers, the Flutter engine and the extractor on a
+        // roomy heap; low RAM boxes get a sixth of a heap that is already small.
+        private const val HEAP_DIVISOR = 3L
+        private const val HEAP_DIVISOR_LOW_RAM = 6L
         // Broadcast captions ride inside the video as CEA-608 messages rather
         // than as their own stream, and the extractor only looks for them when
         // the transport stream announces them in a caption service descriptor.
@@ -1366,13 +1371,19 @@ class Media3VideoView(
     // the byte budget to the app heap and stretch the streaming time
     // ceiling so direct play keeps a real runway, leaving local playback
     // durations at their defaults.
+    //
+    // The byte budget must stay strictly below the heap: it is the only brake
+    // that tracks bitrate, and once it is unreachable the loader never pauses.
+    // DEFAULT_MUXED_BUFFER_SIZE is 137.6 MiB, which is larger than the whole
+    // heap on a 128 MiB device, so it must never be used as a lower bound.
+    // DEFAULT_MIN_BUFFER_SIZE (12.5 MiB) is the floor instead. The same applies
+    // to the stock load control, whose derived target is the same 137.6 MiB,
+    // so low RAM devices need a smaller budget rather than the defaults.
     private fun buildLoadControl(): DefaultLoadControl {
-        // Low RAM boxes cant spare a third of the heap for runway on top of
-        // decode buffers, so they keep the stock budgets.
-        if (isLowRamDevice) return DefaultLoadControl.Builder().build()
-        val targetBufferBytes = (Runtime.getRuntime().maxMemory() / 3)
+        val divisor = if (isLowRamDevice) HEAP_DIVISOR_LOW_RAM else HEAP_DIVISOR
+        val targetBufferBytes = (Runtime.getRuntime().maxMemory() / divisor)
             .coerceAtMost(MAX_TARGET_BUFFER_BYTES)
-            .coerceAtLeast(DefaultLoadControl.DEFAULT_MUXED_BUFFER_SIZE.toLong())
+            .coerceAtLeast(DefaultLoadControl.DEFAULT_MIN_BUFFER_SIZE.toLong())
             .toInt()
         return DefaultLoadControl.Builder()
             .setTargetBufferBytes(targetBufferBytes)


### PR DESCRIPTION
## The bug

Every Media3 direct play dies after ~110 s on an Amazon Fire TV Stick HD (AFTSS, Android 9, MediaTek). Reproduced 6 times across 2.3.2 and 2.4.0.

```
ERROR [media] Media3 error: ERROR_CODE_IO_UNSPECIFIED Source error caused by m: Source error
  <- q: Unexpected OutOfMemoryError: Failed to allocate a 65552 byte allocation
     with 44216 free bytes and 43KB until OOM,
     max allowed footprint 134217728, growth limit 134217728
```

`134217728` = 128 MiB = the Java heap this device grants the app. Media3 buffers until the heap is gone; the OOM surfaces as a generic `Source error`.

Media: MKV, 1080p, HEVC, EAC3, ~24.4 Mbps. Same file plays fine on the mpv/libmpv backend, which buffers in native memory rather than on the Java heap.

## Root cause

`Media3VideoView.buildLoadControl()` is the only `LoadControl` in the tree:

```kotlin
val targetBufferBytes = (Runtime.getRuntime().maxMemory() / 3)   // 44.7 MB, sane
    .coerceAtMost(MAX_TARGET_BUFFER_BYTES)                       // 384 MB, never binds
    .coerceAtLeast(DefaultLoadControl.DEFAULT_MUXED_BUFFER_SIZE)  // 137.6 MiB, overrides
    .toInt()
```

From media3 1.10.1 (`DefaultLoadControl.java:135-159`, `C.java:1113`):

| constant | value |
|---|---|
| `DEFAULT_BUFFER_SEGMENT_SIZE` | 65,536 |
| `DEFAULT_VIDEO_BUFFER_SIZE` | 2000 × 65536 = 131,072,000 |
| `DEFAULT_AUDIO_BUFFER_SIZE` | 200 × 65536 = 13,107,200 |
| `DEFAULT_TEXT_BUFFER_SIZE` | 2 × 65536 = 131,072 |
| **`DEFAULT_MUXED_BUFFER_SIZE`** | **144,310,272 = 137.6 MiB** |

The floor is 10 MiB larger than the entire 128 MiB heap, so it silently discards the heap-aware `/3` value above it.

`targetBufferSizeReached` (`DefaultLoadControl.java:766`) compares allocated bytes against that target and can therefore never be true — **the byte brake does not exist**. The time brake is unreachable too: `STREAMING_MAX_BUFFER_MS` = 120 s, and 120 s at 24.4 Mbps is 366 MB.

With both brakes above the heap ceiling, `shouldContinueLoading()` returns `true` until the heap dies. A progressive MKV source keeps a single HTTP range request open and never pauses — which matches the reverse proxy log showing one request and no follow-up.

Confirmation from the allocation size: `DefaultAllocator.java:107` does `new byte[65536]`; plus the 16-byte array header that is exactly the **65552** from the crash.

Secondary amplifier: `DefaultAllocator.trim()` (`:134`) only frees down to `targetBufferSize`, so at a 137.6 MiB target it is a permanent no-op and the free list is never returned to the heap.

## Regression

Introduced by 7a828045 ("Give high-bitrate remux direct play a real buffer runway", fixes #728), which added `buildLoadControl()` including the `coerceAtLeast`.

0d70ef50 added `if (isLowRamDevice) return DefaultLoadControl.Builder().build()` 95 minutes later. That guard does not help here for two reasons:

1. Fire OS on the Stick HD does not set `ro.config.low_ram`, so it never fires.
2. Even when it does fire, the stock control leaves `targetBufferBytes` at `LENGTH_UNSET`, and `calculateTargetBufferBytes()` (`:847`) derives **the same 144,310,272 bytes** from the selected video + audio + text tracks. Only the duration cap changes (50 s instead of 120 s), and 50 s at 24.4 Mbps is still 152 MB. The guard moves the OOM, it does not prevent it.

## The fix

Use `DEFAULT_MIN_BUFFER_SIZE` (12.5 MiB) as the floor so the heap fraction stays the binding constraint, and give low RAM devices a smaller share instead of the broken defaults.

This preserves the intent of #728 in full. The byte budget *is* the bitrate-aware brake: 42.7 MiB on a 128 MiB heap is ~14 s of runway at 24.4 Mbps and ~67 s at 5 Mbps, so low bitrate sources still get the whole 120 s runway the original change aimed for, while a high bitrate remux is capped at a heap-safe value.

On the AFTSS: `134,217,728 / 3 = 44,739,242` (42.7 MiB). Floor does not bind, cap does not bind, and the loader actually pauses.

## Notes for review

- At 24.4 Mbps `minBufferMs` (50 s = 152 MB) stays unreachable, so `shouldContinueLoading()` takes the first branch at `:783` and stops there via `!targetBufferSizeReached`. Correct, because `prioritizeTimeOverSizeThresholds` is `false`. If `"Target buffer size reached with less than 500ms of buffered media data"` ever shows up, the answer is `HEAP_DIVISOR = 2`, **not** flipping `prioritizeTimeOverSizeThresholds`, which would disable the byte brake again.
- `android:largeHeap` is not set in the manifest. Adding it is reasonable on its own merits, but it is not a fix here: without this change the target still does not track bitrate and the OOM only arrives later.
- One measurement I could not fully reconcile: the proxy logged "a single range request of ~139 MB". If that is bytes actually transferred, it works out to 1.26 MB/s, below the 24.4 Mbps stream rate — at which point the buffer would stay thin and there would be no OOM at all. The numbers only line up if ~139 MB is the requested range size rather than the transferred volume. Checking `$body_bytes_sent` against `$request_time` for that request would settle it; ~330-450 MB over 110 s would confirm the model end to end. Independently of that, a byte target above the total heap is a defect on its own and is sufficient to explain an allocator-driven OOM.

## Testing

Static analysis against the media3 1.10.1 sources; I do not have an AFTSS to verify the runtime behaviour on. Would appreciate a check from anyone with a 128 MiB heap device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kmdhV682fbv2FSSckBauP
