### PR TITLE
feat(media-bar): add Aya media bar style

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4667,6 +4667,10 @@
   "@mediaBarModeBanner": {
     "description": "Media bar style option: Banner"
   },
+  "mediaBarModeAya": "Aya",
+  "@mediaBarModeAya": {
+    "description": "Media bar style option: Aya"
+  },
   "enableMediaBar": "Enable Media Bar",
   "@enableMediaBar": {
     "description": "Setting for enabling media bar"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6208,6 +6208,12 @@ abstract class AppLocalizations {
   /// **'Banner'**
   String get mediaBarModeBanner;
 
+  /// Media bar style option: Aya
+  ///
+  /// In en, this message translates to:
+  /// **'Aya'**
+  String get mediaBarModeAya;
+
   /// Setting for enabling media bar
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3428,6 +3428,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktiveer mediabalk';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3436,6 +3436,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'تمكين شريط الوسائط';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3444,6 +3444,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Уключыць медыяпанэль';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3444,6 +3444,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Активиране на медийната лента';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3417,6 +3417,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'মিডিয়া বার সক্রিয় করুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3468,6 +3468,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Activa la barra multimèdia';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3439,6 +3439,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Povolit panel médií';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3452,6 +3452,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Galluogi Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3425,6 +3425,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktiver Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3514,6 +3514,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Medienleiste aktivieren';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3463,6 +3463,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Ενεργοποιήστε τη γραμμή πολυμέσων';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3409,6 +3409,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Enable Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3423,6 +3423,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Ebligu Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3447,6 +3447,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Habilitar barra de medios';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3432,6 +3432,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Luba meediariba';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3405,6 +3405,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'نوار رسانه را فعال کنید';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3441,6 +3441,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Ota Media Bar käyttöön';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3470,6 +3470,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Activer la barre média';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3462,6 +3462,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Activar a barra multimedia';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3399,6 +3399,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'הפעל את סרגל המדיה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3415,6 +3415,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'मीडिया बार सक्षम करें';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3550,6 +3550,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Omogući medijsku traku';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3448,6 +3448,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Médiasáv engedélyezése';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3426,6 +3426,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktifkan Bar Media';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3446,6 +3446,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Abilita Barra Media';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3357,6 +3357,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'メディアバーを有効にする';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3437,6 +3437,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Медиа жолағын қосыңыз';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3443,6 +3443,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'ಮೀಡಿಯಾ ಬಾರ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3350,6 +3350,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => '미디어 바 활성화';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3443,6 +3443,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Įgalinti medijos juostą';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3444,6 +3444,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Iespējot multivides joslu';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3444,6 +3444,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Овозможи медиумска лента';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3445,6 +3445,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'മീഡിയ ബാർ പ്രവർത്തനക്ഷമമാക്കുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3429,6 +3429,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Медиа мөрийг идэвхжүүлнэ үү';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3422,6 +3422,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktiver Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3444,6 +3444,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Mediabalk inschakelen';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3416,6 +3416,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'ਮੀਡੀਆ ਬਾਰ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3431,6 +3431,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Włącz pasek multimediów';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3441,6 +3441,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Habilitar Barra de Mídia';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3449,6 +3449,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Activați bara media';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3454,6 +3454,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Включить медиа-панель';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3422,6 +3422,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'මාධ්‍ය තීරුව සබල කරන්න';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3449,6 +3449,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Povoliť panel médií';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3451,6 +3451,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Omogoči vrstico z mediji';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3450,6 +3450,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktivizo shiritin e medias';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3549,6 +3549,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Омогући траку медија';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3431,6 +3431,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Aktivera Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3447,6 +3447,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Washa Upau wa Midia';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3448,6 +3448,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'மீடியா பட்டியை இயக்கு';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3443,6 +3443,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'మీడియా బార్‌ని ప్రారంభించండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3404,6 +3404,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'เปิดใช้งานแถบสื่อ';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3452,6 +3452,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Paganahin ang Media Bar';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3433,6 +3433,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Medya Çubuğunu Etkinleştir';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3431,6 +3431,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Media Bar نى قوزغىتىڭ';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3450,6 +3450,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Увімкнути мультимедійну панель';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3428,6 +3428,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => 'Bật thanh phương tiện';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -3327,6 +3327,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => '啟用媒體欄';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3312,6 +3312,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mediaBarModeBanner => 'Banner';
 
   @override
+  String get mediaBarModeAya => 'Aya';
+
+  @override
   String get enableMediaBar => '启用媒体栏';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -25,6 +25,7 @@ class UserPreferences extends ChangeNotifier {
   static const mediaBarModeBookshelf = 'bookshelf';
   static const mediaBarModeGallery = 'gallery';
   static const mediaBarModeBanner = 'banner';
+  static const mediaBarModeAya = 'aya';
   static const mediaBarModeOff = 'off';
   static const mediaBarModeValues = <String>{
     mediaBarModeMoonfin,
@@ -32,6 +33,7 @@ class UserPreferences extends ChangeNotifier {
     mediaBarModeBookshelf,
     mediaBarModeGallery,
     mediaBarModeBanner,
+    mediaBarModeAya,
     mediaBarModeOff,
   };
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2170,7 +2170,10 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   void _navigateFromMediaBarToNavbar() {
-    widget.onItemSelected(null);
+    widget.onItemSelected(
+      null,
+      preserveBackground: _isAyaMode(),
+    );
     if (_scrollController.hasClients && _scrollController.offset > 0) {
       unawaited(
         _scrollController.animateTo(

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -310,7 +310,10 @@ class _HomeShellState extends State<_HomeShell>
     setState(() {});
   }
 
-  void onItemSelected(AggregatedItem? item) {
+  void onItemSelected(
+      AggregatedItem? item, {
+        bool preserveBackground = false,
+      }) {
     _selectionDebounce?.cancel();
     _selectionDebounce = Timer(_selectionDelay, () {
       if (!mounted) return;
@@ -323,9 +326,15 @@ class _HomeShellState extends State<_HomeShell>
       });
 
       _backdropDebounce?.cancel();
-      _backdropDebounce = Timer(_backdropDelay, () {
-        _backgroundService.setBackground(item, context: BlurContext.browsing);
-      });
+
+      if (!preserveBackground) {
+        _backdropDebounce = Timer(_backdropDelay, () {
+          _backgroundService.setBackground(
+            item,
+            context: BlurContext.browsing,
+          );
+        });
+      }
 
       _maybePlayThemeMusic(item);
     });
@@ -621,7 +630,10 @@ class _ContentRows extends StatefulWidget {
   final MediaBarViewModel mediaBarViewModel;
   final UserPreferences prefs;
   final ValueNotifier<AggregatedItem?> selectedItemNotifier;
-  final ValueChanged<AggregatedItem?> onItemSelected;
+  final void Function(
+      AggregatedItem? item, {
+      bool preserveBackground,
+      }) onItemSelected;
   final ValueNotifier<bool> isHoverPausedNotifier;
   final ValueNotifier<bool> isScrolledToTopNotifier;
   final ValueChanged<bool>? onScrolledToTopChanged;
@@ -2307,7 +2319,10 @@ class _ContentRowsState extends State<_ContentRows>
     _verticalNavInFlight = true;
     try {
       _finishSharedPreview(releaseResources: true);
-      widget.onItemSelected(null);
+      widget.onItemSelected(
+          null,
+          preserveBackground: _isAyaMode(),
+      );
       if (mounted) {
         setState(() {
           _infoRevealedNotifier.value = false;

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -2079,6 +2079,10 @@ class _ContentRowsState extends State<_ContentRows>
       return 200.0;
     }
 
+    if (_isAyaMode()) {
+      return screenHeight * 0.65;
+    }
+
     if (!PlatformDetection.useMobileUi) {
       return screenHeight;
     }
@@ -2111,6 +2115,13 @@ class _ContentRowsState extends State<_ContentRows>
       widget.prefs.get(UserPreferences.mediaBarMode),
     );
     return mode == UserPreferences.mediaBarModeBanner;
+  }
+
+  bool _isAyaMode() {
+    final mode = UserPreferences.normalizeMediaBarMode(
+      widget.prefs.get(UserPreferences.mediaBarMode),
+    );
+    return mode == UserPreferences.mediaBarModeAya;
   }
 
   double _pinnedInfoCollapseOffset() {

--- a/lib/ui/screens/settings/media_bar_settings_screen.dart
+++ b/lib/ui/screens/settings/media_bar_settings_screen.dart
@@ -361,6 +361,7 @@ class _MediaBarSettingsScreenState extends State<MediaBarSettingsScreen> {
                         l10n.mediaBarModeBookshelf,
                     UserPreferences.mediaBarModeGallery: l10n.mediaBarModeGallery,
                     UserPreferences.mediaBarModeBanner: l10n.mediaBarModeBanner,
+                    UserPreferences.mediaBarModeAya: l10n.mediaBarModeAya,
                     UserPreferences.mediaBarModeOff: l10n.mediaBarModeOff,
                   },
                   onChanged: _pushSync,

--- a/lib/ui/screens/setup/setup_wizard_previews.dart
+++ b/lib/ui/screens/setup/setup_wizard_previews.dart
@@ -227,6 +227,7 @@ Widget mediaBarPreview(String mode) => _liveOrFallback(
     UserPreferences.mediaBarModeBookshelf => _bookshelfBar(context, items),
     UserPreferences.mediaBarModeGallery => _galleryBar(context, items),
     UserPreferences.mediaBarModeBanner => _bannerBar(context, items),
+    UserPreferences.mediaBarModeAya => _ayaBar(context, items),
     // The rows carry the whole screen with the bar off, so the preview packs
     // them tighter than the style default to show more than one.
     UserPreferences.mediaBarModeOff => _homeRowsScreen(
@@ -273,6 +274,7 @@ Widget _dots({
   required double inactiveAlpha,
   double gap = 4,
   bool pillActive = false,
+  double? height,
 }) {
   return Row(
     mainAxisSize: MainAxisSize.min,
@@ -280,7 +282,8 @@ Widget _dots({
       for (var i = 0; i < count; i++)
         Container(
           width: i == 0 ? active : inactive,
-          height: i == 0 ? (pillActive ? inactive : active) : inactive,
+          height:
+              height ?? (i == 0 ? (pillActive ? inactive : active) : inactive),
           margin: EdgeInsets.symmetric(horizontal: gap),
           decoration: BoxDecoration(
             shape: pillActive ? BoxShape.rectangle : BoxShape.circle,
@@ -1479,6 +1482,92 @@ Widget _bannerBar(BuildContext context, List<MediaBarSlideItem> items) {
   );
 }
 
+/// Artwork first, with the logo top left and the page marks top right. The
+/// bar takes 65 percent of the screen on every platform, so the rows always
+/// show underneath it.
+Widget _ayaBar(BuildContext context, List<MediaBarSlideItem> items) {
+  final item = items.first;
+  final size = _designSize();
+
+  final padding = _phone
+      ? const EdgeInsets.fromLTRB(16, 60, 16, 16)
+      : EdgeInsets.fromLTRB(_tv ? 80 : 32, _tv ? 71 : 32, _tv ? 80 : 32, 32);
+
+  // Phones preview in portrait, which is where the poster is used.
+  final artwork = _phone
+      ? (item.posterUrl ?? item.backdropUrl)
+      : item.backdropUrl;
+
+  final bar = Padding(
+    padding: padding,
+    child: ClipRRect(
+      borderRadius: AppRadius.circular(18),
+      child: SizedBox(
+        height: size.height * 0.65 - padding.vertical,
+        width: double.infinity,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            _artwork(artwork),
+            Positioned(
+              left: 44,
+              top: 40,
+              child: _logoOrTitle(
+                item,
+                width: 340,
+                height: 100,
+                alignment: Alignment.topLeft,
+                fallbackStyle: TextStyle(
+                  fontSize: 32,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: -0.5,
+                  height: 1.0,
+                  color: AppColorScheme.onSurface,
+                  shadows: [
+                    Shadow(
+                      blurRadius: 20,
+                      color: AppColorScheme.scrim.withValues(alpha: 0.72),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              top: 22,
+              right: 24,
+              child: _dots(
+                count: 5,
+                active: 16,
+                inactive: 10,
+                inactiveAlpha: 0.30,
+                gap: 2.5,
+                pillActive: true,
+                height: 2,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      bar,
+      Expanded(
+        child: ClipRect(
+          child: OverflowBox(
+            alignment: Alignment.topCenter,
+            maxHeight: double.infinity,
+            child: _homeRowsColumn(context, items, modern: !_phone),
+          ),
+        ),
+      ),
+    ],
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Home rows
 // ---------------------------------------------------------------------------
@@ -2556,6 +2645,34 @@ Widget _fallbackMediaBar(String mode) => switch (mode) {
         _posterCard(22),
         Opacity(opacity: 0.5, child: _posterCard(14)),
         Opacity(opacity: 0.5, child: _posterCard(14)),
+      ],
+    ),
+  ),
+  UserPreferences.mediaBarModeAya => Padding(
+    padding: const EdgeInsets.all(6),
+    child: Stack(
+      fit: StackFit.expand,
+      children: [
+        ClipRRect(borderRadius: AppRadius.circular(6), child: _backdrop()),
+        Padding(
+          padding: const EdgeInsets.all(8),
+          child: Align(
+            alignment: Alignment.topLeft,
+            child: _bar(42, 5, _strong),
+          ),
+        ),
+        Positioned(
+          top: 6,
+          right: 6,
+          child: Row(
+            spacing: 2,
+            children: [
+              _bar(8, 2, _strong),
+              _bar(5, 2, _weak),
+              _bar(5, 2, _weak),
+            ],
+          ),
+        ),
       ],
     ),
   ),

--- a/lib/ui/screens/setup/setup_wizard_screen.dart
+++ b/lib/ui/screens/setup/setup_wizard_screen.dart
@@ -376,6 +376,7 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
       UserPreferences.mediaBarModeBookshelf,
       UserPreferences.mediaBarModeGallery,
       UserPreferences.mediaBarModeBanner,
+      UserPreferences.mediaBarModeAya,
       UserPreferences.mediaBarModeOff,
     ];
     final labels = {
@@ -384,14 +385,17 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
       UserPreferences.mediaBarModeBookshelf: l10n.mediaBarModeBookshelf,
       UserPreferences.mediaBarModeGallery: l10n.mediaBarModeGallery,
       UserPreferences.mediaBarModeBanner: l10n.mediaBarModeBanner,
+      UserPreferences.mediaBarModeAya: l10n.mediaBarModeAya,
       UserPreferences.mediaBarModeOff: l10n.mediaBarModeOff,
     };
     final selected = _mediaBar ?? _prefs.get(UserPreferences.mediaBarMode);
 
     return _OptionLayout(
+      // A remote only moves along one row comfortably, so leanback fits every
+      // style on a single line and lets the card width shrink to suit.
       columns: PlatformDetection.useMobileUi
           ? 2
-          : (PlatformDetection.useLeanbackUi ? 6 : 3),
+          : (PlatformDetection.useLeanbackUi ? modes.length : 4),
       children: [
         for (var i = 0; i < modes.length; i++)
           _OptionCard(

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2669,6 +2669,10 @@ class _MediaBarState extends State<MediaBar>
       _currentIndex = clampedIndex;
     }
 
+    final trailerOverlays = _buildVideoOverlays(
+      allowPersistentMedia3: true,
+    );
+
     return MouseRegion(
       onEnter: (_) => _setPaused(true),
       onExit: (_) => _setPaused(false),
@@ -2705,6 +2709,12 @@ class _MediaBarState extends State<MediaBar>
             padding: _ayaMediaBarInsets(),
             focusExpansionEnabled: widget.prefs.get(
               UserPreferences.cardFocusExpansion,
+            ),
+            trailerOverlay: trailerOverlays.isEmpty
+                ? null
+                : Stack(
+              fit: StackFit.expand,
+              children: trailerOverlays,
             ),
             onAmbientItemChanged: (item) {
               final backdropUrl = item.backdropUrl;

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -43,6 +43,7 @@ import 'bounded_network_image.dart';
 import 'fullscreen_backdrop_switcher.dart';
 import 'navigation_layout.dart';
 import 'mediabar/bookshelf_layout.dart';
+import 'mediabar/aya_media_bar.dart';
 import 'mediabar/gallery_coverflow.dart';
 import 'mediabar/gallery_layout.dart';
 import 'mediabar/media_bar_status_focus.dart';
@@ -2622,7 +2623,10 @@ class _MediaBarState extends State<MediaBar>
       BuildContext context,
       List<MediaBarSlideItem> items,
       ) {
-    return _buildSlideshow(context, items);
+    return AyaMediaBar(
+      items: items,
+      height: widget.height,
+    );
   }
 
   void _selectGalleryIndex(int index) {

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:ui';
 
+import 'package:moonfin/ui/widgets/top_toolbar.dart';
+
 import 'offline_aware_image.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
@@ -2619,6 +2621,44 @@ class _MediaBarState extends State<MediaBar>
     );
   }
 
+  EdgeInsets _ayaMediaBarInsets() {
+    final navbarIsTop =
+        widget.prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+    final isTvTopNavbar =
+        navbarIsTop &&
+            PlatformDetection.isTV &&
+            !PlatformDetection.useMobileUi;
+    final hasDesktopSidebar =
+        !navbarIsTop && !PlatformDetection.useMobileUi;
+
+    final safeTop = MediaQuery.paddingOf(context).top;
+
+    const contentPadding = 32.0;
+    const tvTopNavbarHorizontalInset = 48.0;
+    const desktopSidebarInset = 56.0;
+    const desktopToolbarVerticalPadding = 10.0;
+
+    final navigationLeftInset = isTvTopNavbar
+        ? tvTopNavbarHorizontalInset
+        : hasDesktopSidebar
+        ? desktopSidebarInset
+        : 0.0;
+
+    final topInset = navbarIsTop
+        ? safeTop +
+        TopToolbar.heightFor(context) -
+        desktopToolbarVerticalPadding +
+        contentPadding
+        : contentPadding;
+
+    return EdgeInsets.fromLTRB(
+      navigationLeftInset + contentPadding,
+      topInset,
+      contentPadding,
+      contentPadding,
+    );
+  }
+
   Widget _buildAyaSlideshow(
       BuildContext context,
       List<MediaBarSlideItem> items,
@@ -2645,6 +2685,7 @@ class _MediaBarState extends State<MediaBar>
             items: items,
             activeIndex: clampedIndex,
             height: widget.height,
+            padding: _ayaMediaBarInsets(),
           ),
         ),
       ),

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2639,7 +2639,7 @@ class _MediaBarState extends State<MediaBar>
     final hasDesktopSidebar =
         !navbarIsTop && !isMobile;
 
-    final safeTop = MediaQuery.paddingOf(context).top;
+    final safePadding = MediaQuery.paddingOf(context);
 
     const contentPadding = 32.0;
     const mobileHorizontalPadding = 16.0;
@@ -2649,16 +2649,16 @@ class _MediaBarState extends State<MediaBar>
     const desktopToolbarVerticalPadding = 10.0;
 
     if (isMobile) {
-      final topInset = safeTop +
+      final topInset = safePadding.top +
           (navbarIsTop
               ? TopToolbar.heightFor(context) + 12.0
               : 16.0);
 
       return EdgeInsets.fromLTRB(
-        mobileHorizontalPadding,
+        mobileHorizontalPadding + safePadding.left,
         topInset,
-        mobileHorizontalPadding,
-        mobileBottomPadding - 16.0,
+        mobileHorizontalPadding + safePadding.right,
+        mobileBottomPadding,
       );
     }
 
@@ -2673,7 +2673,7 @@ class _MediaBarState extends State<MediaBar>
         : contentPadding;
 
     final topInset = navbarIsTop
-        ? safeTop +
+        ? safePadding.top +
         TopToolbar.heightFor(context) -
         desktopToolbarVerticalPadding +
         contentPadding
@@ -2755,18 +2755,16 @@ class _MediaBarState extends State<MediaBar>
               fit: StackFit.expand,
               children: trailerOverlays,
             ),
-            onAmbientItemChanged: (item) {
-              final backdropUrl = item.backdropUrl;
+              onAmbientArtworkChanged: (artworkUrl) {
+                if (artworkUrl == null || artworkUrl.isEmpty) {
+                  return;
+                }
 
-              if (backdropUrl == null || backdropUrl.isEmpty) {
-                return;
-              }
-
-              _backgroundService.setBackgroundUrl(
-                backdropUrl,
-                context: BlurContext.browsing,
-              );
-            },
+                _backgroundService.setBackgroundUrl(
+                  artworkUrl,
+                  context: BlurContext.browsing,
+                );
+              },
           ),
         ),
       ),

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -558,6 +558,14 @@ class _MediaBarState extends State<MediaBar>
     return mode == UserPreferences.mediaBarModeMakd;
   }
 
+  bool _isAyaMobileMode() {
+    if (!PlatformDetection.useMobileUi) return false;
+    final mode = UserPreferences.normalizeMediaBarMode(
+      widget.prefs.get(UserPreferences.mediaBarMode),
+    );
+    return mode == UserPreferences.mediaBarModeAya;
+  }
+
   void _prefetchAllInBackground(
     List<MediaBarSlideItem> items,
     int centerIndex,
@@ -639,7 +647,7 @@ class _MediaBarState extends State<MediaBar>
     if (!mounted) return;
     setState(() {});
 
-    if (_isMakdMobileMode()) {
+    if (_isMakdMobileMode() || _isAyaMobileMode()) {
       _cancelTrailerPreview();
       return;
     }
@@ -853,7 +861,7 @@ class _MediaBarState extends State<MediaBar>
   }
 
   void _scheduleTrailerPreview(MediaBarSlideItem item) {
-    if (_isMakdMobileMode() || _isBookshelfMode()) {
+    if (_isMakdMobileMode() || _isBookshelfMode() || _isAyaMobileMode()) {
       _cancelTrailerPreview();
       return;
     }
@@ -2624,19 +2632,35 @@ class _MediaBarState extends State<MediaBar>
   EdgeInsets _ayaMediaBarInsets() {
     final navbarIsTop =
         widget.prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+
+    final isMobile = PlatformDetection.useMobileUi;
     final isTvTopNavbar =
-        navbarIsTop &&
-            PlatformDetection.isTV &&
-            !PlatformDetection.useMobileUi;
+        navbarIsTop && PlatformDetection.isTV && !isMobile;
     final hasDesktopSidebar =
-        !navbarIsTop && !PlatformDetection.useMobileUi;
+        !navbarIsTop && !isMobile;
 
     final safeTop = MediaQuery.paddingOf(context).top;
 
     const contentPadding = 32.0;
+    const mobileHorizontalPadding = 16.0;
+    const mobileBottomPadding = 16.0;
     const tvTopNavbarHorizontalInset = 48.0;
     const desktopSidebarInset = 56.0;
     const desktopToolbarVerticalPadding = 10.0;
+
+    if (isMobile) {
+      final topInset = safeTop +
+          (navbarIsTop
+              ? TopToolbar.heightFor(context) + 12.0
+              : 16.0);
+
+      return EdgeInsets.fromLTRB(
+        mobileHorizontalPadding,
+        topInset,
+        mobileHorizontalPadding,
+        mobileBottomPadding - 16.0,
+      );
+    }
 
     final leftInset = isTvTopNavbar
         ? tvTopNavbarHorizontalInset + contentPadding
@@ -2706,6 +2730,17 @@ class _MediaBarState extends State<MediaBar>
         child: GestureDetector(
           onTap: () => _navigateToItem(context, items),
           onLongPress: () => _navigateToItemAndPlay(context, items),
+          onHorizontalDragEnd: PlatformDetection.useMobileUi
+              ? (details) {
+            final velocity = details.primaryVelocity ?? 0;
+
+            if (velocity < -300 && _currentIndex < items.length - 1) {
+              _goToPage(_currentIndex + 1);
+            } else if (velocity > 300 && _currentIndex > 0) {
+              _goToPage(_currentIndex - 1);
+            }
+          }
+              : null,
           child: AyaMediaBar(
             items: items,
             activeIndex: clampedIndex,

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1813,6 +1813,7 @@ class _MediaBarState extends State<MediaBar>
     final useMakdStyle = mode == UserPreferences.mediaBarModeMakd;
     final useBookshelfStyle = mode == UserPreferences.mediaBarModeBookshelf;
     final useGalleryStyle = mode == UserPreferences.mediaBarModeGallery;
+    final useAyaStyle = mode == UserPreferences.mediaBarModeAya;
 
     return switch (state) {
       MediaBarLoading() => _wrapStatusFocus(
@@ -1834,15 +1835,17 @@ class _MediaBarState extends State<MediaBar>
           onSelect: () => widget.viewModel.load(context: context, force: true),
         ),
       MediaBarReady(items: final items) =>
-        items.isEmpty
-            ? const SizedBox.shrink()
-            : (useGalleryStyle
+      items.isEmpty
+          ? const SizedBox.shrink()
+          : (useAyaStyle
+              ? _buildAyaSlideshow(context, items)
+              : (useGalleryStyle
                   ? _buildGallerySlideshow(context, items)
                   : (useBookshelfStyle
-                        ? _buildBookshelfSlideshow(context, items)
-                        : (useMakdStyle
-                              ? _buildMakdSlideshow(context, items)
-                              : _buildSlideshow(context, items)))),
+                      ? _buildBookshelfSlideshow(context, items)
+                      : (useMakdStyle
+                          ? _buildMakdSlideshow(context, items)
+                          : _buildSlideshow(context, items))))),
     };
   }
 
@@ -2613,6 +2616,13 @@ class _MediaBarState extends State<MediaBar>
         ),
       ),
     );
+  }
+
+  Widget _buildAyaSlideshow(
+      BuildContext context,
+      List<MediaBarSlideItem> items,
+      ) {
+    return _buildSlideshow(context, items);
   }
 
   void _selectGalleryIndex(int index) {

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2638,11 +2638,15 @@ class _MediaBarState extends State<MediaBar>
     const desktopSidebarInset = 56.0;
     const desktopToolbarVerticalPadding = 10.0;
 
-    final navigationLeftInset = isTvTopNavbar
-        ? tvTopNavbarHorizontalInset
+    final leftInset = isTvTopNavbar
+        ? tvTopNavbarHorizontalInset + contentPadding
         : hasDesktopSidebar
-        ? desktopSidebarInset
-        : 0.0;
+        ? desktopSidebarInset + contentPadding
+        : contentPadding;
+
+    final rightInset = isTvTopNavbar
+        ? tvTopNavbarHorizontalInset + contentPadding
+        : contentPadding;
 
     final topInset = navbarIsTop
         ? safeTop +
@@ -2652,9 +2656,9 @@ class _MediaBarState extends State<MediaBar>
         : contentPadding;
 
     return EdgeInsets.fromLTRB(
-      navigationLeftInset + contentPadding,
+      leftInset,
       topInset,
-      contentPadding,
+      rightInset,
       contentPadding,
     );
   }
@@ -2679,7 +2683,7 @@ class _MediaBarState extends State<MediaBar>
       child: Focus(
         focusNode: widget.focusNode,
         autofocus: widget.focusNode == null && PlatformDetection.useLeanbackUi,
-        skipTraversal: false,
+        skipTraversal: true,
         onFocusChange: (focused) {
           _handleFocusChange(focused);
 

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2676,7 +2676,24 @@ class _MediaBarState extends State<MediaBar>
         focusNode: widget.focusNode,
         autofocus: widget.focusNode == null && PlatformDetection.useLeanbackUi,
         skipTraversal: false,
-        onFocusChange: _handleFocusChange,
+        onFocusChange: (focused) {
+          _handleFocusChange(focused);
+
+          if (!focused) {
+            return;
+          }
+
+          final backdropUrl = items[clampedIndex].backdropUrl;
+
+          if (backdropUrl == null || backdropUrl.isEmpty) {
+            return;
+          }
+
+          _backgroundService.setBackgroundUrl(
+            backdropUrl,
+            context: BlurContext.browsing,
+          );
+        },
         onKeyEvent: (node, event) => _handleKeyEvent(event, items),
         child: GestureDetector(
           onTap: () => _navigateToItem(context, items),
@@ -2689,6 +2706,18 @@ class _MediaBarState extends State<MediaBar>
             focusExpansionEnabled: widget.prefs.get(
               UserPreferences.cardFocusExpansion,
             ),
+            onAmbientItemChanged: (item) {
+              final backdropUrl = item.backdropUrl;
+
+              if (backdropUrl == null || backdropUrl.isEmpty) {
+                return;
+              }
+
+              _backgroundService.setBackgroundUrl(
+                backdropUrl,
+                context: BlurContext.browsing,
+              );
+            },
           ),
         ),
       ),

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2623,9 +2623,31 @@ class _MediaBarState extends State<MediaBar>
       BuildContext context,
       List<MediaBarSlideItem> items,
       ) {
-    return AyaMediaBar(
-      items: items,
-      height: widget.height,
+    final clampedIndex = _currentIndex.clamp(0, items.length - 1);
+
+    if (clampedIndex != _currentIndex) {
+      _currentIndex = clampedIndex;
+    }
+
+    return MouseRegion(
+      onEnter: (_) => _setPaused(true),
+      onExit: (_) => _setPaused(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        autofocus: widget.focusNode == null && PlatformDetection.useLeanbackUi,
+        skipTraversal: true,
+        onFocusChange: _handleFocusChange,
+        onKeyEvent: (node, event) => _handleKeyEvent(event, items),
+        child: GestureDetector(
+          onTap: () => _navigateToItem(context, items),
+          onLongPress: () => _navigateToItemAndPlay(context, items),
+          child: AyaMediaBar(
+            items: items,
+            activeIndex: clampedIndex,
+            height: widget.height,
+          ),
+        ),
+      ),
     );
   }
 

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2675,7 +2675,7 @@ class _MediaBarState extends State<MediaBar>
       child: Focus(
         focusNode: widget.focusNode,
         autofocus: widget.focusNode == null && PlatformDetection.useLeanbackUi,
-        skipTraversal: true,
+        skipTraversal: false,
         onFocusChange: _handleFocusChange,
         onKeyEvent: (node, event) => _handleKeyEvent(event, items),
         child: GestureDetector(

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -2686,6 +2686,9 @@ class _MediaBarState extends State<MediaBar>
             activeIndex: clampedIndex,
             height: widget.height,
             padding: _ayaMediaBarInsets(),
+            focusExpansionEnabled: widget.prefs.get(
+              UserPreferences.cardFocusExpansion,
+            ),
           ),
         ),
       ),

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -1846,17 +1846,17 @@ class _MediaBarState extends State<MediaBar>
           onSelect: () => widget.viewModel.load(context: context, force: true),
         ),
       MediaBarReady(items: final items) =>
-      items.isEmpty
-          ? const SizedBox.shrink()
-          : (useAyaStyle
-              ? _buildAyaSlideshow(context, items)
-              : (useGalleryStyle
-                  ? _buildGallerySlideshow(context, items)
-                  : (useBookshelfStyle
-                      ? _buildBookshelfSlideshow(context, items)
-                      : (useMakdStyle
-                          ? _buildMakdSlideshow(context, items)
-                          : _buildSlideshow(context, items))))),
+        items.isEmpty
+            ? const SizedBox.shrink()
+            : (useAyaStyle
+                  ? _buildAyaSlideshow(context, items)
+                  : (useGalleryStyle
+                        ? _buildGallerySlideshow(context, items)
+                        : (useBookshelfStyle
+                              ? _buildBookshelfSlideshow(context, items)
+                              : (useMakdStyle
+                                    ? _buildMakdSlideshow(context, items)
+                                    : _buildSlideshow(context, items))))),
     };
   }
 
@@ -2634,10 +2634,8 @@ class _MediaBarState extends State<MediaBar>
         widget.prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
 
     final isMobile = PlatformDetection.useMobileUi;
-    final isTvTopNavbar =
-        navbarIsTop && PlatformDetection.isTV && !isMobile;
-    final hasDesktopSidebar =
-        !navbarIsTop && !isMobile;
+    final isTvTopNavbar = navbarIsTop && PlatformDetection.isTV && !isMobile;
+    final hasDesktopSidebar = !navbarIsTop && !isMobile;
 
     final safePadding = MediaQuery.paddingOf(context);
 
@@ -2649,10 +2647,9 @@ class _MediaBarState extends State<MediaBar>
     const desktopToolbarVerticalPadding = 10.0;
 
     if (isMobile) {
-      final topInset = safePadding.top +
-          (navbarIsTop
-              ? TopToolbar.heightFor(context) + 12.0
-              : 16.0);
+      final topInset =
+          safePadding.top +
+          (navbarIsTop ? TopToolbar.heightFor(context) + 12.0 : 16.0);
 
       return EdgeInsets.fromLTRB(
         mobileHorizontalPadding + safePadding.left,
@@ -2674,32 +2671,25 @@ class _MediaBarState extends State<MediaBar>
 
     final topInset = navbarIsTop
         ? safePadding.top +
-        TopToolbar.heightFor(context) -
-        desktopToolbarVerticalPadding +
-        contentPadding
+              TopToolbar.heightFor(context) -
+              desktopToolbarVerticalPadding +
+              contentPadding
         : contentPadding;
 
-    return EdgeInsets.fromLTRB(
-      leftInset,
-      topInset,
-      rightInset,
-      contentPadding,
-    );
+    return EdgeInsets.fromLTRB(leftInset, topInset, rightInset, contentPadding);
   }
 
   Widget _buildAyaSlideshow(
-      BuildContext context,
-      List<MediaBarSlideItem> items,
-      ) {
+    BuildContext context,
+    List<MediaBarSlideItem> items,
+  ) {
     final clampedIndex = _currentIndex.clamp(0, items.length - 1);
 
     if (clampedIndex != _currentIndex) {
       _currentIndex = clampedIndex;
     }
 
-    final trailerOverlays = _buildVideoOverlays(
-      allowPersistentMedia3: true,
-    );
+    final trailerOverlays = _buildVideoOverlays(allowPersistentMedia3: true);
 
     return MouseRegion(
       onEnter: (_) => _setPaused(true),
@@ -2732,14 +2722,14 @@ class _MediaBarState extends State<MediaBar>
           onLongPress: () => _navigateToItemAndPlay(context, items),
           onHorizontalDragEnd: PlatformDetection.useMobileUi
               ? (details) {
-            final velocity = details.primaryVelocity ?? 0;
+                  final velocity = details.primaryVelocity ?? 0;
 
-            if (velocity < -300 && _currentIndex < items.length - 1) {
-              _goToPage(_currentIndex + 1);
-            } else if (velocity > 300 && _currentIndex > 0) {
-              _goToPage(_currentIndex - 1);
-            }
-          }
+                  if (velocity < -300 && _currentIndex < items.length - 1) {
+                    _goToPage(_currentIndex + 1);
+                  } else if (velocity > 300 && _currentIndex > 0) {
+                    _goToPage(_currentIndex - 1);
+                  }
+                }
               : null,
           child: AyaMediaBar(
             items: items,
@@ -2751,20 +2741,17 @@ class _MediaBarState extends State<MediaBar>
             ),
             trailerOverlay: trailerOverlays.isEmpty
                 ? null
-                : Stack(
-              fit: StackFit.expand,
-              children: trailerOverlays,
-            ),
-              onAmbientArtworkChanged: (artworkUrl) {
-                if (artworkUrl == null || artworkUrl.isEmpty) {
-                  return;
-                }
+                : Stack(fit: StackFit.expand, children: trailerOverlays),
+            onAmbientArtworkChanged: (artworkUrl) {
+              if (artworkUrl == null || artworkUrl.isEmpty) {
+                return;
+              }
 
-                _backgroundService.setBackgroundUrl(
-                  artworkUrl,
-                  context: BlurContext.browsing,
-                );
-              },
+              _backgroundService.setBackgroundUrl(
+                artworkUrl,
+                context: BlurContext.browsing,
+              );
+            },
           ),
         ),
       ),

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -168,15 +168,10 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 
     final item = widget.items[widget.activeIndex];
 
-    widget.onAmbientArtworkChanged?.call(
-      _artworkUrl(context, item),
-    );
+    widget.onAmbientArtworkChanged?.call(_artworkUrl(context, item));
   }
 
-  bool _usesMobilePoster(
-      BuildContext context,
-      MediaBarSlideItem item,
-      ) {
+  bool _usesMobilePoster(BuildContext context, MediaBarSlideItem item) {
     final posterUrl = item.posterUrl;
     final isPortrait =
         MediaQuery.orientationOf(context) == Orientation.portrait;
@@ -187,10 +182,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
         posterUrl.isNotEmpty;
   }
 
-  String? _artworkUrl(
-      BuildContext context,
-      MediaBarSlideItem item,
-      ) {
+  String? _artworkUrl(BuildContext context, MediaBarSlideItem item) {
     if (_usesMobilePoster(context, item)) {
       return item.posterUrl;
     }
@@ -205,15 +197,13 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     final borders = ThemeRegistry.active.borders;
 
     final isHighlighted = _isHighlighted;
-    final shouldExpand =
-        widget.focusExpansionEnabled && isHighlighted;
+    final shouldExpand = widget.focusExpansionEnabled && isHighlighted;
 
     final borderColor = GlassFocusHalo.appleStyleActive
         ? Colors.white
         : borders.focusBorder.color;
 
-    final showGlow =
-        isHighlighted && borders.focusGlow.isNotEmpty;
+    final showGlow = isHighlighted && borders.focusGlow.isNotEmpty;
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,
@@ -263,8 +253,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                     child: Container(
                       decoration: BoxDecoration(
                         borderRadius: AppRadius.circular(
-                          AyaMediaBar._cornerRadius +
-                              AyaMediaBar._focusInset,
+                          AyaMediaBar._cornerRadius + AyaMediaBar._focusInset,
                         ),
                         boxShadow: borders.focusGlow,
                       ),
@@ -272,24 +261,16 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                   ),
                 ),
               ClipRRect(
-                borderRadius: AppRadius.circular(
-                  AyaMediaBar._cornerRadius,
-                ),
+                borderRadius: AppRadius.circular(AyaMediaBar._cornerRadius),
                 child: SizedBox(
                   height: widget.height,
                   width: double.infinity,
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      _buildAnimatedSlide(
-                        context,
-                        theme,
-                        item,
-                      ),
-                      if (widget.trailerOverlay != null)
-                        widget.trailerOverlay!,
-                      if (widget.items.length > 1)
-                        _buildIndicators(),
+                      _buildAnimatedSlide(context, theme, item),
+                      if (widget.trailerOverlay != null) widget.trailerOverlay!,
+                      if (widget.items.length > 1) _buildIndicators(),
                     ],
                   ),
                 ),
@@ -304,8 +285,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                     child: Container(
                       decoration: BoxDecoration(
                         borderRadius: AppRadius.circular(
-                          AyaMediaBar._cornerRadius +
-                              AyaMediaBar._focusInset,
+                          AyaMediaBar._cornerRadius + AyaMediaBar._focusInset,
                         ),
                         border: Border.fromBorderSide(
                           borders.focusBorder.copyWith(
@@ -325,10 +305,10 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
   }
 
   Widget _buildAnimatedSlide(
-      BuildContext context,
-      ThemeData theme,
-      MediaBarSlideItem item,
-      ) {
+    BuildContext context,
+    ThemeData theme,
+    MediaBarSlideItem item,
+  ) {
     return _AyaSlideTransition(
       item: item,
       artworkUrl: _artworkUrl(context, item),
@@ -340,18 +320,12 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       transitionDuration: AyaMediaBar._slideTransitionDuration,
       slideScaleBegin: AyaMediaBar._slideScaleBegin,
       contentBuilder: (slideItem) {
-        return _buildContent(
-          theme,
-          slideItem,
-        );
+        return _buildContent(theme, slideItem);
       },
     );
   }
 
-  Widget _buildContent(
-      ThemeData theme,
-      MediaBarSlideItem item,
-      ) {
+  Widget _buildContent(ThemeData theme, MediaBarSlideItem item) {
     return Stack(
       fit: StackFit.expand,
       children: [
@@ -364,10 +338,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     );
   }
 
-  Widget _buildLogoOrTitle(
-      ThemeData theme,
-      MediaBarSlideItem item,
-      ) {
+  Widget _buildLogoOrTitle(ThemeData theme, MediaBarSlideItem item) {
     final logoUrl = item.logoUrl;
 
     if (logoUrl == null || logoUrl.isEmpty) {
@@ -382,22 +353,14 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
         fit: BoxFit.contain,
         alignment: Alignment.topLeft,
         fadeInDuration: Duration.zero,
-        errorWidget: (_, _, _) => _buildTitle(
-          theme,
-          item.title,
-        ),
+        errorWidget: (_, _, _) => _buildTitle(theme, item.title),
       ),
     );
   }
 
-  Widget _buildTitle(
-      ThemeData theme,
-      String title,
-      ) {
+  Widget _buildTitle(ThemeData theme, String title) {
     return ConstrainedBox(
-      constraints: const BoxConstraints(
-        maxWidth: AyaMediaBar._titleMaxWidth,
-      ),
+      constraints: const BoxConstraints(maxWidth: AyaMediaBar._titleMaxWidth),
       child: Text(
         title,
         maxLines: 2,
@@ -426,34 +389,27 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       right: AyaMediaBar._indicatorRightInset,
       child: Row(
         mainAxisSize: MainAxisSize.min,
-        children: List.generate(
-          widget.items.length,
-              (index) {
-            final isActive = index == widget.activeIndex;
+        children: List.generate(widget.items.length, (index) {
+          final isActive = index == widget.activeIndex;
 
-            return AnimatedContainer(
-              duration: AyaMediaBar._indicatorAnimationDuration,
-              curve: Curves.easeOutCubic,
-              margin: const EdgeInsets.only(
-                left: AyaMediaBar._indicatorSpacing,
-              ),
-              width: isActive
-                  ? AyaMediaBar._indicatorActiveWidth
-                  : AyaMediaBar._indicatorInactiveWidth,
-              height: AyaMediaBar._indicatorHeight,
-              decoration: BoxDecoration(
-                color: isActive
-                    ? AppColorScheme.onSurface
-                    : AppColorScheme.onSurface.withValues(
-                  alpha: AyaMediaBar._indicatorInactiveOpacity,
-                ),
-                borderRadius: AppRadius.circular(
-                  AyaMediaBar._indicatorHeight,
-                ),
-              ),
-            );
-          },
-        ),
+          return AnimatedContainer(
+            duration: AyaMediaBar._indicatorAnimationDuration,
+            curve: Curves.easeOutCubic,
+            margin: const EdgeInsets.only(left: AyaMediaBar._indicatorSpacing),
+            width: isActive
+                ? AyaMediaBar._indicatorActiveWidth
+                : AyaMediaBar._indicatorInactiveWidth,
+            height: AyaMediaBar._indicatorHeight,
+            decoration: BoxDecoration(
+              color: isActive
+                  ? AppColorScheme.onSurface
+                  : AppColorScheme.onSurface.withValues(
+                      alpha: AyaMediaBar._indicatorInactiveOpacity,
+                    ),
+              borderRadius: AppRadius.circular(AyaMediaBar._indicatorHeight),
+            ),
+          );
+        }),
       ),
     );
   }
@@ -497,8 +453,7 @@ class _AyaSlideTransition extends StatefulWidget {
   });
 
   @override
-  State<_AyaSlideTransition> createState() =>
-      _AyaSlideTransitionState();
+  State<_AyaSlideTransition> createState() => _AyaSlideTransitionState();
 }
 
 class _AyaSlideTransitionState extends State<_AyaSlideTransition>
@@ -534,9 +489,7 @@ class _AyaSlideTransitionState extends State<_AyaSlideTransition>
       duration: widget.transitionDuration,
     );
 
-    _transitionController.addStatusListener(
-      _handleTransitionStatus,
-    );
+    _transitionController.addStatusListener(_handleTransitionStatus);
   }
 
   @override
@@ -565,10 +518,7 @@ class _AyaSlideTransitionState extends State<_AyaSlideTransition>
     super.dispose();
   }
 
-  bool _sameSlide(
-      _AyaSlideVisual first,
-      _AyaSlideVisual second,
-      ) {
+  bool _sameSlide(_AyaSlideVisual first, _AyaSlideVisual second) {
     return first.item.itemId == second.item.itemId &&
         first.artworkUrl == second.artworkUrl &&
         first.showContent == second.showContent;
@@ -587,26 +537,18 @@ class _AyaSlideTransitionState extends State<_AyaSlideTransition>
   void _prepareSlide(_AyaSlideVisual slide) {
     final generation = ++_prepareGeneration;
 
-    unawaited(
-      _prepareAndStartSlide(
-        slide,
-        generation,
-      ),
-    );
+    unawaited(_prepareAndStartSlide(slide, generation));
   }
 
   Future<void> _prepareAndStartSlide(
-      _AyaSlideVisual slide,
-      int generation,
-      ) async {
+    _AyaSlideVisual slide,
+    int generation,
+  ) async {
     final artworkUrl = slide.artworkUrl;
 
     if (artworkUrl != null && artworkUrl.isNotEmpty) {
       try {
-        await precacheImage(
-          offlineAwareImageProvider(artworkUrl),
-          context,
-        );
+        await precacheImage(offlineAwareImageProvider(artworkUrl), context);
       } catch (_) {}
     }
 
@@ -671,10 +613,7 @@ class _AyaSlideTransitionState extends State<_AyaSlideTransition>
           depthInDuration: widget.depthInDuration,
           depthOutDuration: widget.depthOutDuration,
         ),
-        if (slide.showContent)
-          widget.contentBuilder(
-            slide.item,
-          ),
+        if (slide.showContent) widget.contentBuilder(slide.item),
       ],
     );
   }
@@ -686,15 +625,13 @@ class _AyaSlideTransitionState extends State<_AyaSlideTransition>
       curve: Curves.easeOutCubic,
     );
 
-    final incomingScale = Tween<double>(
-      begin: widget.slideScaleBegin,
-      end: 1.0,
-    ).animate(
-      CurvedAnimation(
-        parent: _transitionController,
-        curve: Curves.easeOutCubic,
-      ),
-    );
+    final incomingScale = Tween<double>(begin: widget.slideScaleBegin, end: 1.0)
+        .animate(
+          CurvedAnimation(
+            parent: _transitionController,
+            curve: Curves.easeOutCubic,
+          ),
+        );
 
     final incomingSlide = _incomingSlide;
 
@@ -740,8 +677,7 @@ class _AyaBackdropState extends State<_AyaBackdrop>
   late final AnimationController _depthController;
 
   double get _scale {
-    return 1.0 +
-        ((widget.depthScale - 1.0) * _depthController.value);
+    return 1.0 + ((widget.depthScale - 1.0) * _depthController.value);
   }
 
   @override
@@ -826,9 +762,7 @@ class _AyaBackdropState extends State<_AyaBackdrop>
     final artworkUrl = widget.artworkUrl;
 
     if (artworkUrl == null || artworkUrl.isEmpty) {
-      return ColoredBox(
-        color: AppColorScheme.background,
-      );
+      return ColoredBox(color: AppColorScheme.background);
     }
 
     return AnimatedBuilder(
@@ -838,15 +772,10 @@ class _AyaBackdropState extends State<_AyaBackdrop>
         fit: BoxFit.cover,
         alignment: Alignment.center,
         fadeInDuration: Duration.zero,
-        errorWidget: (_, _, _) => ColoredBox(
-          color: AppColorScheme.background,
-        ),
+        errorWidget: (_, _, _) => ColoredBox(color: AppColorScheme.background),
       ),
       builder: (context, child) {
-        return Transform.scale(
-          scale: _scale,
-          child: child,
-        );
+        return Transform.scale(scale: _scale, child: child);
       },
     );
   }

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -28,6 +28,7 @@ class AyaMediaBar extends StatefulWidget {
 
   static const _focusInset = 3.5;
   static const _focusBorderWidth = 3.0;
+  static const _focusScale = 1.006;
 
   static const _slideTransitionDuration = Duration(
     milliseconds: 900,
@@ -37,12 +38,17 @@ class AyaMediaBar extends StatefulWidget {
     milliseconds: 280,
   );
 
+  static const _focusScaleDuration = Duration(
+    milliseconds: 220,
+  );
+
   static const _slideScaleBegin = 1.006;
 
   final List<MediaBarSlideItem> items;
   final int activeIndex;
   final double height;
   final EdgeInsets padding;
+  final bool focusExpansionEnabled;
 
   const AyaMediaBar({
     super.key,
@@ -50,6 +56,7 @@ class AyaMediaBar extends StatefulWidget {
     required this.activeIndex,
     required this.height,
     required this.padding,
+    required this.focusExpansionEnabled,
   });
 
   @override
@@ -66,6 +73,8 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 
     final isFocused = Focus.of(context).hasFocus;
     final isHighlighted = isFocused || _isHovered;
+    final shouldExpand =
+        widget.focusExpansionEnabled && isHighlighted;
 
     final borders = ThemeRegistry.active.borders;
     final borderColor = GlassFocusHalo.appleStyleActive
@@ -79,74 +88,79 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       cursor: SystemMouseCursors.click,
       onEnter: (_) => setState(() => _isHovered = true),
       onExit: (_) => setState(() => _isHovered = false),
-      child: Padding(
-        padding: widget.padding,
-        child: Stack(
-          fit: StackFit.passthrough,
-          clipBehavior: Clip.none,
-          children: [
-            if (showGlow)
-              Positioned(
-                top: -AyaMediaBar._focusInset,
-                bottom: -AyaMediaBar._focusInset,
-                left: -AyaMediaBar._focusInset,
-                right: -AyaMediaBar._focusInset,
-                child: IgnorePointer(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      borderRadius: AppRadius.circular(
-                        AyaMediaBar._cornerRadius +
-                            AyaMediaBar._focusInset,
+      child: AnimatedScale(
+        scale: shouldExpand ? AyaMediaBar._focusScale : 1.0,
+        duration: AyaMediaBar._focusScaleDuration,
+        curve: Curves.easeOutCubic,
+        child: Padding(
+          padding: widget.padding,
+          child: Stack(
+            fit: StackFit.passthrough,
+            clipBehavior: Clip.none,
+            children: [
+              if (showGlow)
+                Positioned(
+                  top: -AyaMediaBar._focusInset,
+                  bottom: -AyaMediaBar._focusInset,
+                  left: -AyaMediaBar._focusInset,
+                  right: -AyaMediaBar._focusInset,
+                  child: IgnorePointer(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: AppRadius.circular(
+                          AyaMediaBar._cornerRadius +
+                              AyaMediaBar._focusInset,
+                        ),
+                        boxShadow: borders.focusGlow,
                       ),
-                      boxShadow: borders.focusGlow,
                     ),
                   ),
                 ),
-              ),
-            ClipRRect(
-              borderRadius: AppRadius.circular(
-                AyaMediaBar._cornerRadius,
-              ),
-              child: SizedBox(
-                height: widget.height,
-                width: double.infinity,
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    _buildAnimatedSlide(
-                      theme,
-                      item,
-                    ),
-                    if (widget.items.length > 1)
-                      _buildIndicators(),
-                  ],
+              ClipRRect(
+                borderRadius: AppRadius.circular(
+                  AyaMediaBar._cornerRadius,
+                ),
+                child: SizedBox(
+                  height: widget.height,
+                  width: double.infinity,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      _buildAnimatedSlide(
+                        theme,
+                        item,
+                      ),
+                      if (widget.items.length > 1)
+                        _buildIndicators(),
+                    ],
+                  ),
                 ),
               ),
-            ),
-            if (isHighlighted)
-              Positioned(
-                top: -AyaMediaBar._focusInset,
-                bottom: -AyaMediaBar._focusInset,
-                left: -AyaMediaBar._focusInset,
-                right: -AyaMediaBar._focusInset,
-                child: IgnorePointer(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      borderRadius: AppRadius.circular(
-                        AyaMediaBar._cornerRadius +
-                            AyaMediaBar._focusInset,
-                      ),
-                      border: Border.fromBorderSide(
-                        borders.focusBorder.copyWith(
-                          color: borderColor,
-                          width: AyaMediaBar._focusBorderWidth,
+              if (isHighlighted)
+                Positioned(
+                  top: -AyaMediaBar._focusInset,
+                  bottom: -AyaMediaBar._focusInset,
+                  left: -AyaMediaBar._focusInset,
+                  right: -AyaMediaBar._focusInset,
+                  child: IgnorePointer(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: AppRadius.circular(
+                          AyaMediaBar._cornerRadius +
+                              AyaMediaBar._focusInset,
+                        ),
+                        border: Border.fromBorderSide(
+                          borders.focusBorder.copyWith(
+                            color: borderColor,
+                            width: AyaMediaBar._focusBorderWidth,
+                          ),
                         ),
                       ),
                     ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -24,9 +24,16 @@ class AyaMediaBar extends StatelessWidget {
   static const _indicatorInactiveWidth = 10.0;
   static const _indicatorHeight = 2.0;
   static const _indicatorInactiveOpacity = 0.30;
-  static const _indicatorAnimationDuration = Duration(
-    milliseconds: 250,
+
+  static const _slideTransitionDuration = Duration(
+    milliseconds: 900,
   );
+
+  static const _indicatorAnimationDuration = Duration(
+    milliseconds: 280,
+  );
+
+  static const _slideScaleBegin = 1.006;
 
   final List<MediaBarSlideItem> items;
   final int activeIndex;
@@ -49,20 +56,99 @@ class AyaMediaBar extends StatelessWidget {
     return Padding(
       padding: padding,
       child: ClipRRect(
-        borderRadius: AppRadius.circular(_cornerRadius),
+        borderRadius: AppRadius.circular(
+          _cornerRadius,
+        ),
         child: SizedBox(
           height: height,
           width: double.infinity,
           child: Stack(
             fit: StackFit.expand,
             children: [
-              _buildBackdrop(item),
-              _buildContent(theme, item),
+              _buildAnimatedSlide(
+                theme,
+                item,
+              ),
               if (items.length > 1) _buildIndicators(),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildAnimatedSlide(
+      ThemeData theme,
+      MediaBarSlideItem item,
+      ) {
+    return AnimatedSwitcher(
+      duration: _slideTransitionDuration,
+      reverseDuration: _slideTransitionDuration,
+      switchInCurve: Curves.easeInOutCubic,
+      switchOutCurve: Curves.easeInOutCubic,
+      layoutBuilder: (
+          Widget? currentChild,
+          List<Widget> previousChildren,
+          ) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ...previousChildren,
+            if (currentChild != null) currentChild,
+          ],
+        );
+      },
+      transitionBuilder: (
+          Widget child,
+          Animation<double> animation,
+          ) {
+        final opacity = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeInOutCubic,
+          reverseCurve: Curves.easeInOutCubic,
+        );
+
+        final scale = Tween<double>(
+          begin: _slideScaleBegin,
+          end: 1.0,
+        ).animate(
+          CurvedAnimation(
+            parent: animation,
+            curve: Curves.easeOutCubic,
+          ),
+        );
+
+        return FadeTransition(
+          opacity: opacity,
+          child: ScaleTransition(
+            scale: scale,
+            child: child,
+          ),
+        );
+      },
+      child: KeyedSubtree(
+        key: ValueKey(activeIndex),
+        child: _buildSlide(
+          theme,
+          item,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSlide(
+      ThemeData theme,
+      MediaBarSlideItem item,
+      ) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildBackdrop(item),
+        _buildContent(
+          theme,
+          item,
+        ),
+      ],
     );
   }
 
@@ -172,7 +258,7 @@ class AyaMediaBar extends StatelessWidget {
 
             return AnimatedContainer(
               duration: _indicatorAnimationDuration,
-              curve: Curves.easeOut,
+              curve: Curves.easeOutCubic,
               margin: const EdgeInsets.only(
                 left: _indicatorSpacing,
               ),

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
@@ -30,11 +32,14 @@ class AyaMediaBar extends StatefulWidget {
   static const _focusBorderWidth = 3.0;
   static const _focusScale = 1.006;
 
+  static const _backdropDepthScale = 1.012;
   static const _slideScaleBegin = 1.006;
 
   static const _slideTransitionDuration = Duration(milliseconds: 900);
   static const _indicatorAnimationDuration = Duration(milliseconds: 280);
   static const _focusScaleDuration = Duration(milliseconds: 220);
+  static const _backdropDepthInDuration = Duration(milliseconds: 320);
+  static const _backdropDepthOutDuration = Duration(seconds: 8);
 
   final List<MediaBarSlideItem> items;
   final int activeIndex;
@@ -294,7 +299,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
         );
       },
       child: KeyedSubtree(
-        key: ValueKey(widget.activeIndex),
+        key: ValueKey(item.itemId),
         child: _buildSlide(theme, item),
       ),
     );
@@ -307,29 +312,16 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     return Stack(
       fit: StackFit.expand,
       children: [
-        _buildBackdrop(item),
+        _AyaBackdrop(
+          key: ValueKey('aya_backdrop_${item.itemId}'),
+          item: item,
+          highlighted: _isHighlighted,
+          depthScale: AyaMediaBar._backdropDepthScale,
+          depthInDuration: AyaMediaBar._backdropDepthInDuration,
+          depthOutDuration: AyaMediaBar._backdropDepthOutDuration,
+        ),
         _buildContent(theme, item),
       ],
-    );
-  }
-
-  Widget _buildBackdrop(MediaBarSlideItem item) {
-    final backdropUrl = item.backdropUrl;
-
-    if (backdropUrl == null || backdropUrl.isEmpty) {
-      return ColoredBox(
-        color: AppColorScheme.background,
-      );
-    }
-
-    return OfflineAwareImage(
-      imageUrl: backdropUrl,
-      fit: BoxFit.cover,
-      alignment: Alignment.center,
-      fadeInDuration: Duration.zero,
-      errorWidget: (_, _, _) => ColoredBox(
-        color: AppColorScheme.background,
-      ),
     );
   }
 
@@ -435,6 +427,143 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
           },
         ),
       ),
+    );
+  }
+}
+
+class _AyaBackdrop extends StatefulWidget {
+  final MediaBarSlideItem item;
+  final bool highlighted;
+  final double depthScale;
+  final Duration depthInDuration;
+  final Duration depthOutDuration;
+
+  const _AyaBackdrop({
+    super.key,
+    required this.item,
+    required this.highlighted,
+    required this.depthScale,
+    required this.depthInDuration,
+    required this.depthOutDuration,
+  });
+
+  @override
+  State<_AyaBackdrop> createState() => _AyaBackdropState();
+}
+
+class _AyaBackdropState extends State<_AyaBackdrop>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _depthController;
+
+  double get _scale {
+    return 1.0 +
+        ((widget.depthScale - 1.0) * _depthController.value);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _depthController = AnimationController(
+      vsync: this,
+      value: widget.highlighted ? 1.0 : 0.0,
+    );
+
+    if (widget.highlighted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !widget.highlighted) {
+          return;
+        }
+
+        unawaited(_retreatFromDepth());
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _AyaBackdrop oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.highlighted == widget.highlighted) {
+      return;
+    }
+
+    if (widget.highlighted) {
+      unawaited(_runDepthCycle());
+    } else {
+      _resetDepth();
+    }
+  }
+
+  @override
+  void dispose() {
+    _depthController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _runDepthCycle() async {
+    _depthController.stop();
+
+    await _depthController.animateTo(
+      1.0,
+      duration: widget.depthInDuration,
+      curve: Curves.easeOutCubic,
+    );
+
+    if (!mounted || !widget.highlighted) {
+      return;
+    }
+
+    await _depthController.animateBack(
+      0.0,
+      duration: widget.depthOutDuration,
+      curve: Curves.linear,
+    );
+  }
+
+  Future<void> _retreatFromDepth() async {
+    _depthController.stop();
+    _depthController.value = 1.0;
+
+    await _depthController.animateBack(
+      0.0,
+      duration: widget.depthOutDuration,
+      curve: Curves.linear,
+    );
+  }
+
+  void _resetDepth() {
+    _depthController.stop();
+    _depthController.value = 0.0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final backdropUrl = widget.item.backdropUrl;
+
+    if (backdropUrl == null || backdropUrl.isEmpty) {
+      return ColoredBox(
+        color: AppColorScheme.background,
+      );
+    }
+
+    return AnimatedBuilder(
+      animation: _depthController,
+      child: OfflineAwareImage(
+        imageUrl: backdropUrl,
+        fit: BoxFit.cover,
+        alignment: Alignment.center,
+        fadeInDuration: Duration.zero,
+        errorWidget: (_, _, _) => ColoredBox(
+          color: AppColorScheme.background,
+        ),
+      ),
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _scale,
+          child: child,
+        );
+      },
     );
   }
 }

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -5,19 +5,24 @@ import '../../../../data/models/media_bar_slide_item.dart';
 class AyaMediaBar extends StatelessWidget {
   final List<MediaBarSlideItem> items;
   final double height;
+  final int activeIndex;
 
   const AyaMediaBar({
     super.key,
     required this.items,
+    required this.activeIndex,
     required this.height,
   });
 
   @override
   Widget build(BuildContext context) {
+    final item = items[activeIndex];
+
     return SizedBox(
       height: height,
-      child: const Center(
-        child: Text('Aya'),
+      width: double.infinity,
+      child: Center(
+        child: Text(item.title),
       ),
     );
   }

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../data/models/media_bar_slide_item.dart';
+import '../../../util/platform_detection.dart';
 import '../focus/glass_focus_halo.dart';
 import '../offline_aware_image.dart';
 
@@ -155,6 +156,22 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     );
   }
 
+  bool _usesMobilePoster(MediaBarSlideItem item) {
+    final posterUrl = item.posterUrl;
+
+    return PlatformDetection.useMobileUi &&
+        posterUrl != null &&
+        posterUrl.isNotEmpty;
+  }
+
+  String? _artworkUrl(MediaBarSlideItem item) {
+    if (_usesMobilePoster(item)) {
+      return item.posterUrl;
+    }
+
+    return item.backdropUrl;
+  }
+
   @override
   Widget build(BuildContext context) {
     final item = widget.items[widget.activeIndex];
@@ -268,7 +285,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       child: KeyedSubtree(
         key: ValueKey('aya_backdrop_slide_${item.itemId}'),
         child: _AyaBackdrop(
-          item: item,
+          artworkUrl: _artworkUrl(item),
           highlighted: _isHighlighted,
           depthScale: AyaMediaBar._backdropDepthScale,
           depthInDuration: AyaMediaBar._backdropDepthInDuration,
@@ -291,7 +308,9 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       transitionBuilder: _buildSlideTransition,
       child: KeyedSubtree(
         key: ValueKey('aya_content_${item.itemId}'),
-        child: _buildContent(theme, item),
+        child: _usesMobilePoster(item)
+            ? const SizedBox.expand()
+            : _buildContent(theme, item),
       ),
     );
   }
@@ -450,14 +469,14 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 }
 
 class _AyaBackdrop extends StatefulWidget {
-  final MediaBarSlideItem item;
+  final String? artworkUrl;
   final bool highlighted;
   final double depthScale;
   final Duration depthInDuration;
   final Duration depthOutDuration;
 
   const _AyaBackdrop({
-    required this.item,
+    required this.artworkUrl,
     required this.highlighted,
     required this.depthScale,
     required this.depthInDuration,
@@ -556,9 +575,9 @@ class _AyaBackdropState extends State<_AyaBackdrop>
 
   @override
   Widget build(BuildContext context) {
-    final backdropUrl = widget.item.backdropUrl;
+    final artworkUrl = widget.artworkUrl;
 
-    if (backdropUrl == null || backdropUrl.isEmpty) {
+    if (artworkUrl == null || artworkUrl.isEmpty) {
       return ColoredBox(
         color: AppColorScheme.background,
       );
@@ -567,7 +586,7 @@ class _AyaBackdropState extends State<_AyaBackdrop>
     return AnimatedBuilder(
       animation: _depthController,
       child: OfflineAwareImage(
-        imageUrl: backdropUrl,
+        imageUrl: artworkUrl,
         fit: BoxFit.cover,
         alignment: Alignment.center,
         fadeInDuration: Duration.zero,

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -46,6 +46,7 @@ class AyaMediaBar extends StatefulWidget {
   final double height;
   final EdgeInsets padding;
   final bool focusExpansionEnabled;
+  final Widget? trailerOverlay;
   final ValueChanged<MediaBarSlideItem>? onAmbientItemChanged;
 
   const AyaMediaBar({
@@ -55,6 +56,7 @@ class AyaMediaBar extends StatefulWidget {
     required this.height,
     required this.padding,
     required this.focusExpansionEnabled,
+    this.trailerOverlay,
     this.onAmbientItemChanged,
   });
 
@@ -212,7 +214,13 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      _buildAnimatedSlide(theme, item),
+                      _buildAnimatedBackdrop(item),
+
+                      if (widget.trailerOverlay != null)
+                        widget.trailerOverlay!,
+
+                      _buildAnimatedContent(theme, item),
+
                       if (widget.items.length > 1)
                         _buildIndicators(),
                     ],
@@ -249,7 +257,28 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     );
   }
 
-  Widget _buildAnimatedSlide(
+  Widget _buildAnimatedBackdrop(MediaBarSlideItem item) {
+    return AnimatedSwitcher(
+      duration: AyaMediaBar._slideTransitionDuration,
+      reverseDuration: AyaMediaBar._slideTransitionDuration,
+      switchInCurve: Curves.easeInOutCubic,
+      switchOutCurve: Curves.easeInOutCubic,
+      layoutBuilder: _buildAnimatedLayout,
+      transitionBuilder: _buildSlideTransition,
+      child: KeyedSubtree(
+        key: ValueKey('aya_backdrop_slide_${item.itemId}'),
+        child: _AyaBackdrop(
+          item: item,
+          highlighted: _isHighlighted,
+          depthScale: AyaMediaBar._backdropDepthScale,
+          depthInDuration: AyaMediaBar._backdropDepthInDuration,
+          depthOutDuration: AyaMediaBar._backdropDepthOutDuration,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAnimatedContent(
       ThemeData theme,
       MediaBarSlideItem item,
       ) {
@@ -258,70 +287,54 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       reverseDuration: AyaMediaBar._slideTransitionDuration,
       switchInCurve: Curves.easeInOutCubic,
       switchOutCurve: Curves.easeInOutCubic,
-      layoutBuilder: (
-          Widget? currentChild,
-          List<Widget> previousChildren,
-          ) {
-        return Stack(
-          fit: StackFit.expand,
-          children: [
-            ...previousChildren,
-            if (currentChild != null) currentChild,
-          ],
-        );
-      },
-      transitionBuilder: (
-          Widget child,
-          Animation<double> animation,
-          ) {
-        final opacity = CurvedAnimation(
-          parent: animation,
-          curve: Curves.easeInOutCubic,
-          reverseCurve: Curves.easeInOutCubic,
-        );
-
-        final scale = Tween<double>(
-          begin: AyaMediaBar._slideScaleBegin,
-          end: 1.0,
-        ).animate(
-          CurvedAnimation(
-            parent: animation,
-            curve: Curves.easeOutCubic,
-          ),
-        );
-
-        return FadeTransition(
-          opacity: opacity,
-          child: ScaleTransition(
-            scale: scale,
-            child: child,
-          ),
-        );
-      },
+      layoutBuilder: _buildAnimatedLayout,
+      transitionBuilder: _buildSlideTransition,
       child: KeyedSubtree(
-        key: ValueKey(item.itemId),
-        child: _buildSlide(theme, item),
+        key: ValueKey('aya_content_${item.itemId}'),
+        child: _buildContent(theme, item),
       ),
     );
   }
 
-  Widget _buildSlide(
-      ThemeData theme,
-      MediaBarSlideItem item,
+  Widget _buildAnimatedLayout(
+      Widget? currentChild,
+      List<Widget> previousChildren,
       ) {
     return Stack(
       fit: StackFit.expand,
       children: [
-        _AyaBackdrop(
-          key: ValueKey('aya_backdrop_${item.itemId}'),
-          item: item,
-          highlighted: _isHighlighted,
-          depthScale: AyaMediaBar._backdropDepthScale,
-          depthInDuration: AyaMediaBar._backdropDepthInDuration,
-          depthOutDuration: AyaMediaBar._backdropDepthOutDuration,
-        ),
-        _buildContent(theme, item),
+        ...previousChildren,
+        if (currentChild != null) currentChild,
       ],
+    );
+  }
+
+  Widget _buildSlideTransition(
+      Widget child,
+      Animation<double> animation,
+      ) {
+    final opacity = CurvedAnimation(
+      parent: animation,
+      curve: Curves.easeInOutCubic,
+      reverseCurve: Curves.easeInOutCubic,
+    );
+
+    final scale = Tween<double>(
+      begin: AyaMediaBar._slideScaleBegin,
+      end: 1.0,
+    ).animate(
+      CurvedAnimation(
+        parent: animation,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+
+    return FadeTransition(
+      opacity: opacity,
+      child: ScaleTransition(
+        scale: scale,
+        child: child,
+      ),
     );
   }
 
@@ -329,10 +342,15 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       ThemeData theme,
       MediaBarSlideItem item,
       ) {
-    return Positioned(
-      left: AyaMediaBar._contentLeftPadding,
-      top: AyaMediaBar._contentTopPadding,
-      child: _buildLogoOrTitle(theme, item),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Positioned(
+          left: AyaMediaBar._contentLeftPadding,
+          top: AyaMediaBar._contentTopPadding,
+          child: _buildLogoOrTitle(theme, item),
+        ),
+      ],
     );
   }
 
@@ -439,7 +457,6 @@ class _AyaBackdrop extends StatefulWidget {
   final Duration depthOutDuration;
 
   const _AyaBackdrop({
-    super.key,
     required this.item,
     required this.highlighted,
     required this.depthScale,

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+import '../../../../data/models/media_bar_slide_item.dart';
+
+class AyaMediaBar extends StatelessWidget {
+  final List<MediaBarSlideItem> items;
+  final double height;
+
+  const AyaMediaBar({
+    super.key,
+    required this.items,
+    required this.height,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+      child: const Center(
+        child: Text('Aya'),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -1,28 +1,198 @@
 import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../data/models/media_bar_slide_item.dart';
+import '../offline_aware_image.dart';
 
 class AyaMediaBar extends StatelessWidget {
+  static const _cornerRadius = 18.0;
+
+  static const _contentLeftPadding = 44.0;
+  static const _contentTopPadding = 40.0;
+
+  static const _logoWidth = 340.0;
+  static const _logoHeight = 100.0;
+
+  static const _titleMaxWidth = 440.0;
+  static const _titleShadowOpacity = 0.72;
+  static const _titleShadowBlurRadius = 20.0;
+
+  static const _indicatorTopInset = 22.0;
+  static const _indicatorRightInset = 24.0;
+  static const _indicatorSpacing = 5.0;
+  static const _indicatorActiveWidth = 16.0;
+  static const _indicatorInactiveWidth = 10.0;
+  static const _indicatorHeight = 2.0;
+  static const _indicatorInactiveOpacity = 0.30;
+  static const _indicatorAnimationDuration = Duration(
+    milliseconds: 250,
+  );
+
   final List<MediaBarSlideItem> items;
-  final double height;
   final int activeIndex;
+  final double height;
+  final EdgeInsets padding;
 
   const AyaMediaBar({
     super.key,
     required this.items,
     required this.activeIndex,
     required this.height,
+    required this.padding,
   });
 
   @override
   Widget build(BuildContext context) {
     final item = items[activeIndex];
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: padding,
+      child: ClipRRect(
+        borderRadius: AppRadius.circular(_cornerRadius),
+        child: SizedBox(
+          height: height,
+          width: double.infinity,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              _buildBackdrop(item),
+              _buildContent(theme, item),
+              if (items.length > 1) _buildIndicators(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBackdrop(MediaBarSlideItem item) {
+    final backdropUrl = item.backdropUrl;
+
+    if (backdropUrl == null || backdropUrl.isEmpty) {
+      return ColoredBox(
+        color: AppColorScheme.background,
+      );
+    }
+
+    return OfflineAwareImage(
+      imageUrl: backdropUrl,
+      fit: BoxFit.cover,
+      alignment: Alignment.center,
+      fadeInDuration: Duration.zero,
+      errorWidget: (_, _, _) => ColoredBox(
+        color: AppColorScheme.background,
+      ),
+    );
+  }
+
+  Widget _buildContent(
+      ThemeData theme,
+      MediaBarSlideItem item,
+      ) {
+    return Positioned(
+      left: _contentLeftPadding,
+      top: _contentTopPadding,
+      child: _buildLogoOrTitle(
+        theme,
+        item,
+      ),
+    );
+  }
+
+  Widget _buildLogoOrTitle(
+      ThemeData theme,
+      MediaBarSlideItem item,
+      ) {
+    final logoUrl = item.logoUrl;
+
+    if (logoUrl == null || logoUrl.isEmpty) {
+      return _buildTitle(
+        theme,
+        item.title,
+      );
+    }
 
     return SizedBox(
-      height: height,
-      width: double.infinity,
-      child: Center(
-        child: Text(item.title),
+      width: _logoWidth,
+      height: _logoHeight,
+      child: OfflineAwareImage(
+        imageUrl: logoUrl,
+        fit: BoxFit.contain,
+        alignment: Alignment.topLeft,
+        fadeInDuration: Duration.zero,
+        errorWidget: (_, _, _) => _buildTitle(
+          theme,
+          item.title,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTitle(
+      ThemeData theme,
+      String title,
+      ) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(
+        maxWidth: _titleMaxWidth,
+      ),
+      child: Text(
+        title,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: theme.textTheme.headlineLarge?.copyWith(
+          fontWeight: FontWeight.w700,
+          letterSpacing: -0.5,
+          height: 1.0,
+          color: AppColorScheme.onSurface,
+          shadows: [
+            Shadow(
+              color: AppColorScheme.scrim.withValues(
+                alpha: _titleShadowOpacity,
+              ),
+              blurRadius: _titleShadowBlurRadius,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIndicators() {
+    return Positioned(
+      top: _indicatorTopInset,
+      right: _indicatorRightInset,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: List.generate(
+          items.length,
+              (index) {
+            final isActive = index == activeIndex;
+
+            return AnimatedContainer(
+              duration: _indicatorAnimationDuration,
+              curve: Curves.easeOut,
+              margin: const EdgeInsets.only(
+                left: _indicatorSpacing,
+              ),
+              width: isActive
+                  ? _indicatorActiveWidth
+                  : _indicatorInactiveWidth,
+              height: _indicatorHeight,
+              decoration: BoxDecoration(
+                color: isActive
+                    ? AppColorScheme.onSurface
+                    : AppColorScheme.onSurface.withValues(
+                  alpha: _indicatorInactiveOpacity,
+                ),
+                borderRadius: AppRadius.circular(
+                  _indicatorHeight,
+                ),
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -30,25 +30,18 @@ class AyaMediaBar extends StatefulWidget {
   static const _focusBorderWidth = 3.0;
   static const _focusScale = 1.006;
 
-  static const _slideTransitionDuration = Duration(
-    milliseconds: 900,
-  );
-
-  static const _indicatorAnimationDuration = Duration(
-    milliseconds: 280,
-  );
-
-  static const _focusScaleDuration = Duration(
-    milliseconds: 220,
-  );
-
   static const _slideScaleBegin = 1.006;
+
+  static const _slideTransitionDuration = Duration(milliseconds: 900);
+  static const _indicatorAnimationDuration = Duration(milliseconds: 280);
+  static const _focusScaleDuration = Duration(milliseconds: 220);
 
   final List<MediaBarSlideItem> items;
   final int activeIndex;
   final double height;
   final EdgeInsets padding;
   final bool focusExpansionEnabled;
+  final ValueChanged<MediaBarSlideItem>? onAmbientItemChanged;
 
   const AyaMediaBar({
     super.key,
@@ -57,6 +50,7 @@ class AyaMediaBar extends StatefulWidget {
     required this.height,
     required this.padding,
     required this.focusExpansionEnabled,
+    this.onAmbientItemChanged,
   });
 
   @override
@@ -64,19 +58,106 @@ class AyaMediaBar extends StatefulWidget {
 }
 
 class _AyaMediaBarState extends State<AyaMediaBar> {
+  FocusNode? _parentFocusNode;
+
+  bool _isFocused = false;
   bool _isHovered = false;
+
+  bool get _isHighlighted => _isFocused || _isHovered;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final focusNode = Focus.maybeOf(context);
+
+    if (identical(_parentFocusNode, focusNode)) {
+      return;
+    }
+
+    _parentFocusNode?.removeListener(_handleFocusChanged);
+
+    _parentFocusNode = focusNode;
+    _isFocused = focusNode?.hasFocus ?? false;
+
+    _parentFocusNode?.addListener(_handleFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant AyaMediaBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.activeIndex == widget.activeIndex || !_isHighlighted) {
+      return;
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_isHighlighted) {
+        return;
+      }
+
+      _notifyAmbientItem();
+    });
+  }
+
+  @override
+  void dispose() {
+    _parentFocusNode?.removeListener(_handleFocusChanged);
+    super.dispose();
+  }
+
+  void _handleFocusChanged() {
+    if (!mounted) {
+      return;
+    }
+
+    final isFocused = _parentFocusNode?.hasFocus ?? false;
+
+    if (_isFocused == isFocused) {
+      return;
+    }
+
+    setState(() {
+      _isFocused = isFocused;
+    });
+  }
+
+  void _setHovered(bool hovered) {
+    if (_isHovered == hovered) {
+      return;
+    }
+
+    setState(() {
+      _isHovered = hovered;
+    });
+
+    if (_isHighlighted) {
+      _notifyAmbientItem();
+    }
+  }
+
+  void _notifyAmbientItem() {
+    if (widget.items.isEmpty ||
+        widget.activeIndex < 0 ||
+        widget.activeIndex >= widget.items.length) {
+      return;
+    }
+
+    widget.onAmbientItemChanged?.call(
+      widget.items[widget.activeIndex],
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final item = widget.items[widget.activeIndex];
     final theme = Theme.of(context);
+    final borders = ThemeRegistry.active.borders;
 
-    final isFocused = Focus.of(context).hasFocus;
-    final isHighlighted = isFocused || _isHovered;
+    final isHighlighted = _isHighlighted;
     final shouldExpand =
         widget.focusExpansionEnabled && isHighlighted;
 
-    final borders = ThemeRegistry.active.borders;
     final borderColor = GlassFocusHalo.appleStyleActive
         ? Colors.white
         : theme.colorScheme.primary;
@@ -86,8 +167,8 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _isHovered = true),
-      onExit: (_) => setState(() => _isHovered = false),
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
       child: AnimatedScale(
         scale: shouldExpand ? AyaMediaBar._focusScale : 1.0,
         duration: AyaMediaBar._focusScaleDuration,
@@ -126,10 +207,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      _buildAnimatedSlide(
-                        theme,
-                        item,
-                      ),
+                      _buildAnimatedSlide(theme, item),
                       if (widget.items.length > 1)
                         _buildIndicators(),
                     ],
@@ -217,10 +295,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       },
       child: KeyedSubtree(
         key: ValueKey(widget.activeIndex),
-        child: _buildSlide(
-          theme,
-          item,
-        ),
+        child: _buildSlide(theme, item),
       ),
     );
   }
@@ -233,10 +308,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
       fit: StackFit.expand,
       children: [
         _buildBackdrop(item),
-        _buildContent(
-          theme,
-          item,
-        ),
+        _buildContent(theme, item),
       ],
     );
   }
@@ -268,10 +340,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     return Positioned(
       left: AyaMediaBar._contentLeftPadding,
       top: AyaMediaBar._contentTopPadding,
-      child: _buildLogoOrTitle(
-        theme,
-        item,
-      ),
+      child: _buildLogoOrTitle(theme, item),
     );
   }
 
@@ -282,10 +351,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     final logoUrl = item.logoUrl;
 
     if (logoUrl == null || logoUrl.isEmpty) {
-      return _buildTitle(
-        theme,
-        item.title,
-      );
+      return _buildTitle(theme, item.title);
     }
 
     return SizedBox(

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -36,7 +36,7 @@ class AyaMediaBar extends StatefulWidget {
   static const _backdropDepthScale = 1.012;
   static const _slideScaleBegin = 1.006;
 
-  static const _slideTransitionDuration = Duration(milliseconds: 900);
+  static const _slideTransitionDuration = Duration(milliseconds: 420);
   static const _indicatorAnimationDuration = Duration(milliseconds: 280);
   static const _focusScaleDuration = Duration(milliseconds: 220);
   static const _backdropDepthInDuration = Duration(milliseconds: 320);
@@ -48,7 +48,7 @@ class AyaMediaBar extends StatefulWidget {
   final EdgeInsets padding;
   final bool focusExpansionEnabled;
   final Widget? trailerOverlay;
-  final ValueChanged<MediaBarSlideItem>? onAmbientItemChanged;
+  final ValueChanged<String?>? onAmbientArtworkChanged;
 
   const AyaMediaBar({
     super.key,
@@ -58,7 +58,7 @@ class AyaMediaBar extends StatefulWidget {
     required this.padding,
     required this.focusExpansionEnabled,
     this.trailerOverlay,
-    this.onAmbientItemChanged,
+    this.onAmbientArtworkChanged,
   });
 
   @override
@@ -67,6 +67,7 @@ class AyaMediaBar extends StatefulWidget {
 
 class _AyaMediaBarState extends State<AyaMediaBar> {
   FocusNode? _parentFocusNode;
+  Orientation? _lastOrientation;
 
   bool _isFocused = false;
   bool _isHovered = false;
@@ -79,16 +80,30 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 
     final focusNode = Focus.maybeOf(context);
 
-    if (identical(_parentFocusNode, focusNode)) {
-      return;
+    if (!identical(_parentFocusNode, focusNode)) {
+      _parentFocusNode?.removeListener(_handleFocusChanged);
+
+      _parentFocusNode = focusNode;
+      _isFocused = focusNode?.hasFocus ?? false;
+
+      _parentFocusNode?.addListener(_handleFocusChanged);
     }
 
-    _parentFocusNode?.removeListener(_handleFocusChanged);
+    final orientation = MediaQuery.orientationOf(context);
+    final orientationChanged =
+        _lastOrientation != null && _lastOrientation != orientation;
 
-    _parentFocusNode = focusNode;
-    _isFocused = focusNode?.hasFocus ?? false;
+    _lastOrientation = orientation;
 
-    _parentFocusNode?.addListener(_handleFocusChanged);
+    if (orientationChanged && _isHighlighted) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_isHighlighted) {
+          return;
+        }
+
+        _notifyAmbientArtwork();
+      });
+    }
   }
 
   @override
@@ -104,7 +119,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
         return;
       }
 
-      _notifyAmbientItem();
+      _notifyAmbientArtwork();
     });
   }
 
@@ -140,32 +155,43 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     });
 
     if (_isHighlighted) {
-      _notifyAmbientItem();
+      _notifyAmbientArtwork();
     }
   }
 
-  void _notifyAmbientItem() {
+  void _notifyAmbientArtwork() {
     if (widget.items.isEmpty ||
         widget.activeIndex < 0 ||
         widget.activeIndex >= widget.items.length) {
       return;
     }
 
-    widget.onAmbientItemChanged?.call(
-      widget.items[widget.activeIndex],
+    final item = widget.items[widget.activeIndex];
+
+    widget.onAmbientArtworkChanged?.call(
+      _artworkUrl(context, item),
     );
   }
 
-  bool _usesMobilePoster(MediaBarSlideItem item) {
+  bool _usesMobilePoster(
+      BuildContext context,
+      MediaBarSlideItem item,
+      ) {
     final posterUrl = item.posterUrl;
+    final isPortrait =
+        MediaQuery.orientationOf(context) == Orientation.portrait;
 
     return PlatformDetection.useMobileUi &&
+        isPortrait &&
         posterUrl != null &&
         posterUrl.isNotEmpty;
   }
 
-  String? _artworkUrl(MediaBarSlideItem item) {
-    if (_usesMobilePoster(item)) {
+  String? _artworkUrl(
+      BuildContext context,
+      MediaBarSlideItem item,
+      ) {
+    if (_usesMobilePoster(context, item)) {
       return item.posterUrl;
     }
 
@@ -184,7 +210,7 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
 
     final borderColor = GlassFocusHalo.appleStyleActive
         ? Colors.white
-        : theme.colorScheme.primary;
+        : borders.focusBorder.color;
 
     final showGlow =
         isHighlighted && borders.focusGlow.isNotEmpty;
@@ -203,6 +229,30 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
             fit: StackFit.passthrough,
             clipBehavior: Clip.none,
             children: [
+              if (isHighlighted)
+                Positioned(
+                  top: 0,
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: IgnorePointer(
+                    child: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: AppRadius.circular(
+                          AyaMediaBar._cornerRadius,
+                        ),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.22),
+                            blurRadius: 28,
+                            spreadRadius: 1,
+                            offset: const Offset(0, 10),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
               if (showGlow)
                 Positioned(
                   top: -AyaMediaBar._focusInset,
@@ -231,13 +281,13 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      _buildAnimatedBackdrop(item),
-
+                      _buildAnimatedSlide(
+                        context,
+                        theme,
+                        item,
+                      ),
                       if (widget.trailerOverlay != null)
                         widget.trailerOverlay!,
-
-                      _buildAnimatedContent(theme, item),
-
                       if (widget.items.length > 1)
                         _buildIndicators(),
                     ],
@@ -274,86 +324,27 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
     );
   }
 
-  Widget _buildAnimatedBackdrop(MediaBarSlideItem item) {
-    return AnimatedSwitcher(
-      duration: AyaMediaBar._slideTransitionDuration,
-      reverseDuration: AyaMediaBar._slideTransitionDuration,
-      switchInCurve: Curves.easeInOutCubic,
-      switchOutCurve: Curves.easeInOutCubic,
-      layoutBuilder: _buildAnimatedLayout,
-      transitionBuilder: _buildSlideTransition,
-      child: KeyedSubtree(
-        key: ValueKey('aya_backdrop_slide_${item.itemId}'),
-        child: _AyaBackdrop(
-          artworkUrl: _artworkUrl(item),
-          highlighted: _isHighlighted,
-          depthScale: AyaMediaBar._backdropDepthScale,
-          depthInDuration: AyaMediaBar._backdropDepthInDuration,
-          depthOutDuration: AyaMediaBar._backdropDepthOutDuration,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildAnimatedContent(
+  Widget _buildAnimatedSlide(
+      BuildContext context,
       ThemeData theme,
       MediaBarSlideItem item,
       ) {
-    return AnimatedSwitcher(
-      duration: AyaMediaBar._slideTransitionDuration,
-      reverseDuration: AyaMediaBar._slideTransitionDuration,
-      switchInCurve: Curves.easeInOutCubic,
-      switchOutCurve: Curves.easeInOutCubic,
-      layoutBuilder: _buildAnimatedLayout,
-      transitionBuilder: _buildSlideTransition,
-      child: KeyedSubtree(
-        key: ValueKey('aya_content_${item.itemId}'),
-        child: _usesMobilePoster(item)
-            ? const SizedBox.expand()
-            : _buildContent(theme, item),
-      ),
-    );
-  }
-
-  Widget _buildAnimatedLayout(
-      Widget? currentChild,
-      List<Widget> previousChildren,
-      ) {
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        ...previousChildren,
-        if (currentChild != null) currentChild,
-      ],
-    );
-  }
-
-  Widget _buildSlideTransition(
-      Widget child,
-      Animation<double> animation,
-      ) {
-    final opacity = CurvedAnimation(
-      parent: animation,
-      curve: Curves.easeInOutCubic,
-      reverseCurve: Curves.easeInOutCubic,
-    );
-
-    final scale = Tween<double>(
-      begin: AyaMediaBar._slideScaleBegin,
-      end: 1.0,
-    ).animate(
-      CurvedAnimation(
-        parent: animation,
-        curve: Curves.easeOutCubic,
-      ),
-    );
-
-    return FadeTransition(
-      opacity: opacity,
-      child: ScaleTransition(
-        scale: scale,
-        child: child,
-      ),
+    return _AyaSlideTransition(
+      item: item,
+      artworkUrl: _artworkUrl(context, item),
+      showContent: !_usesMobilePoster(context, item),
+      highlighted: _isHighlighted,
+      depthScale: AyaMediaBar._backdropDepthScale,
+      depthInDuration: AyaMediaBar._backdropDepthInDuration,
+      depthOutDuration: AyaMediaBar._backdropDepthOutDuration,
+      transitionDuration: AyaMediaBar._slideTransitionDuration,
+      slideScaleBegin: AyaMediaBar._slideScaleBegin,
+      contentBuilder: (slideItem) {
+        return _buildContent(
+          theme,
+          slideItem,
+        );
+      },
     );
   }
 
@@ -468,6 +459,262 @@ class _AyaMediaBarState extends State<AyaMediaBar> {
   }
 }
 
+class _AyaSlideVisual {
+  final MediaBarSlideItem item;
+  final String? artworkUrl;
+  final bool showContent;
+
+  const _AyaSlideVisual({
+    required this.item,
+    required this.artworkUrl,
+    required this.showContent,
+  });
+}
+
+class _AyaSlideTransition extends StatefulWidget {
+  final MediaBarSlideItem item;
+  final String? artworkUrl;
+  final bool showContent;
+  final bool highlighted;
+  final double depthScale;
+  final Duration depthInDuration;
+  final Duration depthOutDuration;
+  final Duration transitionDuration;
+  final double slideScaleBegin;
+  final Widget Function(MediaBarSlideItem item) contentBuilder;
+
+  const _AyaSlideTransition({
+    required this.item,
+    required this.artworkUrl,
+    required this.showContent,
+    required this.highlighted,
+    required this.depthScale,
+    required this.depthInDuration,
+    required this.depthOutDuration,
+    required this.transitionDuration,
+    required this.slideScaleBegin,
+    required this.contentBuilder,
+  });
+
+  @override
+  State<_AyaSlideTransition> createState() =>
+      _AyaSlideTransitionState();
+}
+
+class _AyaSlideTransitionState extends State<_AyaSlideTransition>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _transitionController;
+
+  late _AyaSlideVisual _baseSlide;
+  _AyaSlideVisual? _incomingSlide;
+  late _AyaSlideVisual _desiredSlide;
+
+  bool _isTransitioning = false;
+  int _prepareGeneration = 0;
+
+  _AyaSlideVisual get _widgetSlide {
+    return _AyaSlideVisual(
+      item: widget.item,
+      artworkUrl: widget.artworkUrl,
+      showContent: widget.showContent,
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    final initialSlide = _widgetSlide;
+
+    _baseSlide = initialSlide;
+    _desiredSlide = initialSlide;
+
+    _transitionController = AnimationController(
+      vsync: this,
+      duration: widget.transitionDuration,
+    );
+
+    _transitionController.addStatusListener(
+      _handleTransitionStatus,
+    );
+  }
+
+  @override
+  void didUpdateWidget(covariant _AyaSlideTransition oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.transitionDuration != widget.transitionDuration) {
+      _transitionController.duration = widget.transitionDuration;
+    }
+
+    final nextSlide = _widgetSlide;
+
+    if (!_sameSlide(_desiredSlide, nextSlide)) {
+      _requestSlide(nextSlide);
+    }
+  }
+
+  @override
+  void dispose() {
+    _prepareGeneration++;
+
+    _transitionController
+      ..removeStatusListener(_handleTransitionStatus)
+      ..dispose();
+
+    super.dispose();
+  }
+
+  bool _sameSlide(
+      _AyaSlideVisual first,
+      _AyaSlideVisual second,
+      ) {
+    return first.item.itemId == second.item.itemId &&
+        first.artworkUrl == second.artworkUrl &&
+        first.showContent == second.showContent;
+  }
+
+  void _requestSlide(_AyaSlideVisual slide) {
+    _desiredSlide = slide;
+
+    if (_isTransitioning || _sameSlide(slide, _baseSlide)) {
+      return;
+    }
+
+    _prepareSlide(slide);
+  }
+
+  void _prepareSlide(_AyaSlideVisual slide) {
+    final generation = ++_prepareGeneration;
+
+    unawaited(
+      _prepareAndStartSlide(
+        slide,
+        generation,
+      ),
+    );
+  }
+
+  Future<void> _prepareAndStartSlide(
+      _AyaSlideVisual slide,
+      int generation,
+      ) async {
+    final artworkUrl = slide.artworkUrl;
+
+    if (artworkUrl != null && artworkUrl.isNotEmpty) {
+      try {
+        await precacheImage(
+          offlineAwareImageProvider(artworkUrl),
+          context,
+        );
+      } catch (_) {}
+    }
+
+    if (!mounted ||
+        generation != _prepareGeneration ||
+        !_sameSlide(slide, _desiredSlide) ||
+        _isTransitioning ||
+        _sameSlide(slide, _baseSlide)) {
+      return;
+    }
+
+    setState(() {
+      _incomingSlide = slide;
+      _isTransitioning = true;
+    });
+
+    _transitionController
+      ..duration = widget.transitionDuration
+      ..value = 0.0
+      ..forward();
+  }
+
+  void _handleTransitionStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed || !_isTransitioning) {
+      return;
+    }
+
+    final completedSlide = _incomingSlide;
+
+    if (completedSlide == null) {
+      return;
+    }
+
+    setState(() {
+      _baseSlide = completedSlide;
+      _incomingSlide = null;
+      _isTransitioning = false;
+    });
+
+    _transitionController
+      ..stop()
+      ..value = 0.0;
+
+    final desiredSlide = _desiredSlide;
+
+    if (!_sameSlide(desiredSlide, _baseSlide)) {
+      _prepareSlide(desiredSlide);
+    }
+  }
+
+  Widget _buildSlide(_AyaSlideVisual slide) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _AyaBackdrop(
+          key: ValueKey(
+            'aya_backdrop_${slide.item.itemId}_${slide.artworkUrl}',
+          ),
+          artworkUrl: slide.artworkUrl,
+          highlighted: widget.highlighted,
+          depthScale: widget.depthScale,
+          depthInDuration: widget.depthInDuration,
+          depthOutDuration: widget.depthOutDuration,
+        ),
+        if (slide.showContent)
+          widget.contentBuilder(
+            slide.item,
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final incomingOpacity = CurvedAnimation(
+      parent: _transitionController,
+      curve: Curves.easeOutCubic,
+    );
+
+    final incomingScale = Tween<double>(
+      begin: widget.slideScaleBegin,
+      end: 1.0,
+    ).animate(
+      CurvedAnimation(
+        parent: _transitionController,
+        curve: Curves.easeOutCubic,
+      ),
+    );
+
+    final incomingSlide = _incomingSlide;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildSlide(_baseSlide),
+        if (_isTransitioning && incomingSlide != null)
+          FadeTransition(
+            opacity: incomingOpacity,
+            child: ScaleTransition(
+              scale: incomingScale,
+              child: _buildSlide(incomingSlide),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
 class _AyaBackdrop extends StatefulWidget {
   final String? artworkUrl;
   final bool highlighted;
@@ -476,6 +723,7 @@ class _AyaBackdrop extends StatefulWidget {
   final Duration depthOutDuration;
 
   const _AyaBackdrop({
+    super.key,
     required this.artworkUrl,
     required this.highlighted,
     required this.depthScale,

--- a/lib/ui/widgets/mediabar/aya_media_bar.dart
+++ b/lib/ui/widgets/mediabar/aya_media_bar.dart
@@ -2,9 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../data/models/media_bar_slide_item.dart';
+import '../focus/glass_focus_halo.dart';
 import '../offline_aware_image.dart';
 
-class AyaMediaBar extends StatelessWidget {
+class AyaMediaBar extends StatefulWidget {
   static const _cornerRadius = 18.0;
 
   static const _contentLeftPadding = 44.0;
@@ -24,6 +25,9 @@ class AyaMediaBar extends StatelessWidget {
   static const _indicatorInactiveWidth = 10.0;
   static const _indicatorHeight = 2.0;
   static const _indicatorInactiveOpacity = 0.30;
+
+  static const _focusInset = 3.5;
+  static const _focusBorderWidth = 3.0;
 
   static const _slideTransitionDuration = Duration(
     milliseconds: 900,
@@ -49,29 +53,100 @@ class AyaMediaBar extends StatelessWidget {
   });
 
   @override
+  State<AyaMediaBar> createState() => _AyaMediaBarState();
+}
+
+class _AyaMediaBarState extends State<AyaMediaBar> {
+  bool _isHovered = false;
+
+  @override
   Widget build(BuildContext context) {
-    final item = items[activeIndex];
+    final item = widget.items[widget.activeIndex];
     final theme = Theme.of(context);
 
-    return Padding(
-      padding: padding,
-      child: ClipRRect(
-        borderRadius: AppRadius.circular(
-          _cornerRadius,
-        ),
-        child: SizedBox(
-          height: height,
-          width: double.infinity,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              _buildAnimatedSlide(
-                theme,
-                item,
+    final isFocused = Focus.of(context).hasFocus;
+    final isHighlighted = isFocused || _isHovered;
+
+    final borders = ThemeRegistry.active.borders;
+    final borderColor = GlassFocusHalo.appleStyleActive
+        ? Colors.white
+        : theme.colorScheme.primary;
+
+    final showGlow =
+        isHighlighted && borders.focusGlow.isNotEmpty;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      child: Padding(
+        padding: widget.padding,
+        child: Stack(
+          fit: StackFit.passthrough,
+          clipBehavior: Clip.none,
+          children: [
+            if (showGlow)
+              Positioned(
+                top: -AyaMediaBar._focusInset,
+                bottom: -AyaMediaBar._focusInset,
+                left: -AyaMediaBar._focusInset,
+                right: -AyaMediaBar._focusInset,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: AppRadius.circular(
+                        AyaMediaBar._cornerRadius +
+                            AyaMediaBar._focusInset,
+                      ),
+                      boxShadow: borders.focusGlow,
+                    ),
+                  ),
+                ),
               ),
-              if (items.length > 1) _buildIndicators(),
-            ],
-          ),
+            ClipRRect(
+              borderRadius: AppRadius.circular(
+                AyaMediaBar._cornerRadius,
+              ),
+              child: SizedBox(
+                height: widget.height,
+                width: double.infinity,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    _buildAnimatedSlide(
+                      theme,
+                      item,
+                    ),
+                    if (widget.items.length > 1)
+                      _buildIndicators(),
+                  ],
+                ),
+              ),
+            ),
+            if (isHighlighted)
+              Positioned(
+                top: -AyaMediaBar._focusInset,
+                bottom: -AyaMediaBar._focusInset,
+                left: -AyaMediaBar._focusInset,
+                right: -AyaMediaBar._focusInset,
+                child: IgnorePointer(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: AppRadius.circular(
+                        AyaMediaBar._cornerRadius +
+                            AyaMediaBar._focusInset,
+                      ),
+                      border: Border.fromBorderSide(
+                        borders.focusBorder.copyWith(
+                          color: borderColor,
+                          width: AyaMediaBar._focusBorderWidth,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );
@@ -82,8 +157,8 @@ class AyaMediaBar extends StatelessWidget {
       MediaBarSlideItem item,
       ) {
     return AnimatedSwitcher(
-      duration: _slideTransitionDuration,
-      reverseDuration: _slideTransitionDuration,
+      duration: AyaMediaBar._slideTransitionDuration,
+      reverseDuration: AyaMediaBar._slideTransitionDuration,
       switchInCurve: Curves.easeInOutCubic,
       switchOutCurve: Curves.easeInOutCubic,
       layoutBuilder: (
@@ -109,7 +184,7 @@ class AyaMediaBar extends StatelessWidget {
         );
 
         final scale = Tween<double>(
-          begin: _slideScaleBegin,
+          begin: AyaMediaBar._slideScaleBegin,
           end: 1.0,
         ).animate(
           CurvedAnimation(
@@ -127,7 +202,7 @@ class AyaMediaBar extends StatelessWidget {
         );
       },
       child: KeyedSubtree(
-        key: ValueKey(activeIndex),
+        key: ValueKey(widget.activeIndex),
         child: _buildSlide(
           theme,
           item,
@@ -177,8 +252,8 @@ class AyaMediaBar extends StatelessWidget {
       MediaBarSlideItem item,
       ) {
     return Positioned(
-      left: _contentLeftPadding,
-      top: _contentTopPadding,
+      left: AyaMediaBar._contentLeftPadding,
+      top: AyaMediaBar._contentTopPadding,
       child: _buildLogoOrTitle(
         theme,
         item,
@@ -200,8 +275,8 @@ class AyaMediaBar extends StatelessWidget {
     }
 
     return SizedBox(
-      width: _logoWidth,
-      height: _logoHeight,
+      width: AyaMediaBar._logoWidth,
+      height: AyaMediaBar._logoHeight,
       child: OfflineAwareImage(
         imageUrl: logoUrl,
         fit: BoxFit.contain,
@@ -221,7 +296,7 @@ class AyaMediaBar extends StatelessWidget {
       ) {
     return ConstrainedBox(
       constraints: const BoxConstraints(
-        maxWidth: _titleMaxWidth,
+        maxWidth: AyaMediaBar._titleMaxWidth,
       ),
       child: Text(
         title,
@@ -235,9 +310,9 @@ class AyaMediaBar extends StatelessWidget {
           shadows: [
             Shadow(
               color: AppColorScheme.scrim.withValues(
-                alpha: _titleShadowOpacity,
+                alpha: AyaMediaBar._titleShadowOpacity,
               ),
-              blurRadius: _titleShadowBlurRadius,
+              blurRadius: AyaMediaBar._titleShadowBlurRadius,
             ),
           ],
         ),
@@ -247,33 +322,33 @@ class AyaMediaBar extends StatelessWidget {
 
   Widget _buildIndicators() {
     return Positioned(
-      top: _indicatorTopInset,
-      right: _indicatorRightInset,
+      top: AyaMediaBar._indicatorTopInset,
+      right: AyaMediaBar._indicatorRightInset,
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: List.generate(
-          items.length,
+          widget.items.length,
               (index) {
-            final isActive = index == activeIndex;
+            final isActive = index == widget.activeIndex;
 
             return AnimatedContainer(
-              duration: _indicatorAnimationDuration,
+              duration: AyaMediaBar._indicatorAnimationDuration,
               curve: Curves.easeOutCubic,
               margin: const EdgeInsets.only(
-                left: _indicatorSpacing,
+                left: AyaMediaBar._indicatorSpacing,
               ),
               width: isActive
-                  ? _indicatorActiveWidth
-                  : _indicatorInactiveWidth,
-              height: _indicatorHeight,
+                  ? AyaMediaBar._indicatorActiveWidth
+                  : AyaMediaBar._indicatorInactiveWidth,
+              height: AyaMediaBar._indicatorHeight,
               decoration: BoxDecoration(
                 color: isActive
                     ? AppColorScheme.onSurface
                     : AppColorScheme.onSurface.withValues(
-                  alpha: _indicatorInactiveOpacity,
+                  alpha: AyaMediaBar._indicatorInactiveOpacity,
                 ),
                 borderRadius: AppRadius.circular(
-                  _indicatorHeight,
+                  AyaMediaBar._indicatorHeight,
                 ),
               ),
             );

--- a/test/ui/setup_wizard_previews_test.dart
+++ b/test/ui/setup_wizard_previews_test.dart
@@ -36,6 +36,7 @@ const _mediaBarModes = [
   UserPreferences.mediaBarModeBookshelf,
   UserPreferences.mediaBarModeGallery,
   UserPreferences.mediaBarModeBanner,
+  UserPreferences.mediaBarModeAya,
   UserPreferences.mediaBarModeOff,
 ];
 


### PR DESCRIPTION
# Pull Request

## Summary
Adds **Aya**, a new selectable Media Bar style focused on a simple, artwork-first presentation.

Aya keeps the hero minimal: large artwork, logo or title fallback, pagination indicators, smooth slide transitions, and integration with Moonfin's existing focus, ambient background, auto-advance, and trailer systems.

The layout adapts to mobile by using poster artwork in portrait and backdrop artwork in landscape.

Existing Media Bar styles and their behavior remain unchanged.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Add Aya as a selectable Media Bar style in Display settings.
- Add a dedicated artwork-first Aya Media Bar with rounded artwork, logo/title fallback, pagination indicators, and focus styling.
- Add synchronized artwork and logo transitions, including rapid slide changes.
- Integrate Aya with the existing focus expansion, ambient background, auto-advance, and trailer preview behavior.
- Use poster artwork on mobile portrait and backdrop artwork on landscape.
- Keep ambient artwork in sync with the currently displayed Aya artwork, including orientation changes.
- Add horizontal swipe navigation on mobile.
- Disable trailer previews for Aya on mobile while retaining them on desktop and tvOS.
- Keep existing Media Bar styles unchanged.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Manually tested Aya on macOS, iOS, and a physical Apple TV, including focus navigation, rapid slide switching, responsive layouts, ambient backgrounds, trailer previews, and orientation changes.

The full Flutter test suite passes with **813 tests**.

`flutter analyze` was also run. The repository currently reports existing diagnostics from generated iOS/macOS SourcePackages, package test dependencies, and unrelated files; no diagnostics were reported for the Aya Media Bar changes.

- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open **Settings → Display → Media Bar Style** and select **Aya**.
2. Return to Home and verify the Aya hero renders with artwork, logo/title fallback, pagination indicators, and ambient background.
3. Navigate rapidly between featured items and verify artwork and logo transitions remain synchronized without blank frames.
4. On tvOS, verify focus expansion, focus styling, D-pad navigation, ambient background updates, and trailer previews.
5. On iOS portrait, verify poster artwork is used without an additional logo overlay and swipe between featured items.
6. Rotate iOS to landscape and verify Aya switches to backdrop artwork with logo/title content and updates the ambient background.
7. Rotate back to portrait and verify poster artwork and ambient background update again.
8. Disable Focus Expansion and Auto Advance and verify Aya respects both settings.
9. Switch to another Media Bar style and verify existing styles continue to behave normally.

## Screenshots (if applicable)

### tvOS
<img width="3840" height="2160" alt="tvos-nav-top" src="https://github.com/user-attachments/assets/94974f7f-1f2d-4aab-9442-903f7c90678b" />

<img width="3840" height="2160" alt="tvos-nav-left" src="https://github.com/user-attachments/assets/e6ebf722-3822-445e-8604-218e19d01396" />

### macOS
<img width="3452" height="2152" alt="macos-nav-left" src="https://github.com/user-attachments/assets/0333892b-3c2a-4fdd-8a15-c2c863002f7b" />

### iOS — Portrait
<img width="1170" height="2532" alt="ios-portrait-nav-top" src="https://github.com/user-attachments/assets/3a0cb016-909d-4751-91c0-410ca061ae5e" />

### iOS — Landscape
<img width="2532" height="1170" alt="ios-landscape-nav-left" src="https://github.com/user-attachments/assets/f31e9c70-1989-4cd4-bf5a-28c2531c9c67" />


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced