### PR TITLE
Fix 10 bit video being stream copied to devices that cannot decode it

### DIFF
--- a/lib/playback/device_profile_builder.dart
+++ b/lib/playback/device_profile_builder.dart
@@ -1068,15 +1068,21 @@ class DeviceProfileBuilder {
     );
 
     if (!supportsAvcHigh10) {
+      // Must be stated as a positive allow-list, not `NotEquals 'high 10'`.
+      // The server only serialises positive VideoProfile conditions into the
+      // transcode URL (as `h264-profile=`). A negated condition still blocks
+      // direct play, but nothing carries the veto through to the encoder, so
+      // the server falls back to `-c:v copy` and hands the device the very
+      // High 10 bitstream it just said it cannot decode.
       profiles.add(
         _codecProfile(
           type: 'Video',
           codec: 'h264',
           conditions: <Map<String, dynamic>>[
             _condition(
-              condition: 'NotEquals',
+              condition: 'EqualsAny',
               property: 'VideoProfile',
-              value: 'high 10',
+              value: 'high|main|baseline|constrained baseline',
             ),
           ],
         ),
@@ -1193,15 +1199,18 @@ class DeviceProfileBuilder {
     );
 
     if (!supportsHevcMain10) {
+      // Positive allow-list for the same reason as the AVC High 10 veto above:
+      // `NotEquals 'main 10'` never reaches the encoder, so the server remuxes
+      // the 10-bit stream through untouched.
       profiles.add(
         _codecProfile(
           type: 'Video',
           codec: 'hevc',
           conditions: <Map<String, dynamic>>[
             _condition(
-              condition: 'NotEquals',
+              condition: 'EqualsAny',
               property: 'VideoProfile',
-              value: 'main 10',
+              value: 'main',
             ),
           ],
         ),

--- a/test/playback/device_profile_builder_test.dart
+++ b/test/playback/device_profile_builder_test.dart
@@ -58,15 +58,55 @@ bool _excludesVideoProfile(
     final conditions = codecProfile['Conditions'] as List<dynamic>? ?? const [];
     for (final rawCondition in conditions) {
       final condition = rawCondition as Map<dynamic, dynamic>;
-      if (condition['Property'] == 'VideoProfile' &&
-          condition['Condition'] == 'NotEquals' &&
+      if (condition['Property'] != 'VideoProfile') {
+        continue;
+      }
+
+      // Both spellings exclude the profile. Only the allow-list form survives
+      // into the transcode URL, which is why the builder prefers it, but the
+      // negated form is still in use for other codecs.
+      if (condition['Condition'] == 'NotEquals' &&
           condition['Value'] == videoProfile) {
         return true;
+      }
+
+      if (condition['Condition'] == 'EqualsAny') {
+        final allowed = (condition['Value'] as String)
+            .split('|')
+            .map((value) => value.trim().toLowerCase())
+            .toSet();
+        if (!allowed.contains(videoProfile.toLowerCase())) {
+          return true;
+        }
       }
     }
   }
 
   return false;
+}
+
+/// The server only serialises positive VideoProfile conditions into the
+/// transcode URL, so a negated veto is silently dropped and the stream gets
+/// copied instead of re-encoded.
+bool _vetoSurvivesToTranscodeUrl(
+  Map<String, dynamic> profile,
+  String codec,
+) {
+  final codecProfiles = profile['CodecProfiles'] as List<dynamic>? ?? const [];
+
+  return codecProfiles.any((rawProfile) {
+    final codecProfile = rawProfile as Map<dynamic, dynamic>;
+    if (codecProfile['Type'] != 'Video' || codecProfile['Codec'] != codec) {
+      return false;
+    }
+
+    final conditions = codecProfile['Conditions'] as List<dynamic>? ?? const [];
+    return conditions.any((rawCondition) {
+      final condition = rawCondition as Map<dynamic, dynamic>;
+      return condition['Property'] == 'VideoProfile' &&
+          condition['Condition'] == 'EqualsAny';
+    });
+  });
 }
 
 Set<String> _codecUnsupportedRangeTypes(
@@ -333,6 +373,38 @@ void main() {
       );
 
       expect(_excludesVideoProfile(profile, 'h264', 'high 10'), isFalse);
+    });
+
+    test('states the Hi10p veto positively so the server cannot stream copy '
+        'the 10 bit bitstream', () {
+      final profile = DeviceProfileBuilder.build(
+        supportsAvc: true,
+        avcMainLevel: 51,
+      );
+
+      expect(_vetoSurvivesToTranscodeUrl(profile, 'h264'), isTrue);
+    });
+  });
+
+  group('DeviceProfileBuilder HEVC Main 10', () {
+    test('a device without a 10 bit HEVC decoder transcodes Main 10', () {
+      final profile = DeviceProfileBuilder.build(
+        supportsHevc: true,
+        hevcMainLevel: 120,
+      );
+
+      expect(_excludesVideoProfile(profile, 'hevc', 'main 10'), isTrue);
+      expect(_vetoSurvivesToTranscodeUrl(profile, 'hevc'), isTrue);
+    });
+
+    test('a device with one keeps Main 10 direct playable', () {
+      final profile = DeviceProfileBuilder.build(
+        supportsHevc: true,
+        hevcMainLevel: 120,
+        supportsHevcMain10: true,
+      );
+
+      expect(_excludesVideoProfile(profile, 'hevc', 'main 10'), isFalse);
     });
   });
 


### PR DESCRIPTION
# Pull Request

## Summary
A device that reports no 10 bit decoder still receives the 10 bit bitstream, and plays it back with heavy blocking artifacts.

`_videoCodecProfiles` vetoes the profiles such a device cannot decode with a negated condition — `VideoProfile NotEquals 'high 10'` for AVC, `NotEquals 'main 10'` for HEVC. That is enough to fail the direct play check, so the server correctly reports `TranscodeReasons=VideoProfileNotSupported`. But the server only serialises **positive** `VideoProfile` conditions into the transcode URL as `<codec>-profile=`. A negated condition has no representation there, so the veto is dropped before the encoder is chosen, `EncodingHelper` finds nothing objecting to the source stream, and the segment job runs `-c:v copy`.

The net effect is the worst of both paths: the client loses direct play, the server opens a transcode session, and the device still gets the exact bitstream it just said it could not decode.

Emby's own web client states the same constraint positively (`h264-profile=high,main,baseline,constrainedbaseline`) and gets a real re-encode from the same server, on the same file, in the same minute. This PR adopts that spelling.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # — no existing issue; found while debugging artifacted Hi10p anime playback on an Android TV device.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `lib/playback/device_profile_builder.dart` — AVC High 10 veto restated as `VideoProfile EqualsAny 'high|main|baseline|constrained baseline'` when `supportsAvcHigh10` is false.
- `lib/playback/device_profile_builder.dart` — HEVC Main 10 veto restated as `VideoProfile EqualsAny 'main'` when `supportsHevcMain10` is false.
- `test/playback/device_profile_builder_test.dart` — `_excludesVideoProfile` now understands both the negated and the allow-list spelling, so the existing Hi10p expectations keep their original meaning.
- `test/playback/device_profile_builder_test.dart` — new `_vetoSurvivesToTranscodeUrl` helper plus regression tests asserting the veto is expressed positively for both codecs, and a new HEVC Main 10 group mirroring the existing AVC High 10 group.

Deliberately left alone: the `VideoProfile NotEquals 'none'` conditions, which are codec-presence markers rather than profile vetoes, and the AV1 `NotEquals 'main 10'` branch. AV1 carries bit depth outside the profile field, so that one needs a `VideoBitDepth` condition rather than a renamed profile check, and I had no AV1 10 bit source to verify it against.

## Platform
- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

The bug was **observed** on a physical Android TV device (Android 13, no 10 bit AVC decoder) against Emby 4.9.5.0. The fix itself was verified at the profile level by driving `/Items/{id}/PlaybackInfo` with each condition spelling and reading back the ffmpeg job the server actually started, rather than by reinstalling the app — that isolates the change to the one thing it alters.

`flutter analyze` is clean on both changed files, and `flutter test test/playback/` passes 241 tests.

### Test Steps
1. Pick a source the device cannot decode — `h264 / High 10 / yuv420p10le` for AVC, `hevc / Main 10` for HEVC.
2. POST `/Items/{id}/PlaybackInfo` with a device profile whose codec profile carries `VideoProfile NotEquals 'high 10'`, fetch the returned `TranscodingUrl`, then fetch its first segment. The server writes `ffmpeg-directstream-<id>.txt` and the command line contains `-c:v copy` — the 10 bit stream reaches the device untouched. The returned URL carries no `h264-profile=` parameter.
3. Repeat with `VideoProfile EqualsAny 'high|main|baseline|constrained baseline'`. The URL now carries `h264-profile=high,main,baseline,constrainedbaseline`, the server writes `ffmpeg-transcode-<id>.txt`, and the command line contains `-c:v h264_qsv` — a real 8 bit re-encode.
4. Same A/B on an HEVC Main 10 source: `NotEquals 'main 10'` yields `ffmpeg-remux-<id>.txt` with `-c:v copy`; `EqualsAny 'main'` yields `ffmpeg-transcode-<id>.txt` decoding `hevc_qsv` and encoding `h264_qsv`.
5. `flutter test test/playback/` — 241 passing, including the new regression tests.

## Screenshots (if applicable)
No UI change. The server-side evidence, same file and same server, differing only in the condition spelling:

```
NotEquals 'high 10'   -> ffmpeg-directstream-2116bd3c-... : -c:v copy
EqualsAny allow-list  -> ffmpeg-transcode-f7265599-...    : -c:v h264_qsv
```

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

Branch is rebased on `main` (`fb9724fc`).
