### PR TITLE
bugfig-collections - Unbreak Collections

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1032,6 +1032,8 @@ class ItemDetailViewModel extends ChangeNotifier {
       parentId: itemId,
       startIndex: _collectionFetchedCount,
       limit: _collectionPageSize,
+      recursive: true,
+      includeItemTypes: ['Movie', 'Series', 'Video', 'MusicVideo', 'Audio'],
       fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
     );
     final newItems = _mapItems((data['Items'] as List?) ?? []);
@@ -1098,6 +1100,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       final allData = await _client.itemsApi.getItems(
         parentId: itemId,
         limit: _indexScanLimit,
+        recursive: true,
         fields: 'BasicSyncInfo',
       );
       final allTopLevel = _mapItems((allData['Items'] as List?) ?? []);
@@ -1283,6 +1286,7 @@ class ItemDetailViewModel extends ChangeNotifier {
         fetchFutures.add(() async {
           final data = await _client.itemsApi.getItems(
             parentId: boxSetId,
+            recursive: true,
             sortBy: 'PremiereDate,SortName',
             sortOrder: 'Ascending',
             fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
@@ -1316,6 +1320,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     try {
       final membership = await _client.itemsApi.getItems(
         parentId: boxSetId,
+        recursive: true,
         fields: 'BasicSyncInfo',
       );
       final members = (membership['Items'] as List?) ?? const [];
@@ -1368,6 +1373,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           await Future.wait(batch.map((candidate) async {
             final membership = await _client.itemsApi.getItems(
               parentId: candidate.key,
+              recursive: true,
               fields: 'BasicSyncInfo',
             );
             final members = (membership['Items'] as List?) ?? const [];


### PR DESCRIPTION
# Pull Request

## Summary
So, _somebody_ (it was me) was working on a problem to make sure large collecetions wouldn't crash low-end devices. And in that focus ended up omitting a critical piece of code which rendered Collections as empty when they were not already in the cache. Ooooops. This PR restores `recursive: true` and adds `includeItemTypes` filtering when fetching BoxSet collection items in **item_detail_view_model.dart**. This resolves a regression introduced during the collection lazy loading refactor where non-recursive queries returned 0 items from Jellyfin server API, or returned child TV series episodes that drowned out top-level movie cards in the collection grid.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1036 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added `recursive: true` back to `_fetchCollectionPage()`, `_ensurePlaylistIndexEntries()`, `_loadParentCollection()`, `_boxSetContainsItem()`, and `_findParentCollectionsByScanningBoxSets()` in **item_detail_view_model.dart**.
- Added `includeItemTypes: ['Movie', 'Series', 'Video', 'MusicVideo', 'Audio']` to `_fetchCollectionPage()` in **item_detail_view_model.dart** so TV series sub-episodes are excluded from top-level BoxSet grids.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open BoxSet detail views for a curated collections (e.g., *Alien*, *Evil Dead*, *Predator*, *Star Wars*).
2. Verify that top-level movie and series cards render correctly in the collection grid without returning 0 items or drowning out movies with TV episode sub-items.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Bugged
<img width="2023" height="1182" alt="2026-08-17_21-36-21_Antigravity_IDE" src="https://github.com/user-attachments/assets/9bd49916-3206-44c2-9267-f1d00c947990" />

### Unbugged
<img width="2553" height="1486" alt="2026-08-17_21-00-37_moonfin" src="https://github.com/user-attachments/assets/8ecb0f7d-02f7-44a9-9bf4-8b8ccd1fd678" />
<img width="2553" height="1486" alt="2026-08-17_21-00-42_moonfin" src="https://github.com/user-attachments/assets/0c34e4a0-e2f0-4612-b946-061d3f273862" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
