### PR TITLE
feat(playback): configure a skip action per media segment type

### DIFF
--- a/lib/data/services/media_segment_service.dart
+++ b/lib/data/services/media_segment_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:server_core/server_core.dart';
 
 import '../models/media_segment.dart';
+import '../utils/media_segment_actions.dart';
 import '../../preference/preference_constants.dart';
 import '../../preference/user_preferences.dart';
 
@@ -39,27 +40,8 @@ class MediaSegmentService {
     _activeSegment = null;
   }
 
-  Map<MediaSegmentType, MediaSegmentAction> get actionMap {
-    final raw = _prefs.get(UserPreferences.mediaSegmentActions);
-    final map = <MediaSegmentType, MediaSegmentAction>{};
-    for (final part in raw.split(',')) {
-      final kv = part.split(':');
-      if (kv.length != 2) continue;
-      final name = kv[0].trim();
-      // Reaching for the first letter of a nameless entry throws, and this runs
-      // on every position tick, so one bad entry would take the prompt with it.
-      if (name.isEmpty) continue;
-      final type = MediaSegmentType.fromServerString(
-          name[0].toUpperCase() + name.substring(1));
-      final action = switch (kv[1].trim()) {
-        'skip' => MediaSegmentAction.skip,
-        'askToSkip' => MediaSegmentAction.askToSkip,
-        _ => MediaSegmentAction.nothing,
-      };
-      map[type] = action;
-    }
-    return map;
-  }
+  Map<MediaSegmentType, MediaSegmentAction> get actionMap =>
+      parseMediaSegmentActions(_prefs.get(UserPreferences.mediaSegmentActions));
 
   SegmentCheckResult checkPosition(Duration position) {
     if (_segments.isEmpty) return SegmentCheckResult.none;

--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -238,6 +238,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('maxBitrate', UserPreferences.maxBitrate, SyncCodec.text),
   SyncedField('maxVideoResolution', UserPreferences.maxVideoResolution, SyncCodec.enumName, enumValues: prefs.MaxVideoResolution.values),
   SyncedField('mediaQueuingEnabled', UserPreferences.mediaQueuingEnabled, SyncCodec.boolean),
+  SyncedField('mediaSegmentActions', UserPreferences.mediaSegmentActions, SyncCodec.text),
   SyncedField('mediaSegmentAutoHide', UserPreferences.mediaSegmentAutoHide, SyncCodec.enumName, enumValues: prefs.MediaSegmentAutoHide.values),
   SyncedField('mediaSegmentCountdown', UserPreferences.mediaSegmentCountdown, SyncCodec.enumName, enumValues: prefs.MediaSegmentCountdown.values),
   SyncedField('mergeRadarrSonarrCalendars', UserPreferences.mergeRadarrSonarrCalendars, SyncCodec.boolean),

--- a/lib/data/utils/media_segment_actions.dart
+++ b/lib/data/utils/media_segment_actions.dart
@@ -1,0 +1,82 @@
+import '../models/media_segment.dart';
+import '../../preference/preference_constants.dart';
+
+/// Segment types that can be given an action of their own, in the order they
+/// are offered in settings. [MediaSegmentType.unknown] is deliberately absent:
+/// it is the parser's fallback for a type this build does not recognise, not
+/// something a user can meaningfully configure.
+const List<MediaSegmentType> configurableMediaSegmentTypes = <MediaSegmentType>[
+  MediaSegmentType.intro,
+  MediaSegmentType.recap,
+  MediaSegmentType.preview,
+  MediaSegmentType.commercial,
+  MediaSegmentType.outro,
+];
+
+/// The action's name as it appears in the stored preference.
+///
+/// [MediaSegmentAction.nothing] is written as `doNothing` because that is what
+/// the preset values used before this was configurable per type. Any
+/// unrecognised name parses back to [MediaSegmentAction.nothing], so the two
+/// round trip.
+String mediaSegmentActionName(MediaSegmentAction action) => switch (action) {
+  MediaSegmentAction.skip => 'skip',
+  MediaSegmentAction.askToSkip => 'askToSkip',
+  MediaSegmentAction.nothing => 'doNothing',
+};
+
+MediaSegmentAction mediaSegmentActionFromName(String value) =>
+    switch (value.trim()) {
+      'skip' => MediaSegmentAction.skip,
+      'askToSkip' => MediaSegmentAction.askToSkip,
+      _ => MediaSegmentAction.nothing,
+    };
+
+/// Reads the `type:action` pairs out of a stored preference value.
+///
+/// Malformed entries are skipped rather than thrown on. This is read on every
+/// position tick during playback, so one bad entry must not take the skip
+/// prompt with it.
+Map<MediaSegmentType, MediaSegmentAction> parseMediaSegmentActions(String raw) {
+  final actions = <MediaSegmentType, MediaSegmentAction>{};
+  for (final part in raw.split(',')) {
+    final pair = part.split(':');
+    if (pair.length != 2) continue;
+    final name = pair[0].trim();
+    // Reaching for the first letter of a nameless entry throws.
+    if (name.isEmpty) continue;
+    final type = MediaSegmentType.fromServerString(
+      name[0].toUpperCase() + name.substring(1),
+    );
+    actions[type] = mediaSegmentActionFromName(pair[1]);
+  }
+  return actions;
+}
+
+/// Writes the pairs back out in [configurableMediaSegmentTypes] order.
+///
+/// Types with no entry are left out rather than written as `doNothing`, which
+/// keeps the shipped default (`intro:askToSkip,outro:askToSkip`) byte for byte
+/// identical across a parse and serialise round trip.
+String serializeMediaSegmentActions(
+  Map<MediaSegmentType, MediaSegmentAction> actions,
+) {
+  final parts = <String>[];
+  for (final type in configurableMediaSegmentTypes) {
+    final action = actions[type];
+    if (action == null) continue;
+    parts.add('${type.name}:${mediaSegmentActionName(action)}');
+  }
+  return parts.join(',');
+}
+
+/// The stored value with [type] set to [action], leaving other types alone.
+String withMediaSegmentAction(
+  String raw,
+  MediaSegmentType type,
+  MediaSegmentAction action,
+) {
+  final actions = parseMediaSegmentActions(raw);
+  actions[type] = action;
+  return serializeMediaSegmentActions(actions);
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8364,6 +8364,15 @@
   "settingsSyncplaySubtitle": "Synchronization logic for group sessions",
   "settingsAdvancedOptionsSubtitle": "Specialized player features. Use with caution, as some options may cause playback issues",
   "settingsSkipIntrosAndOutros": "Skip Intros and Outros?",
+  "settingsMediaSegmentTypeAction": "{segment} Segments",
+  "@settingsMediaSegmentTypeAction": {
+    "description": "Setting label for what to do with one type of media segment",
+    "placeholders": {
+      "segment": {
+        "type": "String"
+      }
+    }
+  },
   "settingsMediaSegmentCountdown": "Media Segment Countdown",
   "@settingsMediaSegmentCountdown": {
     "description": "Setting label for media segment countdown customizations"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -15676,6 +15676,12 @@ abstract class AppLocalizations {
   /// **'Skip Intros and Outros?'**
   String get settingsSkipIntrosAndOutros;
 
+  /// Setting label for what to do with one type of media segment
+  ///
+  /// In en, this message translates to:
+  /// **'{segment} Segments'**
+  String settingsMediaSegmentTypeAction(String segment);
+
   /// Setting label for media segment countdown customizations
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -8807,6 +8807,11 @@ class AppLocalizationsAf extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Slaan Intro\'s en Outros oor?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Aftelling vir mediasegmente';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -8788,6 +8788,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'تخطي المقدمات والنهايات؟';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'العد التنازلي لمقاطع الوسائط';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -8853,6 +8853,11 @@ class AppLocalizationsBe extends AppLocalizations {
       'Прапусціць уводныя і канчатковыя часткі?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Адлік медыясегмента';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -8892,6 +8892,11 @@ class AppLocalizationsBg extends AppLocalizations {
       'Пропускане на въведения и изключения?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Обратно броене за медийните сегменти';
 

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -8786,6 +8786,11 @@ class AppLocalizationsBn extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros এবং Outros এড়িয়ে যান?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'মিডিয়া সেগমেন্ট কাউন্টডাউন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -8950,6 +8950,11 @@ class AppLocalizationsCa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Ometeu introduccions i altres?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Compte enrere per els segments';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -8835,6 +8835,11 @@ class AppLocalizationsCs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Přeskočit úvody a závěry?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Odpočet mediálních segmentů';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -8854,6 +8854,11 @@ class AppLocalizationsCy extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hepgor Intros a Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Cyfrif i Lawr Segment Cyfryngau';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -8799,6 +8799,11 @@ class AppLocalizationsDa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Springe introer og outros over?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Nedtælling for mediesegment';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -8941,6 +8941,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros und Outros überspringen?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Countdown für Mediensegmente';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -8942,6 +8942,11 @@ class AppLocalizationsEl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Παράλειψη εισαγωγών και εξόδων;';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Αντίστροφη μέτρηση τμήματος πολυμέσων';
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -8730,6 +8730,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Skip Intros and Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -8791,6 +8791,11 @@ class AppLocalizationsEo extends AppLocalizations {
       'Ĉu preterpasi enkondukojn kaj aliajn?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Antaŭnombrado de aŭdvida segmento';
 

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -8903,6 +8903,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '¿Saltar introducciones y finales?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Cuenta atrás de los segmentos multimedia';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -8811,6 +8811,11 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kas jätta sissejuhatused ja välised vahele?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Meediasegmendi loendur';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -8745,6 +8745,11 @@ class AppLocalizationsFa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'از معرفی و برون رفت بگذرید؟';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'شمارش معکوس بخش رسانه';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -8836,6 +8836,11 @@ class AppLocalizationsFi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Ohitetaanko introt ja loppupalat?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Mediasegmentin ajastin';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -8921,6 +8921,11 @@ class AppLocalizationsFr extends AppLocalizations {
       'Ignorer les intros et les outros ?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Compte à rebours des segments';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -8926,6 +8926,11 @@ class AppLocalizationsGl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Omitir intros e outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Conta atrás dos segmentos multimedia';
 

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -8681,6 +8681,11 @@ class AppLocalizationsHe extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'לדלג על Intros ו-Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'ספירה לאחור של מקטע מדיה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -8775,6 +8775,11 @@ class AppLocalizationsHi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'परिचय और बाह्य को छोड़ें?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'मीडिया सेगमेंट काउंटडाउन';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -9020,6 +9020,11 @@ class AppLocalizationsHr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiti Intros i Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Odbrojavanje medijskog segmenta';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -8886,6 +8886,11 @@ class AppLocalizationsHu extends AppLocalizations {
       'Kihagyod a bevezetőket és a stáblistákat?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Médiaszegmens visszaszámlálása';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -8805,6 +8805,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Lewati Intro dan Outro?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Hitung Mundur Segmen Media';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -8874,6 +8874,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Saltare intro e outro?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Conto alla Rovescia Segmenti Media';
 

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -8553,6 +8553,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'イントロとアウトロをスキップしますか?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'メディアセグメントのカウントダウン';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -8846,6 +8846,11 @@ class AppLocalizationsKk extends AppLocalizations {
       'Кіріспелер мен шығыстарды өткізіп жіберу керек пе?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Медиасегмент кері санағы';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -8863,6 +8863,11 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಪರಿಚಯಗಳು ಮತ್ತು ಔಟ್ರೊಗಳನ್ನು ಬಿಟ್ಟುಬಿಡುವುದೇ?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'ಮಾಧ್ಯಮ ವಿಭಾಗ ಕೌಂಟ್‌ಡೌನ್';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -8542,6 +8542,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '인트로와 아웃트로를 건너뛰시겠습니까?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => '미디어 구간 카운트다운';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -8857,6 +8857,11 @@ class AppLocalizationsLt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Praleisti įžangas ir pabaigas?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Medijos segmento atgalinis skaičiavimas';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -8853,6 +8853,11 @@ class AppLocalizationsLv extends AppLocalizations {
       'Vai izlaist ievadus un noslēgumus?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Multivides segmenta atpakaļskaitīšana';
 

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -8871,6 +8871,11 @@ class AppLocalizationsMk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескокнете воведни и аутроси?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Одбројување за медиумските сегменти';
 

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -8911,6 +8911,11 @@ class AppLocalizationsMl extends AppLocalizations {
       'ആമുഖങ്ങളും ഔട്ട്റോകളും ഒഴിവാക്കണോ?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'മീഡിയ സെഗ്‌മെന്റ് കൗണ്ട്ഡൗൺ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -8824,6 +8824,11 @@ class AppLocalizationsMn extends AppLocalizations {
       'Танилцуулга болон гадуурх хэсгийг алгасах уу?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Медиа сегментийн тоолол';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -8798,6 +8798,11 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vil du hoppe over introer og outroer?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Nedtelling for mediesegment';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -8853,6 +8853,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intro\'s en Outro\'s overslaan?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Aftellen bij mediasegmenten';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -8766,6 +8766,11 @@ class AppLocalizationsPa extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Intros ਅਤੇ Outros ਨੂੰ ਛੱਡਣਾ ਹੈ?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'ਮੀਡੀਆ ਖੰਡ ਕਾਊਂਟਡਾਊਨ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -9063,6 +9063,11 @@ class AppLocalizationsPl extends AppLocalizations {
       'Pomijać czołówki i napisy końcowe?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Odliczanie segmentu materiału';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -8872,6 +8872,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Pular introduções e outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Contagem Regressiva de Segmentos de Mídia';
 

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -8878,6 +8878,11 @@ class AppLocalizationsRo extends AppLocalizations {
       'Sari peste introsuri si versiuni suplimentare?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Numărătoare inversă pentru segmentele media';
 

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -8876,6 +8876,11 @@ class AppLocalizationsRu extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Пропустить интро и аутро?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Обратный отсчёт сегментов';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -8794,6 +8794,11 @@ class AppLocalizationsSi extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'හැඳින්වීම් සහ පිටවීම් මඟ හරින්නද?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'මාධ්‍ය කොටස් ආපසු ගණන් කිරීම';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -8860,6 +8860,11 @@ class AppLocalizationsSk extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Preskočiť úvody a závery?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Odpočítavanie mediálnych segmentov';
 

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -8857,6 +8857,11 @@ class AppLocalizationsSl extends AppLocalizations {
       'Preskočiti uvodne in končne elemente?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Odštevanje predstavnostnih odsekov';
 

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -8884,6 +8884,11 @@ class AppLocalizationsSq extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Të kapërcehen hyrjet dhe daljet?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Numërimi mbrapsht i segmentit të medias';
 

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -9015,6 +9015,11 @@ class AppLocalizationsSr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Прескочити уводе и резултате?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Одбројавање медијског сегмента';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -8813,6 +8813,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Hoppa över Intros och Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Nedräkning för mediesegment';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -8874,6 +8874,11 @@ class AppLocalizationsSw extends AppLocalizations {
       'Ungependa Kuruka Utambulisho na Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown =>
       'Hesabu ya Kurudi Nyuma ya Sehemu ya Maudhui';
 

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -8874,6 +8874,11 @@ class AppLocalizationsTa extends AppLocalizations {
       'அறிமுகங்கள் மற்றும் அவுட்ரோக்களை தவிர்க்கவா?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'மீடியா பிரிவு கவுண்ட்டவுன்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -8867,6 +8867,11 @@ class AppLocalizationsTe extends AppLocalizations {
       'పరిచయాలు మరియు అవుట్‌రోలను దాటవేయాలా?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'మీడియా సెగ్మెంట్ కౌంట్‌డౌన్';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -8739,6 +8739,11 @@ class AppLocalizationsTh extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'ข้ามช่วงแนะนำและส่วนท้ายใช่ไหม';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'การนับถอยหลังของช่วงสื่อ';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -8899,6 +8899,11 @@ class AppLocalizationsTl extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Laktawan ang Intro at Outros?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Media Segment Countdown';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -8812,6 +8812,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => 'Giriş ve Jenerikleri atlansın mı?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Medya Bölümü Geri Sayımı';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -8832,6 +8832,11 @@ class AppLocalizationsUg extends AppLocalizations {
       'Intros ۋە Outros نى ئاتلاپ ئۆتۈپ كېتەمسىز؟';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'مېدىيا بۆلىكى تەتۈر ساناش';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -8876,6 +8876,11 @@ class AppLocalizationsUk extends AppLocalizations {
       'Пропустити введення та завершення?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Відлік медіасегментів';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -8802,6 +8802,11 @@ class AppLocalizationsVi extends AppLocalizations {
       'Bỏ qua phần giới thiệu và phần kết thúc?';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => 'Đếm ngược phân đoạn phương tiện';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -8491,6 +8491,11 @@ class AppLocalizationsYue extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '跳過片頭和片尾？';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => '媒體片段倒數';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -8465,6 +8465,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsSkipIntrosAndOutros => '跳过片头和片尾？';
 
   @override
+  String settingsMediaSegmentTypeAction(String segment) {
+    return '$segment Segments';
+  }
+
+  @override
   String get settingsMediaSegmentCountdown => '媒体片段倒计时';
 
   @override

--- a/lib/ui/screens/settings/panel/automation_queue_screen.dart
+++ b/lib/ui/screens/settings/panel/automation_queue_screen.dart
@@ -37,10 +37,10 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
   Map<String, String> _segmentActionOptions(
     AppLocalizations l10n,
     String current,
+    Map<MediaSegmentType, MediaSegmentAction> actions,
     MediaSegmentType type,
   ) {
-    final selected =
-        parseMediaSegmentActions(current)[type] ?? MediaSegmentAction.nothing;
+    final selected = actions[type] ?? MediaSegmentAction.nothing;
     String valueFor(MediaSegmentAction action) => action == selected
         ? current
         : withMediaSegmentAction(current, type, action);
@@ -104,6 +104,7 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
                   options: _segmentActionOptions(
                     l10n,
                     mediaSegmentActions,
+                    segmentActions,
                     type,
                   ),
                 ),

--- a/lib/ui/screens/settings/panel/automation_queue_screen.dart
+++ b/lib/ui/screens/settings/panel/automation_queue_screen.dart
@@ -8,7 +8,6 @@ class _AutomationQueueScreen extends StatefulWidget {
 }
 
 class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
-  static const _promptSkipSegments = 'intro:askToSkip,outro:askToSkip';
   late final UserPreferences _prefs;
 
   @override
@@ -29,14 +28,43 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
     setState(() {});
   }
 
+  /// The three choices for one segment type, each carrying the whole
+  /// preference value.
+  ///
+  /// The selected action maps back to [current] verbatim rather than to a
+  /// freshly serialised string, so the picker still marks it as selected
+  /// when the stored value lists its types in some other order.
+  Map<String, String> _segmentActionOptions(
+    AppLocalizations l10n,
+    String current,
+    MediaSegmentType type,
+  ) {
+    final selected =
+        parseMediaSegmentActions(current)[type] ?? MediaSegmentAction.nothing;
+    String valueFor(MediaSegmentAction action) => action == selected
+        ? current
+        : withMediaSegmentAction(current, type, action);
+    return {
+      valueFor(MediaSegmentAction.askToSkip): l10n.settingsPromptUser,
+      valueFor(MediaSegmentAction.skip): l10n.settingsSkip,
+      valueFor(MediaSegmentAction.nothing): l10n.settingsDoNothing,
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final nextUpBehavior = _prefs.get(UserPreferences.nextUpBehavior);
     final mediaSegmentActions = _prefs.get(UserPreferences.mediaSegmentActions);
+    final segmentActions = parseMediaSegmentActions(mediaSegmentActions);
+    final promptsForAnySegment = segmentActions.values.any(
+      (action) => action == MediaSegmentAction.askToSkip,
+    );
     final showNextUpOptions = nextUpBehavior != NextUpBehavior.disabled;
+    // Gated on the outro, since this replaces the Skip Outro button.
     final showReplaceSkipOutroWithNextUp =
-        showNextUpOptions && mediaSegmentActions == _promptSkipSegments;
+        showNextUpOptions &&
+        segmentActions[MediaSegmentType.outro] == MediaSegmentAction.askToSkip;
 
     return Scaffold(
       appBar: buildSettingsAppBar(
@@ -60,18 +88,26 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
                 subtitle: l10n.settingsCinemaModeEpisodesSubtitle,
                 icon: Icons.live_tv,
               ),
-              StringPickerPreferenceTile(
-                preference: UserPreferences.mediaSegmentActions,
-                title: l10n.settingsSkipIntrosAndOutros,
-                icon: Icons.content_cut,
-                options: {
-                  _promptSkipSegments: l10n.settingsPromptUser,
-                  'intro:skip,outro:skip': l10n.settingsSkip,
-                  'intro:doNothing,outro:doNothing': l10n.settingsDoNothing,
-                },
-              ),
-              if (mediaSegmentActions == _promptSkipSegments ||
-                  showNextUpOptions)
+              // Every type writes to the one preference, so each tile is
+              // keyed on the current value. The tiles seed their notifier in
+              // initState, so without the key a tile left over from the
+              // previous value would keep showing it and overwrite a
+              // sibling's change on the next pick.
+              for (final type in configurableMediaSegmentTypes)
+                StringPickerPreferenceTile(
+                  key: ValueKey(
+                    'segmentAction_${type.name}_$mediaSegmentActions',
+                  ),
+                  preference: UserPreferences.mediaSegmentActions,
+                  title: l10n.settingsMediaSegmentTypeAction(type.displayName),
+                  icon: Icons.content_cut,
+                  options: _segmentActionOptions(
+                    l10n,
+                    mediaSegmentActions,
+                    type,
+                  ),
+                ),
+              if (promptsForAnySegment || showNextUpOptions)
                 EnumPreferenceTile<MediaSegmentCountdown>(
                   preference: UserPreferences.mediaSegmentCountdown,
                   title: l10n.settingsMediaSegmentCountdown,
@@ -84,7 +120,7 @@ class _AutomationQueueScreenState extends State<_AutomationQueueScreen> {
                     MediaSegmentCountdown.none => l10n.settingsNone,
                   },
                 ),
-              if (mediaSegmentActions == _promptSkipSegments)
+              if (promptsForAnySegment)
                 EnumPreferenceTile<MediaSegmentAutoHide>(
                   preference: UserPreferences.mediaSegmentAutoHide,
                   title: l10n.settingsSkipButtonAutoHide,

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1327,11 +1327,17 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       subtitle: l10n.settingsCinemaModeSubtitle,
       keywords: ['trailers before movie'],
     ),
-    automation.leaf(
-      'media_segment_actions',
-      l10n.settingsSkipIntrosAndOutros,
-      keywords: ['skip intro', 'skip credits', 'segments'],
-    ),
+    for (final type in configurableMediaSegmentTypes)
+      automation.leaf(
+        'media_segment_actions_${type.name}',
+        l10n.settingsMediaSegmentTypeAction(type.displayName),
+        keywords: [
+          'skip',
+          'segments',
+          type.name,
+          if (type == MediaSegmentType.outro) 'credits',
+        ],
+      ),
     automation.leaf(
       'pref_media_segment_countdown',
       l10n.settingsMediaSegmentCountdown,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -17,6 +17,8 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/custom_external_lists_service.dart';
+import '../../../data/models/media_segment.dart';
+import '../../../data/utils/media_segment_actions.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../di/providers.dart';
 import '../../../util/idiom/app_ui_idiom.dart';

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -132,6 +132,7 @@ void main() {
     'mediaBarTrailerCaptions',
     'mediaBarTrailerPreview',
     'mediaQueuingEnabled',
+    'mediaSegmentActions',
     'mediaSegmentAutoHide',
     'mediaSegmentCountdown',
     'mediaTypeBadgeBehavior',

--- a/test/data/utils/media_segment_actions_test.dart
+++ b/test/data/utils/media_segment_actions_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/media_segment.dart';
+import 'package:moonfin/data/utils/media_segment_actions.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+
+void main() {
+  group('parseMediaSegmentActions', () {
+    test('reads every configurable type, not just intro and outro', () {
+      final actions = parseMediaSegmentActions(
+        'intro:askToSkip,recap:skip,preview:doNothing,'
+        'commercial:skip,outro:askToSkip',
+      );
+
+      expect(actions[MediaSegmentType.intro], MediaSegmentAction.askToSkip);
+      expect(actions[MediaSegmentType.recap], MediaSegmentAction.skip);
+      expect(actions[MediaSegmentType.preview], MediaSegmentAction.nothing);
+      expect(actions[MediaSegmentType.commercial], MediaSegmentAction.skip);
+      expect(actions[MediaSegmentType.outro], MediaSegmentAction.askToSkip);
+    });
+
+    test('a type with no entry is absent rather than defaulted', () {
+      final actions = parseMediaSegmentActions('intro:askToSkip');
+
+      expect(actions.containsKey(MediaSegmentType.recap), isFalse);
+    });
+
+    test('an unrecognised action falls back to doing nothing', () {
+      final actions = parseMediaSegmentActions('intro:sometimes');
+
+      expect(actions[MediaSegmentType.intro], MediaSegmentAction.nothing);
+    });
+
+    // This is read on every position tick during playback, so one bad
+    // entry must not take the rest of the map with it.
+    test('malformed entries are skipped without losing the good ones', () {
+      final actions = parseMediaSegmentActions(
+        'intro:askToSkip,,:skip,garbage,recap:skip',
+      );
+
+      expect(actions[MediaSegmentType.intro], MediaSegmentAction.askToSkip);
+      expect(actions[MediaSegmentType.recap], MediaSegmentAction.skip);
+    });
+
+    test('an empty value yields no actions', () {
+      expect(parseMediaSegmentActions(''), isEmpty);
+    });
+  });
+
+  group('serializeMediaSegmentActions', () {
+    test('round trips the shipped default unchanged', () {
+      const shippedDefault = 'intro:askToSkip,outro:askToSkip';
+
+      expect(
+        serializeMediaSegmentActions(parseMediaSegmentActions(shippedDefault)),
+        shippedDefault,
+      );
+    });
+
+    test('writes in a stable order regardless of input order', () {
+      final actions = parseMediaSegmentActions(
+        'outro:skip,recap:skip,intro:skip',
+      );
+
+      expect(
+        serializeMediaSegmentActions(actions),
+        'intro:skip,recap:skip,outro:skip',
+      );
+    });
+
+    test('omits types that have no action', () {
+      expect(
+        serializeMediaSegmentActions({
+          MediaSegmentType.recap: MediaSegmentAction.askToSkip,
+        }),
+        'recap:askToSkip',
+      );
+    });
+  });
+
+  group('withMediaSegmentAction', () {
+    test('adds a type the stored value never mentioned', () {
+      expect(
+        withMediaSegmentAction(
+          'intro:askToSkip,outro:askToSkip',
+          MediaSegmentType.recap,
+          MediaSegmentAction.askToSkip,
+        ),
+        'intro:askToSkip,recap:askToSkip,outro:askToSkip',
+      );
+    });
+
+    test('replaces one type and leaves the others alone', () {
+      expect(
+        withMediaSegmentAction(
+          'intro:askToSkip,outro:askToSkip',
+          MediaSegmentType.intro,
+          MediaSegmentAction.skip,
+        ),
+        'intro:skip,outro:askToSkip',
+      );
+    });
+
+    test('every action survives a write and read back', () {
+      for (final action in MediaSegmentAction.values) {
+        final stored =
+            withMediaSegmentAction('', MediaSegmentType.recap, action);
+
+        expect(
+          parseMediaSegmentActions(stored)[MediaSegmentType.recap],
+          action,
+          reason: 'action $action should round trip',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary

Media segment actions could only be set through three fixed presets, each of
which named only `intro` and `outro`:

```dart
_promptSkipSegments:                l10n.settingsPromptUser,   // 'intro:askToSkip,outro:askToSkip'
'intro:skip,outro:skip':            l10n.settingsSkip,
'intro:doNothing,outro:doNothing':  l10n.settingsDoNothing,
```

No value the UI could produce ever contained `recap:`, `preview:` or
`commercial:`, so those segments always fell through to the `?? MediaSegmentAction.nothing`
fallback in `MediaSegmentService` and could never be skipped. Because each preset
set both types at once, intro and outro could not be configured independently
either.

Everything below the picker already handled the other types: `MediaSegmentType`
has `recap`, `preview` and `commercial`, `fromServerString` parses them, and
`checkPosition` is type agnostic. Only the picker could not express them.

This replaces the preset list with one picker per configurable type, serialising
back into the same comma separated string, so no stored value changes format.

## Related Issues

- Closes #821

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Added `lib/data/utils/media_segment_actions.dart` holding the parse, serialise
  and single type update helpers, plus the ordered list of configurable types.
  `MediaSegmentService.actionMap` parsed the value inline; it now uses the shared
  helper so the settings screen and the service cannot disagree.
- Replaced the single preset picker in **Automation & Queue** with one picker per
  type (Intro, Recap, Preview, Commercial, Outro), each offering Prompt User /
  Skip / Do Nothing.
- Fixed three visibility gates that compared the whole preference against the
  prompt preset. That string no longer identifies "prompts the user" once types
  are independent, so Media Segment Countdown and Auto Hide Skip Button would
  have vanished for any per type combination. They now ask whether **any** type
  prompts. Replace Skip Outro with Next Up asks about the **outro** specifically,
  since that is the button it replaces.
- Each tile carries a `ValueKey` over the current value. All five bind to the one
  preference, and `StringPickerPreferenceTile` seeds its notifier in `initState`,
  so without the key a stale sibling would overwrite the change just made.
- Split the settings search entry into one per type, so searching "recap" now
  finds the setting. Kept "credits" as a keyword on Outro.
- Registered `mediaSegmentActions` in `syncedFields`. It is already listed in
  `_scopedPreferenceKeys`, the set documented as "anything that goes to the
  server profile has to be stored per server and user", but it had no
  `SyncedField`, unlike its `mediaSegmentCountdown` and `mediaSegmentAutoHide`
  neighbours. The pinned `expectedServerKeys` list in the test was updated to
  match.
- One new string, `settingsMediaSegmentTypeAction` (`"{segment} Segments"`), plus
  regenerated localizations. Segment names come from the existing
  `MediaSegmentType.displayName`, matching how the skip button itself is already
  labelled.

`settingsSkipIntrosAndOutros` is now unused. I left the key in `app_en.arb`
rather than deleting it, since translations are owned by Weblate.

> **Note:** the sync half of this needs a matching change in the Moonbase plugin.
> `MoonfinSettingsProfile` names every field it accepts and has no
> `JsonExtensionData`, so `mediaSegmentActions` is dropped on the server until the
> property exists. Companion PR opened against `Moonfin-Client/Plugin`. The picker
> works standalone without it; only cross client sync depends on it.

## Platform

- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [x] Linux
- [x] All / Shared code

## Testing

Built and run on Linux desktop (`flutter run -d linux`, Flutter 3.44.1) against a
Jellyfin 10.11.11 server with Intro Skipper producing real segments — 476 intro,
635 outro, 197 recap and 6 preview across 659 items.

- `flutter analyze` — no new issues in any changed file.
- `flutter test` — 1106 passed. This includes `synced_fields_test.dart`, whose
  "every synced field is stored per server and user" case covers the new field.
- 11 new unit tests for the parse / serialise / update helpers, including that
  the shipped default round trips byte for byte and that malformed entries are
  skipped rather than thrown on.

Verified in the running app: all five rows render; types hold independent values
(Commercial on Skip while the rest prompt); the picker marks the current action
as selected; and Countdown and Auto Hide stay visible while any type prompts.

End to end, a recap segment now raises a **Skip Recap** prompt during playback,
with the countdown, driven purely by the new picker. That was unreachable before
this change, since no value the UI could produce contained `recap:`.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Open **Settings → Automation & Queue** and confirm five rows: Intro, Recap,
   Preview, Commercial and Outro Segments.
2. Set Recap to **Prompt User** and Commercial to **Skip**. Confirm both hold and
   that neither resets the other.
3. Play an episode with a recap segment and confirm the skip prompt appears.
4. Set every type to **Do Nothing** and confirm Media Segment Countdown and Auto
   Hide Skip Button disappear, then return when any one type is set to prompt.
5. Set Outro to anything other than Prompt User and confirm Replace Skip Outro
   with Next Up disappears.
6. Search settings for "recap" and confirm the Recap row is found.

## Screenshots
<img width="1900" height="1030" alt="image" src="https://github.com/user-attachments/assets/9494f3a0-91e8-45ca-af66-d0ea9941e96a" />
<img width="1900" height="1030" alt="image" src="https://github.com/user-attachments/assets/dcd85b8a-568d-47da-93d5-229f9f67577c" />
<img width="1900" height="1030" alt="image" src="https://github.com/user-attachments/assets/27a3c3b8-750a-4af2-84d8-bc027423ce9d" />

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
