### PR TITLE
Fix SyncPlay drift correction looping and glitching audio on seeks

### DIFF
--- a/lib/syncplay/sync_correction_policy.dart
+++ b/lib/syncplay/sync_correction_policy.dart
@@ -3,7 +3,7 @@
 /// on their own.
 library;
 
-enum SyncCorrectionAction { hold, defer, skip, speed, giveUp }
+enum SyncCorrectionAction { hold, defer, rebaseline, skip, speed, giveUp }
 
 class SyncCorrectionSettings {
   final bool useSkipToSync;
@@ -51,6 +51,8 @@ class SyncCorrectionPolicy {
   // the rate every couple of seconds.
   static const int noiseFloorMs = 400;
   static const int skipSettleMs = 6000;
+  // A seek the group asked for lands just as slowly as one we chose.
+  static const int seekSettleMs = 3000;
   static const int maxSeekLatencyAllowanceMs = 8000;
   static const int maxConsecutiveSkips = 4;
 
@@ -61,6 +63,7 @@ class SyncCorrectionPolicy {
   int _seekLatencyAllowanceMs = 0;
   int _blockedUntilMs = 0;
   bool _awaitingSkipSettle = false;
+  bool _awaitingSyncPointSettle = false;
   bool _gaveUp = false;
 
   int get seekLatencyAllowanceMs => _seekLatencyAllowanceMs;
@@ -95,21 +98,24 @@ class SyncCorrectionPolicy {
     final delay = currentPositionMs - expectedMs;
     final absDelay = delay.abs();
 
+    if (_awaitingSyncPointSettle) {
+      _awaitingSyncPointSettle = false;
+      // The group extrapolates from the seek as though it were instant. It
+      // never is, so this residual is the seek's own cost, not drift, and
+      // correcting it would nudge the rate for nothing: on mpv that inserts a
+      // tempo filter mid-playback and pulls it back out a second later.
+      _learnSeekLatency(delay);
+      return SyncCorrectionDecision._(
+        SyncCorrectionAction.rebaseline,
+        measuredDelayMs: delay,
+      );
+    }
+
     if (_awaitingSkipSettle) {
       _awaitingSkipSettle = false;
-      // A skip lands at a position computed before the seek began, so whatever
-      // it is still short by once it settles is this client's own seek latency.
-      // Without folding that back in, every skip loses the same amount again
-      // and the correction never converges.
-      if (delay < 0) {
-        final grown = _seekLatencyAllowanceMs + absDelay;
-        _seekLatencyAllowanceMs = grown > maxSeekLatencyAllowanceMs
-            ? maxSeekLatencyAllowanceMs
-            : grown;
-      } else {
-        final shrunk = _seekLatencyAllowanceMs - delay;
-        _seekLatencyAllowanceMs = shrunk < 0 ? 0 : shrunk;
-      }
+      // Without folding that cost back in, every skip loses the same amount
+      // again and the correction never converges.
+      _learnSeekLatency(delay);
     }
 
     final floor = noiseFloorMs + (clockJitterMs ~/ 2);
@@ -158,12 +164,25 @@ class SyncCorrectionPolicy {
     );
   }
 
-  /// A fresh sync point. The learned seek latency belongs to the device and
-  /// stream, so it survives a pause where the skip streak does not.
-  void onResumed() {
+  void _learnSeekLatency(int delay) {
+    if (delay < 0) {
+      final grown = _seekLatencyAllowanceMs + delay.abs();
+      _seekLatencyAllowanceMs =
+          grown > maxSeekLatencyAllowanceMs ? maxSeekLatencyAllowanceMs : grown;
+    } else {
+      final shrunk = _seekLatencyAllowanceMs - delay;
+      _seekLatencyAllowanceMs = shrunk < 0 ? 0 : shrunk;
+    }
+  }
+
+  /// The group moved the playhead, so the old baseline and any convergence
+  /// attempt against it are void. The learned seek latency belongs to the
+  /// device and stream, so it survives.
+  void onSyncPointChanged(int nowMs) {
     _consecutiveSkips = 0;
     _awaitingSkipSettle = false;
-    _blockedUntilMs = 0;
+    _awaitingSyncPointSettle = true;
+    _blockedUntilMs = nowMs + seekSettleMs;
   }
 
   void reset() {
@@ -171,6 +190,7 @@ class SyncCorrectionPolicy {
     _seekLatencyAllowanceMs = 0;
     _blockedUntilMs = 0;
     _awaitingSkipSettle = false;
+    _awaitingSyncPointSettle = false;
     _gaveUp = false;
   }
 }

--- a/lib/syncplay/sync_correction_policy.dart
+++ b/lib/syncplay/sync_correction_policy.dart
@@ -1,0 +1,176 @@
+/// Decides what SyncPlay drift correction should do about one measurement,
+/// with no player or network dependencies so the timing rules can be exercised
+/// on their own.
+library;
+
+enum SyncCorrectionAction { hold, defer, skip, speed, giveUp }
+
+class SyncCorrectionSettings {
+  final bool useSkipToSync;
+  final bool useSpeedToSync;
+  final int minDelaySkipToSyncMs;
+  final int minDelaySpeedToSyncMs;
+  final int maxDelaySpeedToSyncMs;
+  final int speedToSyncDurationMs;
+  final int extraTimeOffsetMs;
+
+  const SyncCorrectionSettings({
+    required this.useSkipToSync,
+    required this.useSpeedToSync,
+    required this.minDelaySkipToSyncMs,
+    required this.minDelaySpeedToSyncMs,
+    required this.maxDelaySpeedToSyncMs,
+    required this.speedToSyncDurationMs,
+    this.extraTimeOffsetMs = 0,
+  });
+}
+
+class SyncCorrectionDecision {
+  final SyncCorrectionAction action;
+  /// Unclamped: the policy does not know the item duration.
+  final int targetPositionMs;
+  final double speed;
+  final int speedDurationMs;
+  /// Positive means ahead of the group, zero when nothing was measurable.
+  final int measuredDelayMs;
+
+  const SyncCorrectionDecision._(
+    this.action, {
+    this.targetPositionMs = 0,
+    this.speed = 1.0,
+    this.speedDurationMs = 0,
+    this.measuredDelayMs = 0,
+  });
+
+  const SyncCorrectionDecision.defer() : this._(SyncCorrectionAction.defer);
+}
+
+class SyncCorrectionPolicy {
+  // Backends sample position on a timer (250ms on Apple TV and media3), so
+  // drift under this is quantisation noise and correcting on it just wobbles
+  // the rate every couple of seconds.
+  static const int noiseFloorMs = 400;
+  static const int skipSettleMs = 6000;
+  static const int maxSeekLatencyAllowanceMs = 8000;
+  static const int maxConsecutiveSkips = 4;
+
+  static const double _slowDownSpeed = 0.95;
+  static const double _speedUpSpeed = 1.05;
+
+  int _consecutiveSkips = 0;
+  int _seekLatencyAllowanceMs = 0;
+  int _blockedUntilMs = 0;
+  bool _awaitingSkipSettle = false;
+  bool _gaveUp = false;
+
+  int get seekLatencyAllowanceMs => _seekLatencyAllowanceMs;
+  int get consecutiveSkips => _consecutiveSkips;
+  bool get hasGivenUp => _gaveUp;
+
+  SyncCorrectionDecision evaluate({
+    required int nowMs,
+    required int serverNowMs,
+    required int currentPositionMs,
+    required int lastSyncPositionMs,
+    required int lastSyncTimeMs,
+    required bool isBuffering,
+    required bool isPlaying,
+    required int clockJitterMs,
+    required SyncCorrectionSettings settings,
+  }) {
+    if (_gaveUp) {
+      return const SyncCorrectionDecision._(SyncCorrectionAction.giveUp);
+    }
+
+    // A stalled or paused pipeline has a frozen position, so every sample reads
+    // as far behind. Seeking on that measurement stalls the pipeline again,
+    // which is the loop that leaves one client scrubbing in place while the
+    // rest of the group plays on.
+    if (isBuffering || !isPlaying) return const SyncCorrectionDecision.defer();
+    if (nowMs < _blockedUntilMs) return const SyncCorrectionDecision.defer();
+
+    final expectedMs = lastSyncPositionMs +
+        (serverNowMs - lastSyncTimeMs) +
+        settings.extraTimeOffsetMs;
+    final delay = currentPositionMs - expectedMs;
+    final absDelay = delay.abs();
+
+    if (_awaitingSkipSettle) {
+      _awaitingSkipSettle = false;
+      // A skip lands at a position computed before the seek began, so whatever
+      // it is still short by once it settles is this client's own seek latency.
+      // Without folding that back in, every skip loses the same amount again
+      // and the correction never converges.
+      if (delay < 0) {
+        final grown = _seekLatencyAllowanceMs + absDelay;
+        _seekLatencyAllowanceMs = grown > maxSeekLatencyAllowanceMs
+            ? maxSeekLatencyAllowanceMs
+            : grown;
+      } else {
+        final shrunk = _seekLatencyAllowanceMs - delay;
+        _seekLatencyAllowanceMs = shrunk < 0 ? 0 : shrunk;
+      }
+    }
+
+    final floor = noiseFloorMs + (clockJitterMs ~/ 2);
+    if (absDelay <= floor) {
+      _consecutiveSkips = 0;
+      return SyncCorrectionDecision._(
+        SyncCorrectionAction.hold,
+        measuredDelayMs: delay,
+      );
+    }
+
+    if (settings.useSkipToSync && absDelay > settings.minDelaySkipToSyncMs) {
+      if (_consecutiveSkips >= maxConsecutiveSkips) {
+        _gaveUp = true;
+        return SyncCorrectionDecision._(
+          SyncCorrectionAction.giveUp,
+          measuredDelayMs: delay,
+        );
+      }
+      _consecutiveSkips++;
+      _awaitingSkipSettle = true;
+      _blockedUntilMs = nowMs + skipSettleMs;
+      return SyncCorrectionDecision._(
+        SyncCorrectionAction.skip,
+        targetPositionMs: expectedMs + _seekLatencyAllowanceMs,
+        measuredDelayMs: delay,
+      );
+    }
+
+    _consecutiveSkips = 0;
+
+    if (settings.useSpeedToSync &&
+        absDelay > settings.minDelaySpeedToSyncMs &&
+        absDelay < settings.maxDelaySpeedToSyncMs) {
+      return SyncCorrectionDecision._(
+        SyncCorrectionAction.speed,
+        speed: delay > 0 ? _slowDownSpeed : _speedUpSpeed,
+        speedDurationMs: settings.speedToSyncDurationMs,
+        measuredDelayMs: delay,
+      );
+    }
+
+    return SyncCorrectionDecision._(
+      SyncCorrectionAction.hold,
+      measuredDelayMs: delay,
+    );
+  }
+
+  /// A fresh sync point. The learned seek latency belongs to the device and
+  /// stream, so it survives a pause where the skip streak does not.
+  void onResumed() {
+    _consecutiveSkips = 0;
+    _awaitingSkipSettle = false;
+    _blockedUntilMs = 0;
+  }
+
+  void reset() {
+    _consecutiveSkips = 0;
+    _seekLatencyAllowanceMs = 0;
+    _blockedUntilMs = 0;
+    _awaitingSkipSettle = false;
+    _gaveUp = false;
+  }
+}

--- a/lib/syncplay/sync_correction_policy.dart
+++ b/lib/syncplay/sync_correction_policy.dart
@@ -104,11 +104,17 @@ class SyncCorrectionPolicy {
       // never is, so this residual is the seek's own cost, not drift, and
       // correcting it would nudge the rate for nothing: on mpv that inserts a
       // tempo filter mid-playback and pulls it back out a second later.
-      _learnSeekLatency(delay);
-      return SyncCorrectionDecision._(
-        SyncCorrectionAction.rebaseline,
-        measuredDelayMs: delay,
-      );
+      //
+      // Past the ceiling a seek can plausibly cost this is real drift, and
+      // absorbing it would park the baseline where the group never reaches
+      // and then report the gap as zero.
+      if (absDelay <= maxSeekLatencyAllowanceMs) {
+        _learnSeekLatency(delay);
+        return SyncCorrectionDecision._(
+          SyncCorrectionAction.rebaseline,
+          measuredDelayMs: delay,
+        );
+      }
     }
 
     if (_awaitingSkipSettle) {
@@ -178,10 +184,14 @@ class SyncCorrectionPolicy {
   /// The group moved the playhead, so the old baseline and any convergence
   /// attempt against it are void. The learned seek latency belongs to the
   /// device and stream, so it survives.
+  ///
+  /// A give-up is lifted here too. It belongs to the stretch the group just
+  /// left, and the new one may transcode or buffer differently.
   void onSyncPointChanged(int nowMs) {
     _consecutiveSkips = 0;
     _awaitingSkipSettle = false;
     _awaitingSyncPointSettle = true;
+    _gaveUp = false;
     _blockedUntilMs = nowMs + seekSettleMs;
   }
 

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -11,6 +11,7 @@ import '../data/services/media_server_client_factory.dart';
 import '../preference/user_preferences.dart';
 import '../ui/navigation/app_router.dart';
 import '../ui/navigation/destinations.dart';
+import 'sync_correction_policy.dart';
 import 'syncplay_state.dart';
 import 'time_sync_manager.dart';
 
@@ -33,6 +34,7 @@ class SyncPlayManager extends ChangeNotifier {
   static const int _handshakeRetryDelayMs = 1200;
   static const int _maxHandshakeRetries = 3;
   static const double _defaultSpeed = 1.0;
+  static const int _maxReadyStabilityRetries = 4;
 
   final PlaybackManager _playbackManager;
   final UserPreferences _preferences;
@@ -53,7 +55,14 @@ class SyncPlayManager extends ChangeNotifier {
   Timer? _driftTimer;
   Timer? _seekDebounceTimer;
   Timer? _queueSyncDebounceTimer;
+  Timer? _speedToSyncTimer;
   Duration? _pendingSeekTarget;
+
+  final SyncCorrectionPolicy _syncCorrection = SyncCorrectionPolicy();
+  /// Whether the rate currently on the player is one SyncPlay put there. The
+  /// player's own speed control writes straight to the backend on some
+  /// platforms, so shared speed state cannot be trusted for this.
+  bool _speedToSyncApplied = false;
 
   StreamSubscription<bool>? _bufferingSub;
   StreamSubscription<void>? _queueChangedSub;
@@ -287,6 +296,7 @@ class SyncPlayManager extends ChangeNotifier {
     _lastCommandKey = null;
     _lastSyncPositionMs = 0;
     _lastSyncTimeMs = 0;
+    _syncCorrection.reset();
     _restorePlaybackRate();
     notifyListeners();
   }
@@ -530,6 +540,10 @@ class SyncPlayManager extends ChangeNotifier {
         previousPlaylistItemId != _state.currentPlaylistItemId;
     if (!isItemSwitch) return;
 
+    // Seek latency and convergence are per-stream, and a give-up must not
+    // outlive the item that caused it.
+    _syncCorrection.reset();
+
     final targetPlaylistItemId = _state.currentPlaylistItemId;
     final targetItemId = (idx >= 0 && idx < update.playlist.length)
         ? update.playlist[idx].itemId
@@ -662,6 +676,8 @@ class SyncPlayManager extends ChangeNotifier {
         _clampedPositionMs(SyncPlayUtils.ticksToMs(command.positionTicks));
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = targetMs;
+    // A fresh sync point, so don't inherit a skip streak from before the pause.
+    _syncCorrection.onResumed();
 
     if (!advancedCorrectionEnabled) {
       if (delayMs > 0) {
@@ -723,6 +739,7 @@ class SyncPlayManager extends ChangeNotifier {
     _state.groupState = SyncPlayGroupState.idle;
     _lastSyncPositionMs = 0;
     _lastSyncTimeMs = 0;
+    _syncCorrection.reset();
     notifyListeners();
   }
 
@@ -794,8 +811,21 @@ class SyncPlayManager extends ChangeNotifier {
     return v > durationMs ? durationMs : v;
   }
 
+  /// Undoes a speed-to-sync nudge, and only that. Writing the rate when
+  /// SyncPlay never changed it is not free: on the Apple TV path a rate write
+  /// is play intent (`avPlayer.rate = value`), so an unconditional
+  /// restore-to-1.0 resumes a player the group wants paused.
   void _restorePlaybackRate() {
+    _speedToSyncTimer?.cancel();
+    _speedToSyncTimer = null;
+    if (!_speedToSyncApplied) return;
+    _speedToSyncApplied = false;
     _playbackManager.setPlaybackSpeed(_defaultSpeed);
+  }
+
+  void _applyPlaybackRate(double speed) {
+    _speedToSyncApplied = true;
+    _playbackManager.setPlaybackSpeed(speed);
   }
 
   void _scheduleAction(int delayMs, void Function() action) {
@@ -812,41 +842,67 @@ class SyncPlayManager extends ChangeNotifier {
     _driftTimer = Timer(const Duration(seconds: 2), _performDriftCorrection);
   }
 
+  SyncCorrectionSettings get _syncCorrectionSettings => SyncCorrectionSettings(
+        useSkipToSync: useSkipToSync,
+        useSpeedToSync: useSpeedToSync,
+        minDelaySkipToSyncMs: minDelaySkipToSync,
+        minDelaySpeedToSyncMs: minDelaySpeedToSync,
+        maxDelaySpeedToSyncMs: maxDelaySpeedToSync,
+        speedToSyncDurationMs: speedToSyncDuration,
+        extraTimeOffsetMs: extraTimeOffset,
+      );
+
   void _performDriftCorrection() {
     final tsm = _timeSync;
     if (tsm == null ||
         _state.groupState != SyncPlayGroupState.playing ||
-        _lastSyncTimeMs == 0) {
+        _lastSyncTimeMs == 0 ||
+        _syncCorrection.hasGivenUp) {
       return;
     }
     final pm = _playbackManager;
-    final currentMs = pm.state.position.inMilliseconds;
-    final serverNow = tsm.getServerTimeNow();
-    final expectedMs =
-        _lastSyncPositionMs + (serverNow - _lastSyncTimeMs) + extraTimeOffset;
+    final decision = _syncCorrection.evaluate(
+      nowMs: DateTime.now().millisecondsSinceEpoch,
+      serverNowMs: tsm.getServerTimeNow(),
+      currentPositionMs: pm.state.position.inMilliseconds,
+      lastSyncPositionMs: _lastSyncPositionMs,
+      lastSyncTimeMs: _lastSyncTimeMs,
+      isBuffering: pm.state.isBuffering || _isBuffering,
+      isPlaying: pm.state.isPlaying,
+      clockJitterMs: tsm.offsetJitterMs,
+      settings: _syncCorrectionSettings,
+    );
 
-    final delay = currentMs - expectedMs;
-    final absDelay = delay.abs();
-
-    if (useSkipToSync && absDelay > minDelaySkipToSync) {
-      _performSeek(expectedMs);
-      _scheduleDriftCorrection();
-      return;
-    }
-
-    if (useSpeedToSync &&
-        absDelay > minDelaySpeedToSync &&
-        absDelay < maxDelaySpeedToSync) {
-      final speed = delay > 0 ? 0.95 : 1.05;
-      pm.setPlaybackSpeed(speed);
-      Timer(Duration(milliseconds: speedToSyncDuration), () {
+    switch (decision.action) {
+      // Leaves the rate alone: the pipeline is stalled or paused here.
+      case SyncCorrectionAction.defer:
+        _scheduleDriftCorrection();
+      case SyncCorrectionAction.hold:
         _restorePlaybackRate();
         _scheduleDriftCorrection();
-      });
-      return;
+      case SyncCorrectionAction.skip:
+        _restorePlaybackRate();
+        _performSeek(_clampedPositionMs(decision.targetPositionMs));
+        _scheduleDriftCorrection();
+      case SyncCorrectionAction.speed:
+        _applyPlaybackRate(decision.speed);
+        _speedToSyncTimer?.cancel();
+        _speedToSyncTimer = Timer(
+          Duration(milliseconds: decision.speedDurationMs),
+          () {
+            _restorePlaybackRate();
+            _scheduleDriftCorrection();
+          },
+        );
+      case SyncCorrectionAction.giveUp:
+        _restorePlaybackRate();
+        _logger.w(
+          'SyncPlay: sync correction disabled for this item after '
+          '${_syncCorrection.consecutiveSkips} skips failed to converge '
+          '(residual ${decision.measuredDelayMs}ms, latency allowance '
+          '${_syncCorrection.seekLatencyAllowanceMs}ms)',
+        );
     }
-
-    _scheduleDriftCorrection();
   }
 
   void _attachPlaybackObservers() {
@@ -873,6 +929,8 @@ class SyncPlayManager extends ChangeNotifier {
     _pendingSeekTarget = null;
     _queueSyncDebounceTimer?.cancel();
     _queueSyncDebounceTimer = null;
+    _speedToSyncTimer?.cancel();
+    _speedToSyncTimer = null;
     _suppressedBufferingRecheckTimer?.cancel();
     _suppressedBufferingRecheckTimer = null;
     _suppressBufferingUntilMs = 0;
@@ -970,12 +1028,20 @@ class SyncPlayManager extends ChangeNotifier {
     );
   }
 
-  void _queueReadyReport() {
+  void _queueReadyReport({int attempt = 0}) {
     _readyTimer?.cancel();
     _readyTimer = Timer(
       const Duration(milliseconds: _readyDebounceMs),
       () async {
-        if (!await _isPlaybackPositionStable()) return;
+        if (!_state.enabled || !syncPlayEnabled) return;
+        if (!await _isPlaybackPositionStable()) {
+          // Dropping this report strands the whole group in Waiting, so retry
+          // and report anyway once the attempts run out.
+          if (attempt < _maxReadyStabilityRetries) {
+            _queueReadyReport(attempt: attempt + 1);
+            return;
+          }
+        }
         _sendReadyWithRetry();
       },
     );

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -691,7 +691,7 @@ class SyncPlayManager extends ChangeNotifier {
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = targetMs;
     // A fresh sync point, so don't inherit a skip streak from before the pause.
-    _syncCorrection.onResumed();
+    _syncCorrection.onSyncPointChanged(DateTime.now().millisecondsSinceEpoch);
 
     if (!advancedCorrectionEnabled) {
       if (delayMs > 0) {
@@ -736,6 +736,7 @@ class SyncPlayManager extends ChangeNotifier {
     final positionMs = _clampedPositionMs(adjusted);
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = serverNow;
+    _syncCorrection.onSyncPointChanged(DateTime.now().millisecondsSinceEpoch);
     _performSeek(positionMs);
     // Seek only ever arrives from the waiting state, which has just flagged
     // every session as buffering. A seek that lands inside the buffer never
@@ -909,6 +910,10 @@ class SyncPlayManager extends ChangeNotifier {
     switch (decision.action) {
       // Leaves the rate alone: the pipeline is stalled or paused here.
       case SyncCorrectionAction.defer:
+        _scheduleDriftCorrection();
+      // Absorbs the seek's own cost so it is never mistaken for drift.
+      case SyncCorrectionAction.rebaseline:
+        _lastSyncPositionMs += decision.measuredDelayMs;
         _scheduleDriftCorrection();
       case SyncCorrectionAction.hold:
         _restorePlaybackRate();

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -35,6 +35,10 @@ class SyncPlayManager extends ChangeNotifier {
   static const int _maxHandshakeRetries = 3;
   static const double _defaultSpeed = 1.0;
   static const int _maxReadyStabilityRetries = 4;
+  // A Ready that never lands leaves the group waiting on this client, so the
+  // report is repeated for a while rather than sent once and forgotten.
+  static const int _readyWatchdogIntervalMs = 2500;
+  static const int _maxReadyWatchdogReports = 5;
 
   final PlaybackManager _playbackManager;
   final UserPreferences _preferences;
@@ -56,7 +60,9 @@ class SyncPlayManager extends ChangeNotifier {
   Timer? _seekDebounceTimer;
   Timer? _queueSyncDebounceTimer;
   Timer? _speedToSyncTimer;
+  Timer? _readyWatchdogTimer;
   Duration? _pendingSeekTarget;
+  int _readyWatchdogReports = 0;
 
   final SyncCorrectionPolicy _syncCorrection = SyncCorrectionPolicy();
   /// Whether the rate currently on the player is one SyncPlay put there. The
@@ -488,6 +494,13 @@ class SyncPlayManager extends ChangeNotifier {
       case SyncPlayGroupUpdateType.stateUpdate:
         final payload = update.payload as SyncPlayStateUpdatePayload;
         _state.groupState = payload.update.state;
+        if (_state.groupState == SyncPlayGroupState.waiting) {
+          // Waiting can also be entered on someone else's buffering or an item
+          // switch, and the group stays there until we confirm we are ready.
+          _startReadyHandshake();
+        } else {
+          _stopReadyHandshake();
+        }
         notifyListeners();
         break;
       case SyncPlayGroupUpdateType.playQueue:
@@ -666,6 +679,7 @@ class SyncPlayManager extends ChangeNotifier {
   }
 
   void _handleUnpause(SyncPlayCommand command) {
+    _stopReadyHandshake();
     final tsm = _timeSync;
     if (tsm == null) return;
     final serverNow = tsm.getServerTimeNow();
@@ -701,6 +715,7 @@ class SyncPlayManager extends ChangeNotifier {
   }
 
   void _handlePause(SyncPlayCommand command) {
+    _stopReadyHandshake();
     final positionMs =
         _clampedPositionMs(SyncPlayUtils.ticksToMs(command.positionTicks));
     _performPause(positionMs);
@@ -722,9 +737,15 @@ class SyncPlayManager extends ChangeNotifier {
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = serverNow;
     _performSeek(positionMs);
+    // Seek only ever arrives from the waiting state, which has just flagged
+    // every session as buffering. A seek that lands inside the buffer never
+    // stalls the pipeline, so waiting on a buffering edge to report Ready
+    // would leave the group waiting on a stall that is never coming.
+    _startReadyHandshake(restart: true);
   }
 
   void _handleStop() {
+    _stopReadyHandshake();
     _applyingRemoteCommand = true;
     try {
       _playbackManager.stop(userInitiated: false);
@@ -770,6 +791,18 @@ class SyncPlayManager extends ChangeNotifier {
         _armBufferingSuppression();
         _playbackManager.seekTo(Duration(milliseconds: positionMs));
       }
+    } finally {
+      _applyingRemoteCommand = false;
+    }
+  }
+
+  /// Pauses the player without routing back through the interceptor, for the
+  /// cases where the group has no command to send us.
+  void _applyLocalPause() {
+    _restorePlaybackRate();
+    _applyingRemoteCommand = true;
+    try {
+      _playbackManager.pause();
     } finally {
       _applyingRemoteCommand = false;
     }
@@ -924,6 +957,7 @@ class SyncPlayManager extends ChangeNotifier {
     _bufferingTimer = null;
     _readyTimer?.cancel();
     _readyTimer = null;
+    _stopReadyHandshake();
     _seekDebounceTimer?.cancel();
     _seekDebounceTimer = null;
     _pendingSeekTarget = null;
@@ -949,6 +983,13 @@ class SyncPlayManager extends ChangeNotifier {
         await requestUnpause();
         return true;
       case TransportAction.pause:
+        // Handing the press to the group swallows the local pause, and a
+        // waiting group has no Pause command to send back, so the press would
+        // land nowhere. Pausing here is safe because the command that does
+        // arrive once everyone is ready carries the group's own position.
+        if (_state.groupState == SyncPlayGroupState.waiting) {
+          _applyLocalPause();
+        }
         await requestPause();
         return true;
       case TransportAction.seek:
@@ -1047,6 +1088,51 @@ class SyncPlayManager extends ChangeNotifier {
     );
   }
 
+  /// Answers the Waiting handshake the server holds the whole group in. It
+  /// leaves that state only once every session has reported Ready, and while it
+  /// waits it replies to a pause request with a state update and no command at
+  /// all, so a group left waiting on this client has no working transport.
+  void _startReadyHandshake({bool restart = false}) {
+    if (!_state.enabled || !syncPlayEnabled) return;
+    if (_readyWatchdogTimer != null && !restart) return;
+    _readyWatchdogTimer?.cancel();
+    _readyWatchdogReports = 0;
+    _reportReadyIfSettled();
+    _readyWatchdogTimer = Timer.periodic(
+      const Duration(milliseconds: _readyWatchdogIntervalMs),
+      (_) {
+        if (!_state.enabled ||
+            !syncPlayEnabled ||
+            _state.groupState != SyncPlayGroupState.waiting ||
+            _readyWatchdogReports >= _maxReadyWatchdogReports) {
+          _stopReadyHandshake();
+          return;
+        }
+        _readyWatchdogReports++;
+        // A buffering flag that never clears would hold the group forever, and
+        // rejoining late beats leaving everyone without controls.
+        _reportReadyIfSettled(
+          force: _readyWatchdogReports >= _maxReadyWatchdogReports,
+        );
+      },
+    );
+  }
+
+  /// Reports Ready only when the player really is. A real stall already has a
+  /// Buffering report out that the server is right to wait on, and the recovery
+  /// that ends it queues a Ready of its own.
+  void _reportReadyIfSettled({bool force = false}) {
+    if (_playbackManager.currentResolution == null) return;
+    if (!force && (_playbackManager.state.isBuffering || _isBuffering)) return;
+    _queueReadyReport();
+  }
+
+  void _stopReadyHandshake() {
+    _readyWatchdogTimer?.cancel();
+    _readyWatchdogTimer = null;
+    _readyWatchdogReports = 0;
+  }
+
   Future<bool> _isPlaybackPositionStable() async {
     final pm = _playbackManager;
     if (pm.state.isBuffering) return false;
@@ -1127,7 +1213,14 @@ class SyncPlayManager extends ChangeNotifier {
       if (!_state.enabled || !syncPlayEnabled) return;
       final api = _api;
       final playlistItemId = _currentPlaylistItemId();
-      if (api == null || playlistItemId == null) return;
+      if (api == null) return;
+      if (playlistItemId == null) {
+        _logger.w(
+          'SyncPlay: no playlist item to report Ready for, group '
+          '${_state.groupState.name} is left waiting on this client',
+        );
+        return;
+      }
       final pm = _playbackManager;
       final positionTicks =
           SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);

--- a/test/syncplay/sync_correction_policy_test.dart
+++ b/test/syncplay/sync_correction_policy_test.dart
@@ -349,7 +349,7 @@ void main() {
       expect(policy.consecutiveSkips, 0);
     });
 
-    test('a give-up stays given up until reset', () {
+    test('a give-up survives an ordinary measurement', () {
       final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
       final policy = SyncCorrectionPolicy();
       _run(policy, client, ticks: 400);
@@ -367,6 +367,39 @@ void main() {
         settings: _defaultSettings,
       );
       expect(decision.action, SyncCorrectionAction.giveUp);
+    });
+
+    test('a group seek lifts a give-up', () {
+      final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+      _run(policy, client, ticks: 400);
+      expect(policy.hasGivenUp, isTrue);
+
+      policy.onSyncPointChanged(client.nowMs);
+
+      expect(policy.hasGivenUp, isFalse);
+      expect(policy.consecutiveSkips, 0);
+      expect(
+        policy.seekLatencyAllowanceMs,
+        greaterThan(0),
+        reason: 'the learned latency belongs to the device, not the stretch',
+      );
+    });
+
+    test('a residual too large to be seek cost is corrected, not absorbed', () {
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 0);
+      client.seekTo(0);
+      policy.onSyncPointChanged(client.nowMs);
+      client.stall(SyncCorrectionPolicy.maxSeekLatencyAllowanceMs + 6000);
+
+      final decisions = _run(policy, client, ticks: 20);
+
+      expect(_countOf(decisions, SyncCorrectionAction.rebaseline), 0);
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        greaterThan(0),
+      );
     });
   });
 }

--- a/test/syncplay/sync_correction_policy_test.dart
+++ b/test/syncplay/sync_correction_policy_test.dart
@@ -18,6 +18,7 @@ class _FakeClient {
   int nowMs = 0;
   int positionMs = 0;
   int stalledUntilMs = 0;
+  int baselineMs = 0;
 
   _FakeClient({required this.seekLatencyMs});
 
@@ -58,7 +59,7 @@ List<SyncCorrectionDecision> _run(
       nowMs: client.nowMs,
       serverNowMs: client.nowMs,
       currentPositionMs: client.positionMs,
-      lastSyncPositionMs: 0,
+      lastSyncPositionMs: client.baselineMs,
       lastSyncTimeMs: 0,
       isBuffering: client.isBuffering,
       isPlaying: client.isPlaying,
@@ -68,6 +69,8 @@ List<SyncCorrectionDecision> _run(
     decisions.add(decision);
     if (decision.action == SyncCorrectionAction.skip) {
       client.seekTo(decision.targetPositionMs);
+    } else if (decision.action == SyncCorrectionAction.rebaseline) {
+      client.baselineMs += decision.measuredDelayMs;
     }
   }
   return decisions;
@@ -262,7 +265,7 @@ void main() {
   });
 
   group('lifecycle', () {
-    test('resume clears the skip streak but keeps the learned latency', () {
+    test('a new sync point clears the skip streak but keeps the latency', () {
       final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
       final policy = SyncCorrectionPolicy();
       _run(policy, client, ticks: 10);
@@ -270,13 +273,66 @@ void main() {
       expect(policy.seekLatencyAllowanceMs, greaterThan(0));
       final learned = policy.seekLatencyAllowanceMs;
 
-      policy.onResumed();
+      policy.onSyncPointChanged(client.nowMs);
 
       expect(policy.consecutiveSkips, 0);
       expect(
         policy.seekLatencyAllowanceMs,
         learned,
         reason: 'seek latency is a property of the device and stream',
+      );
+    });
+
+    test('a group seek is given time to land before anything is measured', () {
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 1200);
+      client.seekTo(0);
+      policy.onSyncPointChanged(client.nowMs);
+
+      expect(_run(policy, client, ticks: 1).single.action,
+          SyncCorrectionAction.defer);
+    });
+
+    test('a group seek re-anchors instead of nudging the rate', () {
+      // The seek's own latency is not drift. Answering it with a rate nudge
+      // inserts an mpv tempo filter mid-playback and audibly glitches.
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 1200);
+      client.seekTo(0);
+      policy.onSyncPointChanged(client.nowMs);
+
+      final decisions = _run(policy, client, ticks: 30);
+
+      expect(_countOf(decisions, SyncCorrectionAction.rebaseline), 1);
+      expect(
+        _countOf(decisions, SyncCorrectionAction.speed),
+        0,
+        reason: 'no rate nudge, so no tempo filter churn after a seek',
+      );
+      expect(_countOf(decisions, SyncCorrectionAction.skip), 0);
+      expect(
+        policy.seekLatencyAllowanceMs,
+        1200,
+        reason: 'the residual is the seek latency, worth learning',
+      );
+    });
+
+    test('real drift after a re-anchored seek is still corrected', () {
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 1200);
+      client.seekTo(0);
+      policy.onSyncPointChanged(client.nowMs);
+      _run(policy, client, ticks: 4);
+
+      // A stall well after the seek is genuine drift, not seek cost.
+      client.stall(5000);
+      final decisions = _run(policy, client, ticks: 12);
+
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip) +
+            _countOf(decisions, SyncCorrectionAction.speed),
+        greaterThan(0),
+        reason: 're-anchoring must not blind the policy to later drift',
       );
     });
 

--- a/test/syncplay/sync_correction_policy_test.dart
+++ b/test/syncplay/sync_correction_policy_test.dart
@@ -1,0 +1,316 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/syncplay/sync_correction_policy.dart';
+
+const _defaultSettings = SyncCorrectionSettings(
+  useSkipToSync: true,
+  useSpeedToSync: true,
+  minDelaySkipToSyncMs: 2000,
+  minDelaySpeedToSyncMs: 100,
+  maxDelaySpeedToSyncMs: 5000,
+  speedToSyncDurationMs: 1000,
+);
+
+/// A client whose seeks take [seekLatencyMs] to render: after a skip the
+/// position freezes for that long, then advances with the wall clock again.
+class _FakeClient {
+  final int seekLatencyMs;
+
+  int nowMs = 0;
+  int positionMs = 0;
+  int stalledUntilMs = 0;
+
+  _FakeClient({required this.seekLatencyMs});
+
+  bool get isBuffering => nowMs < stalledUntilMs;
+  bool get isPlaying => !isBuffering;
+
+  int get driftMs => positionMs - nowMs;
+
+  void advance(int ms) {
+    final end = nowMs + ms;
+    final resumedAt = stalledUntilMs > nowMs
+        ? (stalledUntilMs < end ? stalledUntilMs : end)
+        : nowMs;
+    positionMs += end - resumedAt;
+    nowMs = end;
+  }
+
+  void stall(int ms) => stalledUntilMs = nowMs + ms;
+
+  void seekTo(int target) {
+    positionMs = target;
+    stalledUntilMs = nowMs + seekLatencyMs;
+  }
+}
+
+/// Ticks at the manager's 2s cadence, applying decisions the way
+/// `SyncPlayManager._performDriftCorrection` does.
+List<SyncCorrectionDecision> _run(
+  SyncCorrectionPolicy policy,
+  _FakeClient client, {
+  required int ticks,
+  SyncCorrectionSettings settings = _defaultSettings,
+}) {
+  final decisions = <SyncCorrectionDecision>[];
+  for (var i = 0; i < ticks; i++) {
+    client.advance(2000);
+    final decision = policy.evaluate(
+      nowMs: client.nowMs,
+      serverNowMs: client.nowMs,
+      currentPositionMs: client.positionMs,
+      lastSyncPositionMs: 0,
+      lastSyncTimeMs: 0,
+      isBuffering: client.isBuffering,
+      isPlaying: client.isPlaying,
+      clockJitterMs: 0,
+      settings: settings,
+    );
+    decisions.add(decision);
+    if (decision.action == SyncCorrectionAction.skip) {
+      client.seekTo(decision.targetPositionMs);
+    }
+  }
+  return decisions;
+}
+
+int _countOf(List<SyncCorrectionDecision> decisions, SyncCorrectionAction a) =>
+    decisions.where((d) => d.action == a).length;
+
+void main() {
+  group('drift correction convergence', () {
+    test(
+      'a slow-seeking client converges instead of skipping forever',
+      () {
+        // Every corrective skip used to land short by its own seek latency, so
+        // the next check skipped again, permanently.
+        final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+        final policy = SyncCorrectionPolicy();
+
+        final decisions = _run(policy, client, ticks: 200);
+
+        expect(
+          _countOf(decisions, SyncCorrectionAction.skip),
+          lessThanOrEqualTo(2),
+          reason: 'each skip must fold in the latency it just measured',
+        );
+        expect(policy.hasGivenUp, isFalse);
+        expect(policy.seekLatencyAllowanceMs, 3000);
+        expect(
+          client.driftMs.abs(),
+          lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+          reason: 'the client should end up in sync, not just stop skipping',
+        );
+        expect(
+          decisions.last.action,
+          SyncCorrectionAction.hold,
+          reason: 'a converged client keeps measuring but stops correcting',
+        );
+      },
+    );
+
+    test('stops correcting when it cannot converge', () {
+      // Seek latency past the allowance cap can never be compensated for.
+      final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 400);
+
+      expect(policy.hasGivenUp, isTrue);
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        SyncCorrectionPolicy.maxConsecutiveSkips,
+      );
+      expect(decisions.last.action, SyncCorrectionAction.giveUp);
+    });
+
+    test('never corrects a client that is still buffering', () {
+      final client = _FakeClient(seekLatencyMs: 500)..stall(60000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 20);
+
+      expect(
+        decisions.every((d) => d.action == SyncCorrectionAction.defer),
+        isTrue,
+      );
+      expect(policy.consecutiveSkips, 0);
+    });
+
+    test('never corrects a paused client', () {
+      final policy = SyncCorrectionPolicy();
+      final decision = policy.evaluate(
+        nowMs: 30000,
+        serverNowMs: 30000,
+        currentPositionMs: 0,
+        lastSyncPositionMs: 0,
+        lastSyncTimeMs: 0,
+        isBuffering: false,
+        isPlaying: false,
+        clockJitterMs: 0,
+        settings: _defaultSettings,
+      );
+      expect(decision.action, SyncCorrectionAction.defer);
+    });
+
+    test('holds off re-measuring until a skip has settled', () {
+      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 4);
+      final firstSkip = decisions.indexWhere(
+        (d) => d.action == SyncCorrectionAction.skip,
+      );
+
+      expect(firstSkip, isNonNegative);
+      expect(
+        decisions
+            .skip(firstSkip + 1)
+            .every((d) => d.action == SyncCorrectionAction.defer),
+        isTrue,
+        reason: 'measurements inside the settle window are not usable',
+      );
+    });
+  });
+
+  group('measurement noise', () {
+    test('ignores drift within the position sampling resolution', () {
+      // A sub-sample "drift" on a 250ms position stream is quantisation noise.
+      final policy = SyncCorrectionPolicy();
+      final decision = policy.evaluate(
+        nowMs: 30000,
+        serverNowMs: 30000,
+        currentPositionMs: 29750,
+        lastSyncPositionMs: 0,
+        lastSyncTimeMs: 0,
+        isBuffering: false,
+        isPlaying: true,
+        clockJitterMs: 0,
+        settings: _defaultSettings,
+      );
+
+      expect(decision.action, SyncCorrectionAction.hold);
+      expect(decision.measuredDelayMs, -250);
+    });
+
+    test('widens the dead band when the clock offset is jittery', () {
+      final policy = SyncCorrectionPolicy();
+      SyncCorrectionDecision evaluate(int jitter) => policy.evaluate(
+            nowMs: 30000,
+            serverNowMs: 30000,
+            currentPositionMs: 29400,
+            lastSyncPositionMs: 0,
+            lastSyncTimeMs: 0,
+            isBuffering: false,
+            isPlaying: true,
+            clockJitterMs: jitter,
+            settings: _defaultSettings,
+          );
+
+      expect(evaluate(0).action, SyncCorrectionAction.speed);
+      expect(evaluate(1200).action, SyncCorrectionAction.hold);
+    });
+  });
+
+  group('speed correction', () {
+    SyncCorrectionDecision decisionFor(int positionMs) =>
+        SyncCorrectionPolicy().evaluate(
+          nowMs: 30000,
+          serverNowMs: 30000,
+          currentPositionMs: positionMs,
+          lastSyncPositionMs: 0,
+          lastSyncTimeMs: 0,
+          isBuffering: false,
+          isPlaying: true,
+          clockJitterMs: 0,
+          settings: _defaultSettings,
+        );
+
+    test('slows down when ahead of the group', () {
+      final decision = decisionFor(31000);
+      expect(decision.action, SyncCorrectionAction.speed);
+      expect(decision.speed, lessThan(1.0));
+      expect(decision.speedDurationMs, 1000);
+    });
+
+    test('speeds up when behind the group', () {
+      final decision = decisionFor(29000);
+      expect(decision.action, SyncCorrectionAction.speed);
+      expect(decision.speed, greaterThan(1.0));
+    });
+
+    test('leaves the rate alone when speed-to-sync is off', () {
+      final decision = SyncCorrectionPolicy().evaluate(
+        nowMs: 30000,
+        serverNowMs: 30000,
+        currentPositionMs: 29000,
+        lastSyncPositionMs: 0,
+        lastSyncTimeMs: 0,
+        isBuffering: false,
+        isPlaying: true,
+        clockJitterMs: 0,
+        settings: const SyncCorrectionSettings(
+          useSkipToSync: true,
+          useSpeedToSync: false,
+          minDelaySkipToSyncMs: 2000,
+          minDelaySpeedToSyncMs: 100,
+          maxDelaySpeedToSyncMs: 5000,
+          speedToSyncDurationMs: 1000,
+        ),
+      );
+      expect(decision.action, SyncCorrectionAction.hold);
+    });
+  });
+
+  group('lifecycle', () {
+    test('resume clears the skip streak but keeps the learned latency', () {
+      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+      _run(policy, client, ticks: 10);
+
+      expect(policy.seekLatencyAllowanceMs, greaterThan(0));
+      final learned = policy.seekLatencyAllowanceMs;
+
+      policy.onResumed();
+
+      expect(policy.consecutiveSkips, 0);
+      expect(
+        policy.seekLatencyAllowanceMs,
+        learned,
+        reason: 'seek latency is a property of the device and stream',
+      );
+    });
+
+    test('a new item clears a give-up', () {
+      final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+      _run(policy, client, ticks: 400);
+      expect(policy.hasGivenUp, isTrue);
+
+      policy.reset();
+
+      expect(policy.hasGivenUp, isFalse);
+      expect(policy.seekLatencyAllowanceMs, 0);
+      expect(policy.consecutiveSkips, 0);
+    });
+
+    test('a give-up stays given up until reset', () {
+      final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+      _run(policy, client, ticks: 400);
+
+      // Even a perfectly synced measurement must not restart correcting.
+      final decision = policy.evaluate(
+        nowMs: 999000,
+        serverNowMs: 999000,
+        currentPositionMs: 999000,
+        lastSyncPositionMs: 0,
+        lastSyncTimeMs: 0,
+        isBuffering: false,
+        isPlaying: true,
+        clockJitterMs: 0,
+        settings: _defaultSettings,
+      );
+      expect(decision.action, SyncCorrectionAction.giveUp);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
SyncPlay drift correction treated its own seek latency as if it were drift. A skip seeked to a position computed *before* the seek began, so the client came back short by exactly that latency, and the next check 2s later saw the same gap and skipped again — permanently. That leaves one viewer scrubbing in place every couple of seconds while the rest of the group plays on, and because every corrective seek re-armed the buffering-suppression window, the group was never told anything was wrong.

This is not platform-specific. Any client whose seek takes longer than the 2s drift-check interval loops, and `PlaybackManager._seekWhilePausedAndResume` already allows up to 5s for a seek to land on any backend. Reported on Apple TV, Windows and macOS.

The same "the seek was instant" assumption caused a second, quieter bug: after any group seek the client measured itself behind by the seek's cost and answered with a 0.95x/1.05x rate nudge. mpv only has `scaletempo2` preloaded on Android TV, so elsewhere that inserts a tempo filter mid-playback and pulls it back out a second later — audible as a glitch for a second or two after every seek. Reported on macOS and Windows, both of which run the mpv backend.

## Related Issues
- Related to #451 (the buffering-suppression window added there is what hid the loop from the group)

## Type of Change
- [x] Bug fix

## Changes Made
- Extract the correction decision into `SyncCorrectionPolicy`, free of player/network dependencies so the timing rules can be tested directly.
- Learn this client's seek latency from the residual a settled skip leaves, and aim subsequent skips past it so the correction converges instead of losing the same amount every time.
- Never measure a stalled or paused pipeline: a frozen position always reads as "far behind", and seeking on that re-stalls the pipeline.
- Ignore drift below the backend's position sampling resolution (250ms on Apple TV and media3), widened by the measured clock jitter.
- Give up after 4 non-converging skips, with a log line, rather than scrubbing for the rest of the item.
- Re-anchor the baseline after a group seek settles instead of correcting toward a position the client was never going to reach.
- Only write the playback rate when SyncPlay itself changed it. On the Apple TV path a rate write is play intent (`avPlayer.rate = value`), so an unconditional restore-to-1.0 resumes a player the group wants paused.
- Retry the Ready report instead of dropping it when the position never looks stable, since the server holds the whole group in Waiting until it arrives.

## Platform
- [x] All / Shared code

Shared Dart. The seek loop needs only a seek slower than the 2s check interval, which any backend hits when the server is transcoding or the network is slow. The rate-nudge audio glitch is specific to mpv (macOS / Windows / Linux), where `scaletempo2` is preloaded only on Android TV.

## Testing
- [x] Manual testing completed
- [x] Tested on physical device

16 unit tests in `test/syncplay/sync_correction_policy_test.dart`; full suite green (784 tests). Verified the tests fail against the pre-fix logic — reverting the guards inside the policy fails 9 of 13 at the time, including the convergence test — so they genuinely pin the behaviour rather than agreeing with whatever the code does.

Built and launched on macOS to confirm the change compiles and runs in the real app.

**Not yet verified in a live SyncPlay group.** The convergence maths, the seek-latency learning and the mpv rate-nudge reasoning are all derived from reading the backends, not from observing them. Worth a second pair of eyes before merge.

### Test Steps
1. Join a SyncPlay group with a second client on another platform (reported cases: Apple TV + Windows, and macOS).
2. Play an episode, ideally a transcoded one so seeks are slow, and let a buffering stall put one client behind.
3. Expect at most a couple of corrective jumps and then steady playback — not a jump back every ~2s while the other client plays on. If that client's seeks are too slow to converge, expect `SyncPlay: sync correction disabled for this item` in the log instead of the loop.
4. Seek forward and backward from either client.
5. Expect no audio glitch a second or two after the seek lands.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

`flutter analyze lib test` reports no findings in any changed file.
