### PR TITLE
fix(androidtv): stop stale video sessions after backgrounding

### DIFF
--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -12,6 +12,7 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
   // right after the app goes to the background. _restoreState runs the same
   // correction on resume, so ten seconds of ticks is enough.
   static const int _maxBgCorrectionTicks = 40;
+  static const Duration _videoBackgroundGracePeriod = Duration(seconds: 3);
 
   final PlaybackManager _manager;
   Duration? _savedPosition;
@@ -20,6 +21,8 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
   int _bgCorrectionTicks = 0;
   bool _bgSeekInFlight = false;
   bool _screenLocked = false;
+  Timer? _videoStopTimer;
+  AggregatedItem? _videoStopItem;
 
   void setScreenLocked(bool locked) {
     _screenLocked = locked;
@@ -31,6 +34,10 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _cancelVideoStop();
+    }
+
     final currentItem = _manager.queueService.currentItem;
     bool isAudio = false;
     if (currentItem is AggregatedItem) {
@@ -40,7 +47,8 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
       if (meta != null) {
         final type = meta['Type']?.toString();
         final mediaType = meta['MediaType']?.toString();
-        isAudio = type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
+        isAudio =
+            type == 'Audio' || type == 'AudioBook' || mediaType == 'Audio';
       }
     }
     if (isAudio) {
@@ -57,6 +65,7 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
         if (backend is Media3PlayerBackend) {
           unawaited(backend.appPaused());
         }
+        _scheduleVideoStop(currentItem);
         break;
       case AppLifecycleState.resumed:
         final backend = _manager.backend;
@@ -68,6 +77,33 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
       default:
         break;
     }
+  }
+
+  void _scheduleVideoStop(dynamic currentItem) {
+    if (!PlatformDetection.isAndroid ||
+        !PlatformDetection.isTV ||
+        currentItem is! AggregatedItem) {
+      return;
+    }
+
+    if (identical(_videoStopItem, currentItem)) return;
+
+    _videoStopTimer?.cancel();
+    _videoStopItem = currentItem;
+    _videoStopTimer = Timer(_videoBackgroundGracePeriod, () {
+      _videoStopTimer = null;
+      if (!identical(_videoStopItem, currentItem) ||
+          !identical(_manager.queueService.currentItem, currentItem)) {
+        return;
+      }
+      unawaited(_manager.stop(userInitiated: false));
+    });
+  }
+
+  void _cancelVideoStop() {
+    _videoStopTimer?.cancel();
+    _videoStopTimer = null;
+    _videoStopItem = null;
   }
 
   void _saveState() {
@@ -89,16 +125,13 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
 
     _bgCorrectionTimer?.cancel();
     _bgCorrectionTicks = 0;
-    _bgCorrectionTimer = Timer.periodic(
-      const Duration(milliseconds: 250),
-      (_) {
-        if (++_bgCorrectionTicks > _maxBgCorrectionTicks) {
-          _stopBgCorrection();
-          return;
-        }
-        _bgCorrect();
-      },
-    );
+    _bgCorrectionTimer = Timer.periodic(const Duration(milliseconds: 250), (_) {
+      if (++_bgCorrectionTicks > _maxBgCorrectionTicks) {
+        _stopBgCorrection();
+        return;
+      }
+      _bgCorrect();
+    });
     unawaited(_bgCorrect());
   }
 

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -12,12 +12,13 @@ class _StaleVideoClaim {
     required this.item,
     required this.position,
     required this.wasPlaying,
+    required this.cleanup,
   });
 
   final AggregatedItem item;
   final Duration position;
   final bool wasPlaying;
-  late final Future<bool> cleanup;
+  final Future<bool> cleanup;
 }
 
 class PlaybackLifecycleHandler with WidgetsBindingObserver {
@@ -123,9 +124,9 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
             ? Duration.zero
             : (_savedPosition ?? Duration.zero),
         wasPlaying: _wasPlaying ?? false,
+        cleanup: _cleanupVideoSession(currentItem),
       );
       _staleVideoClaim = claim;
-      claim.cleanup = _cleanupVideoSession(currentItem);
       unawaited(claim.cleanup);
     });
   }

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -7,6 +7,19 @@ import '../data/models/aggregated_item.dart';
 import '../util/platform_detection.dart';
 import 'media3_player_backend.dart';
 
+class _StaleVideoClaim {
+  _StaleVideoClaim({
+    required this.item,
+    required this.position,
+    required this.wasPlaying,
+  });
+
+  final AggregatedItem item;
+  final Duration position;
+  final bool wasPlaying;
+  late final Future<bool> cleanup;
+}
+
 class PlaybackLifecycleHandler with WidgetsBindingObserver {
   // Detaching the render surface can regress the backend position, but only
   // right after the app goes to the background. _restoreState runs the same
@@ -23,6 +36,9 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
   bool _screenLocked = false;
   Timer? _videoStopTimer;
   AggregatedItem? _videoStopItem;
+  dynamic _savedStateItem;
+  _StaleVideoClaim? _staleVideoClaim;
+  _StaleVideoClaim? _staleRestoreClaim;
 
   void setScreenLocked(bool locked) {
     _screenLocked = locked;
@@ -69,10 +85,12 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
         break;
       case AppLifecycleState.resumed:
         final backend = _manager.backend;
-        if (backend is Media3PlayerBackend) {
+        if (backend is Media3PlayerBackend &&
+            !identical(_staleVideoClaim?.item, currentItem) &&
+            !identical(_staleRestoreClaim?.item, currentItem)) {
           unawaited(backend.appResumed());
         }
-        _restoreState();
+        unawaited(_restoreState());
         break;
       default:
         break;
@@ -86,7 +104,10 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
       return;
     }
 
-    if (identical(_videoStopItem, currentItem)) return;
+    if (identical(_videoStopItem, currentItem) ||
+        identical(_staleVideoClaim?.item, currentItem)) {
+      return;
+    }
 
     _videoStopTimer?.cancel();
     _videoStopItem = currentItem;
@@ -96,9 +117,29 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
           !identical(_manager.queueService.currentItem, currentItem)) {
         return;
       }
-      unawaited(_manager.stop(userInitiated: false));
+      final claim = _StaleVideoClaim(
+        item: currentItem,
+        position: _isLiveTv(currentItem)
+            ? Duration.zero
+            : (_savedPosition ?? Duration.zero),
+        wasPlaying: _wasPlaying ?? false,
+      );
+      _staleVideoClaim = claim;
+      claim.cleanup = _cleanupVideoSession(currentItem);
+      unawaited(claim.cleanup);
     });
   }
+
+  Future<bool> _cleanupVideoSession(AggregatedItem item) async {
+    try {
+      return await _manager.stopForBackground(item);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  bool _isLiveTv(AggregatedItem item) =>
+      item.type == 'TvChannel' || item.type == 'LiveTvChannel';
 
   void _cancelVideoStop() {
     _videoStopTimer?.cancel();
@@ -107,7 +148,13 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
   }
 
   void _saveState() {
-    if (_manager.queueService.currentItem == null) return;
+    final currentItem = _manager.queueService.currentItem;
+    if (currentItem == null) return;
+    if (!identical(_savedStateItem, currentItem)) {
+      _savedPosition = null;
+      _wasPlaying = null;
+      _savedStateItem = currentItem;
+    }
 
     final newPos = _manager.state.position;
     if (_savedPosition != null && newPos < _savedPosition!) {
@@ -171,10 +218,43 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
 
     if (_screenLocked) return;
 
+    if (_staleRestoreClaim != null) return;
+
+    final staleClaim = _staleVideoClaim;
+    if (staleClaim != null) {
+      _staleVideoClaim = null;
+      _staleRestoreClaim = staleClaim;
+      _savedPosition = null;
+      _wasPlaying = null;
+      _savedStateItem = null;
+
+      try {
+        final cleanupSucceeded = await staleClaim.cleanup;
+        if (!cleanupSucceeded ||
+            !identical(_manager.queueService.currentItem, staleClaim.item)) {
+          return;
+        }
+        await _manager.startQueuedPlayback(
+          startPosition: staleClaim.position,
+          freshResolution: true,
+        );
+        if (!staleClaim.wasPlaying && _manager.state.isPlaying) {
+          await _manager.pause();
+        }
+      } catch (_) {
+      } finally {
+        if (identical(_staleRestoreClaim, staleClaim)) {
+          _staleRestoreClaim = null;
+        }
+      }
+      return;
+    }
+
     final savedPos = _savedPosition;
     final wasPlaying = _wasPlaying;
     _savedPosition = null;
     _wasPlaying = null;
+    _savedStateItem = null;
 
     if (savedPos == null || wasPlaying == null) return;
     if (_manager.queueService.currentItem == null) return;

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -2350,6 +2350,11 @@ class Media3VideoView(
     }
 
     private fun stopPlaybackAndRestoreDisplayMode() {
+        // A canonical stop ends ownership of this source. Clear it before
+        // touching the player because appPaused may already have released it,
+        // and an immediately queued appResumed must not restore stale media.
+        lastSourceArguments = null
+        lastPlaybackPositionMs = 0L
         player.stop()
         player.clearMediaItems()
         restorePreferredDisplayMode()

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -9,6 +9,20 @@ import 'queue_service.dart';
 import 'stream_resolution_result.dart';
 import 'track_ordinal_mapper.dart';
 
+class _ProgressGeneration {
+  _ProgressGeneration({
+    required this.item,
+    required this.resolution,
+    required this.service,
+  });
+
+  final dynamic item;
+  final StreamResolutionResult resolution;
+  final PlayerService? service;
+  bool ended = false;
+  Duration stopPosition = Duration.zero;
+}
+
 class PlaybackManager implements AudioOwnable {
   static const _mediaReadyPollInterval = Duration(milliseconds: 100);
   static const _defaultMediaReadyTimeout = Duration(seconds: 60);
@@ -45,6 +59,7 @@ class PlaybackManager implements AudioOwnable {
   final Set<PlayerBackend> _retainedBackends = <PlayerBackend>{};
   final List<StreamSubscription> _streamSubs = [];
   Timer? _progressTimer;
+  _ProgressGeneration? _progressGeneration;
   StreamResolutionResult? _currentResolution;
   dynamic _lastPlaybackItem;
   StreamResolutionResult? _lastPlaybackResolution;
@@ -89,7 +104,7 @@ class PlaybackManager implements AudioOwnable {
   Future<void> Function()? _onOfflineStop;
   Future<void> Function(String url)? _onOfflineAutoNext;
   Map<String, Map<String, dynamic>> _offlineMetadataByUrl = {};
-  Future<void>? _stopInFlight;
+  Future<bool>? _stopInFlight;
   int _playbackSessionToken = 0;
   Future<void>? _externalSubsLoaded;
   Duration _deferredStartPosition = Duration.zero;
@@ -1065,9 +1080,15 @@ class PlaybackManager implements AudioOwnable {
     bool enableDirectPlay = true,
     bool enableDirectStream = true,
     bool enableTranscoding = true,
+    bool freshResolution = false,
   }) async {
     _deferredStartPosition = Duration.zero;
     _deferPlaybackToExternalPlayer = false;
+    if (freshResolution) {
+      // A background timeout has ended ownership of the old source. Do not
+      // carry its selected source into the new PlaybackInfo request.
+      _mediaSourceId = null;
+    }
     await _playCurrentItem(
       startPosition: startPosition,
       enableDirectPlay: enableDirectPlay,
@@ -1669,19 +1690,92 @@ class PlaybackManager implements AudioOwnable {
 
   void _startProgressTimer() {
     _stopProgressTimer();
+    final item = queueService.currentItem;
+    final resolution = _currentResolution;
+    if (item == null || resolution == null) return;
+
+    var generation = _progressGeneration;
+    if (generation == null ||
+        generation.ended ||
+        !identical(generation.item, item) ||
+        !identical(generation.resolution, resolution)) {
+      if (generation != null && !generation.ended) {
+        _retireProgressGeneration(generation, currentPlaybackPosition);
+        _issuePlaybackStop(generation);
+      }
+      generation = _ProgressGeneration(
+        item: item,
+        resolution: resolution,
+        service: _service,
+      );
+      _progressGeneration = generation;
+    }
+
+    final activeGeneration = generation;
     _progressTimer = Timer.periodic(const Duration(seconds: 5), (_) {
-      final item = queueService.currentItem;
-      final resolution = _currentResolution;
-      if (item == null || resolution == null) return;
-      _service?.onPlaybackProgress(
-        item,
-        resolution,
-        state.position,
-        isPaused: !state.isPlaying,
-        audioStreamIndex: _audioStreamIndex,
-        subtitleStreamIndex: _subtitleStreamIndex,
+      if (activeGeneration.ended ||
+          !identical(_progressGeneration, activeGeneration)) {
+        return;
+      }
+      Future<void>? progress;
+      try {
+        progress = activeGeneration.service?.onPlaybackProgress(
+          activeGeneration.item,
+          activeGeneration.resolution,
+          state.position,
+          isPaused: !state.isPlaying,
+          audioStreamIndex: _audioStreamIndex,
+          subtitleStreamIndex: _subtitleStreamIndex,
+        );
+      } catch (_) {
+        return;
+      }
+      if (progress == null) return;
+      unawaited(
+        progress.then<void>(
+          (_) => _progressSettled(activeGeneration),
+          onError: (Object _, StackTrace _) =>
+              _progressSettled(activeGeneration),
+        ),
       );
     });
+  }
+
+  void _progressSettled(_ProgressGeneration generation) {
+    if (generation.ended) {
+      // The request may have reached the server after the original stop. A
+      // second stop, scoped to this generation's old PlaySessionId, ensures
+      // that no late progress report can be the server's final state.
+      _issuePlaybackStop(generation);
+    }
+  }
+
+  void _retireProgressGeneration(
+    _ProgressGeneration generation,
+    Duration position,
+  ) {
+    generation
+      ..ended = true
+      ..stopPosition = position;
+    if (identical(_progressGeneration, generation)) {
+      _progressGeneration = null;
+    }
+  }
+
+  void _issuePlaybackStop(_ProgressGeneration generation) {
+    final service = generation.service;
+    if (service == null) return;
+    try {
+      unawaited(
+        service
+            .onPlaybackStop(
+              generation.item,
+              generation.resolution,
+              generation.stopPosition,
+            )
+            .catchError((_) {}),
+      );
+    } catch (_) {}
   }
 
   void _stopProgressTimer() {
@@ -1743,6 +1837,20 @@ class PlaybackManager implements AudioOwnable {
   Future<void> stop({bool userInitiated = true}) async {
     if (userInitiated && await _maybeIntercept(TransportAction.stop)) return;
     await _stopAndReportCurrent();
+  }
+
+  /// Ends the server/backend ownership of a backgrounded video while keeping
+  /// the expected queued item available for a fresh resolution on return.
+  Future<bool> stopForBackground(dynamic expectedItem) async {
+    if (_stopInFlight != null ||
+        !identical(queueService.currentItem, expectedItem)) {
+      return false;
+    }
+    return _stopAndReportCurrent(
+      skipQueueChange: true,
+      expectedItem: expectedItem,
+      releaseServerResources: true,
+    );
   }
 
   Future<void> seekTo(Duration position) async {
@@ -2245,6 +2353,10 @@ class PlaybackManager implements AudioOwnable {
     _stopProgressTimer();
     final item = queueService.currentItem ?? _lastPlaybackItem;
     final resolution = _currentResolution ?? _lastPlaybackResolution;
+    final progressGeneration = _progressGeneration;
+    if (progressGeneration != null) {
+      _retireProgressGeneration(progressGeneration, currentPos);
+    }
     _currentResolution = null;
 
     // Stop the backend before tearing down the server session so the old
@@ -2582,14 +2694,22 @@ class PlaybackManager implements AudioOwnable {
     }
   }
 
-  Future<void> _stopAndReportCurrent({bool skipQueueChange = false}) async {
+  Future<bool> _stopAndReportCurrent({
+    bool skipQueueChange = false,
+    dynamic expectedItem,
+    bool releaseServerResources = false,
+  }) async {
     final existingStop = _stopInFlight;
     if (existingStop != null) {
       await existingStop;
-      return;
+      return false;
     }
 
     final stopFuture = (() async {
+      if (expectedItem != null &&
+          !identical(queueService.currentItem, expectedItem)) {
+        return false;
+      }
       _deferredStartPosition = Duration.zero;
       _deferPlaybackToExternalPlayer = false;
       _playbackSessionToken++;
@@ -2603,7 +2723,7 @@ class PlaybackManager implements AudioOwnable {
           state.reset();
           _setBringupState(const PlaybackBringupState.idle());
         }
-        return;
+        return true;
       }
       if (_isOfflinePlayback) {
         if (!skipQueueChange) {
@@ -2622,21 +2742,44 @@ class PlaybackManager implements AudioOwnable {
           state.reset();
           _setBringupState(const PlaybackBringupState.idle());
         }
-        return;
+        return true;
       }
       final item = queueService.currentItem;
       final resolution = _currentResolution ?? _lastPlaybackResolution;
       final reportItem = item ?? _lastPlaybackItem;
+      final backendPos = _backend?.position ?? Duration.zero;
+      final pos = Duration(
+        microseconds: [
+          backendPos.inMicroseconds,
+          state.position.inMicroseconds,
+          _lastKnownPosition.inMicroseconds,
+        ].reduce((a, b) => a > b ? a : b),
+      );
+      final progressGeneration = _progressGeneration;
+      if (progressGeneration != null) {
+        _retireProgressGeneration(progressGeneration, pos);
+      }
       if (reportItem != null && resolution != null) {
-        final backendPos = _backend?.position ?? Duration.zero;
-        final pos = Duration(
-          microseconds: [
-            backendPos.inMicroseconds,
-            state.position.inMicroseconds,
-            _lastKnownPosition.inMicroseconds,
-          ].reduce((a, b) => a > b ? a : b),
-        );
-        unawaited(_service?.onPlaybackStop(reportItem, resolution, pos).catchError((_) => null));
+        if (progressGeneration != null &&
+            identical(progressGeneration.item, reportItem) &&
+            identical(progressGeneration.resolution, resolution)) {
+          _issuePlaybackStop(progressGeneration);
+        } else {
+          try {
+            unawaited(
+              _service
+                      ?.onPlaybackStop(reportItem, resolution, pos)
+                      .catchError((_) {}) ??
+                  Future<void>.value(),
+            );
+          } catch (_) {}
+        }
+        if (releaseServerResources &&
+            resolution.playMethod != StreamPlayMethod.directPlay) {
+          try {
+            unawaited(_service?.stopTranscoding(resolution).catchError((_) {}));
+          } catch (_) {}
+        }
       }
       _currentResolution = null;
       _lastPlaybackItem = null;
@@ -2651,11 +2794,12 @@ class PlaybackManager implements AudioOwnable {
         state.reset();
         _setBringupState(const PlaybackBringupState.idle());
       }
+      return true;
     })();
 
     _stopInFlight = stopFuture;
     try {
-      await stopFuture;
+      return await stopFuture;
     } finally {
       if (identical(_stopInFlight, stopFuture)) {
         _stopInFlight = null;

--- a/test/playback/playback_lifecycle_handler_test.dart
+++ b/test/playback/playback_lifecycle_handler_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -13,6 +14,9 @@ class _MockPlaybackManager extends Mock implements PlaybackManager {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() {
+    registerFallbackValue(Duration.zero);
+  });
 
   late _MockPlaybackManager manager;
   late QueueService queue;
@@ -47,7 +51,13 @@ void main() {
     when(
       () => manager.currentOfflineMetadata,
     ).thenAnswer((_) => offlineMetadata);
-    when(() => manager.stop(userInitiated: false)).thenAnswer((_) async {});
+    when(() => manager.stopForBackground(any())).thenAnswer((_) async => true);
+    when(
+      () => manager.startQueuedPlayback(
+        startPosition: any(named: 'startPosition'),
+        freshResolution: any(named: 'freshResolution'),
+      ),
+    ).thenAnswer((_) async {});
     when(() => manager.resume()).thenAnswer((_) async {});
     handler = PlaybackLifecycleHandler(manager);
   });
@@ -72,11 +82,11 @@ void main() {
           handler.didChangeAppLifecycleState(state);
           await tester.pump(const Duration(milliseconds: 2999));
 
-          verifyNever(() => manager.stop(userInitiated: false));
+          verifyNever(() => manager.stopForBackground(any()));
 
           await tester.pump(const Duration(milliseconds: 1));
 
-          verify(() => manager.stop(userInitiated: false)).called(1);
+          verify(() => manager.stopForBackground(any())).called(1);
         });
       });
     }
@@ -92,12 +102,12 @@ void main() {
       handler.didChangeAppLifecycleState(AppLifecycleState.paused);
       await tester.pump(const Duration(seconds: 3));
 
-      verify(() => manager.stop(userInitiated: false)).called(1);
+      verify(() => manager.stopForBackground(any())).called(1);
 
       handler.didChangeAppLifecycleState(AppLifecycleState.paused);
       await tester.pump(const Duration(seconds: 3));
 
-      verifyNever(() => manager.stop(userInitiated: false));
+      verifyNever(() => manager.stopForBackground(any()));
     });
   });
 
@@ -115,8 +125,122 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(seconds: 2));
 
-      verifyNever(() => manager.stop(userInitiated: false));
+      verifyNever(() => manager.stopForBackground(any()));
       verify(() => manager.resume()).called(1);
+    });
+  });
+
+  for (final type in <String>['Movie', 'Episode']) {
+    testWidgets('$type timeout resumes through a fresh session at position', (
+      tester,
+    ) async {
+      await asAndroidTv(() async {
+        final current = item(type);
+        queue.setQueue(<dynamic>[current]);
+        playerState.setPosition(const Duration(seconds: 90));
+        playerState.setPlaying(true);
+
+        handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+        await tester.pump(const Duration(seconds: 3));
+        handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+        await tester.pump();
+
+        verify(() => manager.stopForBackground(current)).called(1);
+        verify(
+          () => manager.startQueuedPlayback(
+            startPosition: const Duration(seconds: 90),
+            freshResolution: true,
+          ),
+        ).called(1);
+      });
+    });
+  }
+
+  testWidgets('live TV timeout resumes fresh at the live edge', (tester) async {
+    await asAndroidTv(() async {
+      final current = item('LiveTvChannel');
+      queue.setQueue(<dynamic>[current]);
+      playerState.setPosition(const Duration(minutes: 12));
+      playerState.setPlaying(true);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 3));
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await tester.pump();
+
+      verify(() => manager.stopForBackground(current)).called(1);
+      verify(
+        () => manager.startQueuedPlayback(
+          startPosition: Duration.zero,
+          freshResolution: true,
+        ),
+      ).called(1);
+    });
+  });
+
+  testWidgets('resume racing timeout waits for its claimed cleanup once', (
+    tester,
+  ) async {
+    await asAndroidTv(() async {
+      final cleanup = Completer<bool>();
+      when(
+        () => manager.stopForBackground(any()),
+      ).thenAnswer((_) => cleanup.future);
+      final current = item('Movie');
+      queue.setQueue(<dynamic>[current]);
+      playerState.setPosition(const Duration(seconds: 45));
+      playerState.setPlaying(true);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 3));
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await tester.pump();
+
+      verifyNever(
+        () => manager.startQueuedPlayback(
+          startPosition: any(named: 'startPosition'),
+          freshResolution: any(named: 'freshResolution'),
+        ),
+      );
+
+      cleanup.complete(true);
+      await tester.pump();
+
+      verify(
+        () => manager.startQueuedPlayback(
+          startPosition: const Duration(seconds: 45),
+          freshResolution: true,
+        ),
+      ).called(1);
+    });
+  });
+
+  testWidgets('replacement ownership cannot restart the timed-out item', (
+    tester,
+  ) async {
+    await asAndroidTv(() async {
+      final cleanup = Completer<bool>();
+      when(
+        () => manager.stopForBackground(any()),
+      ).thenAnswer((_) => cleanup.future);
+      final oldItem = item('Movie');
+      queue.setQueue(<dynamic>[oldItem]);
+      playerState.setPlaying(true);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 3));
+      queue.setQueue(<dynamic>[item('Episode')]);
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      cleanup.complete(true);
+      await tester.pump();
+
+      verifyNever(
+        () => manager.startQueuedPlayback(
+          startPosition: any(named: 'startPosition'),
+          freshResolution: any(named: 'freshResolution'),
+        ),
+      );
     });
   });
 
