### PR TITLE
bugfix-audiobooks - Ensure Bookmarks and Notes are backed up and synced across clients

### DIFF
--- a/lib/data/services/audiobook_bookmarks_service.dart
+++ b/lib/data/services/audiobook_bookmarks_service.dart
@@ -46,12 +46,19 @@ class AudiobookBookmarksService {
   static String _key(String serverId, String itemId) =>
       'audiobook_bookmarks_${serverId}_$itemId';
 
+  /// Set while a local edit hasn't reached the server. It decides which side
+  /// wins the next sync, so an edit made offline isn't replaced by the older
+  /// list the server still holds.
+  static String _dirtyKey(String serverId, String itemId) =>
+      'audiobook_bookmarks_dirty_${serverId}_$itemId';
+
   final _controllers = <String, StreamController<List<AudiobookBookmark>>>{};
 
   MediaServerClient? _resolveClient(String serverId) {
     try {
-      final factory = GetIt.instance<MediaServerClientFactory>();
-      return factory.getClientIfExists(serverId) ?? GetIt.instance<MediaServerClient>();
+      return GetIt.instance<MediaServerClientFactory>().getClientIfExists(
+        serverId,
+      );
     } catch (_) {
       return null;
     }
@@ -70,10 +77,6 @@ class AudiobookBookmarksService {
       }
     }
     localList.sort((a, b) => a.positionMs.compareTo(b.positionMs));
-
-    // Background sync from Moonbase server
-    unawaited(_syncFromMoonbase(serverId, itemId, localList));
-
     return localList;
   }
 
@@ -86,6 +89,7 @@ class AudiobookBookmarksService {
     Future.microtask(() async {
       final value = await load(serverId, itemId);
       if (!controller.isClosed) controller.add(value);
+      await syncFromServer(serverId, itemId);
     });
     return controller.stream;
   }
@@ -113,11 +117,7 @@ class AudiobookBookmarksService {
       next.map((b) => jsonEncode(b.toJson())).toList(),
     );
     _notify(serverId, itemId, next);
-
-    final client = _resolveClient(serverId);
-    if (client != null) {
-      unawaited(_syncToMoonbase(client, itemId, next));
-    }
+    unawaited(_pushToServer(serverId, itemId, next));
   }
 
   Future<void> removeAt(String serverId, String itemId, int positionMs) async {
@@ -132,18 +132,31 @@ class AudiobookBookmarksService {
       next.map((b) => jsonEncode(b.toJson())).toList(),
     );
     _notify(serverId, itemId, next);
+    unawaited(_pushToServer(serverId, itemId, next));
+  }
 
+  Future<void> _pushToServer(
+    String serverId,
+    String itemId,
+    List<AudiobookBookmark> list,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_dirtyKey(serverId, itemId), true);
     final client = _resolveClient(serverId);
-    if (client != null) {
-      unawaited(_syncToMoonbase(client, itemId, next));
+    if (client == null) return;
+    if (await _syncToMoonbase(client, itemId, list)) {
+      await prefs.remove(_dirtyKey(serverId, itemId));
     }
   }
 
-  Future<void> _syncFromMoonbase(
-    String serverId,
-    String itemId,
-    List<AudiobookBookmark> localList,
-  ) async {
+  /// Reconciles this device with the server for one item.
+  ///
+  /// The server holds a whole list per item, so what it returns is the state
+  /// every device agreed on. Taking it as it stands is what lets a bookmark
+  /// deleted elsewhere stay deleted, which merging the two lists could never
+  /// express.
+  /// Local wins only while it holds an edit the server hasn't taken.
+  Future<void> syncFromServer(String serverId, String itemId) async {
     final client = _resolveClient(serverId);
     if (client == null) return;
     final token = client.accessToken;
@@ -184,29 +197,21 @@ class AudiobookBookmarksService {
         }
       }
 
-      final mergedMap = <int, AudiobookBookmark>{};
-      for (final b in localList) {
-        mergedMap[b.positionMs] = b;
-      }
-      for (final b in serverBookmarks) {
-        if (!mergedMap.containsKey(b.positionMs)) {
-          mergedMap[b.positionMs] = b;
-        }
-      }
-
-      final mergedList = mergedMap.values.toList()
-        ..sort((a, b) => a.positionMs.compareTo(b.positionMs));
-
       final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(_dirtyKey(serverId, itemId)) ?? false) {
+        final localList = await load(serverId, itemId);
+        if (await _syncToMoonbase(client, itemId, localList)) {
+          await prefs.remove(_dirtyKey(serverId, itemId));
+        }
+        return;
+      }
+
+      serverBookmarks.sort((a, b) => a.positionMs.compareTo(b.positionMs));
       await prefs.setStringList(
         _key(serverId, itemId),
-        mergedList.map((b) => jsonEncode(b.toJson())).toList(),
+        serverBookmarks.map((b) => jsonEncode(b.toJson())).toList(),
       );
