### PR TITLE
fix(tvos): stop home trailers on pushed routes

### DIFF
--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -417,7 +417,6 @@ class _MediaBarState extends State<MediaBar>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (!PlatformDetection.isMobile && !PlatformDetection.isAppleTV) return;
     final topmost = ModalRoute.isCurrentOf(context) ?? true;
     if (topmost == _isHomeRouteTopmost) return;
     _isHomeRouteTopmost = topmost;

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -417,7 +417,7 @@ class _MediaBarState extends State<MediaBar>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (!PlatformDetection.isMobile) return;
+    if (!PlatformDetection.isMobile && !PlatformDetection.isAppleTV) return;
     final topmost = ModalRoute.isCurrentOf(context) ?? true;
     if (topmost == _isHomeRouteTopmost) return;
     _isHomeRouteTopmost = topmost;


### PR DESCRIPTION
# Pull Request

## Summary

Prevents Home media-bar trailers from starting behind pushed top-level pages on Apple TV.

Native top-level navigation pushes pages such as Search, Genres, Favorites, Folders, Seerr, and libraries while Home remains mounted underneath. The media bar already tracks whether Home is the current route on mobile, but that check was skipped on tvOS because Apple TV is not classified as mobile.

This change enables the existing route-awareness logic on Apple TV. It preserves the intended Home toolbar behavior while ensuring trailer timers and previews stop whenever another route covers Home. Other platforms remain unchanged.

## Related Issues

None reported.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- Run the existing ModalRoute.isCurrentOf check on Apple TV as well as mobile.
- Stop pending Home trailer activity when a pushed route covers Home.
- Preserve normal trailer behavior when Home is the current route.
- Preserve existing behavior on non-tvOS platforms.

## Platform

- [ ] Android
- [ ] iOS
- [ ] macOS
- [x] tvOS
- [ ] Windows
- [ ] Linux
- [ ] Web

## Testing

- [ ] Tested on an emulator or simulator
- [x] Tested on a physical device
- [x] Manually tested
- [ ] Not tested

### Test Steps

1. Open Home and confirm media-bar trailers still start normally.
2. Navigate to another top-level page such as Search, Genres, or Seerr.
3. Leave the page idle long enough for the previous Home trailer timer to fire.
4. Confirm no Home trailer appears behind the current page and the navigation chrome remains visible.
5. Return to Home and confirm normal trailer behavior resumes.

A successful tvOS build was completed, and the reported behavior was verified on a physical Apple TV.

## Screenshots

Not applicable; this is a route-lifecycle behavior fix.

## Checklist

- [x] Code builds successfully
- [x] Code follows the project code style
- [x] No unnecessary commented-out code
- [x] No new warnings introduced