### PR TITLE
fix(media3): make subtitle offset and size independent of aspect ratio

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -2832,6 +2832,31 @@ class Media3VideoView(
         applyVideoLayout()
     }
 
+    // The Dart side only reports a codec when it drives the selection itself.
+    // Media3 picks the track on its own for a preferred text language or a
+    // closed caption, so the selected track's mime type is the reliable test
+    // and the codec hint is only a fallback for a track not selected yet.
+    private val selectedSubtitleIsAss: Boolean
+        get() = codecToMimeType(selectedSubtitleCodec) == MimeTypes.TEXT_SSA ||
+            selectedTextTrackIsAss()
+
+    private fun selectedTextTrackIsAss(): Boolean {
+        for (group in player.currentTracks.groups) {
+            if (group.type != C.TRACK_TYPE_TEXT) {
+                continue
+            }
+            for (index in 0 until group.length) {
+                if (!group.isTrackSelected(index)) {
+                    continue
+                }
+                if (MimeTypes.TEXT_SSA.equals(group.getTrackFormat(index).sampleMimeType, true)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
     private fun applyVideoLayout() {
         val videoLayoutParams = videoView.layoutParams as? FrameLayout.LayoutParams
             ?: FrameLayout.LayoutParams(
@@ -2847,20 +2872,23 @@ class Media3VideoView(
             )
 
         // ASS is positioned against the video picture, so its overlay tracks
-        // the video box. PGS and VOBSUB cues instead carry positions relative
-        // to their own full-frame plane, so pinning them to a letterboxed box
-        // would push them toward the center. Keep bitmap cues on the full frame.
+        // the video box. Everything else belongs on the full frame: PGS and
+        // VOBSUB cues carry positions relative to their own full-frame plane,
+        // and text cues have no relationship to the picture at all. The
+        // vertical offset is a fraction of this view's height, so pinning text
+        // to a letterboxed box would make one setting land at a different
+        // on-screen position for every aspect ratio.
         fun applyBounds(width: Int, height: Int) {
             applyLayoutBounds(videoView, videoLayoutParams, width, height)
-            if (selectedSubtitleIsBitmap) {
+            if (selectedSubtitleIsAss) {
+                applyLayoutBounds(subtitleView, subtitleLayoutParams, width, height)
+            } else {
                 applyLayoutBounds(
                     subtitleView,
                     subtitleLayoutParams,
                     FrameLayout.LayoutParams.MATCH_PARENT,
                     FrameLayout.LayoutParams.MATCH_PARENT,
                 )
-            } else {
-                applyLayoutBounds(subtitleView, subtitleLayoutParams, width, height)
             }
         }
 


### PR DESCRIPTION
# Pull Request: fix(media3): make subtitle offset and size independent of aspect ratio

Branch: `fix/media3-subtitle-ratio`

Commit: `ceb630f6`

---

## Summary

Subtitle vertical offset and text size are fractions of the SubtitleView's height, and that view was pinned to the letterboxed video box for every non-bitmap track. The same setting therefore landed at a different on-screen position and size for every aspect ratio. Text cues now use the full frame, ASS keeps the video box.

## Related Issues

- Closes #
- Fixes #1137 
- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Replace the bitmap/non-bitmap test in `applyVideoLayout()` with an ASS/non-ASS test, making the full frame the default instead of the exception.
- Identify ASS from the selected track's `TEXT_SSA` mime type, with the Dart codec hint as fallback, since that hint is absent when Media3 selects the track itself (preferred text language, closed captions).
- Update the comment above `applyBounds`, which documented the old two-case reasoning.

One file: `packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt`

## Platform

- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [x] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Google TV emulator, Android 16 (API 36), 1920x1080.

### Test Steps

1. Vertical offset 0.04, zoom FIT. Play `Film1` (1920x800, SUBRIP FRA, Direct Play), then `Episode1` (3840x1920, SUBRIP FRA, Direct Play). Subtitles now sit at the same distance from the bottom, and at the same size.
2. Switch zoom FIT to CROP on both files: subtitles no longer jump.
3. PGS: verified pixel-identical against a pre-fix build of the same frame.
4. ASS: still positioned against the picture.

## Screenshots (if applicable)

<img width="3448" height="980" alt="2026-08-12_15-49" src="https://github.com/user-attachments/assets/88e43fe6-72ac-4454-a15b-6ac7663dd0f9" />
<img width="3452" height="986" alt="2026-08-12_14-58" src="https://github.com/user-attachments/assets/a7b30ada-2429-4df9-b15a-af61e8ee9a16" />

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