@@ -143,7 +267,7 @@ void main() {
 
         await tester.pump(const Duration(seconds: 4));
 
-        verifyNever(() => manager.stop(userInitiated: false));
+        verifyNever(() => manager.stopForBackground(any()));
       });
     },
   );
@@ -160,10 +284,10 @@ void main() {
       handler.didChangeAppLifecycleState(AppLifecycleState.paused);
 
       await tester.pump(const Duration(milliseconds: 2999));
-      verifyNever(() => manager.stop(userInitiated: false));
+      verifyNever(() => manager.stopForBackground(any()));
 
       await tester.pump(const Duration(milliseconds: 1));
-      verify(() => manager.stop(userInitiated: false)).called(1);
+      verify(() => manager.stopForBackground(any())).called(1);
     });
   });
 

--- a/test/playback/playback_lifecycle_handler_test.dart
+++ b/test/playback/playback_lifecycle_handler_test.dart
@@ -1,0 +1,219 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/playback/playback_lifecycle_handler.dart';
+import 'package:moonfin/util/platform_detection.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _MockPlaybackManager extends Mock implements PlaybackManager {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockPlaybackManager manager;
+  late QueueService queue;
+  late PlayerState playerState;
+  late PlaybackLifecycleHandler handler;
+  Map<String, dynamic>? offlineMetadata;
+
+  AggregatedItem item(String type) => AggregatedItem(
+    id: type,
+    serverId: 'server',
+    rawData: <String, dynamic>{'Type': type},
+  );
+
+  Future<void> asAndroidTv(Future<void> Function() body) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    PlatformDetection.setTvMode(true);
+    try {
+      await body();
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+      PlatformDetection.setTvMode(false);
+    }
+  }
+
+  setUp(() {
+    manager = _MockPlaybackManager();
+    queue = QueueService();
+    playerState = PlayerState();
+    when(() => manager.queueService).thenReturn(queue);
+    when(() => manager.state).thenReturn(playerState);
+    when(() => manager.backend).thenReturn(null);
+    when(
+      () => manager.currentOfflineMetadata,
+    ).thenAnswer((_) => offlineMetadata);
+    when(() => manager.stop(userInitiated: false)).thenAnswer((_) async {});
+    when(() => manager.resume()).thenAnswer((_) async {});
+    handler = PlaybackLifecycleHandler(manager);
+  });
+
+  tearDown(() {
+    WidgetsBinding.instance.removeObserver(handler);
+    queue.dispose();
+    playerState.dispose();
+  });
+
+  for (final type in <String>['TvChannel', 'Movie', 'Episode']) {
+    for (final state in <AppLifecycleState>[
+      AppLifecycleState.hidden,
+      AppLifecycleState.paused,
+    ]) {
+      testWidgets('$state delays the Android TV $type stop for three seconds', (
+        tester,
+      ) async {
+        await asAndroidTv(() async {
+          queue.setQueue(<dynamic>[item(type)]);
+
+          handler.didChangeAppLifecycleState(state);
+          await tester.pump(const Duration(milliseconds: 2999));
+
+          verifyNever(() => manager.stop(userInitiated: false));
+
+          await tester.pump(const Duration(milliseconds: 1));
+
+          verify(() => manager.stop(userInitiated: false)).called(1);
+        });
+      });
+    }
+  }
+
+  testWidgets('duplicate background events schedule and report one stop', (
+    tester,
+  ) async {
+    await asAndroidTv(() async {
+      queue.setQueue(<dynamic>[item('LiveTvChannel')]);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.hidden);
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 3));
+
+      verify(() => manager.stop(userInitiated: false)).called(1);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 3));
+
+      verifyNever(() => manager.stop(userInitiated: false));
+    });
+  });
+
+  testWidgets('resume cancels the stop and retains resume restoration', (
+    tester,
+  ) async {
+    await asAndroidTv(() async {
+      queue.setQueue(<dynamic>[item('TvChannel')]);
+      playerState.setPlaying(true);
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await tester.pump(const Duration(seconds: 2));
+      playerState.setPlaying(false);
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 2));
+
+      verifyNever(() => manager.stop(userInitiated: false));
+      verify(() => manager.resume()).called(1);
+    });
+  });
+
+  testWidgets(
+    'audio, offline items, and non-TV platforms do not schedule a stop',
+    (tester) async {
+      await asAndroidTv(() async {
+        for (final type in <String>['Audio', 'AudioBook']) {
+          queue.setQueue(<dynamic>[item(type)]);
+          handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+        }
+
+        offlineMetadata = <String, dynamic>{'Type': 'Movie'};
+        queue.setQueue(<dynamic>['offline-file']);
+        handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        queue.setQueue(<dynamic>[item('TvChannel')]);
+        PlatformDetection.setTvMode(false);
+        handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        PlatformDetection.setTvMode(true);
+        handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+        await tester.pump(const Duration(seconds: 4));
+
+        verifyNever(() => manager.stop(userInitiated: false));
+      });
+    },
+  );
+
+  testWidgets('a replacement item receives its own three-second timer', (
+    tester,
+  ) async {
+    await asAndroidTv(() async {
+      queue.setQueue(<dynamic>[item('Movie')]);
+      handler.didChangeAppLifecycleState(AppLifecycleState.hidden);
+
+      await tester.pump(const Duration(seconds: 2));
+      queue.setQueue(<dynamic>[item('Episode')]);
+      handler.didChangeAppLifecycleState(AppLifecycleState.paused);
+
+      await tester.pump(const Duration(milliseconds: 2999));
+      verifyNever(() => manager.stop(userInitiated: false));
+
+      await tester.pump(const Duration(milliseconds: 1));
+      verify(() => manager.stop(userInitiated: false)).called(1);
+    });
+  });
+
+  test('Media3 canonical stop invalidates only background restoration', () {
+    final source = File(
+      'packages/moonfin_native_video/android/src/main/kotlin/'
+      'org/moonfin/nativevideo/Media3VideoView.kt',
+    ).readAsStringSync();
+
+    expect(
+      source,
+      contains('''
+    private fun stopPlaybackAndRestoreDisplayMode() {
+        // A canonical stop ends ownership of this source. Clear it before
+        // touching the player because appPaused may already have released it,
+        // and an immediately queued appResumed must not restore stale media.
+        lastSourceArguments = null
+        lastPlaybackPositionMs = 0L
+        player.stop()
+'''),
+    );
+    expect(
+      source,
+      contains('''
+                "appPaused" -> {
+                    if (currentMediaType != "audio") {
+                        forceReleasePlayer()
+                    }
+'''),
+    );
+    expect(
+      source,
+      contains('''
+    fun resumeFromBackground() {
+        if (!isPlayerReleased) return
+        ensurePlayerAlive()
+        val args = lastSourceArguments ?: return
+'''),
+    );
+
+    final forceReleaseStart = source.indexOf('    fun forceReleasePlayer() {');
+    final disposeStart = source.indexOf(
+      '    override fun dispose()',
+      forceReleaseStart,
+    );
+    expect(forceReleaseStart, greaterThanOrEqualTo(0));
+    expect(disposeStart, greaterThan(forceReleaseStart));
+    expect(
+      source.substring(forceReleaseStart, disposeStart),
+      isNot(contains('lastSourceArguments = null')),
+    );
+  });
+}

--- a/test/playback/playback_lifecycle_handler_test.dart
+++ b/test/playback/playback_lifecycle_handler_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
@@ -289,55 +288,5 @@ void main() {
       await tester.pump(const Duration(milliseconds: 1));
       verify(() => manager.stopForBackground(any())).called(1);
     });
-  });
-
-  test('Media3 canonical stop invalidates only background restoration', () {
-    final source = File(
-      'packages/moonfin_native_video/android/src/main/kotlin/'
-      'org/moonfin/nativevideo/Media3VideoView.kt',
-    ).readAsStringSync();
-
-    expect(
-      source,
-      contains('''
-    private fun stopPlaybackAndRestoreDisplayMode() {
-        // A canonical stop ends ownership of this source. Clear it before
-        // touching the player because appPaused may already have released it,
-        // and an immediately queued appResumed must not restore stale media.
-        lastSourceArguments = null
-        lastPlaybackPositionMs = 0L
-        player.stop()
-'''),
-    );
-    expect(
-      source,
-      contains('''
-                "appPaused" -> {
-                    if (currentMediaType != "audio") {
-                        forceReleasePlayer()
-                    }
-'''),
-    );
-    expect(
-      source,
-      contains('''
-    fun resumeFromBackground() {
-        if (!isPlayerReleased) return
-        ensurePlayerAlive()
-        val args = lastSourceArguments ?: return
-'''),
-    );
-
-    final forceReleaseStart = source.indexOf('    fun forceReleasePlayer() {');
-    final disposeStart = source.indexOf(
-      '    override fun dispose()',
-      forceReleaseStart,
-    );
-    expect(forceReleaseStart, greaterThanOrEqualTo(0));
-    expect(disposeStart, greaterThan(forceReleaseStart));
-    expect(
-      source.substring(forceReleaseStart, disposeStart),
-      isNot(contains('lastSourceArguments = null')),
-    );
   });
 }

