### PR TITLE
feat(seerr): add duotone genre backdrops for seerr rows

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -72,6 +72,7 @@ import '../../navigation/route_lifecycle_observer.dart';
 import '../../util/home_row_title_localizer.dart';
 import '../../../util/game_library.dart';
 import 'home_view_model.dart';
+import '../../widgets/seerr/seerr_genre_label.dart';
 
 Color get _homeBackground => AppColorScheme.background;
 
@@ -3607,8 +3608,12 @@ class _ContentRowsState extends State<_ContentRows>
     double requestScale, {
     bool isMyMediaRow = false,
   }) {
+    // MediaType belongs in the key: a Seerr genre card takes the TMDB genre id
+    // as its item id, and a genre in both the movie row and the series row has
+    // the same id in each, so the second row would reuse the first row's image.
     final key =
-        '${item.serverId}|${item.id}|${imageType.index}|${height.round()}'
+        '${item.serverId}|${item.id}|${item.rawData['MediaType']}'
+        '|${imageType.index}|${height.round()}'
         '|$useSeriesThumbs|${requestScale.toStringAsFixed(2)}|$isMyMediaRow';
     final cached = _rowImageUrlCache[key];
     if (cached != null || _rowImageUrlCache.containsKey(key)) {
@@ -4746,8 +4751,15 @@ class _ContentRowsState extends State<_ContentRows>
             cardSubtitleWidget = null;
           }
 
+                  // Seerr genre cards print their name across the artwork,
+                  // the way the Jellyfin genre row does.
+                  final isSeerrGenreCard =
+                      _isSeerrFilterRow(row) && item.type == 'Genre';
                   final card = MediaCard(
                     title: cardTitle,
+                    imageOverlays: isSeerrGenreCard
+                        ? [Positioned.fill(child: SeerrGenreLabel(name: item.name))]
+                        : const <Widget>[],
                     subtitle: cardSubtitle,
                     subtitleWidget: cardSubtitleWidget,
                     imageUrl: imageUrl,

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -36,6 +36,7 @@ import '../../../preference/seerr_preferences.dart';
 import '../../../data/viewmodels/seerr_discover_view_model.dart';
 import '../../widgets/seerr/seerr_shortcuts.dart';
 import '../../../data/services/custom_external_lists_service.dart';
+import '../../../util/seerr_genre_art.dart';
 
 class HomeViewModel extends ChangeNotifier {
   /// Cards in a merged row, matching what a single library row shows.
@@ -2249,7 +2250,7 @@ class HomeViewModel extends ChangeNotifier {
               _seerrFilterItem(
                 id: g.id.toString(),
                 name: g.name,
-                imagePath: g.backdrops.isNotEmpty ? g.backdrops.first : '',
+                imagePath: seerrGenreBackdropUrl(g.id, g.backdrops) ?? '',
                 type: 'Genre',
                 mediaType: 'movie',
                 filterType: 'genre',
@@ -2264,7 +2265,7 @@ class HomeViewModel extends ChangeNotifier {
               _seerrFilterItem(
                 id: g.id.toString(),
                 name: g.name,
-                imagePath: g.backdrops.isNotEmpty ? g.backdrops.first : '',
+                imagePath: seerrGenreBackdropUrl(g.id, g.backdrops) ?? '',
                 type: 'Genre',
                 mediaType: 'tv',
                 filterType: 'genre',

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -27,6 +27,8 @@ import '../../widgets/focus/locked_focus_row.dart';
 import '../../widgets/seerr/seerr_shortcuts.dart';
 import '../../widgets/horizontal_scroll_section.dart';
 import '../../widgets/quick_return_wrapper.dart';
+import '../../../util/seerr_genre_art.dart';
+import '../../widgets/seerr/seerr_genre_label.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w300';
 const _tmdbBackdropBase = 'https://image.tmdb.org/t/p/w1280';
@@ -790,9 +792,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       autofocus: autofocusFirst,
       focusNode: autofocusFirst ? firstFocusNode : null,
       itemBuilder: (context, genre, index, isFocused) {
-        final backdrop = genre.backdrops.isNotEmpty
-            ? '$_tmdbBackdropBase${genre.backdrops.first}'
-            : null;
+        final backdrop = seerrGenreBackdropUrl(genre.id, genre.backdrops);
         return _GenreCard(
           name: genre.name,
           imageUrl: backdrop,
@@ -1208,18 +1208,22 @@ class _GenreCardState extends State<_GenreCard> with FocusStateMixin {
                     )
                   else
                     Container(color: AppColorScheme.surfaceVariant),
-                  Container(
-                    decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          AppColorScheme.scrim.withValues(alpha: 0),
-                          AppColorScheme.scrim.withValues(alpha: 0.73),
-                        ],
+                  // A genre card carries its name across the middle. A
+                  // shortcut keeps the bottom gradient its lower-left label
+                  // needs, under the icon it shows instead.
+                  if (widget.icon != null)
+                    Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            AppColorScheme.scrim.withValues(alpha: 0),
+                            AppColorScheme.scrim.withValues(alpha: 0.73),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
                   if (widget.icon != null)
                     Center(
                       child: Icon(
@@ -1228,27 +1232,30 @@ class _GenreCardState extends State<_GenreCard> with FocusStateMixin {
                         color: AppColorScheme.onSurface.withValues(alpha: 0.8),
                       ),
                     ),
-                  Positioned(
-                    bottom: 8,
-                    left: 8,
-                    right: 8,
-                    child: Text(
-                      widget.name,
-                      style: TextStyle(
-                        color: AppColorScheme.onSurface,
-                        fontWeight: FontWeight.w600,
-                        fontSize: 14,
-                        shadows: [
-                          Shadow(
-                            blurRadius: 4,
-                            color: AppColorScheme.scrim,
-                          ),
-                        ],
+                  if (widget.icon == null)
+                    SeerrGenreLabel(name: widget.name)
+                  else
+                    Positioned(
+                      bottom: 8,
+                      left: 8,
+                      right: 8,
+                      child: Text(
+                        widget.name,
+                        style: TextStyle(
+                          color: AppColorScheme.onSurface,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14,
+                          shadows: [
+                            Shadow(
+                              blurRadius: 4,
+                              color: AppColorScheme.scrim,
+                            ),
+                          ],
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                     ),
-                  ),
                   if (effectiveFocused)
                     Container(
                       decoration: BoxDecoration(

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -108,6 +108,23 @@ class MediaCard extends StatefulWidget {
     this.isBanner = false,
   });
 
+  /// The genre name grows with the card, so it reads well both on a poster
+  /// and on a focused thumbnail. Long names shrink to fit.
+  static const _genreLabelRatio = 14 / 200;
+  static const _genreLabelMinSize = 14.0;
+  static const _genreLabelMaxSize = 24.0;
+
+  /// The Seerr genre rows draw their own label and call this, so both come out
+  /// the same size.
+  static double genreLabelFontSize(double cardWidth) =>
+      (cardWidth * _genreLabelRatio).clamp(
+        _genreLabelMinSize,
+        _genreLabelMaxSize,
+      );
+
+  /// Letter spacing grows with the text.
+  static double genreLabelLetterSpacing(double fontSize) => fontSize * 0.18;
+
   static IconData iconForType(String? type) {
     switch (type) {
       case 'Folder':
@@ -369,7 +386,10 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
                           height: titleLineHeight,
                           width: cardWidth,
                           child: showMarquee
-                              ? MarqueeText(text: widget.title!, style: titleStyle)
+                              ? MarqueeText(
+                                  text: widget.title!,
+                                  style: titleStyle,
+                                )
                               : Text(
                                   widget.title!,
                                   maxLines: 1,
@@ -622,7 +642,8 @@ class _CardImage extends StatelessWidget {
   Widget build(BuildContext context) {
     final radius = isCircular ? 999.0 : 8.0;
     final showBorder = !suppressFocusBorder && (focused || hovered);
-    final borderColor = focusColor ??
+    final borderColor =
+        focusColor ??
         (GlassFocusHalo.appleStyleActive
             ? Colors.white
             : Theme.of(context).colorScheme.primary);
@@ -678,7 +699,9 @@ class _CardImage extends StatelessWidget {
                           children: [
                             BoundedNetworkImage(
                               imageUrl: imageUrl!,
-                              fit: (itemType == 'Network' || itemType == 'Studio')
+                              fit:
+                                  (itemType == 'Network' ||
+                                      itemType == 'Studio')
                                   ? BoxFit.contain
                                   : BoxFit.cover,
                               fadeInDuration: Duration.zero,
@@ -694,26 +717,37 @@ class _CardImage extends StatelessWidget {
                                 color: Colors.black.withValues(alpha: 0.45),
                               ),
                               if (title != null && title!.isNotEmpty)
-                                Center(
-                                  child: Padding(
-                                    padding: const EdgeInsets.all(12.0),
-                                    child: FittedBox(
-                                      fit: BoxFit.scaleDown,
-                                      child: Text(
-                                        title!.toUpperCase(),
-                                        textAlign: TextAlign.center,
-                                        style: TextStyle(
-                                          fontSize: 14,
-                                          fontWeight: FontWeight.bold,
-                                          letterSpacing: 2.5,
-                                          color: Theme.of(context)
-                                              .colorScheme
-                                              .onSurface
-                                              .withValues(alpha: 0.9),
+                                LayoutBuilder(
+                                  builder: (context, constraints) {
+                                    final fontSize =
+                                        MediaCard.genreLabelFontSize(
+                                          constraints.maxWidth,
+                                        );
+                                    return Center(
+                                      child: Padding(
+                                        padding: const EdgeInsets.all(12.0),
+                                        child: FittedBox(
+                                          fit: BoxFit.scaleDown,
+                                          child: Text(
+                                            title!.toUpperCase(),
+                                            textAlign: TextAlign.center,
+                                            style: TextStyle(
+                                              fontSize: fontSize,
+                                              fontWeight: FontWeight.bold,
+                                              letterSpacing:
+                                                  MediaCard.genreLabelLetterSpacing(
+                                                    fontSize,
+                                                  ),
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .onSurface
+                                                  .withValues(alpha: 0.9),
+                                            ),
+                                          ),
                                         ),
                                       ),
-                                    ),
-                                  ),
+                                    );
+                                  },
                                 ),
                             ],
                           ],

--- a/lib/ui/widgets/seerr/seerr_genre_label.dart
+++ b/lib/ui/widgets/seerr/seerr_genre_label.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../media_card.dart';
+
 /// The genre name across the middle of its artwork, the way Seerr shows it, in
-/// the same lettering as the Jellyfin genre row so the two rows match. It darkens
-/// the image behind the text: some duotone backdrops come out light enough that
-/// white text would be hard to read on them.
+/// the same lettering and size as the Jellyfin genre row.
 class SeerrGenreLabel extends StatelessWidget {
   const SeerrGenreLabel({super.key, required this.name});
 
@@ -13,23 +13,27 @@ class SeerrGenreLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: AppColorScheme.scrim.withValues(alpha: 0.3),
-      alignment: Alignment.center,
-      padding: const EdgeInsets.all(12),
-      child: FittedBox(
-        fit: BoxFit.scaleDown,
-        child: Text(
-          name.toUpperCase(),
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 14,
-            fontWeight: FontWeight.bold,
-            letterSpacing: 2.5,
-            color: AppColorScheme.onSurface.withValues(alpha: 0.9),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final fontSize = MediaCard.genreLabelFontSize(constraints.maxWidth);
+        return Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.all(12),
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Text(
+              name.toUpperCase(),
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: fontSize,
+                fontWeight: FontWeight.bold,
+                letterSpacing: MediaCard.genreLabelLetterSpacing(fontSize),
+                color: AppColorScheme.onSurface.withValues(alpha: 0.9),
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/widgets/seerr/seerr_genre_label.dart
+++ b/lib/ui/widgets/seerr/seerr_genre_label.dart
@@ -9,6 +9,12 @@ import '../media_card.dart';
 class SeerrGenreLabel extends StatelessWidget {
   const SeerrGenreLabel({super.key, required this.name});
 
+  /// Darkens the artwork behind the name. Several duotone pairs, the yellow
+  /// and the light green among them, come out bright enough that white
+  /// lettering is hard to read straight on top of them. Lighter than the
+  /// Jellyfin genre row's veil, since the point of the duotone is its colour.
+  static const scrimOpacity = 0.3;
+
   final String name;
 
   @override
@@ -19,6 +25,7 @@ class SeerrGenreLabel extends StatelessWidget {
         return Container(
           alignment: Alignment.center,
           padding: const EdgeInsets.all(12),
+          color: AppColorScheme.scrim.withValues(alpha: scrimOpacity),
           child: FittedBox(
             fit: BoxFit.scaleDown,
             child: Text(

--- a/lib/ui/widgets/seerr/seerr_genre_label.dart
+++ b/lib/ui/widgets/seerr/seerr_genre_label.dart
@@ -27,7 +27,6 @@ class SeerrGenreLabel extends StatelessWidget {
             fontWeight: FontWeight.bold,
             letterSpacing: 2.5,
             color: AppColorScheme.onSurface.withValues(alpha: 0.9),
-            shadows: [Shadow(blurRadius: 4, color: AppColorScheme.scrim)],
           ),
         ),
       ),

--- a/lib/ui/widgets/seerr/seerr_genre_label.dart
+++ b/lib/ui/widgets/seerr/seerr_genre_label.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import 'package:moonfin_design/moonfin_design.dart';
+
+/// The genre name across the middle of its artwork, the way Seerr shows it, in
+/// the same lettering as the Jellyfin genre row so the two rows match. It darkens
+/// the image behind the text: some duotone backdrops come out light enough that
+/// white text would be hard to read on them.
+class SeerrGenreLabel extends StatelessWidget {
+  const SeerrGenreLabel({super.key, required this.name});
+
+  final String name;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: AppColorScheme.scrim.withValues(alpha: 0.3),
+      alignment: Alignment.center,
+      padding: const EdgeInsets.all(12),
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(
+          name.toUpperCase(),
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 2.5,
+            color: AppColorScheme.onSurface.withValues(alpha: 0.9),
+            shadows: [Shadow(blurRadius: 4, color: AppColorScheme.scrim)],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/seerr_genre_art.dart
+++ b/lib/util/seerr_genre_art.dart
@@ -1,0 +1,60 @@
+/// Genre artwork the way Seerr builds it: TMDB recolours the backdrop through its
+/// duotone filter, so a genre keeps its own colour even when two genres end up on
+/// the same film. The colours and the genre they belong to come from Overseerr
+/// (MIT).
+library;
+
+const _black = ('1F2937', 'D1D5DB');
+const _red = ('991B1B', 'FCA5A5');
+const _darkred = ('1F2937', 'F87171');
+const _blue = ('032541', '01b4e4');
+const _lightblue = ('1F2937', '60A5FA');
+const _darkblue = ('1F2937', '2864d2');
+const _orange = ('92400E', 'FCD34D');
+const _darkorange = ('552c01', 'd47c1d');
+const _lightgreen = ('065F46', '6EE7B7');
+const _purple = ('5B21B6', 'C4B5FD');
+const _darkpurple = ('480c8b', 'a96bef');
+const _yellow = ('777e0d', 'e4ed55');
+const _pink = ('9D174D', 'F9A8D4');
+
+const _genreTones = <int, (String, String)>{
+  28: _red, // Action
+  12: _darkpurple, // Adventure
+  16: _blue, // Animation
+  35: _orange, // Comedy
+  80: _darkblue, // Crime
+  99: _lightgreen, // Documentary
+  18: _pink, // Drama
+  10751: _yellow, // Family
+  14: _lightblue, // Fantasy
+  36: _orange, // History
+  27: _black, // Horror
+  10402: _blue, // Music
+  9648: _purple, // Mystery
+  10749: _pink, // Romance
+  878: _lightblue, // Science Fiction
+  10770: _red, // TV Movie
+  53: _black, // Thriller
+  10752: _darkred, // War
+  37: _orange, // Western
+  10759: _darkpurple, // Action & Adventure
+  10762: _blue, // Kids
+  10763: _black, // News
+  10764: _darkorange, // Reality
+  10765: _lightblue, // Sci-Fi & Fantasy
+  10766: _pink, // Soap
+  10767: _lightgreen, // Talk
+  10768: _darkred, // War & Politics
+};
+
+/// The duotone backdrop for a genre row card, or null when the genre came back
+/// without artwork.
+String? seerrGenreBackdropUrl(int genreId, List<String> backdrops) {
+  if (backdrops.isEmpty) return null;
+  final (dark, light) = _genreTones[genreId] ?? _black;
+  // Seerr skips the front of the list: those are the most popular films, and a
+  // popular film sits in several genres, so it is what shows up twice.
+  final path = backdrops.length > 4 ? backdrops[4] : backdrops.last;
+  return 'https://image.tmdb.org/t/p/w1280_filter(duotone,$dark,$light)$path';
+}

--- a/test/ui/widgets/seerr/seerr_genre_label_test.dart
+++ b/test/ui/widgets/seerr/seerr_genre_label_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/media_card.dart';
+import 'package:moonfin/ui/widgets/seerr/seerr_genre_label.dart';
+
+const _cardSize = Size(200, 300);
+
+/// The home rows hand the label to the card as a filled overlay, while the
+/// discover grid drops it straight into a stack. Both have to darken the whole
+/// card, so both are covered here.
+Future<void> _pump(
+  WidgetTester tester, {
+  required bool positioned,
+  Size size = _cardSize,
+}) async {
+  const label = SeerrGenreLabel(name: 'Science Fiction');
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: size.width,
+            height: size.height,
+            child: Stack(
+              children: [
+                if (positioned) const Positioned.fill(child: label) else label,
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+final _scrim = find.descendant(
+  of: find.byType(SeerrGenreLabel),
+  matching: find.byType(Container),
+);
+
+void main() {
+  for (final positioned in [true, false]) {
+    final where = positioned ? 'as a filled overlay' : 'as a bare stack child';
+
+    group(where, () {
+      testWidgets('shows the genre name in capitals', (tester) async {
+        await _pump(tester, positioned: positioned);
+        expect(find.text('SCIENCE FICTION'), findsOneWidget);
+      });
+
+      // Without this the name sits straight on the duotone artwork, and the
+      // lighter genre colours leave it barely readable.
+      testWidgets('darkens the artwork behind the name', (tester) async {
+        await _pump(tester, positioned: positioned);
+
+        final color = tester.widget<Container>(_scrim).color;
+        expect(color, isNotNull);
+        expect(color!.a, closeTo(SeerrGenreLabel.scrimOpacity, 0.001));
+      });
+
+      testWidgets('the darkening covers the whole card', (tester) async {
+        await _pump(tester, positioned: positioned);
+
+        final box = tester.renderObject<RenderBox>(_scrim);
+        expect(box.size, _cardSize);
+      });
+    });
+  }
+
+  testWidgets('the lettering grows with the card', (tester) async {
+    await _pump(tester, positioned: true);
+    final small = tester.widget<Text>(find.text('SCIENCE FICTION')).style!;
+
+    await _pump(tester, positioned: true, size: const Size(600, 900));
+    final large = tester.widget<Text>(find.text('SCIENCE FICTION')).style!;
+
+    expect(large.fontSize, greaterThan(small.fontSize!));
+    expect(
+      small.fontSize,
+      MediaCard.genreLabelFontSize(_cardSize.width),
+      reason: 'it sizes off the card, same as the jellyfin genre row',
+    );
+  });
+}

--- a/test/util/seerr_genre_art_test.dart
+++ b/test/util/seerr_genre_art_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/seerr_genre_art.dart';
+
+/// TMDB paths carry their leading slash, so the built URL joins without one.
+const _backdrops = [
+  '/first.jpg',
+  '/second.jpg',
+  '/third.jpg',
+  '/fourth.jpg',
+  '/fifth.jpg',
+  '/sixth.jpg',
+];
+
+const _action = 28;
+const _horror = 27;
+const _sciFi = 878;
+
+void main() {
+  group('which backdrop it picks', () {
+    test('takes the fifth, past the popular films at the front', () {
+      expect(
+        seerrGenreBackdropUrl(_action, _backdrops),
+        endsWith('/fifth.jpg'),
+      );
+    });
+
+    test('a short list falls back to the last entry', () {
+      expect(
+        seerrGenreBackdropUrl(_action, const ['/only.jpg', '/second.jpg']),
+        endsWith('/second.jpg'),
+      );
+    });
+
+    test('a single backdrop is still usable', () {
+      expect(
+        seerrGenreBackdropUrl(_action, const ['/only.jpg']),
+        endsWith('/only.jpg'),
+      );
+    });
+
+    test('exactly five takes the last, which is also the fifth', () {
+      expect(
+        seerrGenreBackdropUrl(_action, _backdrops.take(5).toList()),
+        endsWith('/fifth.jpg'),
+      );
+    });
+
+    test('no artwork gives no url', () {
+      expect(seerrGenreBackdropUrl(_action, const []), isNull);
+    });
+  });
+
+  group('the duotone it asks TMDB for', () {
+    test('builds the filter url around the genre colours', () {
+      expect(
+        seerrGenreBackdropUrl(_action, _backdrops),
+        'https://image.tmdb.org/t/p/w1280_filter(duotone,991B1B,FCA5A5)/fifth.jpg',
+      );
+    });
+
+    // Two genres often share the same popular film, which is what used to
+    // make their cards identical. The colours are what keep them apart.
+    test('two genres sharing a backdrop still get different art', () {
+      final action = seerrGenreBackdropUrl(_action, _backdrops);
+      final sciFi = seerrGenreBackdropUrl(_sciFi, _backdrops);
+
+      expect(action, isNot(sciFi));
+      expect(action, endsWith('/fifth.jpg'));
+      expect(sciFi, endsWith('/fifth.jpg'));
+    });
+
+    test('a genre the list doesn\'t name still gets a colour', () {
+      final unknown = seerrGenreBackdropUrl(-1, _backdrops);
+
+      expect(unknown, isNotNull);
+      expect(unknown, contains('_filter(duotone,'));
+      expect(
+        unknown,
+        seerrGenreBackdropUrl(_horror, _backdrops),
+        reason: 'the fallback is the same tone horror uses',
+      );
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Seerr genre cards all looked alike. Genres that share a popular film got the same backdrop, because we took `backdrops.first` and the most popular film is exactly the one several genres have in common. On top of that, the film row and the show row showed identical images: `home_screen.dart` remembers image URLs under the item's id, and for a genre card that id is the TMDB genre id, the same in both rows. Cards now build their backdrop the way Seerr's own client does, through TMDB's duotone filter, so every genre has its own colour and stays distinct even when two land on the same film.

## Related Issues

- Closes #1195 
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- New `lib/util/seerr_genre_art.dart`: `seerrGenreBackdropUrl()` builds the TMDB `w1280_filter(duotone,…)` URL for a genre. The colours and the genre they belong to are taken from Seerr, so a genre looks the same here as it does there. It reads `backdrops[4]`, again matching Seerr: the first few entries are the most popular films, and those are what repeat across genres.
- New `lib/ui/widgets/seerr/seerr_genre_label.dart`: the genre name across the middle of the card, with the backdrop darkened 30% behind it, since some duotone backdrops come out light enough that white text is hard to read on them. It uses the same lettering as the Jellyfin genre row so the two rows look like they belong to the same app.
- Add `MediaType` to the name `_cachedRowImageUrl()` files its results under. Without it the show row gets handed the film row's image for every genre the two have in common.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Enable both Seerr genre rows on Home. Each card has its own colour, and the repeats between genres are gone.
2. The genre name reads across the middle of the artwork and also under the card, matching the Jellyfin genre row.
3. Seerr --> Discover: the genre cards match the home rows. The shortcut cards next to them are unchanged.

## Screenshots (if applicable)

### Before
<img width="1840" height="1115" alt="Screenshot 2026-08-19 at 18 14 54" src="https://github.com/user-attachments/assets/b09e614a-48fe-453c-888c-ba1105515dc2" />

### After (two screenshots as my branch include the #1184 change)
Classic:
<img width="1840" height="1115" alt="Screenshot 2026-08-19 at 17 31 26" src="https://github.com/user-attachments/assets/8a96e712-1515-4916-b15b-cfdaaaabc172" />
Modern:
<img width="1840" height="1115" alt="Screenshot 2026-08-19 at 17 32 04" src="https://github.com/user-attachments/assets/4f870374-699b-4491-a5ea-a5222935e77e" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
