### PR TITLE
fix: RTL D-pad navigation and layout issues on Android TV

### DIFF
--- a/lib/ui/screens/auth/login_screen.dart
+++ b/lib/ui/screens/auth/login_screen.dart
@@ -713,10 +713,6 @@ class _LoginScreenState extends State<LoginScreen> {
           Text(
             _formatCode(_quickConnectCode!),
             textAlign: TextAlign.center,
-            // The Unicode bidi algorithm reorders the two digit groups as
-            // blocks under an RTL paragraph direction (the space between
-            // them is a neutral char resolved by paragraph direction), so
-            // the code shown would not match the server's actual code.
             textDirection: TextDirection.ltr,
             style: TextStyle(
               fontSize: 48,

--- a/lib/ui/screens/auth/login_screen.dart
+++ b/lib/ui/screens/auth/login_screen.dart
@@ -713,6 +713,9 @@ class _LoginScreenState extends State<LoginScreen> {
           Text(
             _formatCode(_quickConnectCode!),
             textAlign: TextAlign.center,
+            // The space between the digit groups is bidi neutral, so an RTL
+            // paragraph swaps the groups and shows a code the server never
+            // issued. Pinning the text LTR keeps the digits in reading order.
             textDirection: TextDirection.ltr,
             style: TextStyle(
               fontSize: 48,

--- a/lib/ui/screens/auth/login_screen.dart
+++ b/lib/ui/screens/auth/login_screen.dart
@@ -713,6 +713,11 @@ class _LoginScreenState extends State<LoginScreen> {
           Text(
             _formatCode(_quickConnectCode!),
             textAlign: TextAlign.center,
+            // The Unicode bidi algorithm reorders the two digit groups as
+            // blocks under an RTL paragraph direction (the space between
+            // them is a neutral char resolved by paragraph direction), so
+            // the code shown would not match the server's actual code.
+            textDirection: TextDirection.ltr,
             style: TextStyle(
               fontSize: 48,
               fontWeight: FontWeight.bold,

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -48,9 +48,6 @@ class DetailsTabBar extends StatelessWidget {
     this.wrap = false,
   });
 
-  // The tab row mirrors under RTL (ambient Directionality), so which
-  // physical key steps the index forward/back flips; onExitLeft always
-  // fires at the physical-left edge.
   _DetailsTabItem _buildTabItem(BuildContext context, int i, {Key? key}) {
     final isRtl = Directionality.of(context) == TextDirection.rtl;
     void step(int delta) => focusNodeFor(i + delta).requestFocus();
@@ -518,8 +515,6 @@ class _PillTabBarState extends State<_PillTabBar> {
     final thumbColor = glass ? onSurface.withValues(alpha: 0.22) : accent;
 
     final hasThumb = selectedIndex >= 0 && selectedIndex < _widths.length;
-    // The tab Row mirrors under RTL, so the thumb's offset must accumulate
-    // from whichever edge is the row's actual start under Directionality.
     final isRtl = Directionality.of(context) == TextDirection.rtl;
     var thumbOffset = 0.0;
     for (var i = 0; i < selectedIndex && i < _widths.length; i++) {

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -48,40 +48,51 @@ class DetailsTabBar extends StatelessWidget {
     this.wrap = false,
   });
 
-  _DetailsTabItem _buildTabItem(int i, {Key? key}) => _DetailsTabItem(
-        key: key,
-        label: labels[i],
-        isSelected: selectedIndex == i,
-        segmented: segmented,
-        pill: pill,
-        focusNode: focusNodeFor(i),
-        onSelect: () => onSelect(i),
-        onNavigateDown:
-            onNavigateDown != null ? () => onNavigateDown!(i) : null,
-        onNavigateUp: onExitUp,
-        onNavigateLeft: () {
-          if (i > 0) {
-            focusNodeFor(i - 1).requestFocus();
-            return true;
-          }
-          if (onExitLeft != null) {
-            onExitLeft!();
-            return true;
-          }
-          return false;
-        },
-        onNavigateRight: () {
-          if (i < labels.length - 1) {
-            focusNodeFor(i + 1).requestFocus();
-          }
-        },
-      );
+  // The tab row mirrors under RTL (ambient Directionality), so which
+  // physical key steps the index forward/back flips; onExitLeft always
+  // fires at the physical-left edge.
+  _DetailsTabItem _buildTabItem(BuildContext context, int i, {Key? key}) {
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    void step(int delta) => focusNodeFor(i + delta).requestFocus();
+    return _DetailsTabItem(
+      key: key,
+      label: labels[i],
+      isSelected: selectedIndex == i,
+      segmented: segmented,
+      pill: pill,
+      focusNode: focusNodeFor(i),
+      onSelect: () => onSelect(i),
+      onNavigateDown:
+          onNavigateDown != null ? () => onNavigateDown!(i) : null,
+      onNavigateUp: onExitUp,
+      onNavigateLeft: () {
+        final delta = isRtl ? 1 : -1;
+        if (i + delta >= 0 && i + delta < labels.length) {
+          step(delta);
+          return true;
+        }
+        if (!isRtl && onExitLeft != null) {
+          onExitLeft!();
+          return true;
+        }
+        return false;
+      },
+      onNavigateRight: () {
+        final delta = isRtl ? -1 : 1;
+        if (i + delta >= 0 && i + delta < labels.length) {
+          step(delta);
+        } else if (isRtl && onExitLeft != null) {
+          onExitLeft!();
+        }
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     if (pill) return _PillTabBar(this);
 
-    _DetailsTabItem item(int i) => _buildTabItem(i);
+    _DetailsTabItem item(int i) => _buildTabItem(context, i);
 
     if (segmented) {
       final container = Container(
@@ -507,9 +518,12 @@ class _PillTabBarState extends State<_PillTabBar> {
     final thumbColor = glass ? onSurface.withValues(alpha: 0.22) : accent;
 
     final hasThumb = selectedIndex >= 0 && selectedIndex < _widths.length;
-    var thumbLeft = 0.0;
+    // The tab Row mirrors under RTL, so the thumb's offset must accumulate
+    // from whichever edge is the row's actual start under Directionality.
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    var thumbOffset = 0.0;
     for (var i = 0; i < selectedIndex && i < _widths.length; i++) {
-      thumbLeft += _widths[i];
+      thumbOffset += _widths[i];
     }
 
     final stack = Stack(
@@ -520,7 +534,8 @@ class _PillTabBarState extends State<_PillTabBar> {
             curve: Curves.easeOutCubic,
             top: 0,
             bottom: 0,
-            left: thumbLeft,
+            left: isRtl ? null : thumbOffset,
+            right: isRtl ? thumbOffset : null,
             width: _widths[selectedIndex],
             child: Container(
               decoration: BoxDecoration(
@@ -541,7 +556,7 @@ class _PillTabBarState extends State<_PillTabBar> {
           mainAxisSize: MainAxisSize.min,
           children: [
             for (var i = 0; i < _labels.length; i++)
-              _config._buildTabItem(i, key: _segmentKeys[i]),
+              _config._buildTabItem(context, i, key: _segmentKeys[i]),
           ],
         ),
       ],

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -62,13 +62,16 @@ class DetailsTabBar extends StatelessWidget {
       onNavigateDown:
           onNavigateDown != null ? () => onNavigateDown!(i) : null,
       onNavigateUp: onExitUp,
+      // The escape follows the physical key, matching the other tab rows: a
+      // Left press that can't step any further leaves through onExitLeft,
+      // whichever index sits at that edge.
       onNavigateLeft: () {
         final delta = isRtl ? 1 : -1;
         if (i + delta >= 0 && i + delta < labels.length) {
           step(delta);
           return true;
         }
-        if (!isRtl && onExitLeft != null) {
+        if (onExitLeft != null) {
           onExitLeft!();
           return true;
         }
@@ -78,8 +81,6 @@ class DetailsTabBar extends StatelessWidget {
         final delta = isRtl ? -1 : 1;
         if (i + delta >= 0 && i + delta < labels.length) {
           step(delta);
-        } else if (isRtl && onExitLeft != null) {
-          onExitLeft!();
         }
       },
     );

--- a/lib/ui/widgets/focus/focusable_action_bar.dart
+++ b/lib/ui/widgets/focus/focusable_action_bar.dart
@@ -116,8 +116,6 @@ class FocusableActionBarState extends State<FocusableActionBar> {
     if (!event.isActionable) return KeyEventResult.ignored;
     final k = event.logicalKey;
     if (k.isLeftKey || k.isRightKey) {
-      // The action row mirrors under RTL (ambient Directionality), so the
-      // index step and which "navigate out" callback applies both flip.
       final isRtl = Directionality.of(context) == TextDirection.rtl;
       final movesToNextIndex = k.isRightKey != isRtl;
       if (movesToNextIndex) {

--- a/lib/ui/widgets/focus/focusable_action_bar.dart
+++ b/lib/ui/widgets/focus/focusable_action_bar.dart
@@ -115,27 +115,34 @@ class FocusableActionBarState extends State<FocusableActionBar> {
 
     if (!event.isActionable) return KeyEventResult.ignored;
     final k = event.logicalKey;
-    if (k.isLeftKey) {
-      if (index > 0) {
-        _nodes[index - 1].requestFocus();
+    if (k.isLeftKey || k.isRightKey) {
+      // The action row mirrors under RTL (ambient Directionality), so the
+      // index step and which "navigate out" callback applies both flip.
+      final isRtl = Directionality.of(context) == TextDirection.rtl;
+      final movesToNextIndex = k.isRightKey != isRtl;
+      if (movesToNextIndex) {
+        if (index < _nodes.length - 1) {
+          _nodes[index + 1].requestFocus();
+          return KeyEventResult.handled;
+        }
+        final navigate = isRtl ? widget.onNavigateLeft : widget.onNavigateRight;
+        if (navigate != null) {
+          navigate();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.handled;
+      } else {
+        if (index > 0) {
+          _nodes[index - 1].requestFocus();
+          return KeyEventResult.handled;
+        }
+        final navigate = isRtl ? widget.onNavigateRight : widget.onNavigateLeft;
+        if (navigate != null) {
+          navigate();
+          return KeyEventResult.handled;
+        }
         return KeyEventResult.handled;
       }
-      if (widget.onNavigateLeft != null) {
-        widget.onNavigateLeft!();
-        return KeyEventResult.handled;
-      }
-      return KeyEventResult.handled;
-    }
-    if (k.isRightKey) {
-      if (index < _nodes.length - 1) {
-        _nodes[index + 1].requestFocus();
-        return KeyEventResult.handled;
-      }
-      if (widget.onNavigateRight != null) {
-        widget.onNavigateRight!();
-        return KeyEventResult.handled;
-      }
-      return KeyEventResult.handled;
     }
     if (k.isUpKey) {
       if (widget.onNavigateUp != null) widget.onNavigateUp!();

--- a/lib/ui/widgets/focus/locked_focus_row.dart
+++ b/lib/ui/widgets/focus/locked_focus_row.dart
@@ -243,29 +243,38 @@ class LockedFocusRowState<T> extends State<LockedFocusRow<T>> {
 
     if (!event.isActionable) return KeyEventResult.ignored;
     final key = event.logicalKey;
-    if (key.isLeftKey) {
-      if (_focusedIndex > 0) {
-        _setFocusedIndex(_focusedIndex - 1);
-        _scrollToIndex(_focusedIndex);
+    if (key.isLeftKey || key.isRightKey) {
+      // The list scrolls in whatever direction the ambient Directionality
+      // mirrors it to, so index+1 lands on-screen-left under RTL instead of
+      // on-screen-right. Flip the index step (and which physical edge each
+      // callback represents) so the highlight always follows the pressed key.
+      final isRtl = Directionality.of(context) == TextDirection.rtl;
+      final movesToNextIndex = key.isRightKey != isRtl;
+      if (movesToNextIndex) {
+        if (_focusedIndex < widget.items.length - 1) {
+          _setFocusedIndex(_focusedIndex + 1);
+          _scrollToIndex(_focusedIndex);
+          return KeyEventResult.handled;
+        }
+        final edge = isRtl ? widget.onLeftEdge : widget.onRightEdge;
+        if (edge != null) {
+          edge();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.handled;
+      } else {
+        if (_focusedIndex > 0) {
+          _setFocusedIndex(_focusedIndex - 1);
+          _scrollToIndex(_focusedIndex);
+          return KeyEventResult.handled;
+        }
+        final edge = isRtl ? widget.onRightEdge : widget.onLeftEdge;
+        if (edge != null) {
+          edge();
+          return KeyEventResult.handled;
+        }
         return KeyEventResult.handled;
       }
-      if (widget.onLeftEdge != null) {
-        widget.onLeftEdge!();
-        return KeyEventResult.handled;
-      }
-      return KeyEventResult.handled;
-    }
-    if (key.isRightKey) {
-      if (_focusedIndex < widget.items.length - 1) {
-        _setFocusedIndex(_focusedIndex + 1);
-        _scrollToIndex(_focusedIndex);
-        return KeyEventResult.handled;
-      }
-      if (widget.onRightEdge != null) {
-        widget.onRightEdge!();
-        return KeyEventResult.handled;
-      }
-      return KeyEventResult.handled;
     }
     if (key.isUpKey) {
       final handled = widget.onVerticalNavigation?.call(true) ?? false;

--- a/lib/ui/widgets/focus/locked_focus_row.dart
+++ b/lib/ui/widgets/focus/locked_focus_row.dart
@@ -244,10 +244,6 @@ class LockedFocusRowState<T> extends State<LockedFocusRow<T>> {
     if (!event.isActionable) return KeyEventResult.ignored;
     final key = event.logicalKey;
     if (key.isLeftKey || key.isRightKey) {
-      // The list scrolls in whatever direction the ambient Directionality
-      // mirrors it to, so index+1 lands on-screen-left under RTL instead of
-      // on-screen-right. Flip the index step (and which physical edge each
-      // callback represents) so the highlight always follows the pressed key.
       final isRtl = Directionality.of(context) == TextDirection.rtl;
       final movesToNextIndex = key.isRightKey != isRtl;
       if (movesToNextIndex) {

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -744,6 +744,43 @@ class _MediaBarState extends State<MediaBar>
     }
   }
 
+  /// Prev/next arrows swap on-screen sides under RTL so "next" always sits
+  /// toward the reading-forward (physical-left) edge, matching the rest of
+  /// the RTL-mirrored UI. The avatar/sidebar-hidden left slot stays a
+  /// physical-screen concept regardless of which logical arrow lands there.
+  List<Widget> _buildNavArrows(
+    BuildContext context,
+    int itemCount, {
+    double nextRightInset = 0,
+  }) {
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final prevArrow = _NavArrow(
+      icon: isRtl ? Icons.chevron_right : Icons.chevron_left,
+      onTap: _currentIndex > 0 ? () => _goToPage(_currentIndex - 1) : null,
+    );
+    final nextArrow = _NavArrow(
+      icon: isRtl ? Icons.chevron_left : Icons.chevron_right,
+      onTap: () => _goToPage((_currentIndex + 1) % itemCount),
+    );
+    final leftArrow = isRtl ? nextArrow : prevArrow;
+    final rightArrow = isRtl ? prevArrow : nextArrow;
+    return [
+      if (!_hideLeftNavArrowForSidebar)
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          child: Center(child: leftArrow),
+        ),
+      Positioned(
+        right: nextRightInset,
+        top: 0,
+        bottom: 0,
+        child: Center(child: rightArrow),
+      ),
+    ];
+  }
+
   void _onPageChanged(int index) {
     setState(() => _currentIndex = index);
     _syncMakdBackdropWithCurrentSlide();
@@ -2098,34 +2135,8 @@ class _MediaBarState extends State<MediaBar>
                         ),
                       ),
                     ),
-                  if (items.length > 1 && !PlatformDetection.useMobileUi) ...[
-                    if (!_hideLeftNavArrowForSidebar)
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        bottom: 0,
-                        child: Center(
-                          child: _NavArrow(
-                            icon: Icons.chevron_left,
-                            onTap: _currentIndex > 0
-                                ? () => _goToPage(_currentIndex - 1)
-                                : null,
-                          ),
-                        ),
-                      ),
-                    Positioned(
-                      right: 0,
-                      top: 0,
-                      bottom: 0,
-                      child: Center(
-                        child: _NavArrow(
-                          icon: Icons.chevron_right,
-                          onTap: () =>
-                              _goToPage((_currentIndex + 1) % items.length),
-                        ),
-                      ),
-                    ),
-                  ],
+                  if (items.length > 1 && !PlatformDetection.useMobileUi)
+                    ..._buildNavArrows(context, items.length),
                 ],
               ),
             ),
@@ -2413,34 +2424,12 @@ class _MediaBarState extends State<MediaBar>
                           ),
                   if (items.length > 1 &&
                       !PlatformDetection.useMobileUi &&
-                      !_isTrailerPlaying) ...[
-                    if (!_hideLeftNavArrowForSidebar)
-                      Positioned(
-                        left: 0,
-                        top: 0,
-                        bottom: 0,
-                        child: Center(
-                          child: _NavArrow(
-                            icon: Icons.chevron_left,
-                            onTap: _currentIndex > 0
-                                ? () => _goToPage(_currentIndex - 1)
-                                : null,
-                          ),
-                        ),
-                      ),
-                    Positioned(
-                      right: 44,
-                      top: 0,
-                      bottom: 0,
-                      child: Center(
-                        child: _NavArrow(
-                          icon: Icons.chevron_right,
-                          onTap: () =>
-                              _goToPage((_currentIndex + 1) % items.length),
-                        ),
-                      ),
+                      !_isTrailerPlaying)
+                    ..._buildNavArrows(
+                      context,
+                      items.length,
+                      nextRightInset: 44,
                     ),
-                  ],
                 ],
               ),
             ),

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -744,18 +744,12 @@ class _MediaBarState extends State<MediaBar>
     }
   }
 
-  /// Prev/next arrows swap on-screen sides under RTL so "next" always sits
-  /// toward the reading-forward (physical-left) edge, matching the rest of
-  /// the RTL-mirrored UI. The avatar/sidebar-hidden left slot stays a
-  /// physical-screen concept regardless of which logical arrow lands there.
   List<Widget> _buildNavArrows(
     BuildContext context,
     int itemCount, {
     double nextRightInset = 0,
   }) {
     final isRtl = Directionality.of(context) == TextDirection.rtl;
-    // The icon always matches the action (prev looks backward, next looks
-    // forward) — only the on-screen slot it lands in flips for RTL below.
     final prevArrow = _NavArrow(
       icon: Icons.chevron_left,
       onTap: _currentIndex > 0 ? () => _goToPage(_currentIndex - 1) : null,
@@ -2697,8 +2691,6 @@ class _MediaBarState extends State<MediaBar>
 
     if (key == LogicalKeyboardKey.arrowLeft ||
         key == LogicalKeyboardKey.arrowRight) {
-      // Matches the hero chevrons: "advance" follows the reading-forward
-      // direction, which swaps to the physical-left key under RTL.
       final isRtl = Directionality.of(context) == TextDirection.rtl;
       final isPhysicalLeftKey = key == LogicalKeyboardKey.arrowLeft;
       final advances = isPhysicalLeftKey == isRtl;
@@ -2714,9 +2706,6 @@ class _MediaBarState extends State<MediaBar>
       } else if (_currentIndex > 0) {
         _goToPage(_currentIndex - 1);
       }
-      // The sidebar is pinned to the physical-left edge regardless of
-      // locale, so it's only ever reached by a physical-left press that
-      // didn't move the banner.
       if (_currentIndex == beforeIndex &&
           isPhysicalLeftKey &&
           widget.onNavigateLeft != null) {

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -754,12 +754,14 @@ class _MediaBarState extends State<MediaBar>
     double nextRightInset = 0,
   }) {
     final isRtl = Directionality.of(context) == TextDirection.rtl;
+    // The icon always matches the action (prev looks backward, next looks
+    // forward) — only the on-screen slot it lands in flips for RTL below.
     final prevArrow = _NavArrow(
-      icon: isRtl ? Icons.chevron_right : Icons.chevron_left,
+      icon: Icons.chevron_left,
       onTap: _currentIndex > 0 ? () => _goToPage(_currentIndex - 1) : null,
     );
     final nextArrow = _NavArrow(
-      icon: isRtl ? Icons.chevron_left : Icons.chevron_right,
+      icon: Icons.chevron_right,
       onTap: () => _goToPage((_currentIndex + 1) % itemCount),
     );
     final leftArrow = isRtl ? nextArrow : prevArrow;
@@ -2693,21 +2695,32 @@ class _MediaBarState extends State<MediaBar>
 
     if (event is! KeyDownEvent) return KeyEventResult.ignored;
 
-    if (key == LogicalKeyboardKey.arrowLeft) {
-      if (_currentIndex > 0) {
-        _goToPage(_currentIndex - 1);
-      } else if (widget.onNavigateLeft != null) {
-        widget.onNavigateLeft!();
-      }
-      return KeyEventResult.handled;
-    }
-    if (key == LogicalKeyboardKey.arrowRight) {
-      if (_isBookshelfMode()) {
-        if (_currentIndex < items.length - 1) {
-          _goToPage(_currentIndex + 1);
+    if (key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.arrowRight) {
+      // Matches the hero chevrons: "advance" follows the reading-forward
+      // direction, which swaps to the physical-left key under RTL.
+      final isRtl = Directionality.of(context) == TextDirection.rtl;
+      final isPhysicalLeftKey = key == LogicalKeyboardKey.arrowLeft;
+      final advances = isPhysicalLeftKey == isRtl;
+      final beforeIndex = _currentIndex;
+      if (advances) {
+        if (_isBookshelfMode()) {
+          if (_currentIndex < items.length - 1) {
+            _goToPage(_currentIndex + 1);
+          }
+        } else {
+          _goToPage((_currentIndex + 1) % items.length);
         }
-      } else {
-        _goToPage((_currentIndex + 1) % items.length);
+      } else if (_currentIndex > 0) {
+        _goToPage(_currentIndex - 1);
+      }
+      // The sidebar is pinned to the physical-left edge regardless of
+      // locale, so it's only ever reached by a physical-left press that
+      // didn't move the banner.
+      if (_currentIndex == beforeIndex &&
+          isPhysicalLeftKey &&
+          widget.onNavigateLeft != null) {
+        widget.onNavigateLeft!();
       }
       return KeyEventResult.handled;
     }

--- a/lib/ui/widgets/mediabar/banner_media_bar.dart
+++ b/lib/ui/widgets/mediabar/banner_media_bar.dart
@@ -145,8 +145,6 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
     }
     if (key == LogicalKeyboardKey.arrowLeft ||
         key == LogicalKeyboardKey.arrowRight) {
-      // Matches the hero chevrons: "advance" follows the reading-forward
-      // direction, which swaps to the physical-left key under RTL.
       final isRtl = Directionality.of(context) == TextDirection.rtl;
       final isPhysicalLeftKey = key == LogicalKeyboardKey.arrowLeft;
       final advances = isPhysicalLeftKey == isRtl;
@@ -156,9 +154,6 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
       } else if (_index > 0) {
         _setIndex(_index - 1);
       }
-      // The sidebar is pinned to the physical-left edge regardless of
-      // locale, so it's only ever reached by a physical-left press that
-      // didn't move the banner.
       if (_index == beforeIndex &&
           isPhysicalLeftKey &&
           widget.onNavigateLeft != null) {

--- a/lib/ui/widgets/mediabar/banner_media_bar.dart
+++ b/lib/ui/widgets/mediabar/banner_media_bar.dart
@@ -143,16 +143,27 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
       widget.onNavigateUp?.call();
       return KeyEventResult.handled;
     }
-    if (key == LogicalKeyboardKey.arrowLeft) {
-      if (_index > 0) {
+    if (key == LogicalKeyboardKey.arrowLeft ||
+        key == LogicalKeyboardKey.arrowRight) {
+      // Matches the hero chevrons: "advance" follows the reading-forward
+      // direction, which swaps to the physical-left key under RTL.
+      final isRtl = Directionality.of(context) == TextDirection.rtl;
+      final isPhysicalLeftKey = key == LogicalKeyboardKey.arrowLeft;
+      final advances = isPhysicalLeftKey == isRtl;
+      final beforeIndex = _index;
+      if (advances) {
+        if (items.length > 1) _setIndex(_index + 1);
+      } else if (_index > 0) {
         _setIndex(_index - 1);
-      } else if (widget.onNavigateLeft != null) {
+      }
+      // The sidebar is pinned to the physical-left edge regardless of
+      // locale, so it's only ever reached by a physical-left press that
+      // didn't move the banner.
+      if (_index == beforeIndex &&
+          isPhysicalLeftKey &&
+          widget.onNavigateLeft != null) {
         widget.onNavigateLeft!();
       }
-      return KeyEventResult.handled;
-    }
-    if (key == LogicalKeyboardKey.arrowRight) {
-      if (items.length > 1) _setIndex(_index + 1);
       return KeyEventResult.handled;
     }
     return KeyEventResult.ignored;

--- a/lib/ui/widgets/sliding_pill_tabs.dart
+++ b/lib/ui/widgets/sliding_pill_tabs.dart
@@ -123,8 +123,6 @@ class _SlidingPillTabsState extends State<SlidingPillTabs> {
     final key = event.logicalKey;
     final index = widget.selectedIndex;
     if (key.isLeftKey || key.isRightKey) {
-      // The pill row mirrors under RTL (ambient Directionality), so the
-      // index step flips; onExitLeft always fires at the physical-left edge.
       final isRtl = Directionality.of(context) == TextDirection.rtl;
       final movesToNextIndex = key.isRightKey != isRtl;
       if (movesToNextIndex) {

--- a/lib/ui/widgets/sliding_pill_tabs.dart
+++ b/lib/ui/widgets/sliding_pill_tabs.dart
@@ -122,16 +122,24 @@ class _SlidingPillTabsState extends State<SlidingPillTabs> {
     }
     final key = event.logicalKey;
     final index = widget.selectedIndex;
-    if (key.isLeftKey) {
-      if (index > 0) {
-        widget.onChanged(index - 1);
-      } else if (widget.onExitLeft != null) {
-        widget.onExitLeft!();
+    if (key.isLeftKey || key.isRightKey) {
+      // The pill row mirrors under RTL (ambient Directionality), so the
+      // index step flips; onExitLeft always fires at the physical-left edge.
+      final isRtl = Directionality.of(context) == TextDirection.rtl;
+      final movesToNextIndex = key.isRightKey != isRtl;
+      if (movesToNextIndex) {
+        if (index < widget.labels.length - 1) {
+          widget.onChanged(index + 1);
+        } else if (isRtl && widget.onExitLeft != null) {
+          widget.onExitLeft!();
+        }
+      } else {
+        if (index > 0) {
+          widget.onChanged(index - 1);
+        } else if (!isRtl && widget.onExitLeft != null) {
+          widget.onExitLeft!();
+        }
       }
-      return KeyEventResult.handled;
-    }
-    if (key.isRightKey) {
-      if (index < widget.labels.length - 1) widget.onChanged(index + 1);
       return KeyEventResult.handled;
     }
     if (event is KeyDownEvent && (key.isUpKey || key.isDownKey)) {

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -62,7 +62,9 @@ class TopToolbar extends StatefulWidget {
 
   /// True while focus is inside the toolbar, so screens can avoid stealing its
   /// d-pad keys. Mirrors [LeftSidebar.isFocusedNotifier].
-  static final ValueNotifier<bool> isFocusedNotifier = ValueNotifier<bool>(false);
+  static final ValueNotifier<bool> isFocusedNotifier = ValueNotifier<bool>(
+    false,
+  );
 
   const TopToolbar({
     super.key,
@@ -150,7 +152,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     };
     _previousFocusNavbarCallback = NavigationLayout.focusNavbarNotifier.value;
     _previousFocusAvatarCallback =
-      NavigationLayout.focusNavbarAvatarNotifier.value;
+        NavigationLayout.focusNavbarAvatarNotifier.value;
     NavigationLayout.focusNavbarNotifier.value = _focusNavbarCallback;
     NavigationLayout.focusNavbarAvatarNotifier.value = _focusAvatarCallback;
     _avatarFocus.addListener(_onAvatarFocusChanged);
@@ -385,7 +387,9 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
 
   void _restoreFocusBelowToolbar() {
     final playBtnNode = NavigationLayout.focusDetailsPlayButtonNotifier.value;
-    if (playBtnNode != null && playBtnNode.context != null && playBtnNode.canRequestFocus) {
+    if (playBtnNode != null &&
+        playBtnNode.context != null &&
+        playBtnNode.canRequestFocus) {
       playBtnNode.requestFocus();
       return;
     }
@@ -484,25 +488,27 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
 
     final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
 
-    final nodes = _toolbarScopeNode.descendants
-        .where((n) => !n.skipTraversal && _isLaidOutFocusNode(n))
-        .where((n) {
-          final isMusicNode = _isDescendantOf(n, _musicBarFocusNode);
-          return insideMusicBar == isMusicNode;
-        })
-        .map((n) {
-          final box = n.context!.findRenderObject() as RenderBox?;
-          final pos = box?.localToGlobal(Offset.zero);
-          return (node: n, x: pos?.dx ?? -1.0);
-        })
-        .where((item) => item.x > 0)
-        .toList()
-      ..sort((a, b) => a.x.compareTo(b.x));
+    final nodes =
+        _toolbarScopeNode.descendants
+            .where((n) => !n.skipTraversal && _isLaidOutFocusNode(n))
+            .where((n) {
+              final isMusicNode = _isDescendantOf(n, _musicBarFocusNode);
+              return insideMusicBar == isMusicNode;
+            })
+            .map((n) {
+              final box = n.context!.findRenderObject() as RenderBox?;
+              final pos = box?.localToGlobal(Offset.zero);
+              return (node: n, x: pos?.dx ?? -1.0);
+            })
+            .where((item) => item.x > 0)
+            .toList()
+          ..sort((a, b) => a.x.compareTo(b.x));
 
     final index = nodes.indexWhere((e) => e.node == primary);
     if (index < 0) return false;
-    final nextIndex =
-        direction == TraversalDirection.right ? index + 1 : index - 1;
+    final nextIndex = direction == TraversalDirection.right
+        ? index + 1
+        : index - 1;
     if (nextIndex < 0 || nextIndex >= nodes.length) {
       // The avatar/back chip sits pinned at the physical left edge
       // (non-directional Alignment.centerLeft), so leaving the icon row's
@@ -609,154 +615,177 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
 
     final manager = GetIt.instance<PlaybackManager>();
     final currentItem = manager.queueService.currentItem;
-    final isMusicActive = currentItem is AggregatedItem && currentItem.isAudioLike;
+    final isMusicActive =
+        currentItem is AggregatedItem && currentItem.isAudioLike;
     final totalHeight = toolbarHeight + TopToolbar.musicBarExtraHeight();
 
-    return SafeArea(
-      bottom: false,
-      child: SizedBox(
-        height: totalHeight,
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
-          child: Focus(
-            focusNode: _toolbarScopeNode,
-            onFocusChange: (hasFocus) {
-              _toolbarHadFocus = hasFocus;
-              TopToolbar.isFocusedNotifier.value = hasFocus;
-            },
-            onKeyEvent: (_, event) {
-              if (event is KeyDownEvent &&
-                  event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                final primary = FocusManager.instance.primaryFocus;
-                if (primary != null) {
-                  final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
-                  if (!insideMusicBar && isMusicActive) {
-                    final musicNodes = _musicBarFocusNode.descendants
-                        .where((n) => !n.skipTraversal && _isLaidOutFocusNode(n))
-                        .map((n) {
-                          final box = n.context!.findRenderObject() as RenderBox?;
-                          final pos = box?.localToGlobal(Offset.zero);
-                          return (node: n, x: pos?.dx ?? -1.0);
-                        })
-                        .where((item) => item.x > 0)
-                        .toList()
-                      ..sort((a, b) => a.x.compareTo(b.x));
+    // The toolbar is fixed chrome, not reading content: it always renders
+    // Home-first/left, Settings-last/right regardless of app locale, so it
+    // does not mirror under RTL the way scrollable rows and tabs do.
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: SafeArea(
+        bottom: false,
+        child: SizedBox(
+          height: totalHeight,
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
+            child: Focus(
+              focusNode: _toolbarScopeNode,
+              onFocusChange: (hasFocus) {
+                _toolbarHadFocus = hasFocus;
+                TopToolbar.isFocusedNotifier.value = hasFocus;
+              },
+              onKeyEvent: (_, event) {
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                  final primary = FocusManager.instance.primaryFocus;
+                  if (primary != null) {
+                    final insideMusicBar = _isDescendantOf(
+                      primary,
+                      _musicBarFocusNode,
+                    );
+                    if (!insideMusicBar && isMusicActive) {
+                      final musicNodes =
+                          _musicBarFocusNode.descendants
+                              .where(
+                                (n) =>
+                                    !n.skipTraversal && _isLaidOutFocusNode(n),
+                              )
+                              .map((n) {
+                                final box =
+                                    n.context!.findRenderObject() as RenderBox?;
+                                final pos = box?.localToGlobal(Offset.zero);
+                                return (node: n, x: pos?.dx ?? -1.0);
+                              })
+                              .where((item) => item.x > 0)
+                              .toList()
+                            ..sort((a, b) => a.x.compareTo(b.x));
 
-                    if (musicNodes.isNotEmpty) {
-                      musicNodes.first.node.requestFocus();
-                      return KeyEventResult.handled;
+                      if (musicNodes.isNotEmpty) {
+                        musicNodes.first.node.requestFocus();
+                        return KeyEventResult.handled;
+                      }
+                    }
+
+                    if (widget.activeRoute != Destinations.home &&
+                        NavigationLayout.focusDetailsPlayButtonNotifier.value ==
+                            null) {
+                      final success = primary.focusInDirection(
+                        TraversalDirection.down,
+                      );
+                      if (success) {
+                        final newFocus = FocusManager.instance.primaryFocus;
+                        if (newFocus != null && _isInsideToolbar(newFocus)) {
+                          return KeyEventResult.handled;
+                        }
+                      }
                     }
                   }
-
-                  if (widget.activeRoute != Destinations.home &&
-                      NavigationLayout.focusDetailsPlayButtonNotifier.value == null) {
-                    final success =
-                        primary.focusInDirection(TraversalDirection.down);
-                    if (success) {
-                      final newFocus = FocusManager.instance.primaryFocus;
-                      if (newFocus != null && _isInsideToolbar(newFocus)) {
+                  _restoreFocusBelowToolbar();
+                  return KeyEventResult.handled;
+                }
+                if (event is KeyDownEvent &&
+                    event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                  final primary = FocusManager.instance.primaryFocus;
+                  if (primary != null) {
+                    final insideMusicBar = _isDescendantOf(
+                      primary,
+                      _musicBarFocusNode,
+                    );
+                    if (insideMusicBar) {
+                      if (_homeFocus.canRequestFocus) {
+                        _homeFocus.requestFocus();
+                        return KeyEventResult.handled;
+                      }
+                      FocusNode? targetNode;
+                      for (final n in _toolbarScopeNode.descendants) {
+                        if (!n.skipTraversal &&
+                            _isLaidOutFocusNode(n) &&
+                            !_isDescendantOf(n, _musicBarFocusNode)) {
+                          final box =
+                              n.context!.findRenderObject() as RenderBox?;
+                          final pos = box?.localToGlobal(Offset.zero);
+                          if (pos != null && pos.dx > 0) {
+                            targetNode = n;
+                            break;
+                          }
+                        }
+                      }
+                      if (targetNode != null) {
+                        targetNode.requestFocus();
                         return KeyEventResult.handled;
                       }
                     }
                   }
                 }
-                _restoreFocusBelowToolbar();
-                return KeyEventResult.handled;
-              }
-              if (event is KeyDownEvent &&
-                  event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                final primary = FocusManager.instance.primaryFocus;
-                if (primary != null) {
-                  final insideMusicBar = _isDescendantOf(primary, _musicBarFocusNode);
-                  if (insideMusicBar) {
-                    if (_homeFocus.canRequestFocus) {
-                      _homeFocus.requestFocus();
-                      return KeyEventResult.handled;
-                    }
-                    FocusNode? targetNode;
-                    for (final n in _toolbarScopeNode.descendants) {
-                      if (!n.skipTraversal && _isLaidOutFocusNode(n) && !_isDescendantOf(n, _musicBarFocusNode)) {
-                        final box = n.context!.findRenderObject() as RenderBox?;
-                        final pos = box?.localToGlobal(Offset.zero);
-                        if (pos != null && pos.dx > 0) {
-                          targetNode = n;
-                          break;
-                        }
-                      }
-                    }
-                    if (targetNode != null) {
-                      targetNode.requestFocus();
-                      return KeyEventResult.handled;
-                    }
-                  }
+                if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
+                    event is KeyDownEvent &&
+                    (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
+                        event.logicalKey == LogicalKeyboardKey.arrowRight)) {
+                  final direction =
+                      event.logicalKey == LogicalKeyboardKey.arrowLeft
+                      ? TraversalDirection.left
+                      : TraversalDirection.right;
+                  _moveWithinToolbar(direction);
+                  // Always consume so the key can't escape sideways into content.
+                  return KeyEventResult.handled;
                 }
-              }
-              if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
-                  event is KeyDownEvent &&
-                  (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
-                      event.logicalKey == LogicalKeyboardKey.arrowRight)) {
-                final direction =
-                    event.logicalKey == LogicalKeyboardKey.arrowLeft
-                        ? TraversalDirection.left
-                        : TraversalDirection.right;
-                _moveWithinToolbar(direction);
-                // Always consume so the key can't escape sideways into content.
-                return KeyEventResult.handled;
-              }
-              return KeyEventResult.ignored;
-            },
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                FocusTraversalGroup(
-                  policy: WidgetOrderTraversalPolicy(),
-                  child: isLandscape
-                      ? SizedBox(
-                          height: toolbarHeight - (vPad * 2),
-                          child: Stack(
-                            alignment: Alignment.center,
-                            children: [
-                              Align(
-                                alignment: Alignment.center,
-                                child: Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: centerSidePadding,
-                                  ),
-                                  child: _buildCenter(),
-                                ),
-                              ),
-                              Align(
-                                alignment: Alignment.centerLeft,
-                                child: _buildStart(),
-                              ),
-                              if (!isMobile)
+                return KeyEventResult.ignored;
+              },
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  FocusTraversalGroup(
+                    policy: WidgetOrderTraversalPolicy(),
+                    child: isLandscape
+                        ? SizedBox(
+                            height: toolbarHeight - (vPad * 2),
+                            child: Stack(
+                              alignment: Alignment.center,
+                              children: [
                                 Align(
-                                  alignment: Alignment.centerRight,
-                                  child: _buildEnd(),
+                                  alignment: Alignment.center,
+                                  child: Padding(
+                                    padding: EdgeInsets.symmetric(
+                                      horizontal: centerSidePadding,
+                                    ),
+                                    child: _buildCenter(),
+                                  ),
                                 ),
-                            ],
-                          ),
-                        )
-                      : SizedBox(
-                          height: toolbarHeight - (vPad * 2),
-                          child: Row(
-                            children: [
-                              _buildStart(),
-                              const SizedBox(width: 12),
-                              Expanded(child: _buildCenter()),
-                              if (!isMobile) ...[
-                                const SizedBox(width: 12),
-                                _buildEnd(),
+                                Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: _buildStart(),
+                                ),
+                                if (!isMobile)
+                                  Align(
+                                    alignment: Alignment.centerRight,
+                                    child: _buildEnd(),
+                                  ),
                               ],
-                            ],
+                            ),
+                          )
+                        : SizedBox(
+                            height: toolbarHeight - (vPad * 2),
+                            child: Row(
+                              children: [
+                                _buildStart(),
+                                const SizedBox(width: 12),
+                                Expanded(child: _buildCenter()),
+                                if (!isMobile) ...[
+                                  const SizedBox(width: 12),
+                                  _buildEnd(),
+                                ],
+                              ],
+                            ),
                           ),
-                        ),
-                ),
-                if (isMusicActive) ...[
-                  const SizedBox(height: 8),
-                  TopMusicBar(focusNode: _musicBarFocusNode),
+                  ),
+                  if (isMusicActive) ...[
+                    const SizedBox(height: 8),
+                    TopMusicBar(focusNode: _musicBarFocusNode),
+                  ],
                 ],
-              ],
+              ),
             ),
           ),
         ),
@@ -903,7 +932,8 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         _prefs.get(UserPreferences.syncPlayEnabled) &&
         _prefs.get(UserPreferences.showSyncPlayButton);
     final seerrPrefs = GetIt.instance<SeerrPreferences>();
-    final showSeerr = _prefs.get(UserPreferences.showSeerrButton) &&
+    final showSeerr =
+        _prefs.get(UserPreferences.showSeerrButton) &&
         GetIt.instance<PluginSyncService>().seerrAvailable;
     final l10n = AppLocalizations.of(context);
     final seerrNavLabel = seerrPrefs.labelOrDefault(l10n.seerr);
@@ -928,208 +958,208 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
       child: _wrapPill(
         isNeon: isNeon,
         child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _orderButton(
-                  order: (order++).toDouble(),
-                  child: ExpandableIconButton(
-                    key: const ValueKey('toolbar_home'),
-                    forceExpanded: alwaysExpanded,
-                    icon: Icons.home_rounded,
-                    label: l10n.home,
-                    baseColor: nextNavColor(),
-                    focusNode: _homeFocus,
-                    onPressed: () {
-                      if (_isActive(Destinations.home)) {
-                        homeRefreshBus.request();
-                        return;
-                      }
-                      homeRefreshBus.requestAfterNavigation();
-                      context.go(Destinations.home);
-                    },
-                  ),
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _orderButton(
+                order: (order++).toDouble(),
+                child: ExpandableIconButton(
+                  key: const ValueKey('toolbar_home'),
+                  forceExpanded: alwaysExpanded,
+                  icon: Icons.home_rounded,
+                  label: l10n.home,
+                  baseColor: nextNavColor(),
+                  focusNode: _homeFocus,
+                  onPressed: () {
+                    if (_isActive(Destinations.home)) {
+                      homeRefreshBus.request();
+                      return;
+                    }
+                    homeRefreshBus.requestAfterNavigation();
+                    context.go(Destinations.home);
+                  },
                 ),
+              ),
+              _gap(),
+              _orderButton(
+                order: (order++).toDouble(),
+                child: ExpandableIconButton(
+                  key: const ValueKey('toolbar_search'),
+                  forceExpanded: alwaysExpanded,
+                  icon: Icons.search_rounded,
+                  label: l10n.search,
+                  baseColor: nextNavColor(),
+                  onPressed: () {
+                    if (_isActive(Destinations.search)) return;
+                    context.navigateTopLevel(Destinations.search);
+                  },
+                ),
+              ),
+              if (showShuffle) ...[
                 _gap(),
                 _orderButton(
                   order: (order++).toDouble(),
                   child: ExpandableIconButton(
-                    key: const ValueKey('toolbar_search'),
+                    key: const ValueKey('toolbar_shuffle'),
                     forceExpanded: alwaysExpanded,
-                    icon: Icons.search_rounded,
-                    label: l10n.search,
+                    icon: Icons.shuffle_rounded,
+                    label: l10n.shuffle,
                     baseColor: nextNavColor(),
-                    onPressed: () {
-                      if (_isActive(Destinations.search)) return;
-                      context.navigateTopLevel(Destinations.search);
-                    },
+                    onPressed: () => showShuffleOverlay(context),
                   ),
                 ),
-                if (showShuffle) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_shuffle'),
-                      forceExpanded: alwaysExpanded,
-                      icon: Icons.shuffle_rounded,
-                      label: l10n.shuffle,
-                      baseColor: nextNavColor(),
-                      onPressed: () => showShuffleOverlay(context),
-                    ),
-                  ),
-                ],
-                if (showGenres) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_genres'),
-                      forceExpanded: alwaysExpanded,
-                      baseColor: nextNavColor(),
-                      iconBuilder: (size, color) => Image.asset(
-                        'assets/icons/genres.png',
-                        width: size,
-                        height: size,
-                        color: color,
-                        fit: BoxFit.contain,
-                      ),
-                      label: l10n.genres,
-                      onPressed: () {
-                        if (_isActive(Destinations.allGenres)) return;
-                        context.navigateTopLevel(Destinations.allGenres);
-                      },
-                    ),
-                  ),
-                ],
-                if (showFavorites) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_favorites'),
-                      forceExpanded: alwaysExpanded,
-                      icon: Icons.favorite_rounded,
-                      label: l10n.favorites,
-                      baseColor: nextNavColor(),
-                      onPressed: () {
-                        if (_isActive(Destinations.allFavorites)) return;
-                        context.navigateTopLevel(Destinations.allFavorites);
-                      },
-                    ),
-                  ),
-                ],
-                if (showFolders) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_folders'),
-                      forceExpanded: alwaysExpanded,
-                      icon: Icons.folder_rounded,
-                      label: l10n.folders,
-                      baseColor: nextNavColor(),
-                      onPressed: () {
-                        if (_isActive(Destinations.folderView)) return;
-                        context.navigateTopLevel(Destinations.folderView);
-                      },
-                    ),
-                  ),
-                ],
-                if (showSyncPlay) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_syncplay'),
-                      forceExpanded: alwaysExpanded,
-                      icon: Icons.groups_rounded,
-                      label: l10n.syncPlay,
-                      baseColor: nextNavColor(),
-                      onPressed: () => Navigator.of(context).push(
-                        MaterialPageRoute<void>(
-                          builder: (_) => const SyncPlayScreen(),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-                if (showSeerr) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: ExpandableIconButton(
-                      key: const ValueKey('toolbar_seerr'),
-                      forceExpanded: alwaysExpanded,
-                      baseColor: nextNavColor(),
-                      iconBuilder: (size, color) => seerrPrefs.isSeerrVariant
-                          ? SeerrIcon(size: size, color: color)
-                          : SeerrIcon(size: size, color: color),
-                      label: seerrNavLabel,
-                      onPressed: () {
-                        if (_isActive(Destinations.seerrDiscover)) return;
-                        context.navigateTopLevel(Destinations.seerrDiscover);
-                      },
-                    ),
-                  ),
-                ],
-                if (showLibraries && _libraries.isNotEmpty) ...[
-                  _gap(),
-                  _orderButton(
-                    order: (order++).toDouble(),
-                    child: useInlineLibraries
-                        ? _buildInlineLibrariesButton(
-                            l10n,
-                            iconColor: nextNavColor(),
-                            alwaysExpanded: alwaysExpanded,
-                          )
-                        : _buildLibrariesButton(
-                            iconColor: nextNavColor(),
-                            alwaysExpanded: alwaysExpanded,
-                          ),
-                  ),
-                ],
+              ],
+              if (showGenres) ...[
                 _gap(),
                 _orderButton(
-                  order: 99,
+                  order: (order++).toDouble(),
                   child: ExpandableIconButton(
-                    key: const ValueKey('toolbar_settings'),
+                    key: const ValueKey('toolbar_genres'),
                     forceExpanded: alwaysExpanded,
-                    icon: Icons.settings_rounded,
-                    label: l10n.settings,
                     baseColor: nextNavColor(),
-                    focusNode: _settingsFocus,
-                    onKeyEvent: (_, event) {
-                      if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
-                          PlatformDetection.isTV &&
-                          event.logicalKey == LogicalKeyboardKey.arrowRight) {
-                        return KeyEventResult.handled;
-                      }
-                      if (event is KeyDownEvent &&
-                          event.logicalKey == LogicalKeyboardKey.arrowLeft &&
-                          useInlineLibraries &&
-                          showLibraries &&
-                          _libraries.isNotEmpty) {
-                        _inlineLibrariesTriggerFocus.requestFocus();
-                        return KeyEventResult.handled;
-                      }
-                      return KeyEventResult.ignored;
-                    },
-                    onPressed: () async {
-                      await SettingsPanel.open(
-                        context,
-                        const SettingsSidePanel(),
-                      );
-                      if (mounted) _settingsFocus.requestFocus();
+                    iconBuilder: (size, color) => Image.asset(
+                      'assets/icons/genres.png',
+                      width: size,
+                      height: size,
+                      color: color,
+                      fit: BoxFit.contain,
+                    ),
+                    label: l10n.genres,
+                    onPressed: () {
+                      if (_isActive(Destinations.allGenres)) return;
+                      context.navigateTopLevel(Destinations.allGenres);
                     },
                   ),
                 ),
               ],
-            ),
+              if (showFavorites) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: ExpandableIconButton(
+                    key: const ValueKey('toolbar_favorites'),
+                    forceExpanded: alwaysExpanded,
+                    icon: Icons.favorite_rounded,
+                    label: l10n.favorites,
+                    baseColor: nextNavColor(),
+                    onPressed: () {
+                      if (_isActive(Destinations.allFavorites)) return;
+                      context.navigateTopLevel(Destinations.allFavorites);
+                    },
+                  ),
+                ),
+              ],
+              if (showFolders) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: ExpandableIconButton(
+                    key: const ValueKey('toolbar_folders'),
+                    forceExpanded: alwaysExpanded,
+                    icon: Icons.folder_rounded,
+                    label: l10n.folders,
+                    baseColor: nextNavColor(),
+                    onPressed: () {
+                      if (_isActive(Destinations.folderView)) return;
+                      context.navigateTopLevel(Destinations.folderView);
+                    },
+                  ),
+                ),
+              ],
+              if (showSyncPlay) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: ExpandableIconButton(
+                    key: const ValueKey('toolbar_syncplay'),
+                    forceExpanded: alwaysExpanded,
+                    icon: Icons.groups_rounded,
+                    label: l10n.syncPlay,
+                    baseColor: nextNavColor(),
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) => const SyncPlayScreen(),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+              if (showSeerr) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: ExpandableIconButton(
+                    key: const ValueKey('toolbar_seerr'),
+                    forceExpanded: alwaysExpanded,
+                    baseColor: nextNavColor(),
+                    iconBuilder: (size, color) => seerrPrefs.isSeerrVariant
+                        ? SeerrIcon(size: size, color: color)
+                        : SeerrIcon(size: size, color: color),
+                    label: seerrNavLabel,
+                    onPressed: () {
+                      if (_isActive(Destinations.seerrDiscover)) return;
+                      context.navigateTopLevel(Destinations.seerrDiscover);
+                    },
+                  ),
+                ),
+              ],
+              if (showLibraries && _libraries.isNotEmpty) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: useInlineLibraries
+                      ? _buildInlineLibrariesButton(
+                          l10n,
+                          iconColor: nextNavColor(),
+                          alwaysExpanded: alwaysExpanded,
+                        )
+                      : _buildLibrariesButton(
+                          iconColor: nextNavColor(),
+                          alwaysExpanded: alwaysExpanded,
+                        ),
+                ),
+              ],
+              _gap(),
+              _orderButton(
+                order: 99,
+                child: ExpandableIconButton(
+                  key: const ValueKey('toolbar_settings'),
+                  forceExpanded: alwaysExpanded,
+                  icon: Icons.settings_rounded,
+                  label: l10n.settings,
+                  baseColor: nextNavColor(),
+                  focusNode: _settingsFocus,
+                  onKeyEvent: (_, event) {
+                    if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+                        PlatformDetection.isTV &&
+                        event.logicalKey == LogicalKeyboardKey.arrowRight) {
+                      return KeyEventResult.handled;
+                    }
+                    if (event is KeyDownEvent &&
+                        event.logicalKey == LogicalKeyboardKey.arrowLeft &&
+                        useInlineLibraries &&
+                        showLibraries &&
+                        _libraries.isNotEmpty) {
+                      _inlineLibrariesTriggerFocus.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                    return KeyEventResult.ignored;
+                  },
+                  onPressed: () async {
+                    await SettingsPanel.open(
+                      context,
+                      const SettingsSidePanel(),
+                    );
+                    if (mounted) _settingsFocus.requestFocus();
+                  },
+                ),
+              ),
+            ],
           ),
         ),
+      ),
     );
   }
 
@@ -1182,7 +1212,10 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         } else if (lib.collectionType == 'books' ||
             lib.collectionType == 'audiobooks') {
           context.navigateTopLevel(
-            Destinations.bookLibrary(lib.id, collectionType: lib.collectionType),
+            Destinations.bookLibrary(
+              lib.id,
+              collectionType: lib.collectionType,
+            ),
           );
         } else if (lib.collectionType == 'livetv') {
           context.navigateTopLevel(Destinations.liveTvGuide);
@@ -1220,7 +1253,10 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         } else if (lib.collectionType == 'books' ||
             lib.collectionType == 'audiobooks') {
           context.navigateTopLevel(
-            Destinations.bookLibrary(lib.id, collectionType: lib.collectionType),
+            Destinations.bookLibrary(
+              lib.id,
+              collectionType: lib.collectionType,
+            ),
           );
         } else if (lib.collectionType == 'livetv') {
           context.navigateTopLevel(Destinations.liveTvGuide);
@@ -1571,7 +1607,9 @@ class _ToolbarLibrariesTriggerButtonState
       final base =
           widget.iconColor ?? AppColorScheme.onSurface.withValues(alpha: 0.6);
       final active = _focused || _hovered || widget.expanded;
-      bgColor = active ? focusColor.withValues(alpha: 0.18) : Colors.transparent;
+      bgColor = active
+          ? focusColor.withValues(alpha: 0.18)
+          : Colors.transparent;
       fgColor = active ? focusColor : base;
     }
 
@@ -1697,7 +1735,9 @@ class _ToolbarLibraryLabelButtonState
       final focusColor = Color(
         _prefs.get(UserPreferences.focusColor).colorValue,
       );
-      bgColor = active ? focusColor.withValues(alpha: 0.18) : Colors.transparent;
+      bgColor = active
+          ? focusColor.withValues(alpha: 0.18)
+          : Colors.transparent;
       fgColor = active
           ? focusColor
           : AppColorScheme.onSurface.withValues(alpha: 0.85);
@@ -2184,17 +2224,24 @@ class _TopMusicBarState extends State<TopMusicBar> {
 
   String? _artUrl(AggregatedItem item) {
     try {
-      final client = _clientFactory.getClientIfExists(item.serverId) ??
+      final client =
+          _clientFactory.getClientIfExists(item.serverId) ??
           GetIt.instance<MediaServerClient>();
       final albumTag = item.albumPrimaryImageTag;
       final albumId = item.albumId;
       if (item.type == 'Audio' && albumTag != null && albumId != null) {
-        return client.imageApi
-            .getPrimaryImageUrl(albumId, maxHeight: 120, tag: albumTag);
+        return client.imageApi.getPrimaryImageUrl(
+          albumId,
+          maxHeight: 120,
+          tag: albumTag,
+        );
       }
       if (item.primaryImageTag != null) {
-        return client.imageApi
-            .getPrimaryImageUrl(item.id, maxHeight: 120, tag: item.primaryImageTag);
+        return client.imageApi.getPrimaryImageUrl(
+          item.id,
+          maxHeight: 120,
+          tag: item.primaryImageTag,
+        );
       }
     } catch (_) {}
     return null;
@@ -2226,14 +2273,14 @@ class _TopMusicBarState extends State<TopMusicBar> {
               height: 32,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: focused
-                    ? AppColorScheme.onSurface
-                    : Colors.transparent,
+                color: focused ? AppColorScheme.onSurface : Colors.transparent,
               ),
               child: AdaptiveIcon(
                 icon,
                 size: 20,
-                color: focused ? AppColorScheme.surface : AppColorScheme.onSurface,
+                color: focused
+                    ? AppColorScheme.surface
+                    : AppColorScheme.onSurface,
               ),
             ),
           );
@@ -2268,11 +2315,18 @@ class _TopMusicBarState extends State<TopMusicBar> {
     }
     return Container(
       decoration: BoxDecoration(
-        color: OverlayColorPalette.resolveColor(
-          GetIt.instance<UserPreferences>().get(UserPreferences.navbarColor),
-        ).withValues(
-          alpha: GetIt.instance<UserPreferences>().get(UserPreferences.navbarOpacity) / 100.0,
-        ),
+        color:
+            OverlayColorPalette.resolveColor(
+              GetIt.instance<UserPreferences>().get(
+                UserPreferences.navbarColor,
+              ),
+            ).withValues(
+              alpha:
+                  GetIt.instance<UserPreferences>().get(
+                    UserPreferences.navbarOpacity,
+                  ) /
+                  100.0,
+            ),
         borderRadius: AppRadius.circular(24),
         border: border,
       ),
@@ -2292,7 +2346,9 @@ class _TopMusicBarState extends State<TopMusicBar> {
     final artist = item.artists.isNotEmpty
         ? item.artists.join(', ')
         : item.albumArtist ?? '';
-    final displayText = artist.isNotEmpty ? '${item.name} - $artist' : item.name;
+    final displayText = artist.isNotEmpty
+        ? '${item.name} - $artist'
+        : item.name;
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     return Center(
@@ -2303,72 +2359,77 @@ class _TopMusicBarState extends State<TopMusicBar> {
           canRequestFocus: false,
           child: FocusTraversalGroup(
             child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ClipRRect(
-                  borderRadius: AppRadius.circular(6),
-                  child: SizedBox(
-                    width: 32,
-                    height: 32,
-                    child: artUrl != null
-                        ? OfflineAwareImage(
-                            imageUrl: artUrl,
-                            fit: BoxFit.cover,
-                          )
-                        : Container(
-                            color: AppColorScheme.onSurface.withValues(alpha: 0.1),
-                            child: Icon(
-                              Icons.music_note,
-                              size: 16,
-                              color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ClipRRect(
+                    borderRadius: AppRadius.circular(6),
+                    child: SizedBox(
+                      width: 32,
+                      height: 32,
+                      child: artUrl != null
+                          ? OfflineAwareImage(
+                              imageUrl: artUrl,
+                              fit: BoxFit.cover,
+                            )
+                          : Container(
+                              color: AppColorScheme.onSurface.withValues(
+                                alpha: 0.1,
+                              ),
+                              child: Icon(
+                                Icons.music_note,
+                                size: 16,
+                                color: AppColorScheme.onSurface.withValues(
+                                  alpha: 0.6,
+                                ),
+                              ),
                             ),
-                          ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Flexible(
-                  child: GestureDetector(
-                    onTap: () => appRouter.push(Destinations.audioPlayer),
-                    child: Text(
-                      displayText,
-                      style: TextStyle(
-                        color: AppColorScheme.onSurface,
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                ),
-                const SizedBox(width: 20),
-                _buildBarButton(
-                  icon: Icons.skip_previous,
-                  onPressed: _manager.previous,
-                ),
-                const SizedBox(width: 4),
-                _buildBarButton(
-                  icon: isPlaying ? Icons.pause : Icons.play_arrow,
-                  onPressed: isPlaying ? _manager.pause : _manager.resume,
-                ),
-                const SizedBox(width: 4),
-                _buildBarButton(
-                  icon: Icons.skip_next,
-                  onPressed: _manager.next,
-                ),
-                const SizedBox(width: 4),
-                _buildBarButton(
-                  icon: Icons.stop,
-                  onPressed: () => unawaited(_manager.stop(userInitiated: true)),
-                ),
-              ],
+                  const SizedBox(width: 12),
+                  Flexible(
+                    child: GestureDetector(
+                      onTap: () => appRouter.push(Destinations.audioPlayer),
+                      child: Text(
+                        displayText,
+                        style: TextStyle(
+                          color: AppColorScheme.onSurface,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 20),
+                  _buildBarButton(
+                    icon: Icons.skip_previous,
+                    onPressed: _manager.previous,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: isPlaying ? Icons.pause : Icons.play_arrow,
+                    onPressed: isPlaying ? _manager.pause : _manager.resume,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: Icons.skip_next,
+                    onPressed: _manager.next,
+                  ),
+                  const SizedBox(width: 4),
+                  _buildBarButton(
+                    icon: Icons.stop,
+                    onPressed: () =>
+                        unawaited(_manager.stop(userInitiated: true)),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
       ),
-    ),
-  );
+    );
   }
 }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -509,15 +509,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     final nextIndex = direction == TraversalDirection.right
         ? index + 1
         : index - 1;
-    if (nextIndex < 0 || nextIndex >= nodes.length) {
-      if (direction == TraversalDirection.left &&
-          nextIndex < 0 &&
-          _avatarFocus.canRequestFocus) {
-        _avatarFocus.requestFocus();
-        return true;
-      }
-      return false;
-    }
+    if (nextIndex < 0 || nextIndex >= nodes.length) return false;
     nodes[nextIndex].node.requestFocus();
     return true;
   }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -503,7 +503,19 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     if (index < 0) return false;
     final nextIndex =
         direction == TraversalDirection.right ? index + 1 : index - 1;
-    if (nextIndex < 0 || nextIndex >= nodes.length) return false;
+    if (nextIndex < 0 || nextIndex >= nodes.length) {
+      // The avatar/back chip sits pinned at the physical left edge
+      // (non-directional Alignment.centerLeft), so leaving the icon row's
+      // on-screen leftmost item is always "left", regardless of which
+      // logical icon that is under RTL mirroring.
+      if (direction == TraversalDirection.left &&
+          nextIndex < 0 &&
+          _avatarFocus.canRequestFocus) {
+        _avatarFocus.requestFocus();
+        return true;
+      }
+      return false;
+    }
     nodes[nextIndex].node.requestFocus();
     return true;
   }
@@ -930,15 +942,6 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                     label: l10n.home,
                     baseColor: nextNavColor(),
                     focusNode: _homeFocus,
-                    onKeyEvent: (node, event) {
-                      if (event is KeyDownEvent &&
-                          PlatformDetection.isTV &&
-                          event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-                        _avatarFocus.requestFocus();
-                        return KeyEventResult.handled;
-                      }
-                      return KeyEventResult.ignored;
-                    },
                     onPressed: () {
                       if (_isActive(Destinations.home)) {
                         homeRefreshBus.request();

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -510,10 +510,6 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         ? index + 1
         : index - 1;
     if (nextIndex < 0 || nextIndex >= nodes.length) {
-      // The avatar/back chip sits pinned at the physical left edge
-      // (non-directional Alignment.centerLeft), so leaving the icon row's
-      // on-screen leftmost item is always "left", regardless of which
-      // logical icon that is under RTL mirroring.
       if (direction == TraversalDirection.left &&
           nextIndex < 0 &&
           _avatarFocus.canRequestFocus) {
@@ -619,9 +615,6 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         currentItem is AggregatedItem && currentItem.isAudioLike;
     final totalHeight = toolbarHeight + TopToolbar.musicBarExtraHeight();
 
-    // The toolbar is fixed chrome, not reading content: it always renders
-    // Home-first/left, Settings-last/right regardless of app locale, so it
-    // does not mirror under RTL the way scrollable rows and tabs do.
     return Directionality(
       textDirection: TextDirection.ltr,
       child: SafeArea(

--- a/test/ui/widgets/rtl_dpad_navigation_test.dart
+++ b/test/ui/widgets/rtl_dpad_navigation_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/detail/modern/widgets/details_tab_bar.dart';
+import 'package:moonfin/ui/widgets/focus/locked_focus_row.dart';
+
+// A physical Left press moves the highlight physically left whatever the
+// locale, and an escape fires for the key whose edge focus is actually at.
+// LockedFocusRow is where that rule started and DetailsTabBar held a copy
+// that drifted, so those two are pinned here.
+void main() {
+  group('LockedFocusRow', () {
+    late List<int> indices;
+    late int leftEdge;
+    late int rightEdge;
+    late FocusNode node;
+
+    setUp(() {
+      indices = [];
+      leftEdge = 0;
+      rightEdge = 0;
+      node = FocusNode();
+    });
+
+    tearDown(() => node.dispose());
+
+    Future<void> pump(WidgetTester tester, TextDirection direction) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: direction,
+            child: LockedFocusRow<String>(
+              items: const ['a', 'b', 'c'],
+              hubKey: 'test-${direction.name}',
+              itemExtent: 100,
+              height: 100,
+              focusNode: node,
+              itemBuilder: (context, item, index, isFocused) => Text(item),
+              onIndexChanged: (index, item) => indices.add(index),
+              onLeftEdge: () => leftEdge++,
+              onRightEdge: () => rightEdge++,
+            ),
+          ),
+        ),
+      );
+      node.requestFocus();
+      await tester.pump();
+      // Gaining focus reports the resting index, which isn't a movement.
+      indices.clear();
+    }
+
+    testWidgets('LTR: Right advances and each edge fires its own key', (
+      tester,
+    ) async {
+      await pump(tester, TextDirection.ltr);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(indices, [1]);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(indices, [1, 2]);
+      expect(rightEdge, 1, reason: 'Right at the last item leaves right');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(indices, [1, 2, 1, 0]);
+      expect(leftEdge, 1, reason: 'Left at the first item leaves left');
+    });
+
+    testWidgets('RTL: physical keys still move the highlight physically', (
+      tester,
+    ) async {
+      await pump(tester, TextDirection.rtl);
+
+      // Index 0 sits physically rightmost in a mirrored row, so a physical
+      // Left press moves inward to index 1.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(indices, [1]);
+
+      // The last index is the physically leftmost item, so pressing Left
+      // there leaves through the left edge, not the right one.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(indices, [1, 2]);
+      expect(leftEdge, 1);
+      expect(rightEdge, 0);
+
+      // And back across: physical Right walks to index 0 and then leaves
+      // through the right edge.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(indices, [1, 2, 1, 0]);
+      expect(rightEdge, 1);
+    });
+  });
+
+  group('DetailsTabBar', () {
+    late List<FocusNode> nodes;
+    late int exits;
+
+    setUp(() {
+      nodes = [for (var i = 0; i < 3; i++) FocusNode()];
+      exits = 0;
+    });
+
+    tearDown(() {
+      for (final n in nodes) {
+        n.dispose();
+      }
+    });
+
+    Future<void> pump(WidgetTester tester, TextDirection direction) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Directionality(
+            textDirection: direction,
+            child: Scaffold(
+              body: DetailsTabBar(
+                labels: const ['one', 'two', 'three'],
+                selectedIndex: 0,
+                onSelect: (_) {},
+                focusNodeFor: (index) => nodes[index],
+                onExitLeft: () => exits++,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('LTR: Left at the first tab exits left', (tester) async {
+      await pump(tester, TextDirection.ltr);
+      nodes[0].requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(exits, 1);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(nodes[1].hasFocus, isTrue);
+    });
+
+    testWidgets('RTL: the exit still belongs to the physical Left key', (
+      tester,
+    ) async {
+      await pump(tester, TextDirection.rtl);
+
+      // Index 0 is the physically rightmost tab. Pressing Right there has
+      // nowhere to go and must not throw focus out through the left.
+      nodes[0].requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(exits, 0);
+      expect(nodes[0].hasFocus, isTrue);
+
+      // Physical Left steps inward through the mirrored row.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(nodes[1].hasFocus, isTrue);
+
+      // And at the physically leftmost tab it leaves through onExitLeft.
+      nodes[2].requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(exits, 1);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Fixes several RTL (Hebrew/Arabic) locale bugs on Android TV, found and verified live on a physical Chromecast with Google TV.

## Related Issues
- Related to: none linked

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Home row navigation** (`LockedFocusRow`): fixed D-pad Left/Right mapping to respect RTL mirroring instead of always mapping Left→index-1/Right→index+1.
- **Top toolbar**: replaced the hardcoded "Left from Home jumps to avatar" behavior with a geometry-based fallback that only jumps to the avatar when focus is genuinely at the on-screen-leftmost toolbar item.
- **Top toolbar order**: locked the icon row (Home … Settings) to a fixed LTR order via `Directionality`, per product decision to keep this navbar's layout constant across locales.
- **Hero media banner**: fixed prev/next chevron buttons and D-pad handling so "advance" follows the physical-left key under RTL, and each arrow's icon follows its action (prev/next) rather than its screen slot.
- **Tab bars** (`FocusableActionBar`, `SlidingPillTabs`, `DetailsTabBar`): applied the same Directionality-aware index-step fix as the home row, plus fixed the pill tab bar's selection-thumb offset math which only accumulated from the left under RTL.
- **Quick Connect code display**: forced the 6-digit code `Text` to LTR so the Unicode bidi algorithm no longer reorders the two digit groups inside an RTL paragraph, which previously caused login failures.

## Platform
- [x] All / Shared code

_Note: the widgets touched (`LockedFocusRow`, `FocusableActionBar`, `SlidingPillTabs`, `DetailsTabBar`, `TopToolbar`, hero banner, Quick Connect) are shared across all platforms. The layout/visual RTL fixes (icon order, chevron mapping, offset math, Quick Connect LTR text) apply everywhere; the D-pad focus-navigation fixes only take effect where D-pad/remote focus navigation runs (behind the pre-existing `PlatformDetection.isTV || PlatformDetection.isDesktop` guards), so they're inert on touch-only mobile. Only verified live on Android TV (Chromecast with Google TV) — not yet tested on other platforms.

## Testing
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Tested on emulator / simulator
- [ ] Not tested (explain why):

### Test Steps
1. Set device locale to Hebrew (`he-IL`) on a Chromecast with Google TV.
2. Reproduce each bug (home row D-pad direction, toolbar Left-from-Home, navbar icon order, hero banner arrows, Quick Connect code display/login).
3. Rebuild with the fix applied and verify each behavior on-device; confirm `dart analyze` is clean on all touched files.

## Screenshots (if applicable)
N/A (D-pad navigation and RTL layout behavior; no static screenshots captured)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced

