### PR TITLE
fix: Aether losing subtitle cues it can never reload

### DIFF
--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -2,11 +2,91 @@ import Cocoa
 import FlutterMacOS
 import XCTest
 
-class RunnerTests: XCTestCase {
+@testable import Moonfin
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
-  }
+/// Subtitle overlay cue selection. The overlay holds the only copy of a sidecar
+/// track's cues (the engine publishes such a file once and clears its drain
+/// target), so anything it drops is gone for the rest of the session.
+final class SubtitleOverlayTests: XCTestCase {
 
+    private func cue(_ body: String, _ start: TimeInterval, _ end: TimeInterval) -> SubtitleEvent {
+        SubtitleEvent(
+            startTime: start, endTime: end, text: body,
+            bitmap: nil, bitmapWidth: 0, bitmapHeight: 0)
+    }
+
+    private func makeOverlay() -> SubtitleOverlay {
+        SubtitleOverlay(frame: CGRect(x: 0, y: 0, width: 1920, height: 1080))
+    }
+
+    // MARK: - Selection
+
+    func testCuesSharingAWindowAreAllSelected() {
+        let cues = [cue("You know what I think?", 10, 14), cue("Maybe.", 11, 13)]
+        let covering = SubtitleOverlay.activeEvents(in: cues, at: 12)
+        XCTAssertEqual(covering.count, 2)
+    }
+
+    func testSelectionIsHalfOpenOnTheEndTime() {
+        let cues = [cue("A", 10, 12), cue("B", 12, 14)]
+        XCTAssertEqual(SubtitleOverlay.activeEvents(in: cues, at: 12).map(\.text), ["B"])
+    }
+
+    func testSelectionIsEmptyBetweenCues() {
+        let cues = [cue("A", 10, 12), cue("B", 14, 16)]
+        XCTAssertTrue(SubtitleOverlay.activeEvents(in: cues, at: 13).isEmpty)
+    }
+
+    // MARK: - Rendering
+
+    func testSimultaneousSpeakersBothRender() {
+        let overlay = makeOverlay()
+        overlay.setEvents([cue("- Look at me.", 10, 14), cue("- I am looking.", 10, 14)])
+        overlay.update(currentTime: 11)
+
+        XCTAssertEqual(overlay.activeText, "- Look at me.\n- I am looking.")
+    }
+
+    /// The reported failure: a sidecar track publishes once, the clock jumps
+    /// forward (a seek, a seam shift, a recovery reload landing on its target
+    /// before the picture catches up) and then plays the skipped region. Every
+    /// line in it has to still be there.
+    func testCuesSurviveAForwardClockJump() {
+        let overlay = makeOverlay()
+        overlay.setEvents([
+            cue("You know what I think?", 5, 7),
+            cue("You have to forget her.", 9, 11),
+            cue("Look at me.", 600, 602),
+        ])
+
+        overlay.update(currentTime: 601)
+        XCTAssertEqual(overlay.activeText, "Look at me.")
+
+        overlay.update(currentTime: 6)
+        XCTAssertEqual(overlay.activeText, "You know what I think?")
+        overlay.update(currentTime: 10)
+        XCTAssertEqual(overlay.activeText, "You have to forget her.")
+    }
+
+    /// The engine rewrites a cue's end time in place to close an open-ended
+    /// line, so identity cannot rest on the start time alone.
+    func testARewrittenEndTimeRetiresTheLine() {
+        let overlay = makeOverlay()
+        overlay.setEvents([cue("Maybe.", 10, 20)])
+        overlay.update(currentTime: 15)
+        XCTAssertEqual(overlay.activeText, "Maybe.")
+
+        overlay.setEvents([cue("Maybe.", 10, 12)])
+        XCTAssertEqual(overlay.activeText, "")
+    }
+
+    func testClearDropsTheVisibleLine() {
+        let overlay = makeOverlay()
+        overlay.setEvents([cue("Look at me.", 10, 14)])
+        overlay.update(currentTime: 11)
+        XCTAssertFalse(overlay.activeText.isEmpty)
+
+        overlay.clear()
+        XCTAssertEqual(overlay.activeText, "")
+    }
 }

--- a/tvos/Runner/Playback/Aether/SubtitleOverlay.swift
+++ b/tvos/Runner/Playback/Aether/SubtitleOverlay.swift
@@ -26,9 +26,17 @@ final class SubtitleOverlay: PlatformView {
     private let assImageView = NSImageView()
     #endif
     private var eventQueue: [SubtitleEvent] = []
-    private var activeEvent: SubtitleEvent?
+    /// Every text cue covering the playhead, not just one: cues sharing a window
+    /// are distinct simultaneous speakers and the engine keeps them all.
+    private var activeTextEvents: [SubtitleEvent] = []
+    private var activeBitmapEvent: SubtitleEvent?
     private var lastUpdateTime: TimeInterval = 0
     var delaySeconds: TimeInterval = 0
+
+    /// What the label is showing: the covering cues joined in start order.
+    var activeText: String {
+        activeTextEvents.compactMap(\.text).joined(separator: "\n")
+    }
 
     /// Where the picture sits inside the overlay. A TV gives the video the
     /// whole surface, but a phone letterboxes anything shaped differently, and
@@ -144,8 +152,8 @@ final class SubtitleOverlay: PlatformView {
     private func layoutOverlay() {
         // The point size follows the height, so it changes on resize and on
         // the first real layout after a style was applied against zero bounds.
-        if subtitleFontSize != appliedFontSize, let text = activeEvent?.text {
-            setLabelText(styledText(text))
+        if subtitleFontSize != appliedFontSize, !activeTextEvents.isEmpty {
+            setLabelText(styledText(activeText))
         }
         layoutTextLabel()
         layoutBitmapView()
@@ -189,34 +197,59 @@ final class SubtitleOverlay: PlatformView {
 
     /// The engine republishes the full active-cue set, so replace the queue
     /// wholesale and re-evaluate at the last known clock so a cue swap shows
-    /// without waiting for the next tick.
+    /// without waiting for the next tick. The only writer of `eventQueue`: the
+    /// overlay never drops a cue itself, because for a sidecar track this queue
+    /// is the only copy there is. The engine publishes such a file once and
+    /// clears its drain target, so a cue discarded here never comes back and the
+    /// rest of the session plays with holes in it. Retention belongs to the
+    /// engine, which prunes the tracks it actually drains.
     func setEvents(_ events: [SubtitleEvent]) {
         eventQueue = events.sorted { $0.startTime < $1.startTime }
         if lastUpdateTime > 0 {
-            evaluate(at: lastUpdateTime, evict: false)
-        } else if events.isEmpty, activeEvent != nil {
+            evaluate(at: lastUpdateTime)
+        } else if events.isEmpty {
             hideAll()
         }
     }
 
     func update(currentTime: TimeInterval) {
         lastUpdateTime = currentTime
-        evaluate(at: currentTime, evict: true)
+        evaluate(at: currentTime)
     }
 
-    private func evaluate(at currentTime: TimeInterval, evict: Bool) {
-        let adjusted = currentTime - delaySeconds
-        if evict {
-            eventQueue.removeAll { $0.endTime < adjusted - 0.5 }
-        }
-        let current = eventQueue.first { adjusted >= $0.startTime && adjusted < $0.endTime }
+    /// Every cue whose window covers `adjustedTime`. Static and pure for unit
+    /// tests: a clock that jumps forward and back, and two speakers sharing a
+    /// window, are both decided here.
+    static func activeEvents(
+        in events: [SubtitleEvent], at adjustedTime: TimeInterval
+    ) -> [SubtitleEvent] {
+        events.filter { adjustedTime >= $0.startTime && adjustedTime < $0.endTime }
+    }
 
-        if let current {
-            if activeEvent == nil || activeEvent!.startTime != current.startTime {
-                showEvent(current)
+    /// Whether two cue sets would draw the same block. Keyed on the window as
+    /// well as the text, since the engine rewrites a cue's end time in place to
+    /// close an open-ended line (a teletext page replacement, a PGS trim), and a
+    /// start-only comparison leaves the retired line on screen.
+    private static func drawsTheSame(_ lhs: [SubtitleEvent], _ rhs: [SubtitleEvent]) -> Bool {
+        lhs.count == rhs.count
+            && zip(lhs, rhs).allSatisfy {
+                $0.startTime == $1.startTime && $0.endTime == $1.endTime && $0.text == $1.text
             }
-        } else if activeEvent != nil {
-            hideAll()
+    }
+
+    private func evaluate(at currentTime: TimeInterval) {
+        let adjusted = currentTime - delaySeconds
+        let covering = Self.activeEvents(in: eventQueue, at: adjusted)
+
+        // Text and bitmap are tracked apart so neither hides the other.
+        let texts = covering.filter { $0.text != nil }
+        if !Self.drawsTheSame(texts, activeTextEvents) {
+            showText(texts)
+        }
+
+        let bitmap = covering.first { $0.bitmap != nil }
+        if bitmap?.startTime != activeBitmapEvent?.startTime {
+            showBitmap(bitmap)
         }
     }
 
@@ -255,8 +288,8 @@ final class SubtitleOverlay: PlatformView {
         if let verticalOffset {
             setSubtitlePosition(basePosition: 100 - Int((verticalOffset * 60).rounded()))
         }
-        if let event = activeEvent, event.text != nil {
-            showEvent(event)
+        if !activeTextEvents.isEmpty {
+            showText(activeTextEvents)
         }
     }
 
@@ -270,29 +303,36 @@ final class SubtitleOverlay: PlatformView {
 
     // MARK: - Display
 
-    private func showEvent(_ event: SubtitleEvent) {
-        activeEvent = event
-        if let text = event.text {
-            bitmapView.isHidden = true
-            bitmapView.image = nil
-            setLabelText(styledText(text))
-            textLabel.isHidden = false
-            layoutTextLabel()
-        } else if let bitmap = event.bitmap {
+    /// Draws the cues covering the playhead as one block, joined in start order,
+    /// so the label keeps a single centred frame and the styling stays exactly
+    /// as it was for the common one-cue case.
+    private func showText(_ events: [SubtitleEvent]) {
+        activeTextEvents = events
+        guard !events.isEmpty else {
             textLabel.isHidden = true
             setLabelText(nil)
-            bitmapView.image = Self.platformImage(bitmap)
-            bitmapView.isHidden = false
-            layoutBitmapView()
+            return
         }
+        setLabelText(styledText(activeText))
+        textLabel.isHidden = false
+        layoutTextLabel()
+    }
+
+    private func showBitmap(_ event: SubtitleEvent?) {
+        activeBitmapEvent = event
+        guard let bitmap = event?.bitmap else {
+            bitmapView.isHidden = true
+            bitmapView.image = nil
+            return
+        }
+        bitmapView.image = Self.platformImage(bitmap)
+        bitmapView.isHidden = false
+        layoutBitmapView()
     }
 
     private func hideAll() {
-        activeEvent = nil
-        textLabel.isHidden = true
-        setLabelText(nil)
-        bitmapView.isHidden = true
-        bitmapView.image = nil
+        showText([])
+        showBitmap(nil)
     }
 
     private func layoutTextLabel() {
@@ -308,7 +348,7 @@ final class SubtitleOverlay: PlatformView {
     }
 
     private func layoutBitmapView() {
-        guard !bitmapView.isHidden, let event = activeEvent else { return }
+        guard !bitmapView.isHidden, let event = activeBitmapEvent else { return }
         let box = videoBox
         if let rect = event.normalizedRect, let canvas = event.canvasSize,
             canvas.width > 0, canvas.height > 0


### PR DESCRIPTION
# Pull Request

## Summary
Subtitles could stop appearing partway through playback on the Aether engine, and when two speakers talked at once only one line was drawn.

The overlay evicted cues once the playhead moved past them. For a sidecar track that queue is the only copy there is — the engine publishes the file once and clears its drain target — so a cue dropped here never comes back, and the rest of the session plays with holes in it. Any backward move of the clock exposed it: a seek, a seam shift, or a recovery reload landing on its target before the picture catches up. Retention now belongs to the engine, which prunes the tracks it actually drains.

Selection also took only the first cue covering the playhead, so two speakers sharing a window meant one of them never showed. The overlay now keeps every covering text cue.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `SubtitleOverlay` no longer drops cues from `eventQueue`. `setEvents` is the only writer, so a sidecar track survives a backward clock move instead of playing with holes in it.
- Every text cue covering the playhead is kept and drawn as one centred block, joined in starspeakers both render. The common one-cue case is styled and positioned exactly as before.
- Text and bitmap cues are tracked separately (`activeTextEvents` / `activeBitmapEvent`) so neither hides the other.
- Cue identity keys on the window as well as the text, because the engine rewrites an end timen-ended line — a teletext page replacement, a PGS trim. A start-only comparison left theretired line on screen.
- Added `SubtitleOverlayTests` covering cue selection, the half-open end boundary, simultaneooss a forward clock jump, and end-time rewrites.

## Platform
- [ ] Android
- [x] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

`SubtitleOverlay` builds against UIKit and AppKit, so this covers every Apple platform runnin

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why): unit tests are included but have not been run, and no playbacone yet.

### Test Steps
1. Play a video with an external sidecar subtitle track (SRT/ASS) on Aether.
2. Seek forward past several lines, then seek back into the region you skipped — the subtitle.
3. Play a file where two speakers overlap and confirm both lines render together.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced