### PR TITLE
keep size consistent between modern rows and forced wideimage rows

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2420,8 +2420,12 @@ class _ContentRowsState extends State<_ContentRows>
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
+    final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
     final fullScreenRows = _fullScreenRowsEnabled(prefs);
-    final platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+    double platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+    if (isWideRowsV2) {
+      platformScale = platformScale * 2.5;
+    }
 
     double childHeight = 0.0;
     if (row.isLoading) {
@@ -3449,15 +3453,18 @@ class _ContentRowsState extends State<_ContentRows>
       return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
     } else {
       final isSeerrRowOverride = _isSeerrFilterRow(row);
-      final isRowsV2 =
-          prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-          !_isWideArtworkRow(row);
+      final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
+      final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
+
       final rowImageType = isSeerrRowOverride
           ? ImageType.thumb
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-      final platformScale = PlatformDetection.isTV
+      double platformScale = PlatformDetection.isTV
           ? 0.8 * desktopScale
           : desktopScale;
+      if (isWideRowsV2) {
+        platformScale = platformScale * 2.5;
+      }
       var maxCardHeight = 0.0;
       if (isRowsV2) {
         final imageHeight =
@@ -3831,7 +3838,7 @@ class _ContentRowsState extends State<_ContentRows>
         : prefs.get(UserPreferences.posterSize);
     final watchedBehavior = prefs.get(UserPreferences.watchedIndicatorBehavior);
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
-    final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
+    final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion) && !_isHomeRowsStyleV2();
     final useSeriesThumbs = prefs.get(UserPreferences.seriesThumbnailsEnabled);
 
     if (widget.viewModel.isLoading && rows.isEmpty) {
@@ -4407,17 +4414,19 @@ class _ContentRowsState extends State<_ContentRows>
   }) {
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
     final isSeerrRowOverride = _isSeerrFilterRow(row);
-    final isRowsV2 =
-        prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-        !_isWideArtworkRow(row);
+    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
+    final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
     final rowImageType = isSeerrRowOverride
         ? ImageType.thumb
         : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
-    final platformScale = PlatformDetection.isTV
+    double platformScale = PlatformDetection.isTV
         ? 0.8 * desktopScale
         : desktopScale;
+    if (isWideRowsV2) {
+      platformScale = platformScale * 2.5;
+    }
     final v2ImageHeight =
         posterSize.portraitHeight.toDouble() * platformScale * 2;
     final v2MetadataHeightBudget = _v2MetadataBudgetFor(row, prefs);
@@ -4759,7 +4768,7 @@ class _ContentRowsState extends State<_ContentRows>
                     focusColor: (row.rowType == HomeRowType.genres && row.id == 'genres')
                         ? ThemeRegistry.active.borders.focusBorder.color
                         : focusColor,
-                    cardFocusExpansion: isRowsV2 ? false : cardExpansion && !showPreviewVideo,
+                    cardFocusExpansion: _isHomeRowsStyleV2() ? false : cardExpansion && !showPreviewVideo,
                     externalIsFocused: effectiveV2Focused,
                     suppressImageFocusBorder: showPreviewVideo,
                     suppressFocusGlow: suppressFocusGlow,

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -644,6 +644,11 @@ class _ContentRows extends StatefulWidget {
 class _ContentRowsState extends State<_ContentRows>
     with WidgetsBindingObserver, WindowListener
     implements AudioOwnable {
+  /// A wide artwork row has no modern variant, so beside rows drawing at twice
+  /// the poster height it reads as a band of undersized cards. This brings the
+  /// two back to roughly the same height.
+  static const double _wideArtworkModernScale = 2.5;
+
   static const double _kHomeRowLabelInset = 16.0;
   static const double _focusedRowExtraSpacing = 20.0;
   static const Duration _focusedRowSpacingDuration = Duration(
@@ -2420,12 +2425,8 @@ class _ContentRowsState extends State<_ContentRows>
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
-    final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
     final fullScreenRows = _fullScreenRowsEnabled(prefs);
-    double platformScale = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
-    if (isWideRowsV2) {
-      platformScale = platformScale * 2.5;
-    }
+    final platformScale = _rowPlatformScale(row, desktopScale);
 
     double childHeight = 0.0;
     if (row.isLoading) {
@@ -3426,6 +3427,14 @@ class _ContentRowsState extends State<_ContentRows>
     return widget.prefs.get(UserPreferences.desktopUiScale).scaleFactor;
   }
 
+  double _rowPlatformScale(HomeRow row, double desktopScale) {
+    final base = PlatformDetection.isTV ? 0.8 * desktopScale : desktopScale;
+    if (_isHomeRowsStyleV2() && _isWideArtworkRow(row)) {
+      return base * _wideArtworkModernScale;
+    }
+    return base;
+  }
+
   double _squarePosterSide(PosterSize posterSize) {
     final scaleFactor = _desktopUiScaleFactor();
     final platformScale = PlatformDetection.isTV
@@ -3453,18 +3462,13 @@ class _ContentRowsState extends State<_ContentRows>
       return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
     } else {
       final isSeerrRowOverride = _isSeerrFilterRow(row);
-      final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
-      final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
-
+      final isRowsV2 =
+          prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
+          !_isWideArtworkRow(row);
       final rowImageType = isSeerrRowOverride
           ? ImageType.thumb
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
-      double platformScale = PlatformDetection.isTV
-          ? 0.8 * desktopScale
-          : desktopScale;
-      if (isWideRowsV2) {
-        platformScale = platformScale * 2.5;
-      }
+      final platformScale = _rowPlatformScale(row, desktopScale);
       var maxCardHeight = 0.0;
       if (isRowsV2) {
         final imageHeight =
@@ -3838,7 +3842,7 @@ class _ContentRowsState extends State<_ContentRows>
         : prefs.get(UserPreferences.posterSize);
     final watchedBehavior = prefs.get(UserPreferences.watchedIndicatorBehavior);
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
-    final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion) && !_isHomeRowsStyleV2();
+    final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
     final useSeriesThumbs = prefs.get(UserPreferences.seriesThumbnailsEnabled);
 
     if (widget.viewModel.isLoading && rows.isEmpty) {
@@ -4414,19 +4418,15 @@ class _ContentRowsState extends State<_ContentRows>
   }) {
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
     final isSeerrRowOverride = _isSeerrFilterRow(row);
-    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
-    final isWideRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && _isWideArtworkRow(row);
+    final isRowsV2 =
+        prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
+        !_isWideArtworkRow(row);
     final rowImageType = isSeerrRowOverride
         ? ImageType.thumb
         : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
-    double platformScale = PlatformDetection.isTV
-        ? 0.8 * desktopScale
-        : desktopScale;
-    if (isWideRowsV2) {
-      platformScale = platformScale * 2.5;
-    }
+    final platformScale = _rowPlatformScale(row, desktopScale);
     final v2ImageHeight =
         posterSize.portraitHeight.toDouble() * platformScale * 2;
     final v2MetadataHeightBudget = _v2MetadataBudgetFor(row, prefs);


### PR DESCRIPTION
# Pull Request

## Summary
Since the "force wide image" rows (eg studio rows) only have classic row variants, the sizing looks disproportional compared to the rest of the modern rows. 

This PR adjusts the sizing/animation for these rows if the rest of the rows are modern style, to make everything visually consistent

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes @mattsigal 's complaint
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- increase scale by a factor of 2.5 if row is "forced wide image" and user preference is set to modern 
- disable focusExpansionAnimation is user preference is set to modern (since modern rows don't expand, it looks visually out of place when the studio rows do it, plus at this size they clip into each other when expanded so overall it looks better this way)
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Modern:
<img width="3237" height="2018" alt="image" src="https://github.com/user-attachments/assets/c77b5a41-bb32-4a66-b720-03c9f1bd274f" />

Classic:
<img width="3237" height="2018" alt="image" src="https://github.com/user-attachments/assets/982e0287-2470-4913-99da-da3dcf18241f" />

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