-      _notify(serverId, itemId, mergedList);
-
-      if (mergedList.length > serverBookmarks.length) {
-        await _syncToMoonbase(client, itemId, mergedList);
-      }
+      _notify(serverId, itemId, serverBookmarks);
     } catch (_) {
       // Gracefully ignore offline/unreachable network errors
     } finally {
@@ -214,13 +219,13 @@ class AudiobookBookmarksService {
     }
   }
 
-  Future<void> _syncToMoonbase(
+  Future<bool> _syncToMoonbase(
     MediaServerClient client,
     String itemId,
     List<AudiobookBookmark> list,
   ) async {
     final token = client.accessToken;
-    if (token == null || token.isEmpty) return;
+    if (token == null || token.isEmpty) return false;
 
     final dio = Dio(
       BaseOptions(
@@ -243,7 +248,9 @@ class AudiobookBookmarksService {
         '${client.baseUrl}/Moonfin/Bookmarks/$itemId',
         data: list.map((b) => b.toServerJson()).toList(),
       );
+      return true;
     } catch (_) {
+      return false;
     } finally {
       dio.close();
     }

--- a/lib/data/services/audiobook_bookmarks_service.dart
+++ b/lib/data/services/audiobook_bookmarks_service.dart
@@ -1,7 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
+import 'package:get_it/get_it.dart';
+import 'package:server_core/server_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'media_server_client_factory.dart';
 
 /// A single user-saved position inside an audiobook.
 class AudiobookBookmark {
@@ -21,39 +26,55 @@ class AudiobookBookmark {
         'c': createdAt.toIso8601String(),
       };
 
+  Map<String, dynamic> toServerJson() => {
+        'positionMs': positionMs,
+        'label': label,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
   factory AudiobookBookmark.fromJson(Map<String, dynamic> json) {
     return AudiobookBookmark(
-      positionMs: (json['p'] as num?)?.toInt() ?? 0,
-      label: json['l'] as String? ?? '',
-      createdAt: DateTime.tryParse(json['c'] as String? ?? '') ?? DateTime.now(),
+      positionMs: (json['p'] as num?)?.toInt() ?? (json['positionMs'] as num?)?.toInt() ?? 0,
+      label: json['l'] as String? ?? json['label'] as String? ?? '',
+      createdAt: DateTime.tryParse(json['c'] as String? ?? json['createdAt'] as String? ?? '') ?? DateTime.now(),
     );
   }
 }
 
-/// Persists bookmarks per server+item using [SharedPreferences].
-///
-/// Storage layout mirrors the existing book reader bookmark format: one
-/// `StringList` per item, each entry a JSON object.
+/// Persists bookmarks per server+item using [SharedPreferences] and syncs with Moonbase server.
 class AudiobookBookmarksService {
   static String _key(String serverId, String itemId) =>
       'audiobook_bookmarks_${serverId}_$itemId';
 
   final _controllers = <String, StreamController<List<AudiobookBookmark>>>{};
 
+  MediaServerClient? _resolveClient(String serverId) {
+    try {
+      final factory = GetIt.instance<MediaServerClientFactory>();
+      return factory.getClientIfExists(serverId) ?? GetIt.instance<MediaServerClient>();
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<List<AudiobookBookmark>> load(String serverId, String itemId) async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getStringList(_key(serverId, itemId)) ?? const <String>[];
-    final out = <AudiobookBookmark>[];
+    final localList = <AudiobookBookmark>[];
     for (final s in raw) {
       try {
         final map = jsonDecode(s) as Map<String, dynamic>;
-        out.add(AudiobookBookmark.fromJson(map));
+        localList.add(AudiobookBookmark.fromJson(map));
       } catch (_) {
         continue;
       }
     }
-    out.sort((a, b) => a.positionMs.compareTo(b.positionMs));
-    return out;
+    localList.sort((a, b) => a.positionMs.compareTo(b.positionMs));
+
+    // Background sync from Moonbase server
+    unawaited(_syncFromMoonbase(serverId, itemId, localList));
+
+    return localList;
   }
 
   Stream<List<AudiobookBookmark>> watch(String serverId, String itemId) {
@@ -62,7 +83,6 @@ class AudiobookBookmarksService {
       key,
       () => StreamController<List<AudiobookBookmark>>.broadcast(),
     );
-    // Emit current value asynchronously to new subscribers.
     Future.microtask(() async {
       final value = await load(serverId, itemId);
       if (!controller.isClosed) controller.add(value);
@@ -87,11 +107,17 @@ class AudiobookBookmarksService {
         createdAt: DateTime.now(),
       ),
     ]..sort((a, b) => a.positionMs.compareTo(b.positionMs));
+
     await prefs.setStringList(
       key,
       next.map((b) => jsonEncode(b.toJson())).toList(),
     );
     _notify(serverId, itemId, next);
+
+    final client = _resolveClient(serverId);
+    if (client != null) {
+      unawaited(_syncToMoonbase(client, itemId, next));
+    }
   }
 
   Future<void> removeAt(String serverId, String itemId, int positionMs) async {
@@ -100,11 +126,127 @@ class AudiobookBookmarksService {
     final current = await load(serverId, itemId);
     final next =
         current.where((b) => b.positionMs != positionMs).toList(growable: false);
+
     await prefs.setStringList(
       key,
       next.map((b) => jsonEncode(b.toJson())).toList(),
     );
     _notify(serverId, itemId, next);
+
+    final client = _resolveClient(serverId);
+    if (client != null) {
+      unawaited(_syncToMoonbase(client, itemId, next));
+    }
+  }
+
+  Future<void> _syncFromMoonbase(
+    String serverId,
+    String itemId,
+    List<AudiobookBookmark> localList,
+  ) async {
+    final client = _resolveClient(serverId);
+    if (client == null) return;
+    final token = client.accessToken;
+    if (token == null || token.isEmpty) return;
+
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Authorization': buildServerAuthorizationHeader(
+            scheme: 'MediaBrowser',
+            deviceInfo: client.deviceInfo,
+            accessToken: token,
+          ),
+          'Accept': 'application/json',
+        },
+      ),
+    );
+    configureServerDio(dio);
+
+    try {
+      final response = await dio.get<dynamic>('${client.baseUrl}/Moonfin/Bookmarks/$itemId');
+      if (response.data == null) return;
+
+      List<dynamic>? serverRaw;
+      if (response.data is Map) {
+        serverRaw = (response.data as Map)['bookmarks'] as List<dynamic>?;
+      } else if (response.data is List) {
+        serverRaw = response.data as List<dynamic>?;
+      }
+      if (serverRaw == null) return;
+
+      final serverBookmarks = <AudiobookBookmark>[];
+      for (final item in serverRaw) {
+        if (item is Map<String, dynamic>) {
+          serverBookmarks.add(AudiobookBookmark.fromJson(item));
+        }
+      }
+
+      final mergedMap = <int, AudiobookBookmark>{};
+      for (final b in localList) {
+        mergedMap[b.positionMs] = b;
+      }
+      for (final b in serverBookmarks) {
+        if (!mergedMap.containsKey(b.positionMs)) {
+          mergedMap[b.positionMs] = b;
+        }
+      }
+
+      final mergedList = mergedMap.values.toList()
+        ..sort((a, b) => a.positionMs.compareTo(b.positionMs));
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(
+        _key(serverId, itemId),
+        mergedList.map((b) => jsonEncode(b.toJson())).toList(),
+      );
+      _notify(serverId, itemId, mergedList);
+
+      if (mergedList.length > serverBookmarks.length) {
+        await _syncToMoonbase(client, itemId, mergedList);
+      }
+    } catch (_) {
+      // Gracefully ignore offline/unreachable network errors
+    } finally {
+      dio.close();
+    }
+  }
+
+  Future<void> _syncToMoonbase(
+    MediaServerClient client,
+    String itemId,
+    List<AudiobookBookmark> list,
+  ) async {
+    final token = client.accessToken;
+    if (token == null || token.isEmpty) return;
+
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Authorization': buildServerAuthorizationHeader(
+            scheme: 'MediaBrowser',
+            deviceInfo: client.deviceInfo,
+            accessToken: token,
+          ),
+          'Content-Type': 'application/json',
+        },
+      ),
+    );
+    configureServerDio(dio);
+
+    try {
+      await dio.post<dynamic>(
+        '${client.baseUrl}/Moonfin/Bookmarks/$itemId',
+        data: list.map((b) => b.toServerJson()).toList(),
+      );
+    } catch (_) {
+    } finally {
+      dio.close();
+    }
   }
 
   void _notify(String serverId, String itemId, List<AudiobookBookmark> value) {

--- a/lib/data/services/audiobook_notes_service.dart
+++ b/lib/data/services/audiobook_notes_service.dart
@@ -57,6 +57,12 @@ class AudiobookNote {
 
 /// Persists notes per server+item using [SharedPreferences] and syncs with Moonbase server.
 class AudiobookNotesService {
+  /// Set while a local edit hasn't reached the server. It decides which side
+  /// wins the next sync, so an edit made offline isn't replaced by the older
+  /// list the server still holds.
+  static String _dirtyKey(String serverId, String itemId) =>
+      'audiobook_notes_dirty_${serverId}_$itemId';
+
   static String _key(String serverId, String itemId) =>
       'audiobook_notes_${serverId}_$itemId';
 
@@ -64,8 +70,9 @@ class AudiobookNotesService {
 
   MediaServerClient? _resolveClient(String serverId) {
     try {
-      final factory = GetIt.instance<MediaServerClientFactory>();
-      return factory.getClientIfExists(serverId) ?? GetIt.instance<MediaServerClient>();
+      return GetIt.instance<MediaServerClientFactory>().getClientIfExists(
+        serverId,
+      );
     } catch (_) {
       return null;
     }
@@ -84,10 +91,6 @@ class AudiobookNotesService {
       }
     }
     localList.sort((a, b) => a.positionMs.compareTo(b.positionMs));
-
-    // Background sync from Moonbase server
-    unawaited(_syncFromMoonbase(serverId, itemId, localList));
-
     return localList;
   }
 
@@ -100,6 +103,7 @@ class AudiobookNotesService {
     Future.microtask(() async {
       final value = await load(serverId, itemId);
       if (!controller.isClosed) controller.add(value);
+      await syncFromServer(serverId, itemId);
     });
     return controller.stream;
   }
@@ -155,17 +159,30 @@ class AudiobookNotesService {
     final controller = _controllers[_key(serverId, itemId)];
     if (controller != null && !controller.isClosed) controller.add(notes);
 
+    unawaited(_pushToServer(serverId, itemId, notes));
+  }
+
+  Future<void> _pushToServer(
+    String serverId,
+    String itemId,
+    List<AudiobookNote> list,
+  ) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_dirtyKey(serverId, itemId), true);
     final client = _resolveClient(serverId);
-    if (client != null) {
-      unawaited(_syncToMoonbase(client, itemId, notes));
+    if (client == null) return;
+    if (await _syncToMoonbase(client, itemId, list)) {
+      await prefs.remove(_dirtyKey(serverId, itemId));
     }
   }
 
-  Future<void> _syncFromMoonbase(
-    String serverId,
-    String itemId,
-    List<AudiobookNote> localList,
-  ) async {
+  /// Reconciles this device with the server for one item.
+  ///
+  /// The server holds a whole list per item, so what it returns is the state
+  /// every device agreed on. Taking it as it stands is what lets a note deleted
+  /// elsewhere stay deleted, which merging the two lists could never express.
+  /// Local wins only while it holds an edit the server hasn't taken.
+  Future<void> syncFromServer(String serverId, String itemId) async {
     final client = _resolveClient(serverId);
     if (client == null) return;
     final token = client.accessToken;
@@ -204,30 +221,22 @@ class AudiobookNotesService {
         }
       }
 
-      final mergedMap = <String, AudiobookNote>{};
-      for (final n in localList) {
-        mergedMap[n.id] = n;
-      }
-      for (final n in serverNotes) {
-        if (!mergedMap.containsKey(n.id)) {
-          mergedMap[n.id] = n;
-        }
-      }
-
-      final mergedList = mergedMap.values.toList()
-        ..sort((a, b) => a.positionMs.compareTo(b.positionMs));
-
       final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(_dirtyKey(serverId, itemId)) ?? false) {
+        final localList = await load(serverId, itemId);
+        if (await _syncToMoonbase(client, itemId, localList)) {
+          await prefs.remove(_dirtyKey(serverId, itemId));
+        }
+        return;
+      }
+
+      serverNotes.sort((a, b) => a.positionMs.compareTo(b.positionMs));
       await prefs.setStringList(
         _key(serverId, itemId),
-        mergedList.map((n) => jsonEncode(n.toJson())).toList(),
+        serverNotes.map((n) => jsonEncode(n.toJson())).toList(),
       );
       final controller = _controllers[_key(serverId, itemId)];
-      if (controller != null && !controller.isClosed) controller.add(mergedList);
-
-      if (mergedList.length > serverNotes.length) {
-        await _syncToMoonbase(client, itemId, mergedList);
-      }
+      if (controller != null && !controller.isClosed) controller.add(serverNotes);
     } catch (_) {
       // Gracefully ignore network errors
     } finally {
@@ -235,13 +244,13 @@ class AudiobookNotesService {
     }
   }
 
-  Future<void> _syncToMoonbase(
+  Future<bool> _syncToMoonbase(
     MediaServerClient client,
     String itemId,
     List<AudiobookNote> notes,
   ) async {
     final token = client.accessToken;
-    if (token == null || token.isEmpty) return;
+    if (token == null || token.isEmpty) return false;
 
     final dio = Dio(
       BaseOptions(
@@ -264,7 +273,9 @@ class AudiobookNotesService {
         '${client.baseUrl}/Moonfin/Bookmarks/$itemId/Notes',
         data: notes.map((n) => n.toServerJson()).toList(),
       );
+      return true;
     } catch (_) {
+      return false;
     } finally {
       dio.close();
     }

--- a/lib/data/services/audiobook_notes_service.dart
+++ b/lib/data/services/audiobook_notes_service.dart
@@ -1,7 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
+import 'package:get_it/get_it.dart';
+import 'package:server_core/server_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'media_server_client_factory.dart';
 
 /// A timestamped freeform note attached to a position in an audiobook.
 class AudiobookNote {
@@ -33,37 +38,57 @@ class AudiobookNote {
         'u': updatedAt.toIso8601String(),
       };
 
+  Map<String, dynamic> toServerJson() => {
+        'id': id,
+        'positionMs': positionMs,
+        'body': body,
+        'updatedAt': updatedAt.toIso8601String(),
+      };
+
   factory AudiobookNote.fromJson(Map<String, dynamic> json) {
     return AudiobookNote(
       id: json['id'] as String? ?? DateTime.now().microsecondsSinceEpoch.toString(),
-      positionMs: (json['p'] as num?)?.toInt() ?? 0,
-      body: json['b'] as String? ?? '',
-      updatedAt: DateTime.tryParse(json['u'] as String? ?? '') ?? DateTime.now(),
+      positionMs: (json['p'] as num?)?.toInt() ?? (json['positionMs'] as num?)?.toInt() ?? 0,
+      body: json['b'] as String? ?? json['body'] as String? ?? '',
+      updatedAt: DateTime.tryParse(json['u'] as String? ?? json['updatedAt'] as String? ?? '') ?? DateTime.now(),
     );
   }
 }
 
-/// Persists notes per server+item using [SharedPreferences].
+/// Persists notes per server+item using [SharedPreferences] and syncs with Moonbase server.
 class AudiobookNotesService {
   static String _key(String serverId, String itemId) =>
       'audiobook_notes_${serverId}_$itemId';
 
   final _controllers = <String, StreamController<List<AudiobookNote>>>{};
 
+  MediaServerClient? _resolveClient(String serverId) {
+    try {
+      final factory = GetIt.instance<MediaServerClientFactory>();
+      return factory.getClientIfExists(serverId) ?? GetIt.instance<MediaServerClient>();
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<List<AudiobookNote>> load(String serverId, String itemId) async {
     final prefs = await SharedPreferences.getInstance();
     final raw = prefs.getStringList(_key(serverId, itemId)) ?? const <String>[];
-    final out = <AudiobookNote>[];
+    final localList = <AudiobookNote>[];
     for (final s in raw) {
       try {
         final map = jsonDecode(s) as Map<String, dynamic>;
-        out.add(AudiobookNote.fromJson(map));
+        localList.add(AudiobookNote.fromJson(map));
       } catch (_) {
         continue;
       }
     }
-    out.sort((a, b) => a.positionMs.compareTo(b.positionMs));
-    return out;
+    localList.sort((a, b) => a.positionMs.compareTo(b.positionMs));
+
+    // Background sync from Moonbase server
+    unawaited(_syncFromMoonbase(serverId, itemId, localList));
+
+    return localList;
   }
 
   Stream<List<AudiobookNote>> watch(String serverId, String itemId) {
@@ -129,6 +154,120 @@ class AudiobookNotesService {
     );
     final controller = _controllers[_key(serverId, itemId)];
     if (controller != null && !controller.isClosed) controller.add(notes);
+
+    final client = _resolveClient(serverId);
+    if (client != null) {
+      unawaited(_syncToMoonbase(client, itemId, notes));
+    }
+  }
+
+  Future<void> _syncFromMoonbase(
+    String serverId,
+    String itemId,
+    List<AudiobookNote> localList,
+  ) async {
+    final client = _resolveClient(serverId);
+    if (client == null) return;
+    final token = client.accessToken;
+    if (token == null || token.isEmpty) return;
+
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Authorization': buildServerAuthorizationHeader(
+            scheme: 'MediaBrowser',
+            deviceInfo: client.deviceInfo,
+            accessToken: token,
+          ),
+          'Accept': 'application/json',
+        },
+      ),
+    );
+    configureServerDio(dio);
+
+    try {
+      final response = await dio.get<dynamic>('${client.baseUrl}/Moonfin/Bookmarks/$itemId');
+      if (response.data == null) return;
+
+      List<dynamic>? serverRaw;
+      if (response.data is Map) {
+        serverRaw = (response.data as Map)['notes'] as List<dynamic>?;
+      }
+      if (serverRaw == null) return;
+
+      final serverNotes = <AudiobookNote>[];
+      for (final item in serverRaw) {
+        if (item is Map<String, dynamic>) {
+          serverNotes.add(AudiobookNote.fromJson(item));
+        }
+      }
+
+      final mergedMap = <String, AudiobookNote>{};
+      for (final n in localList) {
+        mergedMap[n.id] = n;
+      }
+      for (final n in serverNotes) {
+        if (!mergedMap.containsKey(n.id)) {
+          mergedMap[n.id] = n;
+        }
+      }
+
+      final mergedList = mergedMap.values.toList()
+        ..sort((a, b) => a.positionMs.compareTo(b.positionMs));
+
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setStringList(
+        _key(serverId, itemId),
+        mergedList.map((n) => jsonEncode(n.toJson())).toList(),
+      );
+      final controller = _controllers[_key(serverId, itemId)];
+      if (controller != null && !controller.isClosed) controller.add(mergedList);
+
+      if (mergedList.length > serverNotes.length) {
+        await _syncToMoonbase(client, itemId, mergedList);
+      }
+    } catch (_) {
+      // Gracefully ignore network errors
+    } finally {
+      dio.close();
+    }
+  }
+
+  Future<void> _syncToMoonbase(
+    MediaServerClient client,
+    String itemId,
+    List<AudiobookNote> notes,
+  ) async {
+    final token = client.accessToken;
+    if (token == null || token.isEmpty) return;
+
+    final dio = Dio(
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 5),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Authorization': buildServerAuthorizationHeader(
+            scheme: 'MediaBrowser',
+            deviceInfo: client.deviceInfo,
+            accessToken: token,
+          ),
+          'Content-Type': 'application/json',
+        },
+      ),
+    );
+    configureServerDio(dio);
+
+    try {
+      await dio.post<dynamic>(
+        '${client.baseUrl}/Moonfin/Bookmarks/$itemId/Notes',
+        data: notes.map((n) => n.toServerJson()).toList(),
+      );
+    } catch (_) {
+    } finally {
+      dio.close();
+    }
   }
 
   void dispose() {


### PR DESCRIPTION
# Pull Request

## Summary
Client-side update that upgrades `AudiobookBookmarksService` and `AudiobookNotesService` to use a hybrid local-first + Moonbase server sync strategy, restoring bookmarks and timestamped notes automatically across device updates and reinstallations.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/245

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **audiobook_bookmarks_service.dart** to fetch and merge server bookmarks from `/Moonfin/Bookmarks/{itemId}` while retaining local `SharedPreferences` cache for offline resilience.
- Updated **audiobook_notes_service.dart** to fetch and merge timestamped notes from `/Moonfin/Bookmarks/{itemId}/Notes`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [ ] Manual testing completed
- [X] Not tested (explain why):Tested via emulator.

### Test Steps
1. Executed `flutter analyze` on modified service files (0 issues found).
2. Saved audiobook bookmarks and freeform notes in the audiobook player.
3. Verified background server sync to `/Moonfin/Bookmarks/{itemId}`.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
