### PR TITLE
Allow requesting unrequested seasons while another is pending

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -12569,12 +12569,23 @@ Widget? _seerrRequestButton(
   final status = (seerr.state.tv?.status ?? '').toLowerCase();
   final isContinuing =
       status.isNotEmpty && status != 'ended' && status != 'canceled';
+  final quality = seerr.state.quality(is4k: is4k);
+  // A season nobody has requested (or that isn't already in the library)
+  // stays requestable even while another season on this track is still
+  // pending - Seerr's own aggregate status only reflects what was already
+  // asked for, not the whole show.
+  final hasUnrequestedSeasons = seerr.state.isTv &&
+      seerrSeasonNumbersOf(
+        seerr.state.tv?.seasons ?? const [],
+        seerr.state.numberOfSeasons ?? 0,
+      ).any((s) => !quality.unavailableOrRequestedSeasons.contains(s));
   final action = seerrRequestActionFor(
-    seerr.state.quality(is4k: is4k),
+    quality,
     l10n,
     allowed: is4k ? seerr.canRequest4k : seerr.canRequest,
     isTv: seerr.state.isTv,
     isContinuing: isContinuing,
+    hasUnrequestedSeasons: hasUnrequestedSeasons,
   );
   if (action.kind != SeerrRequestActionKind.request) return null;
   return _DetailActionButton(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -12570,10 +12570,7 @@ Widget? _seerrRequestButton(
   final isContinuing =
       status.isNotEmpty && status != 'ended' && status != 'canceled';
   final quality = seerr.state.quality(is4k: is4k);
-  // A season nobody has requested (or that isn't already in the library)
-  // stays requestable even while another season on this track is still
-  // pending - Seerr's own aggregate status only reflects what was already
-  // asked for, not the whole show.
+  // The same set the request sheet reads to decide which seasons it may offer.
   final hasUnrequestedSeasons = seerr.state.isTv &&
       seerrSeasonNumbersOf(
         seerr.state.tv?.seasons ?? const [],

--- a/lib/ui/widgets/seerr/seerr_request_action.dart
+++ b/lib/ui/widgets/seerr/seerr_request_action.dart
@@ -27,27 +27,33 @@ class SeerrRequestAction {
 ///
 /// Full availability is only final for a movie or an ended series. A
 /// continuing series can always grow another season, so it keeps offering
-/// Request More even with every aired season in the library.
+/// Request More even with every aired season in the library. Likewise,
+/// [hasUnrequestedSeasons] (a season nobody has asked for at all, computed
+/// from [SeerrQualityStatus.unavailableOrRequestedSeasons] against the show's
+/// real season list) keeps Request More available even while the *rest* of
+/// the track sits at plain "pending" (status 2, not yet 4/partial) - Seerr's
+/// aggregate status only reflects what was already requested, so a season
+/// that was never part of any request must not be gated on it.
 SeerrRequestAction seerrRequestActionFor(
   SeerrQualityStatus q,
   AppLocalizations l10n, {
   required bool allowed,
   bool isTv = false,
   bool isContinuing = false,
+  bool hasUnrequestedSeasons = false,
 }) {
-  final continuingFullyAvailable = isTv && isContinuing && q.isFullyAvailable;
+  final hasMoreToRequest = (isTv && isContinuing && q.isFullyAvailable) ||
+      (isTv && hasUnrequestedSeasons);
   final canShowRequest = allowed &&
-      (!q.isFullyAvailable || continuingFullyAvailable) &&
-      (!q.hasExistingRequest ||
-          q.isPartiallyAvailable ||
-          continuingFullyAvailable);
-  final hasOpenRequest = q.activeRequests.isNotEmpty &&
-      (!q.isFullyAvailable || continuingFullyAvailable);
+      (!q.isFullyAvailable || hasMoreToRequest) &&
+      (!q.hasExistingRequest || q.isPartiallyAvailable || hasMoreToRequest);
+  final hasOpenRequest =
+      q.activeRequests.isNotEmpty && (!q.isFullyAvailable || hasMoreToRequest);
 
   if (canShowRequest) {
     return SeerrRequestAction(
       SeerrRequestActionKind.request,
-      q.isPartiallyAvailable || continuingFullyAvailable
+      q.isPartiallyAvailable || hasMoreToRequest
           ? (q.is4k ? l10n.requestMore4k : l10n.requestMore)
           : (q.is4k ? l10n.request4k : l10n.request),
     );

--- a/lib/ui/widgets/seerr/seerr_request_action.dart
+++ b/lib/ui/widgets/seerr/seerr_request_action.dart
@@ -27,13 +27,13 @@ class SeerrRequestAction {
 ///
 /// Full availability is only final for a movie or an ended series. A
 /// continuing series can always grow another season, so it keeps offering
-/// Request More even with every aired season in the library. Likewise,
-/// [hasUnrequestedSeasons] (a season nobody has asked for at all, computed
-/// from [SeerrQualityStatus.unavailableOrRequestedSeasons] against the show's
-/// real season list) keeps Request More available even while the *rest* of
-/// the track sits at plain "pending" (status 2, not yet 4/partial) - Seerr's
-/// aggregate status only reflects what was already requested, so a season
-/// that was never part of any request must not be gated on it.
+/// Request More even with every aired season in the library.
+///
+/// [hasUnrequestedSeasons] says a season is still there for the asking. The
+/// track status only describes what was already requested, so on its own it
+/// hides the button once any request is open, even for a season nobody has
+/// touched. The flag relaxes that one gate and nothing else, since a season
+/// left to ask for says nothing about whether the show is complete.
 SeerrRequestAction seerrRequestActionFor(
   SeerrQualityStatus q,
   AppLocalizations l10n, {
@@ -42,18 +42,22 @@ SeerrRequestAction seerrRequestActionFor(
   bool isContinuing = false,
   bool hasUnrequestedSeasons = false,
 }) {
-  final hasMoreToRequest = (isTv && isContinuing && q.isFullyAvailable) ||
-      (isTv && hasUnrequestedSeasons);
+  final continuingFullyAvailable = isTv && isContinuing && q.isFullyAvailable;
+  final seasonsLeftToAsk = isTv && hasUnrequestedSeasons;
   final canShowRequest = allowed &&
-      (!q.isFullyAvailable || hasMoreToRequest) &&
-      (!q.hasExistingRequest || q.isPartiallyAvailable || hasMoreToRequest);
-  final hasOpenRequest =
-      q.activeRequests.isNotEmpty && (!q.isFullyAvailable || hasMoreToRequest);
+      (!q.isFullyAvailable || continuingFullyAvailable) &&
+      (!q.hasExistingRequest ||
+          q.isPartiallyAvailable ||
+          continuingFullyAvailable ||
+          seasonsLeftToAsk);
+  final hasOpenRequest = q.activeRequests.isNotEmpty &&
+      (!q.isFullyAvailable || continuingFullyAvailable);
 
   if (canShowRequest) {
     return SeerrRequestAction(
       SeerrRequestActionKind.request,
-      q.isPartiallyAvailable || hasMoreToRequest
+      // Without the existing request test the first ask would read More.
+      q.isPartiallyAvailable || continuingFullyAvailable || q.hasExistingRequest
           ? (q.is4k ? l10n.requestMore4k : l10n.requestMore)
           : (q.is4k ? l10n.request4k : l10n.request),
     );

--- a/test/ui/widgets/seerr/seerr_request_action_test.dart
+++ b/test/ui/widgets/seerr/seerr_request_action_test.dart
@@ -126,10 +126,7 @@ void main() {
       expect(action.kind, SeerrRequestActionKind.requested);
     });
 
-    test(
-        'a plain-pending track (status 2) with an unrequested season still '
-        'offers request more, even though nothing is partially available yet',
-        () {
+    test('a pending request does not hide a season nobody has asked for', () {
       final q = _track(
         status: 2,
         requests: [_request(status: SeerrRequest.statusPending)],
@@ -145,10 +142,7 @@ void main() {
       expect(action.label, _l10n.requestMore);
     });
 
-    test(
-        'a plain-pending track with nothing left unrequested still just '
-        'reads requested (unchanged from before hasUnrequestedSeasons existed)',
-        () {
+    test('a pending request with every season spoken for reads requested', () {
       final q = _track(
         status: 2,
         requests: [_request(status: SeerrRequest.statusPending)],
@@ -163,7 +157,7 @@ void main() {
       expect(action.kind, SeerrRequestActionKind.requested);
     });
 
-    test('hasUnrequestedSeasons is ignored for movies (isTv: false)', () {
+    test('a movie has no seasons, so the season rule never applies', () {
       final q = _track(
         status: 2,
         requests: [_request(status: SeerrRequest.statusPending)],
@@ -176,6 +170,36 @@ void main() {
         hasUnrequestedSeasons: true,
       );
       expect(action.kind, SeerrRequestActionKind.requested);
+    });
+
+    test('the first ask on a series reads request, not request more', () {
+      // Nothing requested and nothing in the library, so every season counts
+      // as one left to ask for.
+      final q = _track(status: 1);
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        hasUnrequestedSeasons: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.request);
+      expect(action.label, _l10n.request);
+    });
+
+    test('a season left to ask for does not reopen an ended series', () {
+      // A season list that came back short is what makes this reachable, and
+      // it must not be enough to reopen a show the server calls complete.
+      final q = _track(status: 5);
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        isContinuing: false,
+        hasUnrequestedSeasons: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.none);
     });
   });
 

--- a/test/ui/widgets/seerr/seerr_request_action_test.dart
+++ b/test/ui/widgets/seerr/seerr_request_action_test.dart
@@ -125,6 +125,58 @@ void main() {
       );
       expect(action.kind, SeerrRequestActionKind.requested);
     });
+
+    test(
+        'a plain-pending track (status 2) with an unrequested season still '
+        'offers request more, even though nothing is partially available yet',
+        () {
+      final q = _track(
+        status: 2,
+        requests: [_request(status: SeerrRequest.statusPending)],
+      );
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        hasUnrequestedSeasons: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.request);
+      expect(action.label, _l10n.requestMore);
+    });
+
+    test(
+        'a plain-pending track with nothing left unrequested still just '
+        'reads requested (unchanged from before hasUnrequestedSeasons existed)',
+        () {
+      final q = _track(
+        status: 2,
+        requests: [_request(status: SeerrRequest.statusPending)],
+      );
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: true,
+        hasUnrequestedSeasons: false,
+      );
+      expect(action.kind, SeerrRequestActionKind.requested);
+    });
+
+    test('hasUnrequestedSeasons is ignored for movies (isTv: false)', () {
+      final q = _track(
+        status: 2,
+        requests: [_request(status: SeerrRequest.statusPending)],
+      );
+      final action = seerrRequestActionFor(
+        q,
+        _l10n,
+        allowed: true,
+        isTv: false,
+        hasUnrequestedSeasons: true,
+      );
+      expect(action.kind, SeerrRequestActionKind.requested);
+    });
   });
 
   group('seerrCancelLabelFor', () {


### PR DESCRIPTION
## Summary
`seerrRequestActionFor` gated the whole "Request More" button on Seerr's aggregate media status, which only reflects what was already requested - so once any season sat at plain "pending" (status 2, not yet "partially available"), the button disappeared entirely, blocking seasons that were never part of any request at all (e.g. requesting an unreleased season, then wanting to also request Season 1).

## Related Issues
None - found this myself while using the app.

## Type of Change
- [x] Bug fix

## Changes Made
- `seerrRequestActionFor` gains a `hasUnrequestedSeasons` param - when true, keeps Request More available even while the rest of the track sits at plain "pending"
- `item_detail_screen.dart` computes `hasUnrequestedSeasons` from `SeerrQualityStatus.unavailableOrRequestedSeasons` against the show's real season list
- New unit tests covering the fix case, the unchanged-behavior case, and that it's ignored for movies

## Platform
- [x] All / Shared code

## Testing
- [x] Manual testing completed

### Test Steps
1. Request an unreleased season (one that hasn't premiered yet)
2. Try to request another season that was never part of any request (e.g. Season 1)
3. Before the fix: stuck, unable to request again - the button disappears entirely
4. After the fix: Request More stays available for the unrequested season, and requesting it succeeds

## Screenshots
N/A - button visibility logic only, no UI layout change.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)