### PR TITLE
fix(l10n): restore the {type} placeholder in Finnish

### DIFF
--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -9281,7 +9281,7 @@
     "@onWatchlist": {
         "description": "Details screen button label when the title is already on the Seerr watchlist"
     },
-    "requestSeriesOrMovie4k": "Pyydä 4K {tyyppi}",
+    "requestSeriesOrMovie4k": "Pyydä 4K {type}",
     "@requestSeriesOrMovie4k": {
         "description": "Bottom sheet title for requesting media in 4K",
         "placeholders": {

--- a/lib/l10n/app_peo.arb
+++ b/lib/l10n/app_peo.arb
@@ -1,4 +1,5 @@
 {
+    "@@locale": "peo",
     "appTitle": "Moonfin",
     "@appTitle": {
         "description": "The application title"


### PR DESCRIPTION
# Pull Request

## Summary
main does not build from source. The Finnish translation of `requestSeriesOrMovie4k` localised the placeholder name itself — the message reads `Pyydä 4K {tyyppi}` while the metadata in the same block still declares `type`. gen-l10n merges placeholders across every locale, so the generated method becomes `requestSeriesOrMovie4k(String type, Object tyyppi)` and the one-argument call in `seerr_request_dialog.dart:42` no longer compiles.

The committed `app_localizations.dart` predates the translation, so the tree looks healthy until l10n is regenerated — which `flutter pub get` does on every build.

Introduced by 75ebc836 (Translated using Weblate (Finnish)).

## Related Issues
- Related to #1222

## Type of Change
- [x] Bug fix

## Changes Made
- Restore the `{type}` placeholder in `app_fi.arb` so it matches the declared metadata
- Declare `@@locale` in `app_peo.arb`, the same one-line change as #1222, without which CI cannot reach this fix. Happy to drop that commit and rebase if #1222 lands first.

## Platform
- [x] All / Shared code

## Testing
- [x] Manual testing completed
- [x] Tested on physical device

### Test Steps
1. On main, run `flutter pub get` — l10n generation fails on `app_peo.arb`.
2. With only the peo declaration, the build then fails compiling `requestSeriesOrMovie4k`.
3. With both changes, `flutter pub get` and `flutter analyze` are clean and the app builds and runs on a physical Android device.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced