### PR TITLE
fix(seerr): seerr page rows localization and hovering

### DIFF
--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -10,7 +10,6 @@ import '../utils/bounded_concurrency.dart';
 
 class SeerrDiscoverRow {
   final SeerrRowType type;
-  final String title;
   final List<SeerrDiscoverItem> items;
   final List<SeerrGenre> genres;
   final List<SeerrNetwork> networks;
@@ -21,7 +20,6 @@ class SeerrDiscoverRow {
 
   const SeerrDiscoverRow({
     required this.type,
-    required this.title,
     this.items = const [],
     this.genres = const [],
     this.networks = const [],
@@ -42,7 +40,6 @@ class SeerrDiscoverRow {
   }) =>
       SeerrDiscoverRow(
         type: type,
-        title: title,
         items: items ?? this.items,
         genres: genres ?? this.genres,
         networks: networks ?? this.networks,
@@ -150,7 +147,6 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       await _refreshRecentlyAddedGate(activeRows);
       _rows = _visibleRows(activeRows).map((type) => SeerrDiscoverRow(
         type: type,
-        title: _titleForRowType(type),
         isLoading: true,
       )).toList();
       notifyListeners();
@@ -521,19 +517,4 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  static String _titleForRowType(SeerrRowType type) => switch (type) {
-    SeerrRowType.shortcuts => 'Seerr Browse',
-    SeerrRowType.recentRequests => 'Recent Requests',
-    SeerrRowType.yourWatchlist => 'Your Watchlist',
-    SeerrRowType.recentlyAdded => 'Recently Added',
-    SeerrRowType.trending => 'Trending',
-    SeerrRowType.popularMovies => 'Popular Movies',
-    SeerrRowType.movieGenres => 'Movie Genres',
-    SeerrRowType.upcomingMovies => 'Upcoming Movies',
-    SeerrRowType.studios => 'Studios',
-    SeerrRowType.popularSeries => 'Popular Series',
-    SeerrRowType.seriesGenres => 'Series Genres',
-    SeerrRowType.upcomingSeries => 'Upcoming Series',
-    SeerrRowType.networks => 'Networks',
-  };
 }

--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -801,8 +801,9 @@ class _AlphaLetterButtonState extends State<_AlphaLetterButton>
           onTap: widget.onTap,
           child: AnimatedContainer(
             duration: const Duration(milliseconds: 120),
-            width: 30,
+            constraints: const BoxConstraints(minWidth: 30),
             height: 34,
+            padding: const EdgeInsets.symmetric(horizontal: 6),
             alignment: Alignment.center,
             decoration: BoxDecoration(
               color: widget.isSelected
@@ -821,6 +822,8 @@ class _AlphaLetterButtonState extends State<_AlphaLetterButton>
             ),
             child: Text(
               widget.label,
+              maxLines: 1,
+              softWrap: false,
               style: TextStyle(
                 fontSize: 15,
                 fontWeight:

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -25,6 +25,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/focus/locked_focus_row.dart';
 import '../../widgets/seerr/seerr_shortcuts.dart';
+import '../../util/home_row_title_localizer.dart';
 import '../../widgets/horizontal_scroll_section.dart';
 import '../../widgets/quick_return_wrapper.dart';
 import '../../../util/seerr_genre_art.dart';
@@ -508,7 +509,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   }
 
   Widget _buildRowContainer({
-    required String title,
+    required SeerrRowType type,
     required double rowHeight,
     required bool isLoading,
     required bool hasItems,
@@ -516,6 +517,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     required Widget child,
   }) {
     final l10n = AppLocalizations.of(context);
+    final title = localizeSeerrRowTitle(type, l10n);
     final desktopScale = GetIt.instance<UserPreferences>()
         .get(UserPreferences.desktopUiScale)
         .scaleFactor;
@@ -595,7 +597,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       child: LockedFocusRow<SeerrDiscoverItem>(
         key: focusKey,
         items: row.items,
-        hubKey: 'seerr_discover_media_${rowIndex}_${row.title}',
+        hubKey: 'seerr_discover_media_${rowIndex}_${row.type.name}',
         controller: _getRowScroll(rowIndex),
         itemExtent: 130,
         itemSpacing: 12 * desktopScale,
@@ -647,7 +649,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      title: row.title,
+      type: row.type,
       rowHeight: 260,
       isLoading: row.isLoading && row.items.isEmpty,
       hasItems: row.items.isNotEmpty,
@@ -718,7 +720,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      title: row.title,
+      type: row.type,
       rowHeight: 100 * desktopScale,
       isLoading: false,
       hasItems: true,
@@ -752,7 +754,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrGenre>(
       key: focusKey,
       items: row.genres,
-      hubKey: 'seerr_discover_genres_${rowIndex}_${row.title}',
+      hubKey: 'seerr_discover_genres_${rowIndex}_${row.type.name}',
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -814,7 +816,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      title: row.title,
+      type: row.type,
       rowHeight: 90,
       isLoading: row.isLoading && row.genres.isEmpty,
       hasItems: row.genres.isNotEmpty,
@@ -838,7 +840,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrNetwork>(
       key: focusKey,
       items: row.networks,
-      hubKey: 'seerr_discover_networks_${rowIndex}_${row.title}',
+      hubKey: 'seerr_discover_networks_${rowIndex}_${row.type.name}',
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -899,7 +901,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      title: row.title,
+      type: row.type,
       rowHeight: 90,
       isLoading: row.isLoading && row.networks.isEmpty,
       hasItems: row.networks.isNotEmpty,
@@ -923,7 +925,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrStudio>(
       key: focusKey,
       items: row.studios,
-      hubKey: 'seerr_discover_studios_${rowIndex}_${row.title}',
+      hubKey: 'seerr_discover_studios_${rowIndex}_${row.type.name}',
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -984,7 +986,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      title: row.title,
+      type: row.type,
       rowHeight: 90,
       isLoading: row.isLoading && row.studios.isEmpty,
       hasItems: row.studios.isNotEmpty,

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -1181,7 +1181,11 @@ class _GenreCardState extends State<_GenreCard> with FocusStateMixin {
     final focusColor =
         Color(GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue);
     final externallyDriven = widget.externalIsFocused != null;
-    final effectiveFocused = widget.externalIsFocused ?? (focused || hovered);
+    // The row drives focus and knows nothing about the mouse, so hovering has
+    // to count too. Same rule as MediaCard.
+    final effectiveFocused = externallyDriven
+        ? (widget.externalIsFocused! || hovered)
+        : (focused || hovered);
 
     final inner = GestureDetector(
       onTap: widget.onTap,
@@ -1318,7 +1322,11 @@ class _LogoCardState extends State<_LogoCard> with FocusStateMixin {
     final focusColor =
         Color(GetIt.instance<UserPreferences>().get(UserPreferences.focusColor).colorValue);
     final externallyDriven = widget.externalIsFocused != null;
-    final effectiveFocused = widget.externalIsFocused ?? (focused || hovered);
+    // The row drives focus and knows nothing about the mouse, so hovering has
+    // to count too. Same rule as MediaCard.
+    final effectiveFocused = externallyDriven
+        ? (widget.externalIsFocused! || hovered)
+        : (focused || hovered);
 
     final inner = GestureDetector(
       onTap: widget.onTap,

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1230,21 +1230,6 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     if (mounted) setState(() {});
   }
 
-  String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
-    SeerrRowType.shortcuts => l10n.seerrShortcutsRow,
-    SeerrRowType.recentRequests => l10n.recentRequests,
-    SeerrRowType.yourWatchlist => l10n.yourWatchlist,
-    SeerrRowType.recentlyAdded => l10n.recentlyAdded,
-    SeerrRowType.trending => l10n.trending,
-    SeerrRowType.popularMovies => l10n.popularMovies,
-    SeerrRowType.movieGenres => l10n.movieGenres,
-    SeerrRowType.upcomingMovies => l10n.upcomingMovies,
-    SeerrRowType.studios => l10n.studios,
-    SeerrRowType.popularSeries => l10n.popularSeries,
-    SeerrRowType.seriesGenres => l10n.seriesGenres,
-    SeerrRowType.upcomingSeries => l10n.upcomingSeries,
-    SeerrRowType.networks => l10n.networks,
-  };
 
   @override
   Widget build(BuildContext context) {
@@ -1270,7 +1255,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
                     final row = entry.value;
                     return _SeerrRowSwitchTile(
                       focusNode: rowIndex == 0 ? _firstFocusNode : null,
-                      title: _rowLabel(row.type, l10n),
+                      title: localizeSeerrRowTitle(row.type, l10n),
                       value: row.enabled,
                       onChanged: (enabled) {
                         setState(() {

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1230,7 +1230,6 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     if (mounted) setState(() {});
   }
 
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -24,6 +24,7 @@ import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../../util/home_row_title_localizer.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/preference_tiles.dart';
@@ -397,21 +398,6 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     _focusRowAndEnsureVisible(newIndex);
   }
 
-  String _rowLabel(SeerrRowType type, AppLocalizations l10n) => switch (type) {
-    SeerrRowType.shortcuts => l10n.seerrShortcutsRow,
-    SeerrRowType.recentRequests => l10n.recentRequests,
-    SeerrRowType.recentlyAdded => l10n.recentlyAdded,
-    SeerrRowType.trending => l10n.trending,
-    SeerrRowType.popularMovies => l10n.popularMovies,
-    SeerrRowType.movieGenres => l10n.movieGenres,
-    SeerrRowType.upcomingMovies => l10n.upcomingMovies,
-    SeerrRowType.studios => l10n.studios,
-    SeerrRowType.popularSeries => l10n.popularSeries,
-    SeerrRowType.seriesGenres => l10n.seriesGenres,
-    SeerrRowType.upcomingSeries => l10n.upcomingSeries,
-    SeerrRowType.networks => l10n.networks,
-    SeerrRowType.yourWatchlist => l10n.yourWatchlist,
-  };
 
   @override
   Widget build(BuildContext context) {
@@ -679,7 +665,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
               return _SeerrReorderableTile(
                 key: ValueKey('${row.type}:${row.enabled}'),
                 focusNode: _focusNodes[rowIndex],
-                label: _rowLabel(row.type, l10n),
+                label: localizeSeerrRowTitle(row.type, l10n),
                 enabled: row.enabled,
                 enabledLabel: l10n.enabled,
                 hiddenLabel: l10n.hidden,
@@ -734,7 +720,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
               return _SeerrReorderableTile(
                 key: ValueKey(row.type),
                 focusNode: _focusNodes[rowIndex],
-                label: _rowLabel(row.type, l10n),
+                label: localizeSeerrRowTitle(row.type, l10n),
                 enabled: row.enabled,
                 enabledLabel: l10n.enabled,
                 hiddenLabel: l10n.hidden,

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -398,7 +398,6 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     _focusRowAndEnsureVisible(newIndex);
   }
 
-
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -25,6 +25,7 @@ import '../../../platform/web_runtime_config.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/language_codes.dart';
 import '../../../util/locale_names.dart';
+import '../../util/home_row_title_localizer.dart';
 import '../../../util/overlay_color_palette.dart';
 import '../../../util/game_cores.dart';
 import '../../../util/platform_detection.dart';

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -1,5 +1,25 @@
 import '../../data/models/home_row.dart';
 import '../../l10n/app_localizations.dart';
+import '../../preference/preference_constants.dart';
+
+/// The Seerr page builds its rows from the type alone, so it localizes the
+/// title here rather than carrying one around.
+String localizeSeerrRowTitle(SeerrRowType type, AppLocalizations l10n) =>
+    switch (type) {
+      SeerrRowType.shortcuts => l10n.seerrShortcutsRow,
+      SeerrRowType.recentRequests => l10n.recentRequests,
+      SeerrRowType.recentlyAdded => l10n.recentlyAdded,
+      SeerrRowType.yourWatchlist => l10n.yourWatchlist,
+      SeerrRowType.trending => l10n.trending,
+      SeerrRowType.popularMovies => l10n.popularMovies,
+      SeerrRowType.movieGenres => l10n.movieGenres,
+      SeerrRowType.upcomingMovies => l10n.upcomingMovies,
+      SeerrRowType.studios => l10n.studios,
+      SeerrRowType.popularSeries => l10n.popularSeries,
+      SeerrRowType.seriesGenres => l10n.seriesGenres,
+      SeerrRowType.upcomingSeries => l10n.upcomingSeries,
+      SeerrRowType.networks => l10n.networks,
+    };
 
 String localizeHomeRowTitle({
   required HomeRow row,

--- a/test/ui/util/home_row_title_localizer_test.dart
+++ b/test/ui/util/home_row_title_localizer_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/l10n/app_localizations_en.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/ui/util/home_row_title_localizer.dart';
+
+final _l10n = AppLocalizationsEn();
+
+// The wording the Seerr page showed while these titles were hardcoded in the
+// view model. They are spelled out as literals on purpose, because comparing
+// against the l10n getters would restate the implementation and pass either
+// way.
+const _englishTitles = {
+  SeerrRowType.shortcuts: 'Seerr Browse',
+  SeerrRowType.recentRequests: 'Recent Requests',
+  SeerrRowType.yourWatchlist: 'Your Watchlist',
+  SeerrRowType.recentlyAdded: 'Recently Added',
+  SeerrRowType.trending: 'Trending',
+  SeerrRowType.popularMovies: 'Popular Movies',
+  SeerrRowType.movieGenres: 'Movie Genres',
+  SeerrRowType.upcomingMovies: 'Upcoming Movies',
+  SeerrRowType.studios: 'Studios',
+  SeerrRowType.popularSeries: 'Popular Series',
+  SeerrRowType.seriesGenres: 'Series Genres',
+  SeerrRowType.upcomingSeries: 'Upcoming Series',
+  SeerrRowType.networks: 'Networks',
+};
+
+void main() {
+  test('every row keeps the English title it had before', () {
+    for (final entry in _englishTitles.entries) {
+      expect(
+        localizeSeerrRowTitle(entry.key, _l10n),
+        entry.value,
+        reason: 'the ${entry.key.name} row changed wording in English',
+      );
+    }
+  });
+
+  test('the pinned wording covers every row type', () {
+    expect(_englishTitles.keys.toSet(), SeerrRowType.values.toSet());
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Two fixes on the Seerr page. The row titles were hardcoded in English, so they stayed in English whatever the app language, while the same rows on the home screen were translated. And the genre, studio and network cards ignore the mouse: no border and no zoom on hover, unlike every other row.

## Related Issues
- Closes #
- Fixes #1216 
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- The titles lived in `_titleForRowType` in the view model, which has no `BuildContext` and so can't read translations. The screen resolves the title from the row type instead, where the translations are already at hand. Every string it needs was already translated, so no new keys.
- The two settings screens each had their own copy of that type-to-label mapping. All three now share one function in `home_row_title_localizer.dart`, next to the one the home rows use.
- The focus keys were built from those English titles, so they now use the row type name and stay the same in any language.
- `_GenreCard` and `_LogoCard` resolved focus with `??`. The row always passes a value, so the hover state was never read. They now add hover on top of the row's focus, the same rule `MediaCard` uses.

EDIT: also fixed the "All" button inside Seerr categories page to adapt to wider localized strings. Screenshots below:
### Before
<img width="1840" height="1115" alt="Screenshot 2026-08-21 at 15 06 40" src="https://github.com/user-attachments/assets/c716b295-cce4-43a2-83f1-655d1487b97b" />

### After
<img width="1840" height="1115" alt="Screenshot 2026-08-21 at 15 10 29" src="https://github.com/user-attachments/assets/d3f934e6-dae5-4974-bfef-f739cdc8b82e" />
<img width="1840" height="1115" alt="Screenshot 2026-08-21 at 15 10 13" src="https://github.com/user-attachments/assets/42a87bb7-7984-4d76-9a52-7aeb6c2192c7" />

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [x] Web --> for hovering with mouse fix
- [x] macOS --> for hovering with mouse fix
- [x] Windows --> for hovering with mouse fix
- [x] Linux --> for hovering with mouse fix
- [x] All / Shared code --> for Seerr rows localization fix

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Set the app to a language other than English and open the Seerr page. Every row title is translated and matches the home screen.
2. Switch back to English: the titles follow
3. Hover a genre, studio or network card: white border and zoom, like the other rows.

## Screenshots (if applicable)
### Before
https://github.com/user-attachments/assets/916659e3-bae2-471a-a067-944a2917c326

### After
https://github.com/user-attachments/assets/a9aa7458-5721-4a0f-bf7f-794cc05d5242

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
