### PR TITLE
bugfix-mediadetails - SPOILERMODE, PT. 2: Gotta Catch 'Em All

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13387,7 +13387,8 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            if (episode.overview != null) ...[
+                            if (!prefs.get(UserPreferences.hideDetailsMediaDescription) &&
+                                episode.overview != null) ...[
                               const SizedBox(height: 4),
                               Text(
                                 episode.overview!,
@@ -13658,7 +13659,8 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                       ),
                                 ),
                               ],
-                              if (episode.overview != null) ...[
+                              if (!prefs.get(UserPreferences.hideDetailsMediaDescription) &&
+                                  episode.overview != null) ...[
                                 const SizedBox(height: 4),
                                 Text(
                                   episode.overview!,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -10054,6 +10054,15 @@ String? channelLayoutFromStreams(List<Map<String, dynamic>> streams) {
   return null;
 }
 
+bool _showsEpisodeOverview(AggregatedItem episode, UserPreferences prefs) =>
+    episode.overview != null &&
+    !hidesMediaDescription(
+      itemType: episode.type,
+      hideMediaDescription: prefs.get(
+        UserPreferences.hideDetailsMediaDescription,
+      ),
+    );
+
 bool _isReadableBookItem(AggregatedItem item) {
   final mediaType = item.rawData['MediaType'] as String?;
   return item.type == 'Book' && mediaType != 'Audio';
@@ -13387,8 +13396,7 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            if (!prefs.get(UserPreferences.hideDetailsMediaDescription) &&
-                                episode.overview != null) ...[
+                            if (_showsEpisodeOverview(episode, prefs)) ...[
                               const SizedBox(height: 4),
                               Text(
                                 episode.overview!,
@@ -13659,8 +13667,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                       ),
                                 ),
                               ],
-                              if (!prefs.get(UserPreferences.hideDetailsMediaDescription) &&
-                                  episode.overview != null) ...[
+                              if (_showsEpisodeOverview(episode, prefs)) ...[
                                 const SizedBox(height: 4),
                                 Text(
                                   episode.overview!,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4329,10 +4329,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ? '$customLabel - ${episode.name}'
         : '${l10n.nextUp} - $title';
     final progress = (episode.playedPercentage ?? 0) / 100.0;
+    final hideMediaDescription = widget.prefs.get(
+      UserPreferences.hideDetailsMediaDescription,
+    );
     return UpNextCard(
       label: combinedLabel,
       title: '',
-      description: episode.overview?.trim(),
+      description: hideMediaDescription ? null : episode.overview?.trim(),
       imageUrl: _imageUrl(episode),
       progress: progress,
       remainingLabel: _remainingLabel(episode, l10n),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4329,13 +4329,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ? '$customLabel - ${episode.name}'
         : '${l10n.nextUp} - $title';
     final progress = (episode.playedPercentage ?? 0) / 100.0;
-    final hideMediaDescription = widget.prefs.get(
-      UserPreferences.hideDetailsMediaDescription,
+    final hideOverview = hidesMediaDescription(
+      itemType: episode.type,
+      hideMediaDescription: widget.prefs.get(
+        UserPreferences.hideDetailsMediaDescription,
+      ),
     );
     return UpNextCard(
       label: combinedLabel,
       title: '',
-      description: hideMediaDescription ? null : episode.overview?.trim(),
+      description: hideOverview ? null : episode.overview?.trim(),
       imageUrl: _imageUrl(episode),
       progress: progress,
       remainingLabel: _remainingLabel(episode, l10n),

--- a/test/util/hides_media_description_test.dart
+++ b/test/util/hides_media_description_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/overview_text.dart';
+
+void main() {
+  test('a film and an episode give the story away, so they are held back', () {
+    for (final type in ['Movie', 'Episode']) {
+      expect(
+        hidesMediaDescription(itemType: type, hideMediaDescription: true),
+        isTrue,
+        reason: '$type should be hidden',
+      );
+    }
+  });
+
+  test('a series or a season keeps its description', () {
+    for (final type in ['Series', 'Season', 'BoxSet', 'Person']) {
+      expect(
+        hidesMediaDescription(itemType: type, hideMediaDescription: true),
+        isFalse,
+        reason: '$type is not an episode specific spoiler',
+      );
+    }
+  });
+
+  test('nothing is held back while the setting is off', () {
+    for (final type in ['Movie', 'Episode', 'Series']) {
+      expect(
+        hidesMediaDescription(itemType: type, hideMediaDescription: false),
+        isFalse,
+      );
+    }
+  });
+
+  test('an unknown or missing type keeps its description', () {
+    expect(
+      hidesMediaDescription(itemType: null, hideMediaDescription: true),
+      isFalse,
+    );
+    expect(
+      hidesMediaDescription(itemType: '', hideMediaDescription: true),
+      isFalse,
+    );
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Extend "Hide Media Description on Details Page" preference to Next Up cards and episode lists.

Note: The show description itself is untouched because that isn't an episode specific spoiler.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1088 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Updated **modern_detail_content.dart** (`_computeUpNext`) to hide episode overview descriptions in the Next Up card when `UserPreferences.hideDetailsMediaDescription` is enabled.
- Updated **item_detail_screen.dart** (`DetailNextUpCardState` & `DetailEpisodeCardState`) to hide episode overviews in both classic Next Up cards and episode list cards across Show Main, Season, and Episode detail pages when `UserPreferences.hideDetailsMediaDescription` is enabled.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Toggled "Hide Media Description on Details Page" under Settings -> Personalization -> Details Screen.
2. Verified that episode descriptions in Next Up cards and episode lists (on Show Main, Season, and Episode pages) are hidden cleanly.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### SPOILERS BEING SPOILED
<img width="1718" height="1160" alt="mainpage" src="https://github.com/user-attachments/assets/89d3009c-e342-4a31-8044-5aeb097dbaec" />
<img width="1718" height="1160" alt="mainpage-episode" src="https://github.com/user-attachments/assets/f2741af7-55f9-4483-a13b-4b174de1a196" />

### SPOILERS BEING TOLD "NOT TODAY"
<img width="1718" height="1160" alt="2026-08-22_17-48-54_moonfin" src="https://github.com/user-attachments/assets/7d2fd0f3-3d17-4874-8b5e-a920a3756fd9" />
<img width="1718" height="1160" alt="2026-08-22_17-49-01_moonfin" src="https://github.com/user-attachments/assets/94ff1614-34c1-457a-813e-f521f0ee822a" />

## Checklist
- [ ] Code builds successfully
- [ ] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced
