### PR TITLE
fix(backdrop): prevent fade resets during rapid navigation

### DIFF
--- a/lib/ui/widgets/fullscreen_backdrop_switcher.dart
+++ b/lib/ui/widgets/fullscreen_backdrop_switcher.dart
@@ -28,18 +28,33 @@ class _FullscreenBackdropSwitcherState extends State<FullscreenBackdropSwitcher>
 
   String? _currentUrl;
   String? _incomingUrl;
+  String? _pendingUrl;
 
   @override
   void initState() {
     super.initState();
+
     _controller = AnimationController(vsync: this, duration: widget.duration);
+
     _currentUrl = widget.imageUrl;
+
     _controller.addStatusListener((status) {
-      if (status == AnimationStatus.completed && mounted) {
-        setState(() {
-          _currentUrl = _incomingUrl;
-          _incomingUrl = null;
-        });
+      if (status != AnimationStatus.completed || !mounted) {
+        return;
+      }
+
+      final pending = _pendingUrl;
+
+      final shouldContinue = pending != null && pending != _incomingUrl;
+
+      setState(() {
+        _currentUrl = _incomingUrl;
+        _incomingUrl = shouldContinue ? pending : null;
+        _pendingUrl = null;
+      });
+
+      if (shouldContinue) {
+        _controller.forward(from: 0);
       }
     });
   }
@@ -47,21 +62,44 @@ class _FullscreenBackdropSwitcherState extends State<FullscreenBackdropSwitcher>
   @override
   void didUpdateWidget(FullscreenBackdropSwitcher oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.duration != widget.duration) {
+      _controller.duration = widget.duration;
+    }
+
     final next = widget.imageUrl;
     final shown = _incomingUrl ?? _currentUrl;
-    if (next == shown) return;
 
-    if (next == null) {
-      // Cleared: drop both layers immediately.
-      _controller.stop();
-      setState(() {
-        _currentUrl = null;
-        _incomingUrl = null;
-      });
+    if (next == shown) {
+      _pendingUrl = null;
       return;
     }
 
-    setState(() => _incomingUrl = next);
+    if (next == _pendingUrl) {
+      return;
+    }
+
+    if (next == null) {
+      _controller.stop();
+
+      setState(() {
+        _currentUrl = null;
+        _incomingUrl = null;
+        _pendingUrl = null;
+      });
+
+      return;
+    }
+
+    if (_controller.isAnimating) {
+      _pendingUrl = next;
+      return;
+    }
+
+    setState(() {
+      _incomingUrl = next;
+    });
+
     _controller.forward(from: 0);
   }
 

--- a/lib/ui/widgets/fullscreen_backdrop_switcher.dart
+++ b/lib/ui/widgets/fullscreen_backdrop_switcher.dart
@@ -80,6 +80,7 @@ class _FullscreenBackdropSwitcherState extends State<FullscreenBackdropSwitcher>
     }
 
     if (next == null) {
+      // Cleared: drop all backdrop state immediately.
       _controller.stop();
 
       setState(() {

--- a/test/ui/widgets/fullscreen_backdrop_switcher_test.dart
+++ b/test/ui/widgets/fullscreen_backdrop_switcher_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/fullscreen_backdrop_switcher.dart';
+
+void main() {
+  Widget app(String? imageUrl) {
+    return MaterialApp(
+      home: FullscreenBackdropSwitcher(
+        imageUrl: imageUrl,
+        duration: const Duration(milliseconds: 800),
+        imageBuilder: (url) => Text(url),
+      ),
+    );
+  }
+
+  testWidgets('does not restart the backdrop fade during rapid changes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app('a'));
+
+    await tester.pumpWidget(app('b'));
+    await tester.pump(const Duration(milliseconds: 400));
+
+    await tester.pumpWidget(app('c'));
+
+    final fadeFinder = find.descendant(
+      of: find.byType(FullscreenBackdropSwitcher),
+      matching: find.byType(FadeTransition),
+    );
+
+    final fade = tester.widget<FadeTransition>(fadeFinder);
+
+    expect(
+      fade.opacity.value,
+      greaterThan(0),
+      reason: 'rapid changes should not restart the active fade from zero',
+    );
+  });
+
+  testWidgets('clears all backdrop layers immediately when URL becomes null', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app('a'));
+
+    await tester.pumpWidget(app('b'));
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.pumpWidget(app('c'));
+
+    expect(find.text('a'), findsOneWidget);
+    expect(find.text('b'), findsOneWidget);
+
+    await tester.pumpWidget(app(null));
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsNothing);
+    expect(find.text('c'), findsNothing);
+
+    final fadeFinder = find.descendant(
+      of: find.byType(FullscreenBackdropSwitcher),
+      matching: find.byType(FadeTransition),
+    );
+
+    expect(fadeFinder, findsNothing);
+  });
+
+  testWidgets('drops stale pending backdrop when focus returns to incoming', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app('a'));
+
+    await tester.pumpWidget(app('b'));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    await tester.pumpWidget(app('a'));
+
+    await tester.pumpWidget(app('b'));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('b'), findsOneWidget);
+    expect(find.text('a'), findsNothing);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Fixes ambient backdrop transitions during rapid navigation so active fades are not restarted or dropped when focus changes quickly.

## Related Issues
None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Preserve the active backdrop transition when a new backdrop URL arrives.
- Queue the latest requested backdrop while a transition is in progress.
- Add regression tests for rapid changes, stale pending backdrops, and clearing the backdrop with a null URL.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate rapidly between media items while ambient backgrounds are enabled.
2. Verify the active backdrop transition remains visible and does not restart or disappear during rapid focus changes.
3. Verify the added widget tests pass and the modified files pass Flutter analysis.

## Screenshots (if applicable)
### Before
[before.webm](https://github.com/user-attachments/assets/3deac4d6-7d9f-4922-aab4-5801a164c2cc)

### After
[after.webm](https://github.com/user-attachments/assets/ee9db214-36bb-449d-a77e-258803999ced)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced