### PR TITLE
fix(ui): mark Seerr navigation active

### DIFF
--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -333,6 +333,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     return Scaffold(
       backgroundColor: AppColorScheme.background,
       body: NavigationLayout(
+        activeRoute: Destinations.seerrDiscover,
         showBackButton: true,
         child: QuickReturnWrapper(
           scrollController: _scrollController,


### PR DESCRIPTION
# Pull Request

## Summary

Marks the Seerr discovery screen as the active navigation route.

Previously, the screen did not pass its route to `NavigationLayout`. This caused the navigation controls to treat Seerr as inactive, allowing repeated selections to push duplicate Seerr screens onto the navigation stack. It also prevented the active navigation styling from appearing.

## Related Issues

- N/A

## Type of Change

- [x] Bug fix
- [x] UI/UX update

## Changes Made

- Pass `Destinations.seerrDiscover` as the active route for the Seerr discovery screen.
- Allow the existing active-route guard to prevent duplicate navigation.
- Restore the selected glow/drop-shadow styling for the Seerr navigation item.

## Platform

- [x] tvOS
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested

Tested through TestFlight on a physical Apple TV 4K running tvOS.

Confirmed that:

- Repeatedly selecting Seerr no longer adds duplicate screens to the navigation stack.
- Pressing Back leaves Seerr normally instead of unwinding multiple duplicate screens.
- The Seerr navigation item displays its active selection styling.
- The tvOS build, archive, signing, and TestFlight upload completed successfully.

### Test Steps

1. Open Seerr from the navigation bar.
2. Confirm that the Seerr icon displays its active glow/drop shadow.
3. Select the Seerr icon several more times.
4. Press Back once.
5. Confirm that the app leaves Seerr without stepping through duplicate screens.

## Screenshots (if applicable)

Not provided.

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced