### PR TITLE
bugfix-detailspage - The one about TV Studio logos

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2083,20 +2083,41 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _studiosTab(BuildContext context, AggregatedItem item) {
     // Only the library's own studios can be filtered, so build the cards from
     // those and reuse a TMDB logo whenever a studio name matches one.
+    String normalize(String s) => s.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
+
     final tmdbLogoByName = <String, String>{};
+    final tmdbLogoByNormalized = <String, String>{};
     for (final company in _tmdbStudios) {
       final logo = company.imageUrl;
       if (logo != null) {
-        tmdbLogoByName[company.name.trim().toLowerCase()] = logo;
+        final rawKey = company.name.trim().toLowerCase();
+        final normKey = normalize(company.name);
+        tmdbLogoByName[rawKey] = logo;
+        if (normKey.isNotEmpty) {
+          tmdbLogoByNormalized[normKey] = logo;
+        }
       }
     }
     final studios = <({String name, String? logoUrl})>[];
     for (final s in item.studios) {
       final name = s['Name']?.toString() ?? '';
       if (name.isEmpty) continue;
+      final rawKey = name.trim().toLowerCase();
+      final normKey = normalize(name);
+
+      String? logoUrl = tmdbLogoByName[rawKey] ?? tmdbLogoByNormalized[normKey];
+      if (logoUrl == null && normKey.isNotEmpty) {
+        for (final entry in tmdbLogoByNormalized.entries) {
+          if (normKey.contains(entry.key) || entry.key.contains(normKey)) {
+            logoUrl = entry.value;
+            break;
+          }
+        }
+      }
+
       studios.add((
         name: name,
-        logoUrl: tmdbLogoByName[name.trim().toLowerCase()],
+        logoUrl: logoUrl,
       ));
     }
     if (studios.isEmpty) {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -73,6 +73,62 @@ double _desktopUiScale({UserPreferences? prefs}) {
   return effectivePrefs.get(UserPreferences.desktopUiScale).scaleFactor;
 }
 
+final _studioNamePunctuation = RegExp(r'[^a-z0-9]');
+
+/// Library and TMDB studio names rarely agree on punctuation or spacing, so
+/// they are compared without either.
+String normalizeStudioName(String name) =>
+    name.toLowerCase().replaceAll(_studioNamePunctuation, '');
+
+typedef StudioLogoIndex = ({
+  Map<String, String> byName,
+  Map<String, String> byNormalizedName,
+});
+
+/// Indexes [companies] under both their exact and normalized names. Two of
+/// them can share a normalized key, Apple TV and Apple TV+ for one, so the
+/// exact names are kept apart and consulted first.
+StudioLogoIndex studioLogoIndex(Iterable<StudioCompany> companies) {
+  final byName = <String, String>{};
+  final byNormalizedName = <String, String>{};
+  for (final company in companies) {
+    final logo = company.imageUrl;
+    if (logo == null) continue;
+    byName[company.name.trim().toLowerCase()] = logo;
+    final normalized = normalizeStudioName(company.name);
+    if (normalized.isNotEmpty) {
+      byNormalizedName[normalized] = logo;
+    }
+  }
+  return (byName: byName, byNormalizedName: byNormalizedName);
+}
+
+/// The logo to show for [studioName], if one of [index] is close enough.
+///
+/// Exact names win, then normalized ones. Anything left has to share a start,
+/// because matching anywhere in the name handed Netflix the logo of a company
+/// called X. The longest key wins so the closest name does, rather than
+/// whichever the server listed first.
+String? studioLogoUrlFor(String studioName, StudioLogoIndex index) {
+  final normalized = normalizeStudioName(studioName);
+  final exact =
+      index.byName[studioName.trim().toLowerCase()] ??
+      index.byNormalizedName[normalized];
+  if (exact != null || normalized.isEmpty) return exact;
+
+  String? best;
+  var bestKeyLength = 0;
+  for (final entry in index.byNormalizedName.entries) {
+    final shareStart =
+        entry.key.startsWith(normalized) || normalized.startsWith(entry.key);
+    if (shareStart && entry.key.length > bestKeyLength) {
+      bestKeyLength = entry.key.length;
+      best = entry.value;
+    }
+  }
+  return best;
+}
+
 /// "Modern" detail-screen style: one responsive screen that chooses a landscape
 /// (TV / desktop / any landscape device) or portrait (phone / tablet portrait)
 /// layout. Selected globally via [UserPreferences.detailScreenStyle].
@@ -2083,42 +2139,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _studiosTab(BuildContext context, AggregatedItem item) {
     // Only the library's own studios can be filtered, so build the cards from
     // those and reuse a TMDB logo whenever a studio name matches one.
-    String normalize(String s) => s.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]'), '');
-
-    final tmdbLogoByName = <String, String>{};
-    final tmdbLogoByNormalized = <String, String>{};
-    for (final company in _tmdbStudios) {
-      final logo = company.imageUrl;
-      if (logo != null) {
-        final rawKey = company.name.trim().toLowerCase();
-        final normKey = normalize(company.name);
-        tmdbLogoByName[rawKey] = logo;
-        if (normKey.isNotEmpty) {
-          tmdbLogoByNormalized[normKey] = logo;
-        }
-      }
-    }
+    final logos = studioLogoIndex(_tmdbStudios);
     final studios = <({String name, String? logoUrl})>[];
     for (final s in item.studios) {
       final name = s['Name']?.toString() ?? '';
       if (name.isEmpty) continue;
-      final rawKey = name.trim().toLowerCase();
-      final normKey = normalize(name);
-
-      String? logoUrl = tmdbLogoByName[rawKey] ?? tmdbLogoByNormalized[normKey];
-      if (logoUrl == null && normKey.isNotEmpty) {
-        for (final entry in tmdbLogoByNormalized.entries) {
-          if (normKey.contains(entry.key) || entry.key.contains(normKey)) {
-            logoUrl = entry.value;
-            break;
-          }
-        }
-      }
-
-      studios.add((
-        name: name,
-        logoUrl: logoUrl,
-      ));
+      studios.add((name: name, logoUrl: studioLogoUrlFor(name, logos)));
     }
     if (studios.isEmpty) {
       return const SizedBox.shrink();

--- a/test/ui/screens/detail/studio_logo_matching_test.dart
+++ b/test/ui/screens/detail/studio_logo_matching_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/detail/modern/modern_detail_content.dart';
+
+String? logoFor(String studio, Map<String, String?> companies) {
+  final index = studioLogoIndex([
+    for (final e in companies.entries) (name: e.key, imageUrl: e.value),
+  ]);
+  return studioLogoUrlFor(studio, index);
+}
+
+void main() {
+  test('an exact name wins', () {
+    expect(logoFor('HBO', {'HBO': 'hbo.png'}), 'hbo.png');
+  });
+
+  test('punctuation and spacing differences still match', () {
+    expect(logoFor('Apple TV', {'Apple TV+': 'apple.png'}), 'apple.png');
+    expect(logoFor('StudioCanal', {'Studio Canal': 'canal.png'}), 'canal.png');
+  });
+
+  test('a shared start matches when nothing is exact', () {
+    expect(logoFor('AMC', {'AMC Networks': 'amc.png'}), 'amc.png');
+    expect(logoFor('HBO', {'HBO Max': 'max.png'}), 'max.png');
+  });
+
+  test('a name shared only in the middle or end does not match', () {
+    expect(logoFor('Netflix', {'X': 'x.png'}), isNull);
+    expect(logoFor('Bandai Namco Filmworks', {'AMC': 'amc.png'}), isNull);
+    expect(logoFor('CBBC', {'BBC': 'bbc.png'}), isNull);
+    expect(logoFor('Reel FX Animation Studios', {'FX': 'fx.png'}), isNull);
+  });
+
+  test('the closest name wins rather than the first listed', () {
+    expect(
+      logoFor('Paramount Pictures', {
+        'Paramount+': 'plus.png',
+        'Paramount Pictures International': 'intl.png',
+      }),
+      'intl.png',
+    );
+  });
+
+  test('an exact match beats a longer name that shares its start', () {
+    expect(
+      logoFor('BBC', {'BBC Studios': 'studios.png', 'BBC': 'bbc.png'}),
+      'bbc.png',
+    );
+  });
+
+  test('a company with no logo is skipped', () {
+    expect(logoFor('HBO', {'HBO': null}), isNull);
+  });
+
+  test('a studio with no usable name gets nothing', () {
+    expect(logoFor('...', {'BBC': 'bbc.png'}), isNull);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
The latest test build still wasn't rendering TV Studio logos for me so I looked into it. It appears that the TMDB query wasn't hitting right between the client and Moonbase. This PR solves half of the problem by enhancing the Studios tab logo matching with normalized and substring fallback logic; there will be an accompanying Moonbase PR (https://github.com/Moonfin-Client/Plugin/pull/252/) that makes sure we include TMDB networks alongside production companies when fetching studio logos for TV shows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/252/

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **modern_detail_content.dart** (`_studiosTab`) to perform exact, normalized (alphanumeric), and substring fallback matching between Jellyfin studio names and TMDB company/network logos.
- Fixes fallback text cards when Jellyfin studio names differ slightly from TMDB names (e.g. `Apple TV` vs `Apple TV+` or `AMC` vs `AMC Networks`).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigated to show details (Deadwood, Dark Winds, Foundation, etc.) and selected the Studios tab.
2. Confirmed studio/network logos (HBO, AMC Studios, etc.) render properly inside cards instead of fallback text boxes.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### The Dark Times Before The Fix:
<img width="1629" height="1019" alt="2026-08-22_16-44-29_moonfin" src="https://github.com/user-attachments/assets/8afeb66a-e2c6-4fd8-aaef-fe8b23363a05" />
<img width="1629" height="1019" alt="2026-08-22_16-44-50_moonfin" src="https://github.com/user-attachments/assets/8f4f26dd-7a43-4ddd-bff2-7b70ee7a7e9b" />

### After the Fix (Moonbase + Client patch):
<img width="1718" height="1160" alt="2026-08-22_17-02-47_moonfin" src="https://github.com/user-attachments/assets/ab5123b5-cb01-4685-98b7-b350d79fd367" />
<img width="1718" height="1160" alt="2026-08-22_17-07-30_moonfin" src="https://github.com/user-attachments/assets/efbadded-57a6-403f-9285-2d4d551bbc21" />
<img width="1718" height="1160" alt="2026-08-22_17-08-00_moonfin" src="https://github.com/user-attachments/assets/543dc813-1cc1-4bd2-9474-04b6689f6d2c" />
<img width="1718" height="1160" alt="2026-08-22_17-08-12_moonfin" src="https://github.com/user-attachments/assets/c74112fd-229c-481e-b487-de27cee8ae5b" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
