### PR TITLE
Fix tvOS Search focus skipping past filter tabs

### DIFF
--- a/lib/ui/widgets/sliding_pill_tabs.dart
+++ b/lib/ui/widgets/sliding_pill_tabs.dart
@@ -140,7 +140,13 @@ class _SlidingPillTabsState extends State<SlidingPillTabs> {
       }
       return KeyEventResult.handled;
     }
-    if (event is KeyDownEvent && (key.isUpKey || key.isDownKey)) {
+    if (key.isUpKey || key.isDownKey) {
+      // Keep a repeat from the gesture that focused this pill from escaping
+      // into Flutter's default directional focus traversal. A fresh press can
+      // still leave the pill through the screen's navigation callback.
+      if (event is KeyRepeatEvent) {
+        return KeyEventResult.handled;
+      }
       final handled = widget.onVerticalNavigation?.call(key.isUpKey) ?? false;
       return handled ? KeyEventResult.handled : KeyEventResult.ignored;
     }

--- a/test/ui/widgets/sliding_pill_tabs_test.dart
+++ b/test/ui/widgets/sliding_pill_tabs_test.dart
@@ -1,0 +1,128 @@
+// Mirrors the synthetic key dispatch path used by tvOS/gamepad navigation.
+// ignore_for_file: deprecated_member_use
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/theme/app_theme.dart';
+import 'package:moonfin/ui/widgets/sliding_pill_tabs.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => ThemeRegistry.setActiveById(ThemeRegistry.moonfinId));
+
+  testWidgets(
+    'vertical repeat stays on the pill but a new press enters results',
+    (tester) async {
+      final searchFocus = FocusNode(debugLabel: 'search');
+      final tabsFocus = FocusNode(debugLabel: 'search_tabs');
+      final resultsFocus = FocusNode(debugLabel: 'first_result');
+      addTearDown(searchFocus.dispose);
+      addTearDown(tabsFocus.dispose);
+      addTearDown(resultsFocus.dispose);
+
+      var verticalNavigationCalls = 0;
+      var escapedDownEvents = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppTheme.buildTheme(ThemeRegistry.active),
+          home: Scaffold(
+            body: Focus(
+              onKeyEvent: (_, event) {
+                if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+                    event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                  escapedDownEvents++;
+                  resultsFocus.requestFocus();
+                  return KeyEventResult.handled;
+                }
+                return KeyEventResult.ignored;
+              },
+              child: Column(
+                children: [
+                  Focus(
+                    focusNode: searchFocus,
+                    onKeyEvent: (_, event) {
+                      if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+                          event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                        tabsFocus.requestFocus();
+                        return KeyEventResult.handled;
+                      }
+                      return KeyEventResult.ignored;
+                    },
+                    child: const Text('Search'),
+                  ),
+                  SlidingPillTabs(
+                    labels: const ['All', 'Series'],
+                    selectedIndex: 0,
+                    onChanged: (_) {},
+                    focusNode: tabsFocus,
+                    onVerticalNavigation: (isUp) {
+                      verticalNavigationCalls++;
+                      if (!isUp) resultsFocus.requestFocus();
+                      return !isUp;
+                    },
+                  ),
+                  Focus(
+                    focusNode: resultsFocus,
+                    child: const Text('First result'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      void dispatch(KeyEvent event) {
+        ServicesBinding.instance.keyEventManager.keyMessageHandler?.call(
+          KeyMessage([event], null),
+        );
+      }
+
+      KeyEvent downEvent(Type type) {
+        if (type == KeyRepeatEvent) {
+          return KeyRepeatEvent(
+            physicalKey: PhysicalKeyboardKey.arrowDown,
+            logicalKey: LogicalKeyboardKey.arrowDown,
+            timeStamp: Duration.zero,
+          );
+        }
+        return KeyDownEvent(
+          physicalKey: PhysicalKeyboardKey.arrowDown,
+          logicalKey: LogicalKeyboardKey.arrowDown,
+          timeStamp: Duration.zero,
+        );
+      }
+
+      searchFocus.requestFocus();
+      await tester.pump();
+
+      dispatch(downEvent(KeyDownEvent));
+      await tester.pump();
+      expect(tabsFocus.hasFocus, isTrue);
+      expect(verticalNavigationCalls, 0);
+
+      dispatch(downEvent(KeyRepeatEvent));
+      await tester.pump();
+      expect(tabsFocus.hasFocus, isTrue);
+      expect(verticalNavigationCalls, 0);
+      expect(escapedDownEvents, 0);
+
+      dispatch(
+        KeyUpEvent(
+          physicalKey: PhysicalKeyboardKey.arrowDown,
+          logicalKey: LogicalKeyboardKey.arrowDown,
+          timeStamp: Duration.zero,
+        ),
+      );
+      dispatch(downEvent(KeyDownEvent));
+      await tester.pump();
+      expect(resultsFocus.hasFocus, isTrue);
+      expect(verticalNavigationCalls, 1);
+      expect(escapedDownEvents, 0);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

On tvOS, a single downward Siri Remote touch gesture from the Search field could move focus to the filter pill bar and then continue through multiple result sections.

`SlidingPillTabs` accepted both `KeyDownEvent` and `KeyRepeatEvent`, but only handled vertical navigation for fresh key-down events. A repeated Down event could therefore escape into Flutter's default directional focus traversal.

This change consumes vertical repeats while the pill bar owns focus. Fresh Up/Down presses still use the existing navigation callback, and left/right pill navigation remains unchanged.

## Related Issues

None filed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Consume repeated Up/Down events while `SlidingPillTabs` owns focus.
- Preserve fresh vertical navigation and existing left/right tab behavior.
- Add a regression test covering the Search → filter pill handoff, repeated Down event, release, and subsequent fresh Down press.

## Platform

- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Automated verification:

- `flutter test test/ui/widgets/sliding_pill_tabs_test.dart`
- `flutter analyze lib/ui/widgets/sliding_pill_tabs.dart test/ui/widgets/sliding_pill_tabs_test.dart`
- tvOS release archive completed successfully

Physical Apple TV verification:

- A single downward touch gesture from Search now stops on the filter pill bar.
- A repeated Down event from the same gesture no longer escapes into the results.
- After release, a new Down press enters the first result normally.

### Test Steps

1. Focus the Search field on Apple TV.
2. Make one short downward Siri Remote touch gesture.
3. Confirm focus stops on the filter pill bar without scrolling through the results.
4. Release the gesture and press Down again.
5. Confirm focus enters the first result normally.
6. Confirm left/right navigation still moves between filter pills.

## Screenshots (if applicable)

Not applicable; this is a focus-event handling fix.

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced