### PR TITLE
Fix/preserve paused state during re-resolution

### DIFF
--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Resolve dependencies
         run: flutter-tvos pub get
 
+      - name: Static analysis
+        run: flutter-tvos analyze --no-fatal-warnings --no-fatal-infos
+
       - name: Import App Store Connect API key
         env:
           ASC_KEY_BASE64: ${{ secrets.APPLE_ASC_API_KEY_BASE64 }}
@@ -82,10 +85,37 @@ jobs:
 
       - name: Prepare Flutter build settings and pods
         run: |
-          flutter-tvos build tvos --release --no-tree-shake-icons --dart-define=MOONFIN_TVOS=true || true
+          set -euo pipefail
+
+          BASE_BUILD=$(awk -F'+' '/^version:/ {gsub(/[[:space:]]/, "", $2); print $2; exit}' pubspec.yaml)
+
+          if ! [[ "$BASE_BUILD" =~ ^[0-9]+$ ]]; then
+            echo "::error::Could not read a numeric build number from pubspec.yaml"
+            exit 1
+          fi
+
+          BUILD_NUMBER=$((BASE_BUILD + GITHUB_RUN_NUMBER * 1000 + GITHUB_RUN_ATTEMPT))
+
+          echo "MOONFIN_TVOS_BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
+          echo "Using tvOS TestFlight build number: $BUILD_NUMBER"
+
+          flutter-tvos build tvos \
+            --release \
+            --no-tree-shake-icons \
+            --build-number="$BUILD_NUMBER" \
+            --dart-define=MOONFIN_TVOS=true || true
+
           test -f tvos/Flutter/Generated.xcconfig
+
           grep -q '^FLUTTER_ROOT=' tvos/Flutter/Generated.xcconfig \
             || echo "FLUTTER_ROOT=$HOME/flutter-tvos" >> tvos/Flutter/Generated.xcconfig
+
+          ACTUAL_BUILD=$(awk -F= '/^FLUTTER_BUILD_NUMBER=/{print $2; exit}' tvos/Flutter/Generated.xcconfig)
+
+          if [ "$ACTUAL_BUILD" != "$BUILD_NUMBER" ]; then
+            echo "::error::Generated Flutter build number ($ACTUAL_BUILD) does not match expected build number ($BUILD_NUMBER)"
+            exit 1
+          fi
 
       - name: Stage flutter_assets for the Xcode copy phase
         run: |
@@ -176,6 +206,21 @@ jobs:
             CODE_SIGN_STYLE=Automatic \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             archive
+                    
+          APP="$RUNNER_TEMP/Runner.xcarchive/Products/Applications/Runner.app"
+
+          APP_BUILD=$(plutil -extract CFBundleVersion raw "$APP/Info.plist")
+          EXT_BUILD=$(plutil -extract CFBundleVersion raw "$APP/PlugIns/MoonfinTopShelf.appex/Info.plist")
+
+          echo "Archived Runner build number: $APP_BUILD"
+          echo "Archived Top Shelf build number: $EXT_BUILD"
+
+          [ "$APP_BUILD" = "$MOONFIN_TVOS_BUILD_NUMBER" ] \
+            || { echo "::error::Runner build number does not match generated tvOS build number"; exit 1; }
+
+          [ "$EXT_BUILD" = "$APP_BUILD" ] \
+            || { echo "::error::Top Shelf build number does not match Runner"; exit 1; }
+
           APPEX="$RUNNER_TEMP/Runner.xcarchive/Products/Applications/Runner.app/PlugIns/MoonfinTopShelf.appex/MoonfinTopShelf"
           test -e "$APPEX" \
             || { echo "::error::Top Shelf extension missing from archive"; exit 1; }

--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Resolve dependencies
         run: flutter-tvos pub get
 
-      - name: Static analysis
-        run: flutter-tvos analyze --no-fatal-warnings --no-fatal-infos
-
       - name: Import App Store Connect API key
         env:
           ASC_KEY_BASE64: ${{ secrets.APPLE_ASC_API_KEY_BASE64 }}
@@ -85,37 +82,10 @@ jobs:
 
       - name: Prepare Flutter build settings and pods
         run: |
-          set -euo pipefail
-
-          BASE_BUILD=$(awk -F'+' '/^version:/ {gsub(/[[:space:]]/, "", $2); print $2; exit}' pubspec.yaml)
-
-          if ! [[ "$BASE_BUILD" =~ ^[0-9]+$ ]]; then
-            echo "::error::Could not read a numeric build number from pubspec.yaml"
-            exit 1
-          fi
-
-          BUILD_NUMBER=$((BASE_BUILD + GITHUB_RUN_NUMBER * 1000 + GITHUB_RUN_ATTEMPT))
-
-          echo "MOONFIN_TVOS_BUILD_NUMBER=$BUILD_NUMBER" >> "$GITHUB_ENV"
-          echo "Using tvOS TestFlight build number: $BUILD_NUMBER"
-
-          flutter-tvos build tvos \
-            --release \
-            --no-tree-shake-icons \
-            --build-number="$BUILD_NUMBER" \
-            --dart-define=MOONFIN_TVOS=true || true
-
+          flutter-tvos build tvos --release --no-tree-shake-icons --dart-define=MOONFIN_TVOS=true || true
           test -f tvos/Flutter/Generated.xcconfig
-
           grep -q '^FLUTTER_ROOT=' tvos/Flutter/Generated.xcconfig \
             || echo "FLUTTER_ROOT=$HOME/flutter-tvos" >> tvos/Flutter/Generated.xcconfig
-
-          ACTUAL_BUILD=$(awk -F= '/^FLUTTER_BUILD_NUMBER=/{print $2; exit}' tvos/Flutter/Generated.xcconfig)
-
-          if [ "$ACTUAL_BUILD" != "$BUILD_NUMBER" ]; then
-            echo "::error::Generated Flutter build number ($ACTUAL_BUILD) does not match expected build number ($BUILD_NUMBER)"
-            exit 1
-          fi
 
       - name: Stage flutter_assets for the Xcode copy phase
         run: |
@@ -206,21 +176,6 @@ jobs:
             CODE_SIGN_STYLE=Automatic \
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             archive
-                    
-          APP="$RUNNER_TEMP/Runner.xcarchive/Products/Applications/Runner.app"
-
-          APP_BUILD=$(plutil -extract CFBundleVersion raw "$APP/Info.plist")
-          EXT_BUILD=$(plutil -extract CFBundleVersion raw "$APP/PlugIns/MoonfinTopShelf.appex/Info.plist")
-
-          echo "Archived Runner build number: $APP_BUILD"
-          echo "Archived Top Shelf build number: $EXT_BUILD"
-
-          [ "$APP_BUILD" = "$MOONFIN_TVOS_BUILD_NUMBER" ] \
-            || { echo "::error::Runner build number does not match generated tvOS build number"; exit 1; }
-
-          [ "$EXT_BUILD" = "$APP_BUILD" ] \
-            || { echo "::error::Top Shelf build number does not match Runner"; exit 1; }
-
           APPEX="$RUNNER_TEMP/Runner.xcarchive/Products/Applications/Runner.app/PlugIns/MoonfinTopShelf.appex/MoonfinTopShelf"
           test -e "$APPEX" \
             || { echo "::error::Top Shelf extension missing from archive"; exit 1; }

--- a/lib/playback/aether_backend.dart
+++ b/lib/playback/aether_backend.dart
@@ -167,6 +167,7 @@ class AetherBackend implements PlayerBackend {
     Duration startPosition = Duration.zero,
   }) async {
     final payload = mediaItem is Map ? mediaItem : const <String, dynamic>{};
+    final autoPlay = payload['autoPlay'] != false;
     final url = mediaItem is String
         ? mediaItem
         : payload['url']?.toString() ?? '';
@@ -188,7 +189,7 @@ class AetherBackend implements PlayerBackend {
     await _invoke<void>('setSource', {
       'url': url,
       'headers': headers,
-      'autoPlay': true,
+      'autoPlay': autoPlay,
       'startPositionMs': startPosition.inMilliseconds,
       'audioStreamIndex': (payload['audioStreamIndex'] as num?)?.toInt() ?? -1,
       'isLive': payload['isLive'] == true,

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -284,6 +284,8 @@ class AppleTvBackend implements PlayerBackend {
         : payload['url']?.toString() ?? '';
     if (_disposed || url.isEmpty) return;
 
+    final autoPlay = payload['autoPlay'] != false;
+    
     final headers = payload['headers'] is Map
         ? (payload['headers'] as Map).map(
             (key, value) => MapEntry(key.toString(), value.toString()),
@@ -302,14 +304,15 @@ class AppleTvBackend implements PlayerBackend {
     _log(
       'play ${_describeUrl(url)} live=${payload['isLive'] == true} '
       'audioOnly=$audioOnly startMs=${startPosition.inMilliseconds} '
-      'headers=${(headers.keys.toList()..sort()).join(',')}',
+      'headers=${(headers.keys.toList()..sort()).join(',')}'
+      'autoPlay=$autoPlay ',
     );
     await _ensurePlayerPresented(audioOnly: audioOnly);
 
     await _invoke<void>('setSource', {
       'url': url,
       'headers': headers,
-      'autoPlay': true,
+      'autoPlay': autoPlay,
       'startPositionMs': startPosition.inMilliseconds,
       'container': payload['container']?.toString(),
       'videoRangeType': payload['videoRangeType']?.toString(),

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -278,7 +278,9 @@ class AppleTvBackend implements PlayerBackend {
     dynamic mediaItem, {
     Duration startPosition = Duration.zero,
   }) async {
-    final payload = mediaItem is Map ? mediaItem : const <String, dynamic>{};
+    final payload = mediaItem is Map 
+      ? mediaItem 
+      : const <String, dynamic>{};
     final url = mediaItem is String
         ? mediaItem
         : payload['url']?.toString() ?? '';
@@ -304,8 +306,8 @@ class AppleTvBackend implements PlayerBackend {
     _log(
       'play ${_describeUrl(url)} live=${payload['isLive'] == true} '
       'audioOnly=$audioOnly startMs=${startPosition.inMilliseconds} '
-      'headers=${(headers.keys.toList()..sort()).join(',')}'
-      'autoPlay=$autoPlay ',
+      'headers=${(headers.keys.toList()..sort()).join(',')} '
+      'autoPlay=$autoPlay',
     );
     await _ensurePlayerPresented(audioOnly: audioOnly);
 

--- a/lib/playback/html_video_backend_web.dart
+++ b/lib/playback/html_video_backend_web.dart
@@ -368,6 +368,7 @@ class HtmlVideoBackend extends PlayerBackend {
     if (_disposed) return;
 
     final payload = mediaItem is Map ? mediaItem : const <String, dynamic>{};
+    final autoPlay = payload['autoPlay'] != false;
     final url = mediaItem is String
         ? mediaItem
         : payload['url']?.toString() ?? '';
@@ -382,17 +383,22 @@ class HtmlVideoBackend extends PlayerBackend {
 
     await _applySource(url, container: container, startPosition: startPosition);
 
-    _setBuffering(true);
-    try {
-      await _videoElement.play().toDart;
-      _setPlaying(true);
-    } catch (error) {
+    if (autoPlay) {
+      _setBuffering(true);
+      try {
+        await _videoElement.play().toDart;
+        _setPlaying(true);
+      } catch (error) {
+        _setPlaying(false);
+        _errorStream.add(<String, dynamic>{
+          'event': 'playerError',
+          'message': error.toString(),
+        });
+      } finally {
+        _setBuffering(false);
+      }
+    } else {
       _setPlaying(false);
-      _errorStream.add(<String, dynamic>{
-        'event': 'playerError',
-        'message': error.toString(),
-      });
-    } finally {
       _setBuffering(false);
     }
 

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -684,6 +684,7 @@ class Media3PlayerBackend extends PlayerBackend {
     Duration startPosition = Duration.zero,
   }) async {
     final payload = mediaItem is Map ? mediaItem : const <String, dynamic>{};
+    final autoPlay = payload['autoPlay'] != false;
     final url = mediaItem is String
         ? mediaItem
         : payload['url']?.toString() ?? '';
@@ -769,7 +770,7 @@ class Media3PlayerBackend extends PlayerBackend {
     await _invoke<void>('setSource', {
       'url': url,
       'headers': headers,
-      'autoPlay': true,
+      'autoPlay': autoPlay,
       'startPositionMs': startPosition.inMilliseconds,
       'container': container,
       'videoRangeType': videoRangeType,
@@ -808,7 +809,9 @@ class Media3PlayerBackend extends PlayerBackend {
     await _invoke<void>('setSubtitleRendererMode', {
       'mode': _modeToWire(_requestedSubtitleRendererMode),
     });
-    await _invoke<void>('play');
+    if (autoPlay) {
+      await _invoke<void>('play');
+    }
   }
 
   @override

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -621,6 +621,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     Duration startPosition = Duration.zero,
   }) async {
     final payload = mediaItem is Map ? mediaItem : const <String, dynamic>{};
+    final autoPlay = payload['autoPlay'] != false;
     final url = mediaItem is String
         ? mediaItem
         : payload['url']?.toString() ?? '';
@@ -649,7 +650,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     }
 
     final media = Media(url);
-    final openPaused = startPosition > Duration.zero;
+    final openPaused = !autoPlay || startPosition > Duration.zero;
     await _player.open(media, play: !openPaused);
     _updateStaleState();
     await _applyLinuxHwdecFallbackIfNeeded(media, openPaused: openPaused);

--- a/lib/playback/tizen_player_backend.dart
+++ b/lib/playback/tizen_player_backend.dart
@@ -116,9 +116,15 @@ class TizenPlayerBackend extends PlayerBackend {
   Future<void> play(
     dynamic mediaItem,
     {Duration startPosition = Duration.zero}) async {
+    final payload = mediaItem is Map
+    ? mediaItem
+    : const <String, dynamic>{};
+
+    final autoPlay = payload['autoPlay'] != false;
+
     final url = mediaItem is String
         ? mediaItem
-        : (mediaItem is Map ? mediaItem['url']?.toString() ?? '' : '');
+        : payload['url']?.toString() ?? '';
     if (url.isEmpty) return;
 
     await _disposeController();
@@ -141,7 +147,9 @@ class TizenPlayerBackend extends PlayerBackend {
       await controller.seekTo(startPosition);
     }
     await controller.setPlaybackSpeed(_speed);
-    await controller.play();
+    if (autoPlay) {
+      await controller.play();
+    }
     _onValue();
   }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -287,6 +287,7 @@ class PlaybackManager implements AudioOwnable {
     double? normalizationGainDb,
     String? hybridAudioUrl,
     bool isLive = false,
+    bool autoPlay = true,
   }) {
     final resolvedMediaType = mediaType?.trim().toLowerCase();
 
@@ -349,6 +350,7 @@ class PlaybackManager implements AudioOwnable {
 
     return <String, dynamic>{
       'url': url,
+      'autoPlay': autoPlay,
       if (container != null && container.isNotEmpty) 'container': container,
       if (videoRangeType != null && videoRangeType.isNotEmpty)
         'videoRangeType': videoRangeType,
@@ -869,7 +871,10 @@ class PlaybackManager implements AudioOwnable {
     Future<void> recoverViaTranscode() async {
       _unsupportedAudioRecoveryInFlight = true;
       try {
-        await _reResolveAtCurrentPosition(forceTranscode: true);
+        await _reResolveAtCurrentPosition(
+          forceTranscode: true,
+          isErrorRecovery: true,
+        );
       } catch (_) {
         emitFailedBringupState('Playback failed.');
       } finally {
@@ -1125,6 +1130,7 @@ class PlaybackManager implements AudioOwnable {
     bool enableDirectStream = true,
     bool enableTranscoding = true,
     bool allowStartupRecovery = true,
+    bool autoPlay = true,
   }) async {
     _deferredStartPosition = Duration.zero;
     _deferPlaybackToExternalPlayer = false;
@@ -1352,6 +1358,7 @@ class PlaybackManager implements AudioOwnable {
           enableDirectStream: enableDirectStream,
           enableTranscoding: enableTranscoding,
           allowStartupRecovery: allowStartupRecovery,
+          autoPlay: autoPlay,
         );
         return;
       } finally {
@@ -1471,6 +1478,7 @@ class PlaybackManager implements AudioOwnable {
         normalizationGainDb: resolution.normalizationGainDb,
         hybridAudioUrl: resolution.hybridAudioUrl,
         isLive: resolution.liveStreamId != null,
+        autoPlay: autoPlay,
       );
       await _arbiter?.acquire(AudioProducer.mainPlayback);
       if (sessionToken != _playbackSessionToken) {
@@ -1589,6 +1597,7 @@ class PlaybackManager implements AudioOwnable {
               : enableDirectStream,
           enableTranscoding: forceTranscodeFallback ? true : enableTranscoding,
           allowStartupRecovery: false,
+          autoPlay: autoPlay,
         );
         return;
       }
@@ -1629,7 +1638,10 @@ class PlaybackManager implements AudioOwnable {
           playMethod: resolution.playMethod.name,
         ),
       );
-      await _seekWhilePausedAndResume(startPosition);
+      await _seekWhilePausedAndMaybeResume(
+        startPosition,
+        resumeAfterSeek: autoPlay,
+      );
     }
 
     if (resolution.externalSubtitles.isNotEmpty) {
@@ -1767,7 +1779,10 @@ class PlaybackManager implements AudioOwnable {
     return false;
   }
 
-  Future<void> _seekWhilePausedAndResume(Duration position) async {
+  Future<void> _seekWhilePausedAndMaybeResume(
+    Duration position, {
+    bool resumeAfterSeek = true,
+  }) async {
     await _backend!.seekTo(position);
     for (var i = 0; i < 50; i++) {
       await Future.delayed(const Duration(milliseconds: 100));
@@ -1775,7 +1790,10 @@ class PlaybackManager implements AudioOwnable {
         break;
       }
     }
-    await _backend!.resume();
+
+    if (resumeAfterSeek) {
+      await _backend!.resume();
+    }
   }
 
   Future<void> stop({bool userInitiated = true}) async {
@@ -2252,6 +2270,8 @@ class PlaybackManager implements AudioOwnable {
     bool forceTranscode = false,
     bool isErrorRecovery = false,
   }) {
+    final autoPlayAfterResolve =
+    isErrorRecovery ? true : (_backend?.isPlaying ?? state.isPlaying);
     final previous = _reResolveQueue;
     final run = () async {
       if (previous != null) {
@@ -2262,6 +2282,7 @@ class PlaybackManager implements AudioOwnable {
       await _reResolveNow(
         forceTranscode: forceTranscode,
         isErrorRecovery: isErrorRecovery,
+        autoPlayAfterResolve: autoPlayAfterResolve,
       );
     }();
     _reResolveQueue = run;
@@ -2271,6 +2292,7 @@ class PlaybackManager implements AudioOwnable {
   Future<void> _reResolveNow({
     required bool forceTranscode,
     required bool isErrorRecovery,
+    required bool autoPlayAfterResolve,
   }) async {
     final backendPos = _backend?.position ?? Duration.zero;
     final currentPos = Duration(
@@ -2324,6 +2346,7 @@ class PlaybackManager implements AudioOwnable {
         startPosition: currentPos,
         enableDirectPlay: !forceTranscode,
         enableDirectStream: !forceTranscode,
+        autoPlay: autoPlayAfterResolve,
       );
     } finally {
       _teardownForReResolve = false;
@@ -2616,7 +2639,7 @@ class PlaybackManager implements AudioOwnable {
     }
 
     if (startPosition > Duration.zero) {
-      await _seekWhilePausedAndResume(startPosition);
+      await _seekWhilePausedAndMaybeResume(startPosition);
     }
   }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2270,21 +2270,26 @@ class PlaybackManager implements AudioOwnable {
     bool forceTranscode = false,
     bool isErrorRecovery = false,
   }) {
-    final autoPlayAfterResolve =
-    isErrorRecovery ? true : (_backend?.isPlaying ?? state.isPlaying);
     final previous = _reResolveQueue;
+
     final run = () async {
       if (previous != null) {
         try {
           await previous;
         } catch (_) {}
       }
+
+      final autoPlayAfterResolve = isErrorRecovery
+          ? true
+          : (_backend?.isPlaying ?? state.isPlaying);
+
       await _reResolveNow(
         forceTranscode: forceTranscode,
         isErrorRecovery: isErrorRecovery,
         autoPlayAfterResolve: autoPlayAfterResolve,
       );
     }();
+
     _reResolveQueue = run;
     return run;
   }


### PR DESCRIPTION
# Pull Request

## Summary

Preserves the current playback state when a stream is re-resolved, such as when changing audio tracks or other playback parameters.

Previously, re-resolving a stream while playback was paused could load the replacement source with autoplay enabled, causing playback to resume unexpectedly. This change carries the intended autoplay state through the shared playback manager and has each playback backend honor that state when loading the replacement source.

## Related Issues

No GitHub issue currently linked.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Performance improvement
* [ ] UI/UX update
* [ ] Documentation update
* [ ] Build/CI change
* [ ] Other (describe):

## Changes Made

* Preserve the current playing/paused state before stream re-resolution and pass it through as `autoPlay`.
* Update playback backends to honor the preserved `autoPlay` state instead of unconditionally starting playback.
* Preserve existing autoplay behavior for playback/error recovery while preventing normal re-resolution from unexpectedly resuming a paused session.

## Platform

* [x] Android
* [x] iOS
* [x] tvOS
* [x] Web
* [x] macOS
* [x] Windows
* [x] Linux
* [x] All / Shared code

Also updates the Tizen playback backend.


## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Platforms Tested

- [x]  **tvOS / Apple TV** — Confirmed the original issue and verified the fix. When playback is paused and an audio-track change causes stream re-resolution, playback remains paused. When playback is already playing, it continues playing after re-resolution.
- [x]  **Windows / media_kit (MPV)** — Verified that paused playback remains paused after re-resolution/audio-track switching with the patch applied.
- [x]  **Android / MPV** — Verified that paused playback remains paused after re-resolution/audio-track switching with the patch applied.
- [x] **Android / Media3** — Tested audio-track switching. Media3 switches tracks rapidly/in-place without an observable stream re-resolution, so the original re-resolution behavior was not reproduced. No regression was observed.

### Not Yet Tested

- iOS / macOS (Aether)
- Web
- Tizen
- Linux

### Test Steps

1. Start playback of media containing multiple audio tracks.
2. Allow playback to begin normally.
3. Pause playback.
4. Change the selected audio track.
5. Where the player performs a stream re-resolution/reload, verify that playback remains paused afterward.
6. Resume playback and repeat the audio-track change while actively playing.
7. Verify that actively playing content continues playing after the change.

### Results

On tvOS, Windows MPV, and Android MPV, playback that was paused before stream re-resolution remained paused afterward. Playback that was already playing continued playing as expected.

Android Media3 handled the tested audio-track change in-place without an observable stream re-resolution and showed no regression.

## Screenshots (if applicable)

N/A — this is a playback-state behavior fix with no UI changes.

## Checklist

* [x] Code builds successfully
* [x] Code follows project style and conventions
* [x] No unnecessary commented-out code
* [ ] No new warnings introduced
