### PR TITLE
fix(tvos): show immediate playback launch feedback

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -96,6 +96,19 @@ import '../../../util/platform_detection.dart';
 const _textShadows = [Shadow(blurRadius: 4, color: Colors.black54)];
 const _kCompactBreakpoint = 600.0;
 
+/// Whether video navigation should acknowledge playback before startup ends.
+///
+/// iOS already uses this path; tvOS needs the same immediate transition while
+/// its native player resolves and presents.
+@visibleForTesting
+bool shouldPushVideoPlayerRouteEarly({
+  required String destination,
+  required bool isIOS,
+  required bool isAppleTV,
+}) {
+  return destination == Destinations.videoPlayer && (isIOS || isAppleTV);
+}
+
 bool _isCompact(BuildContext context) =>
     !PlatformDetection.isTV &&
     (PlatformDetection.useMobileUi ||
@@ -8130,8 +8143,11 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   }) async {
     if (!context.mounted) return false;
     final manager = GetIt.instance<PlaybackManager>();
-    final pushVideoEarly =
-        destination == Destinations.videoPlayer && PlatformDetection.isIOS;
+    final pushVideoEarly = shouldPushVideoPlayerRouteEarly(
+      destination: destination,
+      isIOS: PlatformDetection.isIOS,
+      isAppleTV: PlatformDetection.isAppleTV,
+    );
 
     void popTopPlayerRoute() {
       final route = ModalRoute.of(context);

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart' show CupertinoActivityIndicator;
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -56,6 +57,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
   AppThemeController? _themeController;
   ScreensaverController? _screensaverController;
   StreamSubscription<bool>? _screensaverPlayingSub;
+  PlaybackBringupState _bringupState = const PlaybackBringupState.idle();
 
   AppleTvBackend? get _backend {
     try {
@@ -84,13 +86,17 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     _actionSub = _backend?.uiActionStream.listen(_handleUiAction);
     final manager = _manager;
     if (manager != null) {
+      _bringupState = manager.bringupState;
       _queueSub = manager.queueService.queueChangedStream.listen(
         (_) => _onQueueChanged(),
       );
       _sessionEndedSub = manager.sessionEndedStream.listen(
         (_) => _handleExit(),
       );
-      _bringupSub = manager.bringupStateStream.listen((_) {
+      _bringupSub = manager.bringupStateStream.listen((state) {
+        if (mounted) {
+          setState(() => _bringupState = state);
+        }
         _pushMetadata();
         // The initState load can run before the queue item resolves, so retry
         // here. The per-item guard makes repeat events a no-op.
@@ -1412,9 +1418,19 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    final showLaunchFeedback =
+        _bringupState.phase != PlaybackBringupPhase.ready &&
+        _bringupState.phase != PlaybackBringupPhase.failed;
+    return Scaffold(
       backgroundColor: Colors.black,
-      body: SizedBox.expand(),
+      body: showLaunchFeedback
+          ? const Center(
+              child: CupertinoActivityIndicator(
+                radius: 20,
+                color: Colors.white,
+              ),
+            )
+          : const SizedBox.expand(),
     );
   }
 }

--- a/test/ui/screens/detail/item_detail_playback_launch_test.dart
+++ b/test/ui/screens/detail/item_detail_playback_launch_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/navigation/destinations.dart';
+import 'package:moonfin/ui/screens/detail/item_detail_screen.dart';
+
+void main() {
+  test('video playback pushes early on iOS and Apple TV only', () {
+    expect(
+      shouldPushVideoPlayerRouteEarly(
+        destination: Destinations.videoPlayer,
+        isIOS: true,
+        isAppleTV: false,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldPushVideoPlayerRouteEarly(
+        destination: Destinations.videoPlayer,
+        isIOS: false,
+        isAppleTV: true,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldPushVideoPlayerRouteEarly(
+        destination: Destinations.videoPlayer,
+        isIOS: false,
+        isAppleTV: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldPushVideoPlayerRouteEarly(
+        destination: Destinations.externalPlayer,
+        isIOS: true,
+        isAppleTV: true,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/ui/screens/playback/appletv_player_host_screen_test.dart
+++ b/test/ui/screens/playback/appletv_player_host_screen_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/ui/screens/playback/appletv_player_host_screen.dart';
+import 'package:moonfin/ui/widgets/playback/player_loading_overlay.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _MockPlaybackManager extends Mock implements PlaybackManager {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockPlaybackManager manager;
+  late QueueService queue;
+  late PlayerState playerState;
+  late StreamController<PlaybackBringupState> bringupController;
+
+  setUp(() {
+    manager = _MockPlaybackManager();
+    queue = QueueService();
+    playerState = PlayerState();
+    bringupController = StreamController<PlaybackBringupState>.broadcast();
+
+    when(() => manager.bringupState).thenReturn(
+      const PlaybackBringupState.idle(),
+    );
+    when(() => manager.bringupStateStream).thenAnswer(
+      (_) => bringupController.stream,
+    );
+    when(() => manager.queueService).thenReturn(queue);
+    when(() => manager.sessionEndedStream).thenAnswer(
+      (_) => const Stream<void>.empty(),
+    );
+    when(() => manager.state).thenReturn(playerState);
+    when(
+      () => manager.stop(userInitiated: any(named: 'userInitiated')),
+    ).thenAnswer((_) async {});
+
+    GetIt.instance.registerSingleton<PlaybackManager>(manager);
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+    await bringupController.close();
+    queue.dispose();
+    playerState.dispose();
+  });
+
+  testWidgets('shows native-style launch spinner until playback is ready', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AppleTvPlayerHostScreen()),
+    );
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.byType(PlayerLoadingOverlay), findsNothing);
+    final spinner = tester.widget<CupertinoActivityIndicator>(
+      find.byType(CupertinoActivityIndicator),
+    );
+    expect(spinner.radius, 20);
+    expect(spinner.color, Colors.white);
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.resolving),
+    );
+    await tester.pump();
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.byType(PlayerLoadingOverlay), findsNothing);
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.ready),
+    );
+    await tester.pump();
+    expect(find.byType(CupertinoActivityIndicator), findsNothing);
+  });
+
+  testWidgets('removes launch feedback when playback fails', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: AppleTvPlayerHostScreen()),
+    );
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.failed),
+    );
+    await tester.pump();
+
+    expect(find.byType(CupertinoActivityIndicator), findsNothing);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
On tvos, when you press Play it could appear unresponsive while while backend is still in progress. The details screen remained visible during these backend steps. So it didn't feel immediately responsive after pressing Play.

This PR change has more immediate responsiveness by showing the full-screen player host immediately. It displays a centered white activity indicator that appears seamless. 

This does not actually speed-up video loading. 

## Related Issues
None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Show a centered white activity indicator during backend processing.
- Removed the launch indicator when playback is ready or startup fails.
- Add tests for early route navigation and playback bring-up state handling.

## Platform
- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
This build was succesfully tested on a physical Apple TV using TestFlight. It was manually tested by me.

The testing confirmed that pressing the Play button now immediately opens to a black screen with the white spinner. Seamlessly transitions to native player and video playback.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a TV show and select an episode.
2. Press Play.
3. Confirm the full-screen black player view appears immediately with a centered white spinner.
4. Confirm the spinner transitions smoothly into native playback and the video starts normally.

## Screenshots (if applicable)
Not included 

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [ ] No new warnings introduced