### PR TITLE
fix(tvos): improve Top Shelf image quality

### DIFF
--- a/lib/data/services/topshelf_service.dart
+++ b/lib/data/services/topshelf_service.dart
@@ -18,6 +18,11 @@ class TopShelfService {
   static const _maxItems = 15;
   static const _debounceDelay = Duration(seconds: 2);
 
+  static const _image1xMaxWidth = 1920;
+  static const _image1xMaxHeight = 1080;
+  static const _image2xMaxWidth = 3840;
+  static const _image2xMaxHeight = 2160;
+
   Timer? _debounce;
 
   /// Schedules a Top Shelf cache refresh, coalescing the rapid successive
@@ -72,20 +77,75 @@ class TopShelfService {
         ? 'id=$id'
         : 'id=$id&serverId=${Uri.encodeQueryComponent(serverId)}';
 
-    String? image;
+    String? image1x;
+    String? image2x;
+
     final thumbTag = item.thumbImageTag;
+    final backdropTags = item.backdropImageTags;
+    final parentBackdropId = item.parentBackdropItemId;
+    final parentBackdropTags = item.parentBackdropImageTags;
     final primaryTag = item.primaryImageTag;
+
     if (thumbTag != null && thumbTag.isNotEmpty) {
-      image = imageApi.getThumbImageUrl(id, maxWidth: 960, tag: thumbTag);
+      image1x = imageApi.getThumbImageUrl(
+        id,
+        maxWidth: _image1xMaxWidth,
+        tag: thumbTag,
+      );
+
+      image2x = imageApi.getThumbImageUrl(
+        id,
+        maxWidth: _image2xMaxWidth,
+        tag: thumbTag,
+      );
+    } else if (backdropTags.isNotEmpty) {
+      image1x = imageApi.getBackdropImageUrl(
+        id,
+        maxWidth: _image1xMaxWidth,
+        tag: backdropTags.first,
+      );
+
+      image2x = imageApi.getBackdropImageUrl(
+        id,
+        maxWidth: _image2xMaxWidth,
+        tag: backdropTags.first,
+      );
+    } else if (item.type != 'Video' &&
+        item.type != 'MusicVideo' &&
+        parentBackdropId != null &&
+        parentBackdropTags.isNotEmpty) {
+      image1x = imageApi.getBackdropImageUrl(
+        parentBackdropId,
+        maxWidth: _image1xMaxWidth,
+        tag: parentBackdropTags.first,
+      );
+
+      image2x = imageApi.getBackdropImageUrl(
+        parentBackdropId,
+        maxWidth: _image2xMaxWidth,
+        tag: parentBackdropTags.first,
+      );
     } else if (primaryTag != null && primaryTag.isNotEmpty) {
-      image = imageApi.getPrimaryImageUrl(id, maxHeight: 480, tag: primaryTag);
+      image1x = imageApi.getPrimaryImageUrl(
+        id,
+        maxHeight: _image1xMaxHeight,
+        tag: primaryTag,
+      );
+
+      image2x = imageApi.getPrimaryImageUrl(
+        id,
+        maxHeight: _image2xMaxHeight,
+        tag: primaryTag,
+      );
     }
 
     return {
       'id': id,
       'title': item.name,
-      'imageURL': ?image,
-      'contentImageURL': ?image,
+      'imageURL': ?image1x,
+      'contentImageURL': ?image1x,
+      'imageURL2x': ?image2x,
+      'contentImageURL2x': ?image2x,
       'displayURL': 'moonfin://item?$query',
       'playURL': 'moonfin://play?$query',
     };

--- a/lib/data/services/topshelf_service.dart
+++ b/lib/data/services/topshelf_service.dart
@@ -114,6 +114,7 @@ class TopShelfService {
         item.type != 'MusicVideo' &&
         parentBackdropId != null &&
         parentBackdropTags.isNotEmpty) {
+      // Episodes carry no backdrop of their own and borrow the series one.
       image1x = imageApi.getBackdropImageUrl(
         parentBackdropId,
         maxWidth: _image1xMaxWidth,
@@ -145,7 +146,6 @@ class TopShelfService {
       'imageURL': ?image1x,
       'contentImageURL': ?image1x,
       'imageURL2x': ?image2x,
-      'contentImageURL2x': ?image2x,
       'displayURL': 'moonfin://item?$query',
       'playURL': 'moonfin://play?$query',
     };

--- a/tvos/MoonfinTopShelf/ServiceProvider.swift
+++ b/tvos/MoonfinTopShelf/ServiceProvider.swift
@@ -26,6 +26,8 @@ private struct TopShelfCachePayload: Codable {
         let title: String
         let imageURL: String?
         let contentImageURL: String?
+        let imageURL2x: String?
+        let contentImageURL2x: String?
         let displayURL: String
         let playURL: String
         let playbackProgress: Double?
@@ -48,16 +50,12 @@ final class ServiceProvider: TVTopShelfContentProvider {
         guard let payload = try? JSONDecoder().decode(TopShelfCachePayload.self, from: data) else { return nil }
 
         let carouselItems: [TVTopShelfCarouselItem] = payload.sections.flatMap { section in
-            section.items.compactMap { cachedItem -> TVTopShelfCarouselItem? in
+            section.items.map { cachedItem in
                 let item = TVTopShelfCarouselItem(identifier: cachedItem.id)
                 item.title = cachedItem.title
                 item.contextTitle = section.title
 
-                let contentURL = cachedItem.contentImageURL ?? cachedItem.imageURL
-                if let urlString = contentURL, let url = URL(string: urlString) {
-                    item.setImageURL(url, for: .screenScale1x)
-                    item.setImageURL(url, for: .screenScale2x)
-                }
+                configureImages(for: item, cachedItem: cachedItem)
 
                 if let playURL = URL(string: cachedItem.playURL) {
                     item.playAction = TVTopShelfAction(url: playURL)
@@ -71,8 +69,55 @@ final class ServiceProvider: TVTopShelfContentProvider {
             }
         }
 
-        guard !carouselItems.isEmpty else { return nil }
+        guard !carouselItems.isEmpty else {
+            return nil
+        }
 
-        return TVTopShelfCarouselContent(style: .actions, items: carouselItems)
+        return TVTopShelfCarouselContent(
+            style: .actions,
+            items: carouselItems
+        )
+    }
+
+    private func configureImages(
+        for item: TVTopShelfCarouselItem,
+        cachedItem: TopShelfCachePayload.Item
+    ) {
+        let image1x = firstValidURL(
+            cachedItem.contentImageURL,
+            cachedItem.imageURL
+        )
+
+        let image2x = firstValidURL(
+            cachedItem.contentImageURL2x,
+            cachedItem.imageURL2x
+        )
+
+        let resolved1x = image1x ?? image2x
+        let resolved2x = image2x ?? image1x
+
+        if let resolved1x {
+            item.setImageURL(resolved1x, for: .screenScale1x)
+        }
+
+        if let resolved2x {
+            item.setImageURL(resolved2x, for: .screenScale2x)
+        }
+    }
+
+    private func firstValidURL(_ candidates: String?...) -> URL? {
+        for candidate in candidates {
+            guard
+                let candidate,
+                !candidate.isEmpty,
+                let url = URL(string: candidate)
+            else {
+                continue
+            }
+
+            return url
+        }
+
+        return nil
     }
 }

--- a/tvos/MoonfinTopShelf/ServiceProvider.swift
+++ b/tvos/MoonfinTopShelf/ServiceProvider.swift
@@ -27,7 +27,6 @@ private struct TopShelfCachePayload: Codable {
         let imageURL: String?
         let contentImageURL: String?
         let imageURL2x: String?
-        let contentImageURL2x: String?
         let displayURL: String
         let playURL: String
         let playbackProgress: Double?
@@ -88,10 +87,7 @@ final class ServiceProvider: TVTopShelfContentProvider {
             cachedItem.imageURL
         )
 
-        let image2x = firstValidURL(
-            cachedItem.contentImageURL2x,
-            cachedItem.imageURL2x
-        )
+        let image2x = firstValidURL(cachedItem.imageURL2x)
 
         let resolved1x = image1x ?? image2x
         let resolved2x = image2x ?? image1x


### PR DESCRIPTION
# Pull Request

## Summary
Improves Top Shelf image quality on tvOS, especially on Apple TV 4K.

Top Shelf now provides separate 1x and 2x artwork URLs instead of reusing the same lower-resolution image for both scales. It also prefers landscape artwork before falling back to primary artwork to reduce excessive cropping.

## Related Issues

None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Added separate 1x and 2x Top Shelf image URLs.
- Increased requested artwork resolution for high-resolution displays.
- Added landscape artwork fallback using backdrop and parent backdrop images before falling back to primary artwork.
- Kept backwards compatibility with the existing cached Top Shelf payload.

## Platform
- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Built and installed Moonfin on a physical Apple TV.
2. Opened Moonfin to refresh the Top Shelf cache.
3. Returned to the tvOS Home screen and verified Top Shelf artwork rendering.
4. Compared artwork quality before and after the change, including items using landscape fallbacks.

## Screenshots (if applicable)

<table>
  <tr>
    <th colspan="2">Example 1</th>
  </tr>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="1920" height="1080" alt="before-1" src="https://github.com/user-attachments/assets/a13a606f-bcd5-4694-b4cd-75468da1b3ee" /></td>
    <td><img width="1920" height="1080" alt="after-1" src="https://github.com/user-attachments/assets/bc5d5bda-fe90-4749-813f-a0787c31da3b" /></td>
  </tr>

  <tr>
    <th colspan="2">Example 2</th>
  </tr>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img width="1920" height="1080" alt="before-2" src="https://github.com/user-attachments/assets/498e709b-d21f-4e5f-82fa-a6917a0aba2e" /></td>
    <td><img width="1920" height="1080" alt="after-2" src="https://github.com/user-attachments/assets/62d6a4b0-0e0e-4d81-bce6-5d3c26158323" /></td>
  </tr>
</table>

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced