### PR TITLE
expand external player support from android tv to mobile

### DIFF
--- a/lib/di/modules/playback_module.dart
+++ b/lib/di/modules/playback_module.dart
@@ -496,7 +496,7 @@ void registerPlaybackModule() {
     );
   });
   manager.setExternalPlaybackDecider((items) {
-    if (!(PlatformDetection.isAndroid && PlatformDetection.isTV)) {
+    if (!PlatformDetection.isAndroid) {
       return false;
     }
 

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -127,7 +127,7 @@ bool _shouldRedirectVideoToExternalPlayer(String path) {
     return false;
   }
 
-  if (!(PlatformDetection.isAndroid && PlatformDetection.isTV)) {
+  if (!PlatformDetection.isAndroid) {
     return false;
   }
 

--- a/lib/ui/screens/settings/panel/advanced_options_screen.dart
+++ b/lib/ui/screens/settings/panel/advanced_options_screen.dart
@@ -84,42 +84,43 @@ class _AdvancedOptionsScreenState extends State<_AdvancedOptionsScreen> {
                 ],
               ),
             ],
-            if (PlatformDetection.isAndroid && PlatformDetection.isTV) ...[
+            if (PlatformDetection.isAndroid) ...[
               _SectionHeader(l10n.playerRouting),
               adaptiveListSection(
                 children: [
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.preferExoPlayerFfmpeg,
-                    title: l10n.preferSoftwareDecoders,
-                    subtitle: l10n.preferSoftwareDecodersSubtitle,
-                    icon: Icons.memory,
-                  ),
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.media3SkipSilence,
-                    title: l10n.skipSilenceTitle,
-                    subtitle: l10n.skipSilenceSubtitle,
-                    icon: Icons.graphic_eq,
-                  ),
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.media3AllowExternalAudioEffects,
-                    title: l10n.allowExternalAudioEffectsTitle,
-                    subtitle: l10n.allowExternalAudioEffectsSubtitle,
-                    icon: Icons.equalizer,
-                  ),
-                  SwitchPreferenceTile(
-                    preference: UserPreferences.media3TunnelingDisabled,
-                    inverted: true,
-                    title: l10n.enableTunnelingTitle,
-                    subtitle: l10n.enableTunnelingSubtitle,
-                    icon: Icons.tv,
-                  ),
-                  SwitchPreferenceTile(
-                    preference:
-                        UserPreferences.media3MapDolbyVisionProfile7ToHevc,
-                    title: l10n.mapDolbyVisionP7Title,
-                    subtitle: l10n.mapDolbyVisionP7Subtitle,
-                    icon: Icons.hdr_strong,
-                  ),
+                  if (PlatformDetection.isTV) ...[
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.preferExoPlayerFfmpeg,
+                      title: l10n.preferSoftwareDecoders,
+                      subtitle: l10n.preferSoftwareDecodersSubtitle,
+                      icon: Icons.memory,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.media3SkipSilence,
+                      title: l10n.skipSilenceTitle,
+                      subtitle: l10n.skipSilenceSubtitle,
+                      icon: Icons.graphic_eq,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.media3AllowExternalAudioEffects,
+                      title: l10n.allowExternalAudioEffectsTitle,
+                      subtitle: l10n.allowExternalAudioEffectsSubtitle,
+                      icon: Icons.equalizer,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.media3TunnelingDisabled,
+                      inverted: true,
+                      title: l10n.enableTunnelingTitle,
+                      subtitle: l10n.enableTunnelingSubtitle,
+                      icon: Icons.tv,
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.media3MapDolbyVisionProfile7ToHevc,
+                      title: l10n.mapDolbyVisionP7Title,
+                      subtitle: l10n.mapDolbyVisionP7Subtitle,
+                      icon: Icons.hdr_strong,
+                    ),
+                  ],
                   SwitchPreferenceTile(
                     preference: UserPreferences.useExternalPlayer,
                     title: l10n.useExternalPlayer,

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1415,6 +1415,8 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
         l10n.enableTunnelingTitle,
         subtitle: l10n.enableTunnelingSubtitle,
       ),
+    ],
+    if (PlatformDetection.isAndroid) ...[
       advanced.leaf(
         'external_player',
         l10n.useExternalPlayer,


### PR DESCRIPTION
# Pull Request

## Summary
External players were only supported for android tv, but the same logic works on android mobile, it just needed to be ungated

## Related Issues
Link related issues or tickets separated by commas.

- Closes #1176 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- replace isAndroid && isTV with just isAndroid (where applicable to external players)
- 
- 

## Platform
- [X] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. I played something on vlc on my android phone
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
