### PR TITLE
Fix RTL layout on Android TV details screen and top toolbar

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6825,6 +6825,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       }
     }
 
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+
     final Widget rowContent;
     if (!needsOverflow) {
       final normalizedButtons = allButtons.asMap().entries.map((entry) {
@@ -6844,35 +6846,35 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                       widget.upTarget != null
                   ? _focusUpTarget
                   : null),
-          onArrowLeft: index == 0
-              ? _focusSidebar
-              : () {
-                  if (!_focusAdjacent(
-                    (i) => _primaryNodeAt(i, allButtons.length),
-                    index - 1,
-                    -1,
-                    allButtons.length,
-                  )) {
-                    _focusSidebar();
-                  }
-                },
+          onArrowLeft: () {
+            final step = isRtl ? 1 : -1;
+            if (!_focusAdjacent(
+              (i) => _primaryNodeAt(i, allButtons.length),
+              index + step,
+              step,
+              allButtons.length,
+            )) {
+              _focusSidebar();
+            }
+          },
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
-          onArrowRight: index == allButtons.length - 1
-              ? (widget.onArrowRightAtEnd ?? () {})
-              : () {
-                  if (!_focusAdjacent(
-                    (i) => _primaryNodeAt(i, allButtons.length),
-                    index + 1,
-                    1,
-                    allButtons.length,
-                  )) {
-                    (widget.onArrowRightAtEnd ?? () {})();
-                  }
-                },
+          onArrowRight: () {
+            final step = isRtl ? -1 : 1;
+            if (!_focusAdjacent(
+              (i) => _primaryNodeAt(i, allButtons.length),
+              index + step,
+              step,
+              allButtons.length,
+            )) {
+              (widget.onArrowRightAtEnd ?? () {})();
+            }
+          },
         );
       }).toList();
       rowContent = Align(
-        alignment: widget.modernStyle ? Alignment.centerLeft : Alignment.center,
+        alignment: widget.modernStyle
+            ? AlignmentDirectional.centerStart
+            : Alignment.center,
         child: Wrap(
           spacing: buttonSpacing,
           runSpacing: buttonRunSpacing,
@@ -6905,25 +6907,25 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                       widget.upTarget != null
                   ? _focusUpTarget
                   : null),
-          onArrowLeft: index == 0
-              ? _focusSidebar
-              : () {
-                  if (!_focusAdjacent(
-                    _primaryNodePlain,
-                    index - 1,
-                    -1,
-                    primaryButtons.length,
-                  )) {
-                    _focusSidebar();
-                  }
-                },
+          onArrowLeft: () {
+            final step = isRtl ? 1 : -1;
+            if (!_focusAdjacent(
+              _primaryNodePlain,
+              index + step,
+              step,
+              primaryButtons.length,
+            )) {
+              _focusSidebar();
+            }
+          },
           onArrowRight: () {
             // Skip any unmounted slot (e.g. hidden delete-download) and fall
             // through to the More button so it is always reachable.
+            final step = isRtl ? -1 : 1;
             if (!_focusAdjacent(
               _primaryNodePlain,
-              index + 1,
-              1,
+              index + step,
+              step,
               primaryButtons.length,
             )) {
               (widget.actionRowRightFocusNode ?? _overflowMoreFocusNode)
@@ -6967,23 +6969,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             }
           },
           onArrowDown: widget.downTarget != null ? _focusDownTarget : null,
-          onArrowLeft: index == 0
-              ? _focusSidebar
-              : () {
-                  if (!_focusAdjacent(
-                    _extraFocusNode,
-                    index - 1,
-                    -1,
-                    extraButtons.length,
-                  )) {
-                    _focusSidebar();
-                  }
-                },
-          onArrowRight: () {
+          onArrowLeft: () {
+            final step = isRtl ? 1 : -1;
             if (!_focusAdjacent(
               _extraFocusNode,
-              index + 1,
-              1,
+              index + step,
+              step,
+              extraButtons.length,
+            )) {
+              _focusSidebar();
+            }
+          },
+          onArrowRight: () {
+            final step = isRtl ? -1 : 1;
+            if (!_focusAdjacent(
+              _extraFocusNode,
+              index + step,
+              step,
               extraButtons.length,
             )) {
               (widget.onArrowRightAtEnd ?? () {})();
@@ -7013,8 +7015,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           // (e.g. hidden delete-download) so More can always return to the row.
           _focusAdjacent(
             _primaryNodePlain,
-            primaryButtons.length - 1,
-            -1,
+            isRtl ? 0 : primaryButtons.length - 1,
+            isRtl ? 1 : -1,
             primaryButtons.length,
           );
         },
@@ -7048,7 +7050,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
           if (_expanded) {
             rowContent = Align(
-              alignment: Alignment.centerLeft,
+              alignment: AlignmentDirectional.centerStart,
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -7069,7 +7071,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             );
           } else {
             rowContent = Align(
-              alignment: Alignment.centerLeft,
+              alignment: AlignmentDirectional.centerStart,
               child: primaryRow,
             );
           }
@@ -7077,7 +7079,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           // Primary row keeps the More/Less button pinned at its end; the extra
           // buttons reveal in a second wrap below, so More/Less never moves.
           rowContent = Align(
-            alignment: Alignment.centerLeft,
+            alignment: AlignmentDirectional.centerStart,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -7123,7 +7125,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             : WrapAlignment.center;
         rowContent = Align(
           alignment: widget.modernStyle
-              ? Alignment.centerLeft
+              ? AlignmentDirectional.centerStart
               : Alignment.center,
           child: Column(
             mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
+++ b/lib/ui/screens/detail/modern/widgets/details_tab_bar.dart
@@ -584,7 +584,7 @@ class _PillTabBarState extends State<_PillTabBar> {
         final content = _widths.fold<double>(0, (sum, w) => sum + w) + 16.0;
         final pillWidth = content < available ? content : available;
         return Align(
-          alignment: Alignment.centerLeft,
+          alignment: AlignmentDirectional.centerStart,
           child: SizedBox(width: pillWidth, child: pane),
         );
       },

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -607,170 +607,170 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         currentItem is AggregatedItem && currentItem.isAudioLike;
     final totalHeight = toolbarHeight + TopToolbar.musicBarExtraHeight();
 
-    return Directionality(
-      textDirection: TextDirection.ltr,
-      child: SafeArea(
-        bottom: false,
-        child: SizedBox(
-          height: totalHeight,
-          child: Padding(
-            padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
-            child: Focus(
-              focusNode: _toolbarScopeNode,
-              onFocusChange: (hasFocus) {
-                _toolbarHadFocus = hasFocus;
-                TopToolbar.isFocusedNotifier.value = hasFocus;
-              },
-              onKeyEvent: (_, event) {
-                if (event is KeyDownEvent &&
-                    event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                  final primary = FocusManager.instance.primaryFocus;
-                  if (primary != null) {
-                    final insideMusicBar = _isDescendantOf(
-                      primary,
-                      _musicBarFocusNode,
-                    );
-                    if (!insideMusicBar && isMusicActive) {
-                      final musicNodes =
-                          _musicBarFocusNode.descendants
-                              .where(
-                                (n) =>
-                                    !n.skipTraversal && _isLaidOutFocusNode(n),
-                              )
-                              .map((n) {
-                                final box =
-                                    n.context!.findRenderObject() as RenderBox?;
-                                final pos = box?.localToGlobal(Offset.zero);
-                                return (node: n, x: pos?.dx ?? -1.0);
-                              })
-                              .where((item) => item.x > 0)
-                              .toList()
-                            ..sort((a, b) => a.x.compareTo(b.x));
+    return SafeArea(
+      bottom: false,
+      child: SizedBox(
+        height: totalHeight,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: hPad, vertical: vPad),
+          child: Focus(
+            focusNode: _toolbarScopeNode,
+            onFocusChange: (hasFocus) {
+              _toolbarHadFocus = hasFocus;
+              TopToolbar.isFocusedNotifier.value = hasFocus;
+            },
+            onKeyEvent: (_, event) {
+              if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.arrowDown) {
+                final primary = FocusManager.instance.primaryFocus;
+                if (primary != null) {
+                  final insideMusicBar = _isDescendantOf(
+                    primary,
+                    _musicBarFocusNode,
+                  );
+                  if (!insideMusicBar && isMusicActive) {
+                    final musicNodes =
+                        _musicBarFocusNode.descendants
+                            .where(
+                              (n) =>
+                                  !n.skipTraversal && _isLaidOutFocusNode(n),
+                            )
+                            .map((n) {
+                              final box =
+                                  n.context!.findRenderObject() as RenderBox?;
+                              final pos = box?.localToGlobal(Offset.zero);
+                              return (node: n, x: pos?.dx ?? -1.0);
+                            })
+                            .where((item) => item.x > 0)
+                            .toList()
+                          ..sort((a, b) => a.x.compareTo(b.x));
 
-                      if (musicNodes.isNotEmpty) {
-                        musicNodes.first.node.requestFocus();
-                        return KeyEventResult.handled;
-                      }
-                    }
-
-                    if (widget.activeRoute != Destinations.home &&
-                        NavigationLayout.focusDetailsPlayButtonNotifier.value ==
-                            null) {
-                      final success = primary.focusInDirection(
-                        TraversalDirection.down,
-                      );
-                      if (success) {
-                        final newFocus = FocusManager.instance.primaryFocus;
-                        if (newFocus != null && _isInsideToolbar(newFocus)) {
-                          return KeyEventResult.handled;
-                        }
-                      }
+                    if (musicNodes.isNotEmpty) {
+                      musicNodes.first.node.requestFocus();
+                      return KeyEventResult.handled;
                     }
                   }
-                  _restoreFocusBelowToolbar();
-                  return KeyEventResult.handled;
-                }
-                if (event is KeyDownEvent &&
-                    event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                  final primary = FocusManager.instance.primaryFocus;
-                  if (primary != null) {
-                    final insideMusicBar = _isDescendantOf(
-                      primary,
-                      _musicBarFocusNode,
+
+                  if (widget.activeRoute != Destinations.home &&
+                      NavigationLayout.focusDetailsPlayButtonNotifier.value ==
+                          null) {
+                    final success = primary.focusInDirection(
+                      TraversalDirection.down,
                     );
-                    if (insideMusicBar) {
-                      if (_homeFocus.canRequestFocus) {
-                        _homeFocus.requestFocus();
-                        return KeyEventResult.handled;
-                      }
-                      FocusNode? targetNode;
-                      for (final n in _toolbarScopeNode.descendants) {
-                        if (!n.skipTraversal &&
-                            _isLaidOutFocusNode(n) &&
-                            !_isDescendantOf(n, _musicBarFocusNode)) {
-                          final box =
-                              n.context!.findRenderObject() as RenderBox?;
-                          final pos = box?.localToGlobal(Offset.zero);
-                          if (pos != null && pos.dx > 0) {
-                            targetNode = n;
-                            break;
-                          }
-                        }
-                      }
-                      if (targetNode != null) {
-                        targetNode.requestFocus();
+                    if (success) {
+                      final newFocus = FocusManager.instance.primaryFocus;
+                      if (newFocus != null && _isInsideToolbar(newFocus)) {
                         return KeyEventResult.handled;
                       }
                     }
                   }
                 }
-                if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
-                    event is KeyDownEvent &&
-                    (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
-                        event.logicalKey == LogicalKeyboardKey.arrowRight)) {
-                  final direction =
-                      event.logicalKey == LogicalKeyboardKey.arrowLeft
-                      ? TraversalDirection.left
-                      : TraversalDirection.right;
-                  _moveWithinToolbar(direction);
-                  // Always consume so the key can't escape sideways into content.
-                  return KeyEventResult.handled;
+                _restoreFocusBelowToolbar();
+                return KeyEventResult.handled;
+              }
+              if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.arrowUp) {
+                final primary = FocusManager.instance.primaryFocus;
+                if (primary != null) {
+                  final insideMusicBar = _isDescendantOf(
+                    primary,
+                    _musicBarFocusNode,
+                  );
+                  if (insideMusicBar) {
+                    if (_homeFocus.canRequestFocus) {
+                      _homeFocus.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                    FocusNode? targetNode;
+                    for (final n in _toolbarScopeNode.descendants) {
+                      if (!n.skipTraversal &&
+                          _isLaidOutFocusNode(n) &&
+                          !_isDescendantOf(n, _musicBarFocusNode)) {
+                        final box =
+                            n.context!.findRenderObject() as RenderBox?;
+                        final pos = box?.localToGlobal(Offset.zero);
+                        if (pos != null && pos.dx > 0) {
+                          targetNode = n;
+                          break;
+                        }
+                      }
+                    }
+                    if (targetNode != null) {
+                      targetNode.requestFocus();
+                      return KeyEventResult.handled;
+                    }
+                  }
                 }
-                return KeyEventResult.ignored;
-              },
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  FocusTraversalGroup(
-                    policy: WidgetOrderTraversalPolicy(),
-                    child: isLandscape
-                        ? SizedBox(
-                            height: toolbarHeight - (vPad * 2),
-                            child: Stack(
-                              alignment: Alignment.center,
-                              children: [
-                                Align(
-                                  alignment: Alignment.center,
-                                  child: Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: centerSidePadding,
-                                    ),
-                                    child: _buildCenter(),
+              }
+              if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
+                  event is KeyDownEvent &&
+                  (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
+                      event.logicalKey == LogicalKeyboardKey.arrowRight)) {
+                final direction =
+                    event.logicalKey == LogicalKeyboardKey.arrowLeft
+                    ? TraversalDirection.left
+                    : TraversalDirection.right;
+                _moveWithinToolbar(direction);
+                // Always consume so the key can't escape sideways into content.
+                return KeyEventResult.handled;
+              }
+              return KeyEventResult.ignored;
+            },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FocusTraversalGroup(
+                  policy: WidgetOrderTraversalPolicy(),
+                  child: isLandscape
+                      ? SizedBox(
+                          height: toolbarHeight - (vPad * 2),
+                          child: Stack(
+                            alignment: Alignment.center,
+                            children: [
+                              Align(
+                                alignment: Alignment.center,
+                                child: Padding(
+                                  padding: EdgeInsets.symmetric(
+                                    horizontal: centerSidePadding,
                                   ),
+                                  child: _buildCenter(),
                                 ),
+                              ),
+                              Align(
+                                alignment: AlignmentDirectional.centerStart,
+                                child: _buildStart(),
+                              ),
+                              if (!isMobile)
                                 Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: _buildStart(),
+                                  alignment: AlignmentDirectional.centerEnd,
+                                  child: _buildEnd(),
                                 ),
-                                if (!isMobile)
-                                  Align(
-                                    alignment: Alignment.centerRight,
-                                    child: _buildEnd(),
-                                  ),
-                              ],
-                            ),
-                          )
-                        : SizedBox(
-                            height: toolbarHeight - (vPad * 2),
-                            child: Row(
-                              children: [
-                                _buildStart(),
-                                const SizedBox(width: 12),
-                                Expanded(child: _buildCenter()),
-                                if (!isMobile) ...[
-                                  const SizedBox(width: 12),
-                                  _buildEnd(),
-                                ],
-                              ],
-                            ),
+                            ],
                           ),
+                        )
+                      : SizedBox(
+                          height: toolbarHeight - (vPad * 2),
+                          child: Row(
+                            children: [
+                              _buildStart(),
+                              const SizedBox(width: 12),
+                              Expanded(child: _buildCenter()),
+                              if (!isMobile) ...[
+                                const SizedBox(width: 12),
+                                _buildEnd(),
+                              ],
+                            ],
+                          ),
+                        ),
+                ),
+                if (isMusicActive) ...[
+                  const SizedBox(height: 8),
+                  Directionality(
+                    textDirection: TextDirection.ltr,
+                    child: TopMusicBar(focusNode: _musicBarFocusNode),
                   ),
-                  if (isMusicActive) ...[
-                    const SizedBox(height: 8),
-                    TopMusicBar(focusNode: _musicBarFocusNode),
-                  ],
                 ],
-              ),
+              ],
             ),
           ),
         ),
@@ -832,11 +832,6 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
         if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
             event.logicalKey == LogicalKeyboardKey.arrowDown) {
           _restoreFocusBelowToolbar();
-          return KeyEventResult.handled;
-        }
-        if ((PlatformDetection.isTV || PlatformDetection.isDesktop) &&
-            event.logicalKey == LogicalKeyboardKey.arrowRight) {
-          _homeFocus.requestFocus();
           return KeyEventResult.handled;
         }
         return KeyEventResult.ignored;
@@ -1117,13 +1112,21 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                   baseColor: nextNavColor(),
                   focusNode: _settingsFocus,
                   onKeyEvent: (_, event) {
+                    final isRtl =
+                        Directionality.of(context) == TextDirection.rtl;
+                    final outwardKey = isRtl
+                        ? LogicalKeyboardKey.arrowLeft
+                        : LogicalKeyboardKey.arrowRight;
+                    final inwardKey = isRtl
+                        ? LogicalKeyboardKey.arrowRight
+                        : LogicalKeyboardKey.arrowLeft;
                     if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
                         PlatformDetection.isTV &&
-                        event.logicalKey == LogicalKeyboardKey.arrowRight) {
+                        event.logicalKey == outwardKey) {
                       return KeyEventResult.handled;
                     }
                     if (event is KeyDownEvent &&
-                        event.logicalKey == LogicalKeyboardKey.arrowLeft &&
+                        event.logicalKey == inwardKey &&
                         useInlineLibraries &&
                         showLibraries &&
                         _libraries.isNotEmpty) {
@@ -1273,6 +1276,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
       builder: (context, time, _) {
         return Text(
           time,
+          textDirection: TextDirection.ltr,
           style: TextStyle(
             color: isNeon
                 ? AppColorScheme.onSurface


### PR DESCRIPTION
## Summary
Split out of #1239 at reviewer request — this PR contains only the RTL fixes, with the remote-control feature left in #1239.

- Details screen action-button row's D-pad Left/Right was hardcoded to a fixed index step, so a physical Right press moved focus left under RTL. The step direction now flips under RTL, matching the pattern already used in `LockedFocusRow`/`focusable_action_bar.dart`.
- The action-button row and the Cast/Crew/Studios/Details/Similar tab bar stayed pinned to the physical-left edge instead of following the RTL locale; both now use `AlignmentDirectional` so they sit on the correct (reading-start) side.
- Mirrored the top toolbar under RTL: icon row order, avatar, and clock now mirror instead of staying pinned to a fixed LTR layout. Also fixed the avatar's hardcoded "arrowRight jumps to Home" special case (now handled generically by the existing geometry-based toolbar traversal) and made the Settings button's edge-swallow/inline-libraries-trigger jump RTL-aware. The clock's `HH:MM` text is pinned to LTR text direction so Unicode bidi can't reorder the digit groups (same fix already applied to the Quick Connect code).

## Related
- Split from #1239
- Related to #1215 (prior RTL D-pad fixes on Android TV)

## Platform
- [x] Android (Android TV)
- [x] tvOS