### PR TITLE
[UI] Player OSD click-to-dismiss behavior fix & skip button showing together with OSD after auto-hide

### DIFF
--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -3475,9 +3475,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             onVerticalDragUpdate: swipeGestures ? _onVerticalDragUpdate : null,
             onVerticalDragEnd: swipeGestures ? _onVerticalDragEnd : null,
             onVerticalDragCancel: swipeGestures ? _onVerticalDragCancel : null,
-            onPanDown: PlatformDetection.useDesktopUi
-                ? (_) => _showControls()
-                : null,
             behavior: HitTestBehavior.opaque,
             child: Listener(
               onPointerSignal: PlatformDetection.useDesktopUi
@@ -3503,6 +3500,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                       child: ColoredBox(color: Colors.black),
                     ),
                     _buildVideoSurface(),
+                    if (PlatformDetection.isWeb)
+                      const Positioned.fill(
+                        child: ColoredBox(color: Colors.transparent),
+                      ), // Workaround for a Flutter web issue where the video surface can block pointer events.
                     _buildBringupOverlay(context),
                     if (_isRestoringPosition)
                       const Positioned.fill(

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -187,6 +187,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   MediaSegment? _skipSegment;
   Duration? _skipTo;
+  /// True when the auto-hide setting is on for the current segment.
+  bool _skipSegmentAutoHideEnabled = false;
+  /// True while the auto-hide cooldown is still running.
+  bool _skipSegmentAutoHidePending = false;
+  Timer? _skipSegmentAutoHideTimer;
   bool _showNextUp = false;
   AggregatedItem? _nextUpItem;
   bool _nextUpDismissed = false;
@@ -879,6 +884,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _syncMedia3VolumeBoostLevel();
       unawaited(_syncAutoHdrSwitching());
       final isPreroll = _isCurrentPreroll;
+      _resetSkipSegmentAutoHide();
       setState(() {
         _nextUpDismissed = false;
         _showNextUp = false;
@@ -963,6 +969,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
     _cancelTvTemporarySpeedHold();
     _hideTimer?.cancel();
+    _skipSegmentAutoHideTimer?.cancel();
     _displayPlayingDebounce?.cancel();
     _endsAtTicker?.cancel();
     _scrubSeekDebounceTimer?.cancel();
@@ -2183,6 +2190,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final hadNextUpPrompt = _showNextUp;
     if (!hadSkipPrompt && !hadNextUpPrompt) return;
 
+    if (hadSkipPrompt) {
+      _resetSkipSegmentAutoHide();
+    }
     setState(() {
       if (hadSkipPrompt) {
         _skipSegment = null;
@@ -2240,6 +2250,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _controlsVisible = false;
       });
       _hideTimer?.cancel();
+      _scheduleSkipSegmentAutoHide();
       _focusTvSkipSegment();
     } else if (result.isNone && _skipSegment != null) {
       _clearSkipSegment();
@@ -2343,6 +2354,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     if (nextItem == null) return;
 
     _manager.suppressAutoNext = true;
+    _resetSkipSegmentAutoHide();
     setState(() {
       _showNextUp = true;
       _nextUpItem = nextItem;
@@ -2473,6 +2485,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     if (_skipTo != null) {
       _manager.seekTo(_skipTo!);
     }
+    _resetSkipSegmentAutoHide();
     setState(() {
       _skipSegment = null;
       _skipTo = null;
@@ -2486,9 +2499,48 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _clearSkipSegment() {
+    _resetSkipSegmentAutoHide();
     setState(() {
       _skipSegment = null;
       _skipTo = null;
+    });
+  }
+
+  void _resetSkipSegmentAutoHide() {
+    _skipSegmentAutoHideTimer?.cancel();
+    _skipSegmentAutoHideTimer = null;
+    _skipSegmentAutoHideEnabled = false;
+    _skipSegmentAutoHidePending = false;
+  }
+
+  /// Whether the skip button is currently drawn. While the auto-hide cooldown
+  /// runs it stays up on its own; afterwards it rides along with the OSD.
+  /// With auto-hide off it stays up until the segment ends.
+  bool get _isSkipSegmentButtonVisible =>
+      _skipSegment != null &&
+      (!_skipSegmentAutoHideEnabled ||
+          _skipSegmentAutoHidePending ||
+          _controlsVisible);
+
+  /// Hides the skip button after the user-configured cooldown. Once it has
+  /// elapsed the button no longer clears the segment outright: it only hides
+  /// while the OSD is up, and reappears whenever the OSD reappears.
+  void _scheduleSkipSegmentAutoHide() {
+    _skipSegmentAutoHideTimer?.cancel();
+    _skipSegmentAutoHideTimer = null;
+    _skipSegmentAutoHideEnabled = false;
+    _skipSegmentAutoHidePending = false;
+    final seconds = _prefs.get(UserPreferences.mediaSegmentAutoHide).seconds;
+    if (seconds <= 0) return;
+    _skipSegmentAutoHideEnabled = true;
+    _skipSegmentAutoHidePending = true;
+    _skipSegmentAutoHideTimer = Timer(Duration(seconds: seconds), () {
+      _skipSegmentAutoHideTimer = null;
+      if (!mounted || _skipSegment == null) return;
+      _skipSegmentAutoHidePending = false;
+      // If the OSD is hidden the button hides with it; if the OSD is up it
+      // stays, and from now on it follows the OSD visibility.
+      setState(() {});
     });
   }
 
@@ -2644,7 +2696,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _focusTvNextUpPlay();
       return;
     }
-    if (_skipSegment != null) {
+    if (_isSkipSegmentButtonVisible) {
       _focusTvSkipSegment();
       return;
     }
@@ -3149,7 +3201,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         final isBoundaryFocus =
             primaryFocus == _tvTransportLastFocus ||
             primaryFocus == _tvSeekbarFocus;
-        if (isBoundaryFocus && _skipSegment != null) {
+        if (isBoundaryFocus && _isSkipSegmentButtonVisible) {
           _focusTvSkipSegment();
           return KeyEventResult.handled;
         }
@@ -3186,7 +3238,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             _handleNextUpDismiss();
             return KeyEventResult.handled;
           }
-          if (_skipSegment != null) {
+          if (_isSkipSegmentButtonVisible) {
             _dismissSkipSegment();
             return KeyEventResult.handled;
           }
@@ -3440,7 +3492,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           _handleNextUpDismiss();
           return;
         }
-        if (_skipSegment != null) {
+        if (_isSkipSegmentButtonVisible) {
           _dismissSkipSegment();
           return;
         }
@@ -3528,7 +3580,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                       _buildDoubleTapSkipOverlay(),
                     if (_isOsdLocked && !hideOsdForPreroll)
                       _buildLockedOverlay(),
-                    if (_skipSegment != null)
+                    if (_isSkipSegmentButtonVisible)
                       SkipSegmentOverlay(
                         segment: _skipSegment!,
                         onSkip: _skipCurrentSegment,
@@ -3537,9 +3589,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                             : null,
                         onDismiss: _clearSkipSegment,
                         positionStream: _state.positionStream,
-                        autoHideSeconds: _prefs
-                            .get(UserPreferences.mediaSegmentAutoHide)
-                            .seconds,
+                        initialPosition: _state.position,
                       ),
                     if (_showNextUp && _nextUpItem != null)
                       NextUpOverlay(

--- a/lib/ui/widgets/playback/skip_segment_overlay.dart
+++ b/lib/ui/widgets/playback/skip_segment_overlay.dart
@@ -20,9 +20,10 @@ class SkipSegmentOverlay extends StatefulWidget {
   final FocusNode? focusNode;
   final Stream<Duration>? positionStream;
 
-  /// Hides the button after this many seconds. Zero leaves it up until the
-  /// segment ends.
-  final int autoHideSeconds;
+  /// Current playback position at build time, so a freshly created widget
+  /// starts in sync instead of flashing the segment start until the next
+  /// stream tick arrives.
+  final Duration? initialPosition;
 
   const SkipSegmentOverlay({
     super.key,
@@ -31,7 +32,7 @@ class SkipSegmentOverlay extends StatefulWidget {
     required this.onDismiss,
     this.focusNode,
     this.positionStream,
-    this.autoHideSeconds = 0,
+    this.initialPosition,
   });
 
   @override
@@ -41,14 +42,12 @@ class SkipSegmentOverlay extends StatefulWidget {
 class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
   StreamSubscription<Duration>? _positionSubscription;
   Duration _currentPosition = Duration.zero;
-  Timer? _autoHideTimer;
 
   @override
   void initState() {
     super.initState();
-    _currentPosition = widget.segment.start;
+    _currentPosition = widget.initialPosition ?? widget.segment.start;
     _subscribe();
-    _scheduleAutoHide();
   }
 
   @override
@@ -58,26 +57,22 @@ class _SkipSegmentOverlayState extends State<SkipSegmentOverlay> {
         oldWidget.segment != widget.segment) {
       _unsubscribe();
       if (widget.segment != oldWidget.segment) {
-        _currentPosition = widget.segment.start;
-        _scheduleAutoHide();
+        _currentPosition = widget.initialPosition ?? widget.segment.start;
       }
       _subscribe();
+    }
+    // Keep the countdown in sync when the parent rebuilds with a fresh
+    // position (e.g. after a seek) before the next stream tick arrives.
+    final initial = widget.initialPosition;
+    if (initial != null && initial != oldWidget.initialPosition) {
+      _currentPosition = initial;
     }
   }
 
   @override
   void dispose() {
-    _autoHideTimer?.cancel();
     _unsubscribe();
     super.dispose();
-  }
-
-  void _scheduleAutoHide() {
-    _autoHideTimer?.cancel();
-    if (widget.autoHideSeconds <= 0) return;
-    _autoHideTimer = Timer(Duration(seconds: widget.autoHideSeconds), () {
-      if (mounted) widget.onDismiss();
-    });
   }
 
   void _subscribe() {


### PR DESCRIPTION
# Pull Request

## Summary
Like we discussed in PR #604, here are the small two fixes for the player behavior. Now, in the desktop interface, clicks are correctly registered so the controls OSD is not opening and closing directly after (click to dismiss), and on web, clicks not on a button of the OSD are registered (do close/open the overlay).

Also, the skip button now shows together with the controls OSD after it has been auto hidden.

## Related Issues
- Related to PR #604 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Fixed playback controls flickering when clicking on desktop UI.
- Fixed playback controls not hiding correctly after clicks on Web.
- Added a transparent Web overlay to ensure pointer events reach the playback controls.
- Improved skip-segment button auto-hide behavior:
   - Keeps the button visible during the configured cooldown.
   - Hides it together with the OSD after the cooldown expires.
   - Makes it reappear when the playback controls are shown again.
- Updated TV keyboard/focus handling to ignore hidden skip buttons.
- Prevented skip overlays from flashing at the segment start after rebuilds or seeks.
- Moved skip-button auto-hide state management into the video player screen.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
- [X] Tested on emulator / simulator
- [ ] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Manually used the app to verify changes are made correctly

## Screenshots (if applicable)
My server is currently down, of course after performing all the tests for the changes. I can't do recordings now on real media, I can provide you screenshots and recordings when my server is up again (couple days) if you want!

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
