### PR TITLE
bugfix-mediabar - Fixes Playlist/Collections Sources Not Saving for Media Bar

### DIFF
--- a/lib/ui/screens/settings/media_bar_settings_screen.dart
+++ b/lib/ui/screens/settings/media_bar_settings_screen.dart
@@ -125,7 +125,7 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
 
     try {
       final response = await client.itemsApi.getItems(
-        includeItemTypes: ['BoxSet'],
+        includeItemTypes: ['BoxSet', 'Playlist', 'CollectionFolder'],
         sortBy: 'SortName',
         sortOrder: 'Ascending',
         recursive: true,


### PR DESCRIPTION
# Pull Request

## Summary
Expands the item types fetched by the media bar collection selector to include `BoxSet`, `Playlist`, and `CollectionFolder`, preventing user playlists and collection folders from being pruned when configuring media bar sources.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1087 
- Related to # https://github.com/Moonfin-Client/Plugin/pull/225

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated `includeItemTypes` in **media_bar_settings_screen.dart** from `['BoxSet']` to `['BoxSet', 'Playlist', 'CollectionFolder']`.
- Ensures user-configured playlists and collection folders in Jellyfin/Emby are recognized and preserved during collection selector load and save operations.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Opened Media Bar Settings screen.
2. Verified collection selector loads `BoxSet`, `Playlist`, and `CollectionFolder` items.
3. Verified selected playlists and collection folders are correctly saved and restored without being pruned out.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
