### PR TITLE
add address redaction for diagnostic logs

### DIFF
--- a/lib/data/services/log_service.dart
+++ b/lib/data/services/log_service.dart
@@ -72,7 +72,10 @@ class LogService extends ChangeNotifier {
 
   static const int _maxEntries = 2000;
 
-  static final _redactRegex = RegExp(r'(https?://)[^/\s]*(?=/|$)');
+  static final _redactRegex = RegExp(
+    r'((?:https?|wss?)://)[A-Za-z0-9._~%\-:@\[\]]+',
+    caseSensitive: false,
+  );
 
   final UserPreferences _prefs;
   final MediaServerClientFactory _clientFactory;
@@ -255,7 +258,7 @@ class LogService extends ChangeNotifier {
   };
 
   String _redact(String text) {
-    if (text.isEmpty || !text.contains('://')) {
+    if (!text.contains('://')) {
       return text;
     }
     return text.replaceAllMapped(_redactRegex, (match) {

--- a/lib/data/services/log_service.dart
+++ b/lib/data/services/log_service.dart
@@ -72,6 +72,8 @@ class LogService extends ChangeNotifier {
 
   static const int _maxEntries = 2000;
 
+  static final _redactRegex = RegExp(r'(https?://)[^/\s]*(?=/|$)');
+
   final UserPreferences _prefs;
   final MediaServerClientFactory _clientFactory;
   final DeviceInfo _deviceInfo;
@@ -143,8 +145,8 @@ class LogService extends ChangeNotifier {
       time: DateTime.now(),
       level: level,
       category: category,
-      message: message,
-      error: error?.toString(),
+      message: _redact(message),
+      error: error != null ? _redact(error.toString()) : null,
     );
     _entries.addLast(entry);
     while (_entries.length > _maxEntries) {
@@ -251,4 +253,13 @@ class LogService extends ChangeNotifier {
     LogLevel.warning => 900,
     LogLevel.error => 1000,
   };
+
+  String _redact(String text) {
+    if (text.isEmpty || !text.contains('://')) {
+      return text;
+    }
+    return text.replaceAllMapped(_redactRegex, (match) {
+      return '${match.group(1)}[REDACTED]';
+    });
+  }
 }


### PR DESCRIPTION
# Pull Request

## Summary
Some people are sensitive about their server urls, this strips them out if they need to send a log.
ex: 
2026-08-12T19:15:05.905684 DEBUG [network] ← 200 GET http://[REDACTED]/Moonfin/Games/Libraries
2026-08-12T19:15:05.924406 DEBUG [media] Media3: video size 0x0
2026-08-12T19:15:06.949493 DEBUG [network] ← 204 POST http://[REDACTED]/Sessions/Playing/Stopped
2026-08-12T19:15:14.320364 INFO  [general] Uploading diagnostic report (67 entries) to http://[REDACTED]


## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
-added _redactRegex - static regex to match anything between http(s?):// and the next / or end of string
-added _redact function - uses the regex to replace addresses in a string
-modified log function to use _redact on message and error strings

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Turn on diagnostic logging
2. Do stuff
3. Upload
4. Verify addresses are redacted
## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