--- a/test/playback/playback_manager_stale_session_test.dart
+++ b/test/playback/playback_manager_stale_session_test.dart
@@ -1,0 +1,416 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _TestBackend extends Fake implements PlayerBackend {
+  final List<String> playedUrls = <String>[];
+  final List<Duration> startPositions = <Duration>[];
+  int stopCalls = 0;
+  bool playing = false;
+  Duration currentPosition = Duration.zero;
+
+  @override
+  Duration get position => currentPosition;
+
+  @override
+  Duration get duration =>
+      playing ? const Duration(minutes: 30) : Duration.zero;
+
+  @override
+  Duration get buffer => Duration.zero;
+
+  @override
+  bool get isPlaying => playing;
+
+  @override
+  double get playbackSpeed => 1.0;
+
+  @override
+  bool get isBuffering => false;
+
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<Duration> get durationStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<Duration> get bufferStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<bool> get playingStream => const Stream<bool>.empty();
+
+  @override
+  Stream<bool> get bufferingStream => const Stream<bool>.empty();
+
+  @override
+  Stream<bool> get completedStream => const Stream<bool>.empty();
+
+  @override
+  Stream<Map<String, dynamic>>? get errorStream => null;
+
+  @override
+  bool get supportsRuntimeTrackSelection => false;
+
+  @override
+  bool get canRenderBitmapSubtitles => false;
+
+  @override
+  bool get requiresStartupMediaReadyCheck => false;
+
+  @override
+  bool get nativelyHandlesStartPosition => true;
+
+  @override
+  Map<String, dynamic> getDeviceProfile({
+    bool useProgressiveTranscode = false,
+  }) => <String, dynamic>{};
+
+  @override
+  Future<void> play(
+    dynamic mediaItem, {
+    Duration startPosition = Duration.zero,
+  }) async {
+    playedUrls.add((mediaItem as Map<String, dynamic>)['url'] as String);
+    startPositions.add(startPosition);
+    currentPosition = startPosition;
+    playing = true;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    playing = false;
+  }
+
+  @override
+  Future<void> setSubtitleRendererMode(SubtitleRendererMode mode) async {}
+
+  Future<void> setRepeatMode(RepeatMode mode) async {}
+
+  @override
+  void dispose() {}
+}
+
+class _TestResolver extends MediaStreamResolver {
+  int calls = 0;
+  final List<String?> requestedMediaSourceIds = <String?>[];
+  final List<int?> requestedStartTicks = <int?>[];
+
+  @override
+  Future<StreamResolutionResult> resolve(
+    dynamic mediaItem, {
+    Map<String, dynamic>? deviceProfile,
+    int? maxStreamingBitrate,
+    int? audioStreamIndex,
+    int? subtitleStreamIndex,
+    int? startTimeTicks,
+    String? mediaSourceId,
+    bool enableDirectPlay = true,
+    bool enableDirectStream = true,
+    bool enableTranscoding = true,
+  }) async {
+    calls++;
+    requestedMediaSourceIds.add(mediaSourceId);
+    requestedStartTicks.add(startTimeTicks);
+    final type = (mediaItem as Map<String, dynamic>)['Type'];
+    final isLive = type == 'TvChannel' || type == 'LiveTvChannel';
+    return StreamResolutionResult(
+      streamUrl: 'https://example.test/session-$calls',
+      mediaSourceId: 'source-$calls',
+      liveStreamId: isLive ? 'live-$calls' : null,
+      playSessionId: 'session-$calls',
+      playMethod: StreamPlayMethod.directStream,
+    );
+  }
+}
+
+class _ProgressRequest {
+  _ProgressRequest(this.index, this.sessionId, this.events);
+
+  final int index;
+  final String? sessionId;
+  final List<String> events;
+  final Completer<void> completer = Completer<void>();
+
+  Future<void> get future => completer.future.then((_) {
+    events.add('progress:$sessionId:$index');
+  });
+}
+
+class _TestService implements PlayerService {
+  _TestService({this.stallProgress = false});
+
+  final bool stallProgress;
+  final List<String> events = <String>[];
+  final List<_ProgressRequest> progressRequests = <_ProgressRequest>[];
+  final List<StreamResolutionResult> stoppedResolutions =
+      <StreamResolutionResult>[];
+  final List<StreamResolutionResult> transcodingStops =
+      <StreamResolutionResult>[];
+
+  @override
+  Future<void> onPlaybackStart(
+    dynamic mediaItem,
+    StreamResolutionResult resolution, {
+    int? positionTicks,
+    int? audioStreamIndex,
+    int? subtitleStreamIndex,
+  }) async {
+    events.add('start:${resolution.playSessionId}');
+  }
+
+  @override
+  Future<void> onPlaybackProgress(
+    dynamic mediaItem,
+    StreamResolutionResult resolution,
+    Duration position, {
+    bool isPaused = false,
+    int? audioStreamIndex,
+    int? subtitleStreamIndex,
+  }) {
+    if (!stallProgress) {
+      events.add('progress:${resolution.playSessionId}:immediate');
+      return Future<void>.value();
+    }
+    final request = _ProgressRequest(
+      progressRequests.length,
+      resolution.playSessionId,
+      events,
+    );
+    progressRequests.add(request);
+    return request.future;
+  }
+
+  @override
+  Future<void> onPlaybackStop(
+    dynamic mediaItem,
+    StreamResolutionResult resolution,
+    Duration position,
+  ) async {
+    events.add('stop:${resolution.playSessionId}');
+    stoppedResolutions.add(resolution);
+  }
+
+  @override
+  Future<void> closeLiveStream(String liveStreamId) async {}
+
+  @override
+  Future<void> stopTranscoding(StreamResolutionResult resolution) async {
+    transcodingStops.add(resolution);
+  }
+
+  @override
+  void dispose() {}
+}
+
+PlaybackManager _manager(
+  _TestBackend backend,
+  _TestResolver resolver,
+  _TestService service,
+) => PlaybackManager()
+  ..setBackend(backend)
+  ..setResolver(resolver)
+  ..setPlayerService(service);
+
+void main() {
+  for (final type in <String>['Movie', 'Episode']) {
+    test(
+      '$type background stop preserves queue and fresh-resolves position',
+      () async {
+        final backend = _TestBackend();
+        final resolver = _TestResolver();
+        final service = _TestService();
+        final manager = _manager(backend, resolver, service);
+        final item = <String, dynamic>{'Id': type, 'Type': type};
+
+        try {
+          await manager.playItems(<dynamic>[item]);
+          backend.currentPosition = const Duration(seconds: 90);
+
+          expect(await manager.stopForBackground(item), isTrue);
+          expect(manager.queueService.currentItem, same(item));
+          expect(service.stoppedResolutions, hasLength(1));
+          expect(service.stoppedResolutions.single.playSessionId, 'session-1');
+
+          await manager.startQueuedPlayback(
+            startPosition: const Duration(seconds: 90),
+            freshResolution: true,
+          );
+
+          expect(resolver.calls, 2);
+          expect(resolver.requestedMediaSourceIds, <String?>[null, null]);
+          expect(resolver.requestedStartTicks, <int?>[
+            null,
+            const Duration(seconds: 90).inMicroseconds * 10,
+          ]);
+          expect(backend.playedUrls, <String>[
+            'https://example.test/session-1',
+            'https://example.test/session-2',
+          ]);
+          expect(backend.startPositions.last, const Duration(seconds: 90));
+        } finally {
+          manager.dispose();
+        }
+      },
+    );
+  }
+
+  test(
+    'live TV cleanup targets old live/transcode ownership and starts fresh',
+    () async {
+      final backend = _TestBackend();
+      final resolver = _TestResolver();
+      final service = _TestService();
+      final manager = _manager(backend, resolver, service);
+      final item = <String, dynamic>{
+        'Id': 'live-channel',
+        'Type': 'LiveTvChannel',
+      };
+
+      try {
+        await manager.playItems(<dynamic>[item]);
+        backend.currentPosition = const Duration(minutes: 20);
+        expect(await manager.stopForBackground(item), isTrue);
+
+        expect(service.stoppedResolutions.single.liveStreamId, 'live-1');
+        expect(service.transcodingStops.single.playSessionId, 'session-1');
+
+        await manager.startQueuedPlayback(freshResolution: true);
+        expect(backend.startPositions.last, Duration.zero);
+        expect(backend.playedUrls.last, 'https://example.test/session-2');
+        expect(service.events, contains('start:session-2'));
+      } finally {
+        manager.dispose();
+      }
+    },
+  );
+
+  test('background ownership check cannot stop a replacement item', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+    final oldItem = <String, dynamic>{'Id': 'old', 'Type': 'Movie'};
+    final replacement = <String, dynamic>{
+      'Id': 'replacement',
+      'Type': 'Episode',
+    };
+
+    try {
+      await manager.playItems(<dynamic>[oldItem]);
+      manager.queueService.setQueue(<dynamic>[replacement]);
+
+      expect(await manager.stopForBackground(oldItem), isFalse);
+      expect(manager.queueService.currentItem, same(replacement));
+      expect(service.stoppedResolutions, isEmpty);
+      expect(backend.stopCalls, isZero);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  testWidgets(
+    'older overlapping progress completing last is followed by old stop',
+    (tester) async {
+      final backend = _TestBackend();
+      final resolver = _TestResolver();
+      final service = _TestService(stallProgress: true);
+      final manager = _manager(backend, resolver, service);
+      final item = <String, dynamic>{'Id': 'overlap', 'Type': 'Movie'};
+
+      await manager.playItems(<dynamic>[item]);
+      await tester.pump(const Duration(seconds: 10));
+      expect(service.progressRequests, hasLength(2));
+
+      expect(await manager.stopForBackground(item), isTrue);
+      expect(service.events.last, 'stop:session-1');
+
+      service.progressRequests[1].completer.complete();
+      await tester.pump();
+      expect(service.events.takeLast(2), <String>[
+        'progress:session-1:1',
+        'stop:session-1',
+      ]);
+
+      service.progressRequests[0].completer.complete();
+      await tester.pump();
+      expect(service.events.takeLast(2), <String>[
+        'progress:session-1:0',
+        'stop:session-1',
+      ]);
+
+      await tester.pump(const Duration(seconds: 15));
+      expect(service.progressRequests, hasLength(2));
+      manager.dispose();
+    },
+  );
+
+  testWidgets(
+    'stalled progress cannot block teardown or fresh foreground resume',
+    (tester) async {
+      final backend = _TestBackend();
+      final resolver = _TestResolver();
+      final service = _TestService(stallProgress: true);
+      final manager = _manager(backend, resolver, service);
+      final item = <String, dynamic>{'Id': 'stalled', 'Type': 'Movie'};
+
+      await manager.playItems(<dynamic>[item]);
+      await tester.pump(const Duration(seconds: 10));
+      expect(service.progressRequests, hasLength(2));
+
+      await tester.runAsync(() async {
+        expect(
+          await manager
+              .stopForBackground(item)
+              .timeout(const Duration(milliseconds: 100)),
+          isTrue,
+          reason: 'teardown does not await progress',
+        );
+
+        await manager
+            .startQueuedPlayback(
+              startPosition: const Duration(seconds: 30),
+              freshResolution: true,
+            )
+            .timeout(const Duration(milliseconds: 100));
+      });
+      expect(service.events, contains('start:session-2'));
+
+      service.progressRequests[1].completer.complete();
+      await tester.pump();
+      expect(service.events.last, 'stop:session-1');
+      expect(service.stoppedResolutions.last.playSessionId, isNot('session-2'));
+
+      // Request zero intentionally never completes. It neither blocks local
+      // work nor produces a server progress update requiring compensation.
+      manager.dispose();
+    },
+  );
+
+  test('canonical user stop still clears queue and playback state', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+    final item = <String, dynamic>{'Id': 'canonical', 'Type': 'Movie'};
+
+    try {
+      await manager.playItems(<dynamic>[item]);
+      manager.state.setPosition(const Duration(seconds: 15));
+      await manager.stop();
+
+      expect(manager.queueService.currentItem, isNull);
+      expect(manager.state.position, Duration.zero);
+      expect(backend.stopCalls, 1);
+      expect(service.stoppedResolutions.single.playSessionId, 'session-1');
+    } finally {
+      manager.dispose();
+    }
+  });
+}
+
+extension<T> on Iterable<T> {
+  Iterable<T> takeLast(int count) => skip(length - count);
+}


### PR DESCRIPTION
# Pull Request

## Summary

Fixes stale Jellyfin playback sessions when Moonfin remains backgrounded on Android TV, without discarding local VOD resume state.

After the existing three-second background grace period, Moonfin now ends the obsolete server playback claim and releases the current backend/source while retaining the queue item and saved position needed for a safe foreground return. Movies and episodes fresh-resolve at their saved position; Live TV fresh-resolves at the live edge.

This also isolates progress reporting by playback generation so a late request from the retired session cannot revive or overwrite the replacement session.

Audio background playback, offline playback, non-TV platforms, quick background/resume, and the canonical user stop behavior remain unchanged.

## Related Issues

No existing issue found.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Added a narrow Android TV background-stop path that ends stale server ownership without clearing the queue or stored VOD position.
- Preserved the existing three-second grace period and cancellation on quick foreground return.
- Added item-ownership checks so a stale timer cannot stop or restart a replacement queue item.
- Fresh-resolve movies and episodes at the saved position after timeout; fresh-resolve Live TV at the live edge.
- Track progress requests by playback generation and compensate late completions with a stop scoped to the retired session.
- Keep cleanup bounded even when a progress request never completes.
- Preserve the existing destructive canonical stop behavior for explicit/user stop flows.
- Added lifecycle, resume, replacement-item, overlapping-progress, stalled-request, and canonical-stop regression tests.

## Platform
- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [x] Tested on physical device
- [x] Manual testing completed

### Automated checks

- `flutter test test/playback` — 252 tests passed
- Focused lifecycle/stale-session rerun — 23 tests passed
- Touched-file `flutter analyze --no-fatal-infos` — no new findings; four pre-existing info-level lints remain in `playback_manager.dart`
- `git diff --check`
- GitHub Android build — passed (28m30s)
- Independent implementation review focused on stale-session races and bounded cleanup

### Physical validation

Tested on the side-by-side Moonfin beta on an Amazon AFTKA Fire TV against Jellyfin 10.11.11:

1. Played a movie, episode, and Live TV.
2. Exited/backgrounded Moonfin and also powered off the TV without explicitly exiting playback.
3. Confirmed each obsolete Jellyfin session was removed after the grace period.
4. Confirmed movie and episode playback retained the previous resume position.
5. Confirmed Live TV returned through a fresh session at the live edge.
6. Confirmed quick foreground return still cancels the pending cleanup.

Before this fix, Live TV sessions could remain active indefinitely after power-off. With this change, stale server ownership ends while resumable local VOD state survives.

## Screenshots

Not applicable. This is a playback lifecycle change with no UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
