### PR TITLE
feat-playback: The one about Rewinds (please be kind)

### DIFF
--- a/lib/playback/appletv_audio_now_playing_feeder.dart
+++ b/lib/playback/appletv_audio_now_playing_feeder.dart
@@ -60,7 +60,7 @@ class AppleTvAudioNowPlayingFeeder {
       topTitle: raw.name,
       topSubtitle: artist,
       chapters: const [],
-      hasPrevious: _manager.queueService.hasPrevious,
+      hasPrevious: true,
       hasNext: _manager.queueService.hasNext,
       skipForwardMs: 0,
       skipBackMs: 0,

--- a/lib/playback/mpris_service.dart
+++ b/lib/playback/mpris_service.dart
@@ -411,7 +411,9 @@ class _MprisPlayer extends DBusObject {
       case 'CanGoNext':
         return DBusBoolean(q.hasNext);
       case 'CanGoPrevious':
-        return DBusBoolean(q.hasPrevious);
+        // Previous restarts the current item when nothing precedes it, so it
+        // is always available rather than following the queue.
+        return DBusBoolean(q.currentItem != null);
       case 'CanPlay':
         return DBusBoolean(q.currentItem != null);
       case 'CanPause':

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -1215,7 +1215,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
       topTitle: topTitle,
       topSubtitle: topSubtitle,
       chapters: chapters,
-      hasPrevious: manager.queueService.hasPrevious,
+      hasPrevious: true,
       hasNext: manager.queueService.hasNext,
       skipForwardMs: skipForwardMs,
       skipBackMs: skipBackMs,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -1992,7 +1992,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
 
     await backend.setUiMetadata(
-      hasPrevious: _queue.hasPrevious,
+      hasPrevious: true,
       hasNext: _queue.hasNext,
       chapters: chapters,
       skipBackMs: _prefs.get(UserPreferences.skipBackLength),
@@ -4678,7 +4678,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         MediaQuery.of(context).orientation == Orientation.landscape;
     final buttonExtent = isLandscape ? 56.0 : 48.0;
     final buttonIconSize = isLandscape ? 28.0 : 24.0;
-    final hasPrevious = _queue.hasPrevious;
     final hasNext = _queue.hasNext;
 
     return FocusTraversalGroup(
@@ -4689,15 +4688,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.start,
           children: [
-            if (_queue.hasPrevious)
-              _controlButton(
-                Icons.skip_previous_rounded,
-                onPressed: _manager.previous,
-                size: buttonIconSize,
-                extent: buttonExtent,
-                focusNode: _tvTransportFirstFocus,
-                tooltip: l10n.playerTooltipPrevious,
-              ),
+            _controlButton(
+              Icons.skip_previous_rounded,
+              onPressed: _manager.previous,
+              size: buttonIconSize,
+              extent: buttonExtent,
+              focusNode: _tvTransportFirstFocus,
+              tooltip: l10n.playerTooltipPrevious,
+            ),
             const SizedBox(width: 4),
             _controlButton(
               seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
@@ -4705,7 +4703,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                   _seekRelative(-_prefs.get(UserPreferences.skipBackLength)),
               size: buttonIconSize,
               extent: buttonExtent,
-              focusNode: hasPrevious ? null : _tvTransportFirstFocus,
               tooltip: _tooltipMessage(
                 l10n.playerTooltipSeekBack,
                 shortcut: 'Left',
@@ -5851,14 +5848,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (_queue.hasPrevious)
-                      _controlButton(
-                        Icons.skip_previous_rounded,
-                        onPressed: _manager.previous,
-                        size: 40,
-                        extent: 72,
-                        tooltip: l10n.playerTooltipPrevious,
-                      ),
+                    _controlButton(
+                      Icons.skip_previous_rounded,
+                      onPressed: _manager.previous,
+                      size: 40,
+                      extent: 72,
+                      tooltip: l10n.playerTooltipPrevious,
+                    ),
                     _controlButton(
                       seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
                       onPressed: () =>

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1939,23 +1939,17 @@ class PlaybackManager implements AudioOwnable {
 
   Future<void> previous() async {
     if (await _maybeIntercept(TransportAction.previous)) return;
-    if (state.position.inSeconds > 3) {
+    // A press this far in restarts the item, and so does one with nothing to
+    // step back to.
+    if (state.position.inSeconds > 3 || !queueService.hasPrevious) {
       await seekTo(Duration.zero);
       return;
     }
-    if (queueService.hasPrevious) {
-      _mediaSourceId = null;
-      await _stopAndReportCurrent(skipQueueChange: true);
-      _resetBackendSelectionLock();
-      final hadPrevious = queueService.previous();
-      if (hadPrevious) {
-        await _playCurrentItem();
-      } else {
-        await seekTo(Duration.zero);
-      }
-    } else {
-      await seekTo(Duration.zero);
-    }
+    _mediaSourceId = null;
+    await _stopAndReportCurrent(skipQueueChange: true);
+    _resetBackendSelectionLock();
+    queueService.previous();
+    await _playCurrentItem();
   }
 
   Future<void> playFromQueue(int index) async {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1943,12 +1943,18 @@ class PlaybackManager implements AudioOwnable {
       await seekTo(Duration.zero);
       return;
     }
-    _mediaSourceId = null;
-    await _stopAndReportCurrent(skipQueueChange: true);
-    _resetBackendSelectionLock();
-    final hadPrevious = queueService.previous();
-    if (hadPrevious) {
-      await _playCurrentItem();
+    if (queueService.hasPrevious) {
+      _mediaSourceId = null;
+      await _stopAndReportCurrent(skipQueueChange: true);
+      _resetBackendSelectionLock();
+      final hadPrevious = queueService.previous();
+      if (hadPrevious) {
+        await _playCurrentItem();
+      } else {
+        await seekTo(Duration.zero);
+      }
+    } else {
+      await seekTo(Duration.zero);
     }
   }
 

--- a/test/playback/previous_restarts_when_first_test.dart
+++ b/test/playback/previous_restarts_when_first_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _TestBackend extends Fake implements PlayerBackend {
+  final List<Duration> seeks = <Duration>[];
+  int stopCalls = 0;
+  Duration currentPosition = Duration.zero;
+  bool playing = true;
+
+  @override
+  Duration get position => currentPosition;
+
+  @override
+  bool get isPlaying => playing;
+
+  @override
+  Stream<Duration> get positionStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<Duration> get durationStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<Duration> get bufferStream => const Stream<Duration>.empty();
+
+  @override
+  Stream<bool> get playingStream => const Stream<bool>.empty();
+
+  @override
+  Stream<bool> get bufferingStream => const Stream<bool>.empty();
+
+  @override
+  Stream<bool> get completedStream => const Stream<bool>.empty();
+
+  @override
+  Stream<Map<String, dynamic>>? get errorStream => null;
+
+  @override
+  Future<void> seekTo(Duration position) async {
+    seeks.add(position);
+    currentPosition = position;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+    playing = false;
+  }
+}
+
+void main() {
+  late _TestBackend backend;
+  late PlaybackManager manager;
+
+  setUp(() {
+    backend = _TestBackend();
+    manager = PlaybackManager()..setBackend(backend);
+  });
+
+  test('previous restarts the only item rather than stopping it', () async {
+    manager.queueService.setQueue(['only'], startIndex: 0);
+    manager.state.setPosition(const Duration(seconds: 1));
+
+    await manager.previous();
+
+    expect(backend.seeks, [Duration.zero]);
+    expect(
+      backend.stopCalls,
+      0,
+      reason: 'stopping with nothing to step back to left playback dead',
+    );
+  });
+
+  test('previous restarts the first item of a longer queue', () async {
+    manager.queueService.setQueue(['a', 'b', 'c'], startIndex: 0);
+    manager.state.setPosition(const Duration(seconds: 2));
+
+    await manager.previous();
+
+    expect(backend.seeks, [Duration.zero]);
+    expect(manager.queueService.currentIndex, 0);
+    expect(backend.stopCalls, 0);
+  });
+
+  test('previous past three seconds restarts wherever it sits', () async {
+    manager.queueService.setQueue(['a', 'b'], startIndex: 1);
+    manager.state.setPosition(const Duration(seconds: 30));
+
+    await manager.previous();
+
+    expect(backend.seeks, [Duration.zero]);
+    expect(
+      manager.queueService.currentIndex,
+      1,
+      reason: 'a late press restarts rather than stepping back',
+    );
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
For shows that are on S1E2 or later, we have a "Previous" button in the Playback UI. However, this button is dual purpose - clicking it once rewinds the file to the start; clicking it again goes back an episode. Because the original intention was the "go back an episode" the button is hidden for movies and for S1E1 of shows but the "rewind" part of the button is very useful for those files. The intention of this PR is to always render the Previous playback button and fallback to rewinding to 0:00 when no previous queue item exists.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [X] Other (describe): Playback change

## Changes Made
List the key changes included in this PR.

- Updated **video_player_screen.dart** to remove `if (_queue.hasPrevious)` checks so the Previous button (`⏮`) is always rendered across all titles, S1E1, and movies.
- Updated **playback_manager.dart** so that when Previous is triggered with no previous item in queue (or when playback position <= 3s), playback seeks to `Duration.zero` instead of remaining idle or stopping.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Opened a movie and S1E1 of a show.
2. Verified that the Previous button is visible in player transport controls.
3. Clicked Previous and verified it rewinds file to 0:00 and clicking it multiple times doesn't break the space-time continuum.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### BEFORE
S1E2+ (good):
<img width="1718" height="1160" alt="2026-08-22_18-16-08_moonfin" src="https://github.com/user-attachments/assets/5ac5f7b2-e870-47e9-9141-c561c8dc5d5d" />

MOVIE/S1E! (not so good):
<img width="1706" height="1020" alt="2026-08-22_18-14-44_moonfin" src="https://github.com/user-attachments/assets/cf568613-f83f-4e4c-bf0a-c9d4181dfd8a" />
<img width="1718" height="1160" alt="2026-08-22_18-15-56_moonfin" src="https://github.com/user-attachments/assets/18c0d560-ec32-480b-a45b-e30caae153b6" />

### AFTER
<img width="1718" height="1160" alt="2026-08-22_18-30-32_moonfin" src="https://github.com/user-attachments/assets/a774ea3d-f568-4aa7-9262-b9477b3c2818" />
<img width="1701" height="1024" alt="2026-08-22_18-30-54_moonfin" src="https://github.com/user-attachments/assets/f449c329-aec2-46b2-bb28-e1f38001d5bc" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
