### PR TITLE
fix(playback): show immediate launch feedback across clients

### DIFF
--- a/lib/ui/navigation/playback_launcher.dart
+++ b/lib/ui/navigation/playback_launcher.dart
@@ -39,18 +39,21 @@ Future<bool> launchPlayerWhilePreparing(
 
   final session = PlaybackLaunchSession._();
   _activeVideoLaunch = session;
-  manager.beginPlaybackPreparation();
-  // The queue still points at the previous item until preparation finishes.
-  // Keep the temporary internal route from being redirected using stale data.
-  manager.skipExternalRoutingOnce();
 
   Future<Object?> routeFuture;
   try {
+    manager.beginPlaybackPreparation();
+    // The queue still points at the previous item until preparation finishes.
+    // Keep the temporary internal route from being redirected using stale data.
+    manager.skipExternalRoutingOnce();
     routeFuture = context.push(Destinations.videoPlayer);
   } catch (_) {
+    // Release the slot before touching the manager again. The cleanup below
+    // goes through the same call that just threw, and a second throw here
+    // would leave the slot claimed for the rest of the process.
+    _activeVideoLaunch = null;
     manager.consumeSkipExternalRoutingOnce();
     manager.cancelPlaybackPreparation();
-    _activeVideoLaunch = null;
     rethrow;
   }
 

--- a/lib/ui/navigation/playback_launcher.dart
+++ b/lib/ui/navigation/playback_launcher.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:playback_core/playback_core.dart';
+
+import 'destinations.dart';
+
+typedef PlaybackStarter = Future<bool> Function(PlaybackLaunchSession? session);
+
+Future<T> runPlaybackStart<T>(
+  PlaybackLaunchSession? session,
+  Future<T> Function() action,
+) {
+  return session == null ? action() : session.runIfActive(action);
+}
+
+PlaybackLaunchSession? _activeVideoLaunch;
+
+/// Opens the appropriate player around [startPlayback]. Video routes paint
+/// before the start callback runs; audio keeps its existing start-then-open
+/// behavior because its compact player remains visible on the current page.
+Future<bool> launchPlayerWhilePreparing(
+  BuildContext context, {
+  required PlaybackManager manager,
+  required String destination,
+  required PlaybackStarter startPlayback,
+}) async {
+  if (!context.mounted) return false;
+
+  if (destination != Destinations.videoPlayer) {
+    final started = await startPlayback(null);
+    if (!started || !context.mounted) return false;
+    await context.push(destination);
+    return true;
+  }
+
+  if (_activeVideoLaunch != null) return false;
+
+  final session = PlaybackLaunchSession._();
+  _activeVideoLaunch = session;
+  manager.beginPlaybackPreparation();
+  // The queue still points at the previous item until preparation finishes.
+  // Keep the temporary internal route from being redirected using stale data.
+  manager.skipExternalRoutingOnce();
+
+  Future<Object?> routeFuture;
+  try {
+    routeFuture = context.push(Destinations.videoPlayer);
+  } catch (_) {
+    manager.consumeSkipExternalRoutingOnce();
+    manager.cancelPlaybackPreparation();
+    _activeVideoLaunch = null;
+    rethrow;
+  }
+
+  unawaited(
+    routeFuture.whenComplete(() {
+      session._routeOpen = false;
+      if (!session._startupFinished) {
+        session._cancelled = true;
+        manager.cancelPlaybackPreparation();
+      }
+    }),
+  );
+
+  try {
+    // Let the opaque black player and its loading treatment paint before any
+    // item hydration, prompts, or source resolution continues.
+    await WidgetsBinding.instance.endOfFrame;
+    if (!session.isActive) return false;
+
+    final started = await startPlayback(session);
+    if (!started || !session.isActive) {
+      if (started) {
+        unawaited(manager.stop(userInitiated: true));
+      }
+      if (context.mounted) {
+        _closePlayerRoute(context, session);
+      }
+      manager.cancelPlaybackPreparation();
+      return false;
+    }
+
+    session._startupFinished = true;
+    if (manager.playbackDeferredToExternalPlayer) {
+      if (context.mounted) {
+        _closePlayerRoute(context, session);
+      }
+      await routeFuture;
+      if (!context.mounted) return false;
+      routeFuture = context.push(Destinations.externalPlayer);
+    }
+
+    await routeFuture;
+    return true;
+  } on _PlaybackLaunchCanceledException {
+    manager.cancelPlaybackPreparation();
+    return false;
+  } catch (_) {
+    if (context.mounted) {
+      _closePlayerRoute(context, session);
+    }
+    manager.cancelPlaybackPreparation();
+    rethrow;
+  } finally {
+    session._cancelled = true;
+    if (identical(_activeVideoLaunch, session)) {
+      _activeVideoLaunch = null;
+    }
+  }
+}
+
+void _closePlayerRoute(BuildContext context, PlaybackLaunchSession session) {
+  if (!context.mounted || !session._routeOpen) return;
+  final sourceRoute = ModalRoute.of(context);
+  if (sourceRoute != null && !sourceRoute.isCurrent) {
+    Navigator.of(context).pop();
+  }
+}
+
+class PlaybackLaunchSession {
+  PlaybackLaunchSession._();
+
+  bool _routeOpen = true;
+  bool _startupFinished = false;
+  bool _cancelled = false;
+
+  bool get isActive =>
+      identical(_activeVideoLaunch, this) && _routeOpen && !_cancelled;
+
+  Future<T> runIfActive<T>(Future<T> Function() action) {
+    if (!isActive) {
+      throw const _PlaybackLaunchCanceledException();
+    }
+    return action();
+  }
+}
+
+class _PlaybackLaunchCanceledException implements Exception {
+  const _PlaybackLaunchCanceledException();
+}

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -33,6 +33,7 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../navigation/route_lifecycle_observer.dart';
 import '../../navigation/home_refresh_bus.dart';
 import '../../navigation/app_router.dart';
+import '../../navigation/playback_launcher.dart';
 import 'detail_buttons.dart';
 import 'modern/modern_detail_content.dart';
 import '../../../data/repositories/seerr_repository.dart';
@@ -555,29 +556,34 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     String? mediaSourceId,
   ) async {
     final manager = GetIt.instance<PlaybackManager>();
-    final forceTranscode = await _shouldForceTranscodeForDolbyVisionQueue(
+    await launchPlayerWhilePreparing(
       context,
-      [item],
-      mediaSourceId: mediaSourceId,
+      manager: manager,
+      destination: Destinations.videoPlayer,
+      startPlayback: (launchSession) async {
+        final forceTranscode =
+            await _shouldForceTranscodeForDolbyVisionQueue(
+              context,
+              [item],
+              mediaSourceId: mediaSourceId,
+            );
+        if (!context.mounted) return false;
+        return _runWithDolbyVisionStartupFallbackPrompt(
+          context,
+          manager,
+          () => runPlaybackStart(
+            launchSession,
+            () => manager.playItems(
+              [item],
+              startPosition: startPosition,
+              mediaSourceId: mediaSourceId,
+              enableDirectPlay: !forceTranscode,
+              enableDirectStream: !forceTranscode,
+            ),
+          ),
+        );
+      },
     );
-    if (!context.mounted) return;
-    final started = await _runWithDolbyVisionStartupFallbackPrompt(
-      context,
-      manager,
-      () => manager.playItems(
-        [item],
-        startPosition: startPosition,
-        mediaSourceId: mediaSourceId,
-        enableDirectPlay: !forceTranscode,
-        enableDirectStream: !forceTranscode,
-      ),
-    );
-    if (!started || !context.mounted) return;
-
-    final destination = manager.playbackDeferredToExternalPlayer
-        ? Destinations.externalPlayer
-        : Destinations.videoPlayer;
-    unawaited(context.push(destination));
   }
 
   Widget _buildBody(BuildContext context) {
@@ -2555,29 +2561,34 @@ class _DetailContentState extends State<_DetailContent> {
     String? mediaSourceId,
   ) async {
     final manager = GetIt.instance<PlaybackManager>();
-    final forceTranscode = await _shouldForceTranscodeForDolbyVisionQueue(
+    await launchPlayerWhilePreparing(
       context,
-      [item],
-      mediaSourceId: mediaSourceId,
+      manager: manager,
+      destination: Destinations.videoPlayer,
+      startPlayback: (launchSession) async {
+        final forceTranscode =
+            await _shouldForceTranscodeForDolbyVisionQueue(
+              context,
+              [item],
+              mediaSourceId: mediaSourceId,
+            );
+        if (!context.mounted) return false;
+        return _runWithDolbyVisionStartupFallbackPrompt(
+          context,
+          manager,
+          () => runPlaybackStart(
+            launchSession,
+            () => manager.playItems(
+              [item],
+              startPosition: startPosition,
+              mediaSourceId: mediaSourceId,
+              enableDirectPlay: !forceTranscode,
+              enableDirectStream: !forceTranscode,
+            ),
+          ),
+        );
+      },
     );
-    if (!context.mounted) return;
-    final started = await _runWithDolbyVisionStartupFallbackPrompt(
-      context,
-      manager,
-      () => manager.playItems(
-        [item],
-        startPosition: startPosition,
-        mediaSourceId: mediaSourceId,
-        enableDirectPlay: !forceTranscode,
-        enableDirectStream: !forceTranscode,
-      ),
-    );
-    if (!started || !context.mounted) return;
-
-    final destination = manager.playbackDeferredToExternalPlayer
-        ? Destinations.externalPlayer
-        : Destinations.videoPlayer;
-    unawaited(context.push(destination));
   }
 
   List<Widget> _buildChapterAndFeatureSections(
@@ -3386,11 +3397,23 @@ class _DetailContentState extends State<_DetailContent> {
             }
             final manager = GetIt.instance<PlaybackManager>();
             unawaited(() async {
-              await manager.playItems(viewModel.tracks, startIndex: index);
-              if (!context.mounted) return;
               final isAudio = viewModel.tracks.every(_isAudioItem);
-              context.push(
-                isAudio ? Destinations.audioPlayer : Destinations.videoPlayer,
+              await launchPlayerWhilePreparing(
+                context,
+                manager: manager,
+                destination: isAudio
+                    ? Destinations.audioPlayer
+                    : Destinations.videoPlayer,
+                startPlayback: (launchSession) async {
+                  await runPlaybackStart(
+                    launchSession,
+                    () => manager.playItems(
+                      viewModel.tracks,
+                      startIndex: index,
+                    ),
+                  );
+                  return true;
+                },
               );
             }());
           },
@@ -7870,6 +7893,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   /// preroll plays first they're held back instead of landing on the preroll.
   Future<void> _playQueueWithPrerolls(
     PlaybackManager manager, {
+    PlaybackLaunchSession? launchSession,
     required List<AggregatedItem> queue,
     required List<AggregatedItem> prerolls,
     required AggregatedItem target,
@@ -7883,7 +7907,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     bool subtitleSelectionExplicit = false,
   }) async {
     final applyNow = prerolls.isEmpty;
-    final playItemsFuture = manager.playItems(
+    Future<void> playItems() => manager.playItems(
       applyNow
           ? queue
           : <AggregatedItem>[
@@ -7901,6 +7925,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       enableDirectPlay: directAllowed,
       enableDirectStream: directAllowed,
     );
+    final playItemsFuture = launchSession == null
+        ? playItems()
+        : launchSession.runIfActive(playItems);
     // playItems wipes any pending overrides as its first act, so the held back
     // picks have to land after the call and before the await.
     if (!applyNow &&
@@ -8125,62 +8152,19 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   Future<bool> _pushPlayerRouteWhileStartingPlayback(
     BuildContext context, {
     required String destination,
-    required Future<bool> startupFuture,
+    required PlaybackStarter startPlayback,
     bool reloadOnReturn = true,
   }) async {
     if (!context.mounted) return false;
     final manager = GetIt.instance<PlaybackManager>();
-    final pushVideoEarly =
-        destination == Destinations.videoPlayer && PlatformDetection.isIOS;
+    final started = await launchPlayerWhilePreparing(
+      context,
+      manager: manager,
+      destination: destination,
+      startPlayback: startPlayback,
+    );
+    if (!started || !context.mounted) return false;
 
-    void popTopPlayerRoute() {
-      final route = ModalRoute.of(context);
-      if (route != null && !route.isCurrent) {
-        Navigator.of(context).pop();
-      }
-    }
-
-    Future<Object?>? routeFuture;
-    if (destination != Destinations.videoPlayer || pushVideoEarly) {
-      routeFuture = context.push(destination);
-    }
-
-    bool started;
-    try {
-      started = await startupFuture;
-    } catch (_) {
-      if (routeFuture != null && context.mounted) {
-        popTopPlayerRoute();
-      }
-      rethrow;
-    }
-
-    if (!started) {
-      if (routeFuture != null && context.mounted) {
-        popTopPlayerRoute();
-      }
-      return false;
-    }
-
-    if (!context.mounted) return false;
-
-    if (pushVideoEarly &&
-        routeFuture != null &&
-        manager.playbackDeferredToExternalPlayer) {
-      popTopPlayerRoute();
-      routeFuture = null;
-    }
-
-    if (routeFuture == null) {
-      var resolvedDestination = destination;
-      if (manager.playbackDeferredToExternalPlayer) {
-        resolvedDestination = Destinations.externalPlayer;
-      }
-      if (!context.mounted) return false;
-      routeFuture = context.push(resolvedDestination);
-    }
-
-    await routeFuture;
     _syncAudioSelectionFromActivePlayback();
     _syncSubtitleSelectionFromActivePlayback();
 
@@ -8351,7 +8335,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         item.type == 'AlbumArtist' ||
         mediaType == 'Audio';
 
-    final startupFuture = _runWithDolbyVisionStartupFallbackPrompt(
+    PlaybackLaunchSession? launchSession;
+    Future<bool> preparePlayback() => _runWithDolbyVisionStartupFallbackPrompt(
       context,
       manager,
       () async {
@@ -8460,6 +8445,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
             await _playQueueWithPrerolls(
               manager,
+              launchSession: launchSession,
               queue: seriesQueue,
               prerolls: prerolls,
               target: selectedEpisode,
@@ -8518,6 +8504,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
             await _playQueueWithPrerolls(
               manager,
+              launchSession: launchSession,
               queue: seasonQueue,
               prerolls: prerolls,
               target: selectedEpisode,
@@ -8597,6 +8584,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               final directAllowed = !dvForceTranscode && !forceTranscode;
               await _playQueueWithPrerolls(
                 manager,
+                launchSession: launchSession,
                 queue: episodeQueue,
                 prerolls: prerolls,
                 target: selectedEpisode,
@@ -8658,16 +8646,19 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               item: targetItem,
             );
 
-            await manager.playItems(
-              playableQueue,
-              startIndex: startIndex,
-              startPosition: startPosition,
-              audioStreamIndex: epAudioStreamIndex,
-              subtitleStreamIndex: epSubtitleStreamIndex,
-              audioSelectionExplicit: false,
-              subtitleSelectionExplicit: false,
-              enableDirectPlay: directAllowed,
-              enableDirectStream: directAllowed,
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(
+                playableQueue,
+                startIndex: startIndex,
+                startPosition: startPosition,
+                audioStreamIndex: epAudioStreamIndex,
+                subtitleStreamIndex: epSubtitleStreamIndex,
+                audioSelectionExplicit: false,
+                subtitleSelectionExplicit: false,
+                enableDirectPlay: directAllowed,
+                enableDirectStream: directAllowed,
+              ),
             );
             break;
 
@@ -8691,7 +8682,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               }
               throw PlaybackStartupRecoveryAbortedException();
             }
-            await manager.playItems(tracks);
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(tracks),
+            );
             break;
 
           case 'MusicAlbum':
@@ -8730,9 +8724,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             }
             // Music remembers which track was playing but starts it from the
             // beginning, matching standard music player behavior.
-            await manager.playItems(
-              tracks,
-              startIndex: albumStartIndex,
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(
+                tracks,
+                startIndex: albumStartIndex,
+              ),
             );
             break;
 
@@ -8766,12 +8763,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
               tracks,
             );
             final directAllowed = !dvForceTranscode && !forceTranscode;
-            await manager.playItems(
-              tracks,
-              startIndex: startIndex,
-              startPosition: startPosition,
-              enableDirectPlay: directAllowed,
-              enableDirectStream: directAllowed,
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(
+                tracks,
+                startIndex: startIndex,
+                startPosition: startPosition,
+                enableDirectPlay: directAllowed,
+                enableDirectStream: directAllowed,
+              ),
             );
             break;
 
@@ -8818,10 +8818,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                   }
                 }
               }
-              await manager.playItems(
-                children,
-                startIndex: startIndex,
-                startPosition: startPos,
+              await runPlaybackStart(
+                launchSession,
+                () => manager.playItems(
+                  children,
+                  startIndex: startIndex,
+                  startPosition: startPos,
+                ),
               );
               break;
             }
@@ -8849,10 +8852,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                         item.playbackPosition ??
                         Duration.zero)
                     : Duration.zero;
-                await manager.playItems(
-                  siblings,
-                  startIndex: startIndex,
-                  startPosition: startPos,
+                await runPlaybackStart(
+                  launchSession,
+                  () => manager.playItems(
+                    siblings,
+                    startIndex: startIndex,
+                    startPosition: startPos,
+                  ),
                 );
                 break;
               }
@@ -8880,6 +8886,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final directAllowed = !dvForceTranscode && !forceTranscode;
             await _playQueueWithPrerolls(
               manager,
+              launchSession: launchSession,
               queue: <AggregatedItem>[item],
               prerolls: prerolls,
               target: item,
@@ -8901,7 +8908,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       destination: isAudio
           ? Destinations.audioPlayer
           : Destinations.videoPlayer,
-      startupFuture: startupFuture,
+      startPlayback: (session) {
+        launchSession = session;
+        return preparePlayback();
+      },
     );
   }
 
@@ -8910,45 +8920,79 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     AggregatedItem item,
   ) async {
     final manager = GetIt.instance<PlaybackManager>();
-    final queue = await _shuffleQueueForItem(item);
-    final playableQueue = queue
-        .where((e) => isEligibleNextEpisodeCandidate(e) || e.id == item.id)
-        .toList();
-    if (playableQueue.isEmpty) return;
-    if (!context.mounted) return;
+    Future<
+      ({List<AggregatedItem> queue, bool isAudio, bool forceTranscode})?
+    >
+    prepareQueue() async {
+      final queue = await _shuffleQueueForItem(item);
+      final playableQueue = queue
+          .where((e) => isEligibleNextEpisodeCandidate(e) || e.id == item.id)
+          .toList();
+      if (playableQueue.isEmpty || !context.mounted) return null;
 
-    final shuffled = List<AggregatedItem>.from(playableQueue)..shuffle();
-    if (shuffled.isNotEmpty) {
+      final shuffled = List<AggregatedItem>.from(playableQueue)..shuffle();
       shuffled[0] = await _ensureHydrated(shuffled.first);
+      if (!context.mounted) return null;
+      final isAudio = shuffled.every((queuedItem) {
+        final mediaType = queuedItem.rawData['MediaType'] as String?;
+        return queuedItem.type == 'Audio' || mediaType == 'Audio';
+      });
+      final forceTranscode =
+          !isAudio &&
+          await _shouldForceTranscodeForDolbyVision(context, [shuffled.first]);
+      if (!context.mounted) return null;
+      return (
+        queue: shuffled,
+        isAudio: isAudio,
+        forceTranscode: forceTranscode,
+      );
     }
-    if (!context.mounted) return;
-    final isAudio = shuffled.every((queuedItem) {
-      final mediaType = queuedItem.rawData['MediaType'] as String?;
-      return queuedItem.type == 'Audio' || mediaType == 'Audio';
-    });
 
-    final forceTranscode =
-        !isAudio &&
-        await _shouldForceTranscodeForDolbyVision(context, [shuffled.first]);
+    Future<bool> startPlayback(
+      PlaybackLaunchSession? launchSession,
+      ({List<AggregatedItem> queue, bool isAudio, bool forceTranscode})
+      prepared,
+    ) =>
+        _runWithDolbyVisionStartupFallbackPrompt(
+          context,
+          manager,
+          () => runPlaybackStart(
+            launchSession,
+            () => manager.playItems(
+              prepared.queue,
+              enableDirectPlay: !prepared.forceTranscode,
+              enableDirectStream: !prepared.forceTranscode,
+            ),
+          ),
+        );
 
-    if (!context.mounted) return;
+    final canOpenVideoBeforeQueueWork = switch (item.type) {
+      'Series' || 'Season' || 'BoxSet' => true,
+      _ => false,
+    };
+    if (canOpenVideoBeforeQueueWork) {
+      await _pushPlayerRouteWhileStartingPlayback(
+        context,
+        destination: Destinations.videoPlayer,
+        startPlayback: (launchSession) async {
+          final prepared = await prepareQueue();
+          if (prepared == null) return false;
+          return startPlayback(launchSession, prepared);
+        },
+      );
+      return;
+    }
 
-    final startupFuture = _runWithDolbyVisionStartupFallbackPrompt(
-      context,
-      manager,
-      () => manager.playItems(
-        shuffled,
-        enableDirectPlay: !forceTranscode,
-        enableDirectStream: !forceTranscode,
-      ),
-    );
+    final prepared = await prepareQueue();
+    if (prepared == null || !context.mounted) return;
 
     await _pushPlayerRouteWhileStartingPlayback(
       context,
-      destination: isAudio
+      destination: prepared.isAudio
           ? Destinations.audioPlayer
           : Destinations.videoPlayer,
-      startupFuture: startupFuture,
+      startPlayback: (launchSession) =>
+          startPlayback(launchSession, prepared),
     );
   }
 
@@ -9118,24 +9162,29 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (!context.mounted) return;
 
     if (localTrailer != null) {
-      final forceTranscode = await _shouldForceTranscodeForDolbyVisionQueue(
-        context,
-        [localTrailer],
-      );
-      if (!context.mounted) return;
-      final startupFuture = _runWithDolbyVisionStartupFallbackPrompt(
-        context,
-        manager,
-        () => manager.playItems(
-          [localTrailer],
-          enableDirectPlay: !forceTranscode,
-          enableDirectStream: !forceTranscode,
-        ),
-      );
       await _pushPlayerRouteWhileStartingPlayback(
         context,
         destination: Destinations.videoPlayer,
-        startupFuture: startupFuture,
+        startPlayback: (launchSession) async {
+          final forceTranscode =
+              await _shouldForceTranscodeForDolbyVisionQueue(
+                context,
+                [localTrailer!],
+              );
+          if (!context.mounted) return false;
+          return _runWithDolbyVisionStartupFallbackPrompt(
+            context,
+            manager,
+            () => runPlaybackStart(
+              launchSession,
+              () => manager.playItems(
+                [localTrailer!],
+                enableDirectPlay: !forceTranscode,
+                enableDirectStream: !forceTranscode,
+              ),
+            ),
+          );
+        },
       );
       return;
     }
@@ -14812,14 +14861,23 @@ class _AlbumActions extends StatelessWidget {
     final isAudioQueue = queue.every(_isAudioItem);
     unawaited(() async {
       try {
-        await manager.playItems(queue);
+        await launchPlayerWhilePreparing(
+          context,
+          manager: manager,
+          destination: isAudioQueue
+              ? Destinations.audioPlayer
+              : Destinations.videoPlayer,
+          startPlayback: (launchSession) async {
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(queue),
+            );
+            return true;
+          },
+        );
       } catch (_) {
         return;
       }
-      if (!context.mounted) return;
-      context.push(
-        isAudioQueue ? Destinations.audioPlayer : Destinations.videoPlayer,
-      );
     }());
   }
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -25,6 +25,7 @@ import '../../../../util/platform_detection.dart';
 import '../../../../util/focus/dpad_keys.dart';
 import '../../../../util/focus/focus_scroll.dart';
 import '../../../navigation/destinations.dart';
+import '../../../navigation/playback_launcher.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/marquee_text.dart';
 import '../../../widgets/media_card.dart';
@@ -3334,18 +3335,40 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   Future<void> _playTrack(BuildContext context, int index) async {
     final manager = GetIt.instance<PlaybackManager>();
-    await manager.playItems(_vm.tracks, startIndex: index);
-    if (!context.mounted) return;
     final isAudio = _vm.tracks.every(_isAudioItem);
-    context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
+    await launchPlayerWhilePreparing(
+      context,
+      manager: manager,
+      destination: isAudio
+          ? Destinations.audioPlayer
+          : Destinations.videoPlayer,
+      startPlayback: (launchSession) async {
+        await runPlaybackStart(
+          launchSession,
+          () => manager.playItems(_vm.tracks, startIndex: index),
+        );
+        return true;
+      },
+    );
   }
 
   Future<void> _playPlaylistTrack(BuildContext context, int index) async {
     final manager = GetIt.instance<PlaybackManager>();
-    await manager.playItems(_vm.playlistItems, startIndex: index);
-    if (!context.mounted) return;
     final isAudio = _vm.playlistItems.every(_isAudioItem);
-    context.push(isAudio ? Destinations.audioPlayer : Destinations.videoPlayer);
+    await launchPlayerWhilePreparing(
+      context,
+      manager: manager,
+      destination: isAudio
+          ? Destinations.audioPlayer
+          : Destinations.videoPlayer,
+      startPlayback: (launchSession) async {
+        await runPlaybackStart(
+          launchSession,
+          () => manager.playItems(_vm.playlistItems, startIndex: index),
+        );
+        return true;
+      },
+    );
   }
 
   String _getCollectionSortLabel(CollectionSortOption option, AppLocalizations l10n) {
@@ -4351,35 +4374,46 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       onNavigateDown: _focusSelectedTab,
       onTap: () async {
         final manager = GetIt.instance<PlaybackManager>();
-        final hasProgress = (episode!.playbackPosition?.inMilliseconds ?? 0) > 0 ||
-                            (episode.playedPercentage ?? 0) > 0;
+        final targetEpisode = episode!;
+        final hasProgress =
+            (targetEpisode.playbackPosition?.inMilliseconds ?? 0) > 0 ||
+            (targetEpisode.playedPercentage ?? 0) > 0;
         // On a season, follow the list as displayed so playback carries on
         // through the season instead of stopping after this one item.
-        var queue = <AggregatedItem>[episode];
+        var queue = <AggregatedItem>[targetEpisode];
         var startIndex = 0;
         if (item.type == 'Season') {
           final playable = _vm.episodes
-              .where((e) => e.id == episode!.id || isEligibleNextEpisodeCandidate(e))
+              .where(
+                (e) =>
+                    e.id == targetEpisode.id ||
+                    isEligibleNextEpisodeCandidate(e),
+              )
               .toList();
-          final at = playable.indexWhere((e) => e.id == episode!.id);
+          final at = playable.indexWhere((e) => e.id == targetEpisode.id);
           if (at >= 0) {
             queue = playable;
             startIndex = at;
           }
         }
-        await manager.playItems(
-          queue,
-          startIndex: startIndex,
-          startPosition: hasProgress
-              ? (episode.playbackPosition ?? Duration.zero)
-              : Duration.zero,
+        await launchPlayerWhilePreparing(
+          context,
+          manager: manager,
+          destination: Destinations.videoPlayer,
+          startPlayback: (launchSession) async {
+            await runPlaybackStart(
+              launchSession,
+              () => manager.playItems(
+                queue,
+                startIndex: startIndex,
+                startPosition: hasProgress
+                    ? (targetEpisode.playbackPosition ?? Duration.zero)
+                    : Duration.zero,
+              ),
+            );
+            return true;
+          },
         );
-        if (context.mounted) {
-          final destination = manager.playbackDeferredToExternalPlayer
-              ? Destinations.externalPlayer
-              : Destinations.videoPlayer;
-          unawaited(context.push(destination));
-        }
       },
     );
   }

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -56,6 +57,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
   AppThemeController? _themeController;
   ScreensaverController? _screensaverController;
   StreamSubscription<bool>? _screensaverPlayingSub;
+  PlaybackBringupState _bringupState = const PlaybackBringupState.idle();
 
   AppleTvBackend? get _backend {
     try {
@@ -84,13 +86,17 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     _actionSub = _backend?.uiActionStream.listen(_handleUiAction);
     final manager = _manager;
     if (manager != null) {
+      _bringupState = manager.bringupState;
       _queueSub = manager.queueService.queueChangedStream.listen(
         (_) => _onQueueChanged(),
       );
       _sessionEndedSub = manager.sessionEndedStream.listen(
         (_) => _handleExit(),
       );
-      _bringupSub = manager.bringupStateStream.listen((_) {
+      _bringupSub = manager.bringupStateStream.listen((state) {
+        if (mounted) {
+          setState(() => _bringupState = state);
+        }
         _pushMetadata();
         // The initState load can run before the queue item resolves, so retry
         // here. The per-item guard makes repeat events a no-op.
@@ -1405,16 +1411,31 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     _themeController?.removeListener(_onThemeChanged);
     unawaited(_backend?.dismissPlayer() ?? Future<void>.value());
     try {
-      GetIt.instance<PlaybackManager>().stop(userInitiated: true);
+      final manager = GetIt.instance<PlaybackManager>();
+      if (!manager.playbackDeferredToExternalPlayer) {
+        manager.stop(userInitiated: true);
+      }
     } catch (_) {}
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       backgroundColor: Colors.black,
-      body: SizedBox.expand(),
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          const ColoredBox(color: Colors.black),
+          if (_bringupState.phase.isInProgress)
+            const Center(
+              child: CupertinoActivityIndicator(
+                radius: 20,
+                color: Colors.white,
+              ),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -1032,7 +1032,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     if (_wasAlwaysOnTopOnEntry == false && _isAlwaysOnTop) {
       unawaited(_setAlwaysOnTop(false));
     }
-    if (!_isStopping) _manager.stop(userInitiated: false);
+    // The launch coordinator briefly owns this route while Android decides
+    // whether to hand the queue to an external player. Keep that prepared
+    // queue intact when the internal host is being replaced.
+    if (!_isStopping && !_manager.playbackDeferredToExternalPlayer) {
+      _manager.stop(userInitiated: false);
+    }
     unawaited(_restoreSystemUiForExit());
     super.dispose();
   }
@@ -3788,15 +3793,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   bool _isBringupInProgress(PlaybackBringupPhase phase) {
-    return phase == PlaybackBringupPhase.stoppingPrevious ||
-        phase == PlaybackBringupPhase.resolving ||
-        phase == PlaybackBringupPhase.opening ||
-        phase == PlaybackBringupPhase.waitingForReady ||
-        phase == PlaybackBringupPhase.seekingResume;
+    return phase.isInProgress;
   }
 
   String _bringupLabel() {
     switch (_bringupState.phase) {
+      case PlaybackBringupPhase.preparing:
+        return _streamLoadingLabel;
       case PlaybackBringupPhase.stoppingPrevious:
         return 'Stopping previous playback...';
       case PlaybackBringupPhase.resolving:

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -195,6 +195,24 @@ class PlaybackManager implements AudioOwnable {
   String? get lastExplicitSubtitleLanguage => _lastExplicitSubtitleLanguage;
   bool? get lastExplicitSubtitleEnabled => _lastExplicitSubtitleEnabled;
   bool get playbackDeferredToExternalPlayer => _deferPlaybackToExternalPlayer;
+
+  /// Marks the work that happens before [playItems] can take ownership of the
+  /// queue. Player routes use this to render launch feedback while item
+  /// hydration, prompts, and queue construction are still in progress.
+  void beginPlaybackPreparation() {
+    _setBringupState(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.preparing),
+    );
+  }
+
+  /// Clears an abandoned preparation without overwriting a newer playback
+  /// phase that may already have taken ownership.
+  void cancelPlaybackPreparation() {
+    if (_bringupState.phase == PlaybackBringupPhase.preparing) {
+      _setBringupState(const PlaybackBringupState.idle());
+    }
+  }
+
   bool consumeSkipExternalRoutingOnce() {
     final shouldSkip = _skipExternalRoutingOnce;
     _skipExternalRoutingOnce = false;
@@ -3003,6 +3021,7 @@ class PlaybackStartupRecoveryAbortedException implements Exception {
 
 enum PlaybackBringupPhase {
   idle,
+  preparing,
   stoppingPrevious,
   resolving,
   opening,
@@ -3010,6 +3029,20 @@ enum PlaybackBringupPhase {
   seekingResume,
   ready,
   failed,
+}
+
+extension PlaybackBringupPhaseX on PlaybackBringupPhase {
+  bool get isInProgress => switch (this) {
+    PlaybackBringupPhase.preparing ||
+    PlaybackBringupPhase.stoppingPrevious ||
+    PlaybackBringupPhase.resolving ||
+    PlaybackBringupPhase.opening ||
+    PlaybackBringupPhase.waitingForReady ||
+    PlaybackBringupPhase.seekingResume => true,
+    PlaybackBringupPhase.idle ||
+    PlaybackBringupPhase.ready ||
+    PlaybackBringupPhase.failed => false,
+  };
 }
 
 class PlaybackBringupState {

--- a/test/ui/navigation/playback_launcher_test.dart
+++ b/test/ui/navigation/playback_launcher_test.dart
@@ -190,6 +190,59 @@ void main() {
     router.dispose();
   });
 
+  testWidgets('a throw before the route opens releases the launch slot', (
+    tester,
+  ) async {
+    // Disposing a manager closes its bring-up stream, so the first thing the
+    // launcher does throws. The slot has to come back or every later launch
+    // returns false without saying why.
+    final dead = PlaybackManager()..dispose();
+    final live = PlaybackManager();
+    var secondRan = false;
+    Object? firstError;
+
+    final router = _router(
+      onLaunch: (context) {
+        launchPlayerWhilePreparing(
+          context,
+          manager: dead,
+          destination: Destinations.videoPlayer,
+          startPlayback: (_) async => true,
+        ).catchError((Object error) {
+          firstError = error;
+          return false;
+        });
+      },
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    await tester.pumpAndSettle();
+    expect(firstError, isA<StateError>());
+
+    final context = tester.element(find.text('home'));
+    final second = launchPlayerWhilePreparing(
+      context,
+      manager: live,
+      destination: Destinations.videoPlayer,
+      startPlayback: (_) async {
+        secondRan = true;
+        return false;
+      },
+    );
+    await tester.pumpAndSettle();
+    await second;
+
+    expect(
+      secondRan,
+      isTrue,
+      reason: 'the slot was still claimed, so this launch never ran',
+    );
+
+    live.dispose();
+    router.dispose();
+  });
+
   test('bring-up phases identify preparation and playback work', () {
     expect(PlaybackBringupPhase.preparing.isInProgress, isTrue);
     expect(PlaybackBringupPhase.resolving.isInProgress, isTrue);

--- a/test/ui/navigation/playback_launcher_test.dart
+++ b/test/ui/navigation/playback_launcher_test.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:moonfin/ui/navigation/destinations.dart';
+import 'package:moonfin/ui/navigation/playback_launcher.dart';
+import 'package:playback_core/playback_core.dart';
+
+void main() {
+  testWidgets('video route paints before playback preparation runs', (
+    tester,
+  ) async {
+    final manager = PlaybackManager();
+    final startGate = Completer<bool>();
+    var videoBuilt = false;
+    var startedAfterVideoBuilt = false;
+    Future<bool>? launchFuture;
+
+    final router = _router(
+      onLaunch: (context) {
+        launchFuture = launchPlayerWhilePreparing(
+          context,
+          manager: manager,
+          destination: Destinations.videoPlayer,
+          startPlayback: (_) async {
+            startedAfterVideoBuilt = videoBuilt;
+            return startGate.future;
+          },
+        );
+      },
+      videoBuilder: () {
+        videoBuilt = true;
+        return const _RouteBody('video');
+      },
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    expect(manager.bringupState.phase, PlaybackBringupPhase.preparing);
+    expect(startedAfterVideoBuilt, isFalse);
+
+    await tester.pumpAndSettle();
+    expect(find.text('video'), findsOneWidget);
+    expect(startedAfterVideoBuilt, isTrue);
+
+    startGate.complete(false);
+    await tester.pumpAndSettle();
+    expect(await launchFuture, isFalse);
+    expect(find.text('home'), findsOneWidget);
+    expect(manager.bringupState.phase, PlaybackBringupPhase.idle);
+
+    manager.dispose();
+    router.dispose();
+  });
+
+  testWidgets('back during preparation prevents a stale playback start', (
+    tester,
+  ) async {
+    final manager = PlaybackManager();
+    final preparationGate = Completer<void>();
+    var playbackStarted = false;
+    Future<bool>? launchFuture;
+
+    final router = _router(
+      onLaunch: (context) {
+        launchFuture = launchPlayerWhilePreparing(
+          context,
+          manager: manager,
+          destination: Destinations.videoPlayer,
+          startPlayback: (session) async {
+            await preparationGate.future;
+            await runPlaybackStart(session, () async {
+              playbackStarted = true;
+            });
+            return true;
+          },
+        );
+      },
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    await tester.pumpAndSettle();
+    expect(find.text('video'), findsOneWidget);
+
+    router.pop();
+    await tester.pumpAndSettle();
+    preparationGate.complete();
+    await tester.pump();
+
+    expect(await launchFuture, isFalse);
+    expect(playbackStarted, isFalse);
+    expect(find.text('home'), findsOneWidget);
+    expect(manager.bringupState.phase, PlaybackBringupPhase.idle);
+
+    manager.dispose();
+    router.dispose();
+  });
+
+  testWidgets(
+    'a second video launch is ignored while the first owns the route',
+    (tester) async {
+      final manager = PlaybackManager();
+      final startGate = Completer<bool>();
+      late BuildContext sourceContext;
+      Future<bool>? firstLaunch;
+
+      final router = _router(
+        onLaunch: (context) {
+          sourceContext = context;
+          firstLaunch = launchPlayerWhilePreparing(
+            context,
+            manager: manager,
+            destination: Destinations.videoPlayer,
+            startPlayback: (_) => startGate.future,
+          );
+        },
+      );
+      await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+      await tester.tap(find.byKey(const ValueKey('launch')));
+      await tester.pump();
+
+      final secondLaunch = await launchPlayerWhilePreparing(
+        sourceContext,
+        manager: manager,
+        destination: Destinations.videoPlayer,
+        startPlayback: (_) async => true,
+      );
+      expect(secondLaunch, isFalse);
+
+      startGate.complete(false);
+      await tester.pumpAndSettle();
+      expect(await firstLaunch, isFalse);
+
+      manager.dispose();
+      router.dispose();
+    },
+  );
+
+  testWidgets('external playback replaces the temporary internal route once', (
+    tester,
+  ) async {
+    final manager = PlaybackManager()..setExternalPlaybackDecider((_) => true);
+    var videoBuilds = 0;
+    var externalBuilds = 0;
+    Future<bool>? launchFuture;
+
+    final router = _router(
+      onLaunch: (context) {
+        launchFuture = launchPlayerWhilePreparing(
+          context,
+          manager: manager,
+          destination: Destinations.videoPlayer,
+          startPlayback: (session) async {
+            await runPlaybackStart(
+              session,
+              () => manager.playItems(const [
+                <String, dynamic>{'Id': '1'},
+              ]),
+            );
+            return true;
+          },
+        );
+      },
+      videoBuilder: () {
+        videoBuilds++;
+        return const _RouteBody('video');
+      },
+      externalBuilder: () {
+        externalBuilds++;
+        return const _RouteBody('external');
+      },
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('external'), findsOneWidget);
+    expect(videoBuilds, 1);
+    expect(externalBuilds, 1);
+
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(await launchFuture, isTrue);
+
+    manager.dispose();
+    router.dispose();
+  });
+
+  test('bring-up phases identify preparation and playback work', () {
+    expect(PlaybackBringupPhase.preparing.isInProgress, isTrue);
+    expect(PlaybackBringupPhase.resolving.isInProgress, isTrue);
+    expect(PlaybackBringupPhase.ready.isInProgress, isFalse);
+    expect(PlaybackBringupPhase.failed.isInProgress, isFalse);
+  });
+}
+
+GoRouter _router({
+  required void Function(BuildContext context) onLaunch,
+  Widget Function()? videoBuilder,
+  Widget Function()? externalBuilder,
+}) {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (context, _) => Scaffold(
+          body: Column(
+            children: [
+              const Text('home'),
+              FilledButton(
+                key: const ValueKey('launch'),
+                onPressed: () => onLaunch(context),
+                child: const Text('launch'),
+              ),
+            ],
+          ),
+        ),
+      ),
+      GoRoute(
+        path: Destinations.videoPlayer,
+        builder: (_, _) => videoBuilder?.call() ?? const _RouteBody('video'),
+      ),
+      GoRoute(
+        path: Destinations.externalPlayer,
+        builder: (_, _) =>
+            externalBuilder?.call() ?? const _RouteBody('external'),
+      ),
+    ],
+  );
+}
+
+class _RouteBody extends StatelessWidget {
+  const _RouteBody(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text(label)));
+  }
+}

--- a/test/ui/screens/playback/appletv_player_host_screen_test.dart
+++ b/test/ui/screens/playback/appletv_player_host_screen_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/ui/screens/playback/appletv_player_host_screen.dart';
+import 'package:moonfin/ui/widgets/playback/player_loading_overlay.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _MockPlaybackManager extends Mock implements PlaybackManager {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockPlaybackManager manager;
+  late QueueService queue;
+  late PlayerState playerState;
+  late StreamController<PlaybackBringupState> bringupController;
+
+  setUp(() {
+    manager = _MockPlaybackManager();
+    queue = QueueService();
+    playerState = PlayerState();
+    bringupController = StreamController<PlaybackBringupState>.broadcast();
+
+    when(() => manager.bringupState).thenReturn(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.preparing),
+    );
+    when(
+      () => manager.bringupStateStream,
+    ).thenAnswer((_) => bringupController.stream);
+    when(() => manager.queueService).thenReturn(queue);
+    when(
+      () => manager.sessionEndedStream,
+    ).thenAnswer((_) => const Stream<void>.empty());
+    when(() => manager.state).thenReturn(playerState);
+    when(
+      () => manager.stop(userInitiated: any(named: 'userInitiated')),
+    ).thenAnswer((_) async {});
+
+    GetIt.instance.registerSingleton<PlaybackManager>(manager);
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+    await bringupController.close();
+    queue.dispose();
+    playerState.dispose();
+  });
+
+  testWidgets('uses a white native spinner throughout tvOS bring-up', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: AppleTvPlayerHostScreen()));
+
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+    expect(find.byType(PlayerLoadingOverlay), findsNothing);
+    final spinner = tester.widget<CupertinoActivityIndicator>(
+      find.byType(CupertinoActivityIndicator),
+    );
+    expect(spinner.radius, 20);
+    expect(spinner.color, Colors.white);
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.resolving),
+    );
+    await tester.pump();
+    expect(find.byType(CupertinoActivityIndicator), findsOneWidget);
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.ready),
+    );
+    await tester.pump();
+    expect(find.byType(CupertinoActivityIndicator), findsNothing);
+  });
+
+  testWidgets('removes tvOS launch feedback after startup failure', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: AppleTvPlayerHostScreen()));
+
+    bringupController.add(
+      const PlaybackBringupState(phase: PlaybackBringupPhase.failed),
+    );
+    await tester.pump();
+
+    expect(find.byType(CupertinoActivityIndicator), findsNothing);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Starting video playback could appear unresponsive while item preparation, prompts, queue construction, and source resolution were still in progress. The details screen remained visible until that work completed.

This PR opens the full-screen player immediately and displays launch feedback while playback is prepared. tvOS uses a centered native-style white activity indicator, while other clients use the existing Moonfin loading treatment.

This improves perceived responsiveness but does not reduce the actual video loading time.

## Related Issues
None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Add a shared playback launcher that opens the video route before backend preparation begins.
- Track preparation as part of the existing playback bring-up state.
- Apply immediate launch feedback across detail-screen video entry points.
- Preserve audio startup behavior and Android external-player handoff.
- Cancel pending startup safely when the player is dismissed, startup fails, or another launch is already in progress.
- Show a centered native-style white activity indicator during tvOS preparation.
- Add tests for early navigation, cancellation, duplicate launch suppression, external-player handoff, bring-up state, and tvOS loading feedback.

## Platform
- [x] Android
- [x] iOS
- [x] tvOS
- [x] Web
- [x] macOS
- [x] Windows
- [x] Linux
- [x] All / Shared code

## Testing
Seven focused widget and unit tests passed.

Release builds completed successfully for tvOS, Android, Windows, and Web. The behavior was manually verified on Apple TV through TestFlight, Android, Windows, and Web.

Testing confirmed that pressing Play immediately opens the full-screen loading view, transitions smoothly into the player, and starts playback normally.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a movie or TV episode details screen.
2. Press Play.
3. Confirm the full-screen player view appears immediately with loading feedback.
4. Confirm the loading feedback transitions smoothly into playback.
5. Confirm the video starts and plays normally.
6. Repeat on tvOS, Android, Windows, and Web.

## Screenshots (if applicable)
Not included because this change affects a brief animated loading transition.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced