### PR TITLE
fix(windows): Stop Windows saving a maximized window as its windowed …

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -388,6 +388,10 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
   final List<String> _routeHistory = [];
   late final KeyEventCallback _hardwareKeyHandler;
   Timer? _geometrySaveTimer;
+  // Windows answers isMaximized() from an uninitialized WINDOWPLACEMENT and
+  // returns whatever was on the stack, so the state is tracked from the window
+  // events instead, seeded with the state the window was restored into.
+  bool _isMaximized = false;
   int _routeHistoryIndex = -1;
   DateTime? _lastMouseThumbNavAt;
   String? _pendingRouteHistoryLocation;
@@ -409,6 +413,8 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     }
     WidgetsBinding.instance.addObserver(this);
     if (PlatformDetection.isDesktop) {
+      final prefs = GetIt.instance<UserPreferences>();
+      _isMaximized = prefs.get(UserPreferences.windowMaximized);
       windowManager.addListener(this);
       unawaited(windowManager.setPreventClose(true));
     }
@@ -799,12 +805,11 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     try {
       final prefs = GetIt.instance<UserPreferences>();
       final isFullScreen = await windowManager.isFullScreen();
-      final isMaximized = await windowManager.isMaximized();
       await prefs.set(UserPreferences.windowFullscreen, isFullScreen);
-      await prefs.set(UserPreferences.windowMaximized, isMaximized);
+      await prefs.set(UserPreferences.windowMaximized, _isMaximized);
       // Keep the last windowed bounds. Neither state reports the size the
       // window would return to, so saving either would lose the real one.
-      if (isFullScreen || isMaximized) return;
+      if (isFullScreen || _isMaximized) return;
       final size = await windowManager.getSize();
       final pos = await windowManager.getPosition();
       await prefs.set(UserPreferences.windowWidth, size.width);
@@ -823,6 +828,11 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
 
   @override
   void onWindowEvent(String eventName) {
+    if (eventName == 'maximize') {
+      _isMaximized = true;
+    } else if (eventName == 'unmaximize') {
+      _isMaximized = false;
+    }
     if (eventName == 'move' ||
         eventName == 'resize' ||
         eventName == 'moved' ||

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -414,7 +414,9 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
     WidgetsBinding.instance.addObserver(this);
     if (PlatformDetection.isDesktop) {
       final prefs = GetIt.instance<UserPreferences>();
-      _isMaximized = prefs.get(UserPreferences.windowMaximized);
+      _isMaximized =
+          prefs.get(UserPreferences.windowMaximized) &&
+          !prefs.get(UserPreferences.windowFullscreen);
       windowManager.addListener(this);
       unawaited(windowManager.setPreventClose(true));
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:moonfin_design/moonfin_design.dart' show LiquidGlassWidgets;
 import 'package:path_provider/path_provider.dart';
 import 'package:playback_core/playback_core.dart';
+import 'package:screen_retriever/screen_retriever.dart';
 import 'package:window_manager/window_manager.dart';
 
 import 'app.dart';
@@ -41,6 +42,7 @@ import 'platform/web_runtime_config.dart';
 import 'preference/preference_constants.dart';
 import 'preference/user_preferences.dart';
 import 'util/fullscreen_helper.dart';
+import 'util/window_geometry.dart';
 import 'util/http_overrides_stub.dart'
     if (dart.library.io) 'util/http_overrides_io.dart';
 import 'util/game_core_licenses.dart';
@@ -123,17 +125,20 @@ Future<void> _restoreWindowGeometry() async {
   const minW = 800.0;
   const minH = 500.0;
   final hasSavedGeometry = w >= minW && h >= minH;
+  final bounds = hasSavedGeometry
+      ? fitBoundsToWorkAreas(Rect.fromLTWH(x, y, w, h), await _workAreas())
+      : null;
 
   final options = WindowOptions(
-    size: hasSavedGeometry ? Size(w, h) : const Size(1280, 720),
+    size: bounds?.size ?? const Size(1280, 720),
     minimumSize: const Size(minW, minH),
     center: !hasSavedGeometry && !startMaximized,
     skipTaskbar: false,
   );
 
   await windowManager.waitUntilReadyToShow(options, () async {
-    if (hasSavedGeometry) {
-      await windowManager.setPosition(Offset(x, y));
+    if (bounds != null) {
+      await windowManager.setPosition(bounds.topLeft);
     }
     // Before show, so platforms that apply it right away never draw the
     // windowed size first.
@@ -150,6 +155,20 @@ Future<void> _restoreWindowGeometry() async {
       }));
     }
   });
+}
+
+/// Usable areas of the attached displays, or an empty list when they cannot be
+/// read, which leaves saved bounds alone rather than guessing at a screen.
+Future<List<Rect>> _workAreas() async {
+  try {
+    return [
+      for (final display in await screenRetriever.getAllDisplays())
+        (display.visiblePosition ?? Offset.zero) &
+            (display.visibleSize ?? display.size),
+    ];
+  } catch (_) {
+    return const [];
+  }
 }
 
 /// Resolves whether this Android device is a TV, which decides the leanback UI

--- a/lib/util/window_geometry.dart
+++ b/lib/util/window_geometry.dart
@@ -1,0 +1,38 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+/// Pulls saved window bounds back onto a screen they fit on. Geometry written
+/// while the window was maximized reaches past every edge, since Windows
+/// inflates a maximized frame by its invisible resize border, and a display
+/// that has been unplugged or changed resolution leaves the same kind of
+/// rectangle behind. Either one puts the title bar out of reach on the next
+/// launch.
+///
+/// The window keeps its size wherever it still fits, and moves only as far as
+/// it takes to sit inside the work area it already overlaps most.
+Rect fitBoundsToWorkAreas(Rect saved, List<Rect> workAreas) {
+  // Nothing to fit them to, so they stay as they are.
+  if (workAreas.isEmpty) return saved;
+
+  var area = workAreas.first;
+  var bestOverlap = -1.0;
+  for (final candidate in workAreas) {
+    final overlap = candidate.intersect(saved);
+    final covered = overlap.width <= 0 || overlap.height <= 0
+        ? 0.0
+        : overlap.width * overlap.height;
+    if (covered > bestOverlap) {
+      bestOverlap = covered;
+      area = candidate;
+    }
+  }
+
+  final width = math.min(saved.width, area.width);
+  final height = math.min(saved.height, area.height);
+  return Rect.fromLTWH(
+    saved.left.clamp(area.left, math.max(area.left, area.right - width)),
+    saved.top.clamp(area.top, math.max(area.top, area.bottom - height)),
+    width,
+    height,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1672,7 +1672,7 @@ packages:
     source: hosted
     version: "2.1.0"
   screen_retriever:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_retriever
       sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,10 @@ dependencies:
   package_info_plus: ^8.3.1
   uuid: ^4.5.3
   cupertino_icons: ^1.0.9
+  # Direct because restoring a window needs the work areas of the attached
+  # displays to keep it on screen. Keep in step with what window_manager, which
+  # already pulls it in, resolves.
+  screen_retriever: ^0.2.0
   window_manager: ^0.5.1
 
   # Local packages

--- a/test/util/window_geometry_test.dart
+++ b/test/util/window_geometry_test.dart
@@ -1,0 +1,63 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/window_geometry.dart';
+
+void main() {
+  // A 3440x1440 ultrawide with a 40px taskbar along the bottom.
+  const ultrawide = Rect.fromLTWH(0, 0, 3440, 1400);
+
+  // What Windows reports for a window maximized on that screen: the frame
+  // reaches 8px past every edge, so saving it as the windowed geometry brings
+  // the next launch up with its title bar above the top of the screen.
+  const savedWhileMaximized = Rect.fromLTWH(-8, -8, 3456, 1416);
+
+  group('fitBoundsToWorkAreas', () {
+    test('leaves bounds that already sit on a screen alone', () {
+      const windowed = Rect.fromLTWH(400, 200, 1600, 900);
+
+      expect(fitBoundsToWorkAreas(windowed, const [ultrawide]), windowed);
+    });
+
+    test('pulls geometry saved while maximized back onto the screen', () {
+      expect(
+        fitBoundsToWorkAreas(savedWhileMaximized, const [ultrawide]),
+        ultrawide,
+      );
+    });
+
+    test('keeps a window on the second screen it was closed on', () {
+      const secondary = Rect.fromLTWH(3440, 0, 1080, 1880);
+      const onSecondary = Rect.fromLTWH(3600, 300, 800, 1000);
+
+      expect(
+        fitBoundsToWorkAreas(onSecondary, const [ultrawide, secondary]),
+        onSecondary,
+      );
+    });
+
+    test('rescues a window left on a display that is now gone', () {
+      const onUnpluggedScreen = Rect.fromLTWH(3600, 300, 800, 1000);
+
+      final fitted = fitBoundsToWorkAreas(onUnpluggedScreen, const [ultrawide]);
+
+      expect(fitted.size, onUnpluggedScreen.size);
+      expect(ultrawide.contains(fitted.topLeft), isTrue);
+      expect(fitted.right, lessThanOrEqualTo(ultrawide.right));
+    });
+
+    test('shrinks a window too large for the screen that is left', () {
+      const oversized = Rect.fromLTWH(0, 0, 3440, 1400);
+      const smallScreen = Rect.fromLTWH(0, 0, 1920, 1040);
+
+      expect(fitBoundsToWorkAreas(oversized, const [smallScreen]), smallScreen);
+    });
+
+    test('leaves bounds untouched when no display can be read', () {
+      expect(
+        fitBoundsToWorkAreas(savedWhileMaximized, const []),
+        savedWhileMaximized,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Windows reads the maximized window state from an uninitialized
`WINDOWPLACEMENT`, so `windowManager.isMaximized()` answers with whatever was on
the stack. When it came back `false` while the window was maximized, the app both
forgot the window had been maximized and wrote the maximized frame as the
windowed geometry. That frame reaches past every screen edge, so the next launch
came up larger than the screen with its title bar out of reach above the top.

The state is now tracked from the maximize and unmaximize window events, which
come from `WM_SIZE` and are trustworthy. Restored bounds are also fitted back
onto the work area they overlap most, so geometry already written this way is
repaired on the next launch instead of being reapplied.

Introduced by c3130ac3, which added the `isMaximized()` call to
`_saveWindowGeometry`. Before it only `isFullScreen()` was read, which is a plain
bool and reliable. Present in window_manager 0.5.1 and 0.5.2 alike.

## Related Issues
- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- `lib/app.dart`: track the maximized state from the `maximize` and `unmaximize`
  window events, seeded with the state the window was restored into, instead of
  querying `windowManager.isMaximized()` when saving geometry.
- `lib/util/window_geometry.dart`: new `fitBoundsToWorkAreas`, which pulls saved
  bounds back onto the work area they overlap most. Also covers a display that
  has been unplugged or changed resolution.
- `lib/main.dart`: fit the restored bounds before they are applied, reading the
  work areas from `screenRetriever.getAllDisplays()` and leaving the bounds alone
  when the displays cannot be read.
- `pubspec.yaml`: `screen_retriever` promoted to a direct dependency, since
  `main.dart` now imports it. Already in the tree via `window_manager` and
  already registered in the desktop plugin registrants, so nothing new ships —
  `pubspec.lock` changes only `transitive` to `direct main`.
- `test/util/window_geometry_test.dart`: unit tests for the geometry fitting.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [x] Windows
- [ ] Linux
- [ ] All / Shared code

The defect itself is Windows-only. The changed code paths are shared by every
desktop platform, so macOS and Linux are worth a smoke test even though their
behaviour is unchanged.

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Verified on Windows on the machine that originally hit the bug, an ultrawide set
as the primary display, whose saved preference already held the broken geometry.

`flutter test test/util/window_geometry_test.dart` — 6/6 pass. Verified the tests
fail against the previous behaviour by stubbing `fitBoundsToWorkAreas` to the
identity function: 3 failures, including
`Expected Rect.fromLTRB(0, 0, 3440, 1400)` against
`Actual Rect.fromLTRB(-8, -8, 3448, 1408)` — the off-screen window.

`flutter analyze` is clean on every changed file. Note that `lib/app.dart` and
`lib/main.dart` are not `dart format`-clean on main, so the formatter was
deliberately not run on them; both new files pass it unchanged.

### Test Steps
1. Maximize the window with the title bar button, then quit the app while it is
   still maximized.
2. Relaunch. Before this change the window came up windowed but larger than the
   screen, its title bar cut off above the top edge, and it had forgotten it was
   maximized. It now reopens maximized.
3. Restore and maximize a few times, checking that no strip of desktop is left
   uncovered along the edges.
4. On a machine carrying the old broken preference, the first launch after this
   change pulls the window back onto the screen on its own.

## Screenshots (if applicable)
n/a — no UI change.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced