### PR TITLE
fix(apple): centre multi-line subtitles and fix the gap between their backgrounds

### DIFF
--- a/tvos/Runner/Playback/Aether/SubtitleOverlay.swift
+++ b/tvos/Runner/Playback/Aether/SubtitleOverlay.swift
@@ -413,12 +413,27 @@ final class SubtitleOverlay: PlatformView {
         PlatformFont.systemFont(ofSize: appliedFontSize, weight: subtitleFontWeight)
     }
 
+    /// A label's own alignment is ignored once it holds an attributed string,
+    /// so the centring lives here. Line height is pinned to the glyph box
+    /// because the background only fills ascent and descent, leaving the
+    /// font's leading as a gap between stacked lines.
+    private func paragraphStyle(for font: PlatformFont) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.alignment = .center
+        let glyphBox = font.ascender - font.descender
+        style.minimumLineHeight = glyphBox
+        style.maximumLineHeight = glyphBox
+        return style
+    }
+
     private func fillText(_ text: String) -> NSAttributedString {
-        NSAttributedString(
+        let font = labelFont()
+        return NSAttributedString(
             string: text,
             attributes: [
-                .font: labelFont(),
+                .font: font,
                 .foregroundColor: subtitleTextColor,
+                .paragraphStyle: paragraphStyle(for: font),
             ])
     }
 
@@ -429,11 +444,14 @@ final class SubtitleOverlay: PlatformView {
     /// across them. The fill on top covers those, leaving only the half of the
     /// line that falls outside the letter.
     private func outlineText(_ text: String) -> NSAttributedString {
+        let font = labelFont()
         var attrs: [NSAttributedString.Key: Any] = [
-            .font: labelFont(),
+            .font: font,
             // Nothing to fill here, or this copy shows through as a second set
             // of glyphs whenever there is no outline to draw.
             .foregroundColor: PlatformColor.clear,
+            // Must match the fill, or the outline drifts off the letters.
+            .paragraphStyle: paragraphStyle(for: font),
         ]
         if subtitleStrokeWidth > 0 {
             attrs[.strokeColor] = subtitleStrokeColor


### PR DESCRIPTION
# Pull Request

## Summary

Multi-line subtitle cues were left-aligned instead of centred on Apple platforms, and their per-line background boxes didn't line up: a 1-2px line of video showed between them at full screen, and they overlapped in a small window. Both come from the attributed string the subtitle labels are given: it carried no paragraph style, so the labels' own centring was ignored and the line height kept the font's leading outside the filled background.

## Related Issues

- Closes #
- Fixes #1174 
- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Give `fillText()` and `outlineText()` a `.paragraphStyle` with `alignment = .center`. Assigning an attributed string makes its paragraph style authoritative, so the `alignment = .center` set on the labels never applied.
- Pin the line height to the glyph box (`ascender - descender`) so the per-line background, which is filled over ascent and descent, leaves no gap where the font's leading used to be. The point size follows the view height, so this has to hold at any window size, not just full screen.
- Both builders share the same style: they are two stacked labels, and a mismatch would drift the outline off the letters.

One file: `tvos/Runner/Playback/Aether/SubtitleOverlay.swift`, compiled into the macOS, iOS and tvOS targets.

## Platform

- [ ] Android
- [x] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Play a file with .srt subtitles and wait for a two-line cue: the lines are centred on each other, where before both started at the same x.
2. The two background boxes now meet, with no video showing between them.
3. The outline still sits on the glyphs.

## Screenshots (if applicable)
<img width="2710" height="1556" alt="2026-08-17_12-03" src="https://github.com/user-attachments/assets/7a695fb1-d0ba-4f78-9fc3-c508922ea9d3" />
<img width="2712" height="1556" alt="2026-08-17_12-00" src="https://github.com/user-attachments/assets/b0dd3d92-ae0b-460c-9be7-9c6396ff2b6d" />


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced