### PR TITLE
fix(admin): keep plugin filters usable when empty

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -7469,8 +7469,20 @@
   "adminPluginsCatalog": "Catalog",
   "adminPluginsActive": "Active",
   "adminPluginsRestart": "Restart",
+  "adminPluginsRestartRequired": "Restart required",
+  "@adminPluginsRestartRequired": {
+    "description": "Label for the installed-plugin filter showing changes that require a server restart"
+  },
   "adminPluginsNoSearchResults": "No plugins match your search",
   "adminPluginsNoneInstalled": "No plugins installed",
+  "adminPluginsNoneActive": "No active plugins",
+  "@adminPluginsNoneActive": {
+    "description": "Empty state for the active installed-plugin filter"
+  },
+  "adminPluginsNoneRequireRestart": "No plugins require a server restart",
+  "@adminPluginsNoneRequireRestart": {
+    "description": "Empty state for the installed-plugin filter showing changes that require a server restart"
+  },
   "adminPluginsUpdateAvailable": "Update available: v{version}",
   "@adminPluginsUpdateAvailable": {
     "placeholders": {

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -5819,8 +5819,11 @@
     "adminPluginsCatalog": "Catalog",
     "adminPluginsActive": "Active",
     "adminPluginsRestart": "Restart",
+    "adminPluginsRestartRequired": "Restart required",
     "adminPluginsNoSearchResults": "No plugins match your search",
     "adminPluginsNoneInstalled": "No plugins installed",
+    "adminPluginsNoneActive": "No active plugins",
+    "adminPluginsNoneRequireRestart": "No plugins require a server restart",
     "adminPluginsUpdateAvailable": "Update available: v{version}",
     "@adminPluginsUpdateAvailable": {
         "placeholders": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -12544,6 +12544,12 @@ abstract class AppLocalizations {
   /// **'Restart'**
   String get adminPluginsRestart;
 
+  /// Label for the installed-plugin filter showing changes that require a server restart
+  ///
+  /// In en, this message translates to:
+  /// **'Restart required'**
+  String get adminPluginsRestartRequired;
+
   /// No description provided for @adminPluginsNoSearchResults.
   ///
   /// In en, this message translates to:
@@ -12555,6 +12561,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No plugins installed'**
   String get adminPluginsNoneInstalled;
+
+  /// Empty state for the active installed-plugin filter
+  ///
+  /// In en, this message translates to:
+  /// **'No active plugins'**
+  String get adminPluginsNoneActive;
+
+  /// Empty state for the installed-plugin filter showing changes that require a server restart
+  ///
+  /// In en, this message translates to:
+  /// **'No plugins require a server restart'**
+  String get adminPluginsNoneRequireRestart;
 
   /// No description provided for @adminPluginsUpdateAvailable.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -7019,11 +7019,21 @@ class AppLocalizationsAf extends AppLocalizations {
   String get adminPluginsRestart => 'Herbegin';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Geen plugins pas by jou soektog nie';
 
   @override
   String get adminPluginsNoneInstalled => 'Geen plugins geïnstalleer nie';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -6996,10 +6996,20 @@ class AppLocalizationsAr extends AppLocalizations {
   String get adminPluginsRestart => 'إعادة تشغيل';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'لا توجد مكونات إضافية تطابق بحثك';
 
   @override
   String get adminPluginsNoneInstalled => 'لم يتم تثبيت أي مكونات إضافية';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -7042,11 +7042,21 @@ class AppLocalizationsBe extends AppLocalizations {
   String get adminPluginsRestart => 'Перазапуск';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Няма плагінаў, якія адпавядаюць вашаму пошуку';
 
   @override
   String get adminPluginsNoneInstalled => 'Убудоў не ўстаноўлена';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -7082,11 +7082,21 @@ class AppLocalizationsBg extends AppLocalizations {
   String get adminPluginsRestart => 'Рестартирайте';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Няма плъгини, отговарящи на вашето търсене';
 
   @override
   String get adminPluginsNoneInstalled => 'Няма инсталирани добавки';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -7008,11 +7008,21 @@ class AppLocalizationsBn extends AppLocalizations {
   String get adminPluginsRestart => 'রিস্টার্ট করুন';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'কোনো প্লাগইন আপনার অনুসন্ধানের সাথে মেলে না';
 
   @override
   String get adminPluginsNoneInstalled => 'কোন প্লাগইন ইনস্টল করা নেই';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -7128,11 +7128,21 @@ class AppLocalizationsCa extends AppLocalizations {
   String get adminPluginsRestart => 'Reinicieu';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Cap connector coincideix amb la vostra cerca';
 
   @override
   String get adminPluginsNoneInstalled => 'No hi ha connectors instal·lats';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -7035,11 +7035,21 @@ class AppLocalizationsCs extends AppLocalizations {
   String get adminPluginsRestart => 'Restartujte';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Vašemu vyhledávání neodpovídají žádné pluginy';
 
   @override
   String get adminPluginsNoneInstalled => 'Nejsou nainstalovány žádné pluginy';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -7058,11 +7058,21 @@ class AppLocalizationsCy extends AppLocalizations {
   String get adminPluginsRestart => 'Ailgychwyn';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Nid oes unrhyw ategion yn cyfateb i\'ch chwiliad';
 
   @override
   String get adminPluginsNoneInstalled => 'Dim ategion wedi\'u gosod';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -7010,10 +7010,20 @@ class AppLocalizationsDa extends AppLocalizations {
   String get adminPluginsRestart => 'Genstart';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'Ingen plugins matcher din søgning';
 
   @override
   String get adminPluginsNoneInstalled => 'Ingen plugins installeret';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -7140,11 +7140,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get adminPluginsRestart => 'Neustart';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Keine Plugins stimmen mit deiner Suche überein';
 
   @override
   String get adminPluginsNoneInstalled => 'Keine Plugins installiert';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -7118,11 +7118,21 @@ class AppLocalizationsEl extends AppLocalizations {
   String get adminPluginsRestart => 'Επανεκκίνηση';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Δεν υπάρχουν πρόσθετα που να αντιστοιχούν στην αναζήτησή σας';
 
   @override
   String get adminPluginsNoneInstalled => 'Δεν έχουν εγκατασταθεί πρόσθετα';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -6963,10 +6963,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get adminPluginsRestart => 'Restart';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'No plugins match your search';
 
   @override
   String get adminPluginsNoneInstalled => 'No plugins installed';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {
@@ -17656,10 +17666,20 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get adminPluginsRestart => 'Restart';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'No plugins match your search';
 
   @override
   String get adminPluginsNoneInstalled => 'No plugins installed';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -7006,11 +7006,21 @@ class AppLocalizationsEo extends AppLocalizations {
   String get adminPluginsRestart => 'Rekomencu';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Neniuj kromprogramoj kongruas kun via serĉo';
 
   @override
   String get adminPluginsNoneInstalled => 'Neniuj kromprogramoj instalitaj';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -7091,11 +7091,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get adminPluginsRestart => 'Reiniciar';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Ningún plugin coincide con tu búsqueda';
 
   @override
   String get adminPluginsNoneInstalled => 'No hay plugins instalados';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -7015,11 +7015,21 @@ class AppLocalizationsEt extends AppLocalizations {
   String get adminPluginsRestart => 'Taaskäivitage';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Ükski pistikprogramm ei vasta teie otsingule';
 
   @override
   String get adminPluginsNoneInstalled => 'Pluginaid pole installitud';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -6975,11 +6975,21 @@ class AppLocalizationsFa extends AppLocalizations {
   String get adminPluginsRestart => 'راه اندازی مجدد';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'هیچ افزونه ای با جستجوی شما مطابقت ندارد';
 
   @override
   String get adminPluginsNoneInstalled => 'هیچ پلاگینی نصب نشده است';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -7040,11 +7040,21 @@ class AppLocalizationsFi extends AppLocalizations {
   String get adminPluginsRestart => 'Käynnistä uudelleen';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Mikään laajennus ei vastaa hakuasi';
 
   @override
   String get adminPluginsNoneInstalled => 'Laajennuksia ei ole asennettu';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -7117,11 +7117,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get adminPluginsRestart => 'Redémarrer';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Aucun plugin ne correspond à votre recherche';
 
   @override
   String get adminPluginsNoneInstalled => 'Aucun plugin installé';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -7109,11 +7109,21 @@ class AppLocalizationsGl extends AppLocalizations {
   String get adminPluginsRestart => 'Reiniciar';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Ningún complemento coincide coa túa busca';
 
   @override
   String get adminPluginsNoneInstalled => 'Non hai complementos instalados';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -6925,10 +6925,20 @@ class AppLocalizationsHe extends AppLocalizations {
   String get adminPluginsRestart => 'הפעל מחדש';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'אין תוספים שתואמים לחיפוש שלך';
 
   @override
   String get adminPluginsNoneInstalled => 'לא מותקנים תוספים';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -7000,11 +7000,21 @@ class AppLocalizationsHi extends AppLocalizations {
   String get adminPluginsRestart => 'पुनः आरंभ करें';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'कोई भी प्लगइन आपकी खोज से मेल नहीं खाता';
 
   @override
   String get adminPluginsNoneInstalled => 'कोई प्लगइन्स स्थापित नहीं है';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -7218,11 +7218,21 @@ class AppLocalizationsHr extends AppLocalizations {
   String get adminPluginsRestart => 'Ponovno pokretanje';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Nijedan dodatak ne odgovara vašem pretraživanju';
 
   @override
   String get adminPluginsNoneInstalled => 'Nema instaliranih dodataka';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -7077,11 +7077,21 @@ class AppLocalizationsHu extends AppLocalizations {
   String get adminPluginsRestart => 'Újraindítás';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Egyetlen beépülő modul sem felel meg a keresésnek';
 
   @override
   String get adminPluginsNoneInstalled => 'Nincs telepítve beépülő modul';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -7022,11 +7022,21 @@ class AppLocalizationsId extends AppLocalizations {
   String get adminPluginsRestart => 'Mulai Ulang';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Tidak ada plugin yang cocok dengan pencarian Anda';
 
   @override
   String get adminPluginsNoneInstalled => 'Tidak ada plugin yang terinstal';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -7071,11 +7071,21 @@ class AppLocalizationsIt extends AppLocalizations {
   String get adminPluginsRestart => 'Riavvio';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Nessun plugin corrisponde alla ricerca';
 
   @override
   String get adminPluginsNoneInstalled => 'Nessun plugin installato';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -6840,10 +6840,20 @@ class AppLocalizationsJa extends AppLocalizations {
   String get adminPluginsRestart => '再起動';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => '検索に一致するプラグインはありません';
 
   @override
   String get adminPluginsNoneInstalled => 'プラグインがインストールされていません';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -7051,11 +7051,21 @@ class AppLocalizationsKk extends AppLocalizations {
   String get adminPluginsRestart => 'Қайтадан қосу';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Іздеуіңізге сәйкес келетін плагиндер жоқ';
 
   @override
   String get adminPluginsNoneInstalled => 'Ешқандай плагин орнатылмаған';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -7063,12 +7063,22 @@ class AppLocalizationsKn extends AppLocalizations {
   String get adminPluginsRestart => 'ಮರುಪ್ರಾರಂಭಿಸಿ';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'ನಿಮ್ಮ ಹುಡುಕಾಟಕ್ಕೆ ಯಾವುದೇ ಪ್ಲಗಿನ್‌ಗಳು ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ';
 
   @override
   String get adminPluginsNoneInstalled =>
       'ಯಾವುದೇ ಪ್ಲಗಿನ್‌ಗಳನ್ನು ಸ್ಥಾಪಿಸಲಾಗಿಲ್ಲ';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -6832,10 +6832,20 @@ class AppLocalizationsKo extends AppLocalizations {
   String get adminPluginsRestart => '다시 시작';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => '검색어와 일치하는 플러그인이 없습니다';
 
   @override
   String get adminPluginsNoneInstalled => '플러그인이 설치되지 않았습니다.';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -7051,11 +7051,21 @@ class AppLocalizationsLt extends AppLocalizations {
   String get adminPluginsRestart => 'Paleisti iš naujo';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Nėra jūsų paiešką atitinkančių papildinių';
 
   @override
   String get adminPluginsNoneInstalled => 'Įskiepių nėra įdiegta';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -7055,11 +7055,21 @@ class AppLocalizationsLv extends AppLocalizations {
   String get adminPluginsRestart => 'Restartēt';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Neviens spraudnis neatbilst jūsu meklēšanas vaicājumam';
 
   @override
   String get adminPluginsNoneInstalled => 'Nav instalēts neviens spraudnis';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -7067,11 +7067,21 @@ class AppLocalizationsMk extends AppLocalizations {
   String get adminPluginsRestart => 'Рестартирајте';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Нема додатоци кои одговараат на вашето пребарување';
 
   @override
   String get adminPluginsNoneInstalled => 'Нема инсталирани додатоци';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -7094,12 +7094,22 @@ class AppLocalizationsMl extends AppLocalizations {
   String get adminPluginsRestart => 'പുനരാരംഭിക്കുക';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'നിങ്ങളുടെ തിരയലുമായി പൊരുത്തപ്പെടുന്ന പ്ലഗിനുകളൊന്നും ഇല്ല';
 
   @override
   String get adminPluginsNoneInstalled =>
       'പ്ലഗിന്നുകളൊന്നും ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -7031,11 +7031,21 @@ class AppLocalizationsMn extends AppLocalizations {
   String get adminPluginsRestart => 'Дахин эхлүүлэх';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Таны хайлтад тохирох нэмэлт өргөтгөл байхгүй байна';
 
   @override
   String get adminPluginsNoneInstalled => 'Ямар ч залгаас суулгаагүй байна';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -7011,11 +7011,21 @@ class AppLocalizationsNb extends AppLocalizations {
   String get adminPluginsRestart => 'Start på nytt';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Ingen plugins samsvarer med søket ditt';
 
   @override
   String get adminPluginsNoneInstalled => 'Ingen plugins installert';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -7055,11 +7055,21 @@ class AppLocalizationsNl extends AppLocalizations {
   String get adminPluginsRestart => 'Opnieuw opstarten';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Er zijn geen plug-ins die overeenkomen met uw zoekopdracht';
 
   @override
   String get adminPluginsNoneInstalled => 'Geen plug-ins geïnstalleerd';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -6995,11 +6995,21 @@ class AppLocalizationsPa extends AppLocalizations {
   String get adminPluginsRestart => 'ਰੀਸਟਾਰਟ ਕਰੋ';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'ਕੋਈ ਪਲੱਗਇਨ ਤੁਹਾਡੀ ਖੋਜ ਨਾਲ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ';
 
   @override
   String get adminPluginsNoneInstalled => 'ਕੋਈ ਪਲੱਗਇਨ ਸਥਾਪਤ ਨਹੀਂ ਹਨ';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -7246,11 +7246,21 @@ class AppLocalizationsPl extends AppLocalizations {
   String get adminPluginsRestart => 'Uruchom ponownie';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Żadna wtyczka nie pasuje do Twojego wyszukiwania';
 
   @override
   String get adminPluginsNoneInstalled => 'Brak zainstalowanych wtyczek';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -7067,11 +7067,21 @@ class AppLocalizationsPt extends AppLocalizations {
   String get adminPluginsRestart => 'Reiniciar';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Nenhum plugin corresponde à sua pesquisa';
 
   @override
   String get adminPluginsNoneInstalled => 'Nenhum plugin instalado';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -7074,11 +7074,21 @@ class AppLocalizationsRo extends AppLocalizations {
   String get adminPluginsRestart => 'Repornire';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Niciun plugin nu corespunde căutării tale';
 
   @override
   String get adminPluginsNoneInstalled => 'Nu există pluginuri instalate';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -7065,11 +7065,21 @@ class AppLocalizationsRu extends AppLocalizations {
   String get adminPluginsRestart => 'Перезапуск';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Нет плагинов, соответствующих вашему запросу';
 
   @override
   String get adminPluginsNoneInstalled => 'Плагины не установлены';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -7011,11 +7011,21 @@ class AppLocalizationsSi extends AppLocalizations {
   String get adminPluginsRestart => 'යළි අරඹන්න';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'ඔබගේ සෙවුමට ගැලපෙන ප්ලගීන කිසිවක් නැත';
 
   @override
   String get adminPluginsNoneInstalled => 'ප්ලගීන ස්ථාපනය කර නැත';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -7056,11 +7056,21 @@ class AppLocalizationsSk extends AppLocalizations {
   String get adminPluginsRestart => 'Reštartujte';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Vášmu vyhľadávaniu nezodpovedajú žiadne doplnky';
 
   @override
   String get adminPluginsNoneInstalled => 'Nie sú nainštalované žiadne doplnky';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -7052,11 +7052,21 @@ class AppLocalizationsSl extends AppLocalizations {
   String get adminPluginsRestart => 'Znova zaženite';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Noben vtičnik ne ustreza vašemu iskanju';
 
   @override
   String get adminPluginsNoneInstalled => 'Ni nameščenih vtičnikov';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -7079,11 +7079,21 @@ class AppLocalizationsSq extends AppLocalizations {
   String get adminPluginsRestart => 'Rinis';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Asnjë shtojcë nuk përputhet me kërkimin tuaj';
 
   @override
   String get adminPluginsNoneInstalled => 'Asnjë shtojcë e instaluar';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -7216,11 +7216,21 @@ class AppLocalizationsSr extends AppLocalizations {
   String get adminPluginsRestart => 'Поново покрени';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Ниједан додатак не одговара вашој претрази';
 
   @override
   String get adminPluginsNoneInstalled => 'Нема инсталираних додатака';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -7023,10 +7023,20 @@ class AppLocalizationsSv extends AppLocalizations {
   String get adminPluginsRestart => 'Starta om';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'Inga plugins matchar din sökning';
 
   @override
   String get adminPluginsNoneInstalled => 'Inga plugins installerade';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -7069,12 +7069,22 @@ class AppLocalizationsSw extends AppLocalizations {
   String get adminPluginsRestart => 'Anzisha upya';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Hakuna programu-jalizi zinazolingana na utafutaji wako';
 
   @override
   String get adminPluginsNoneInstalled =>
       'Hakuna programu-jalizi zilizosakinishwa';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -7076,12 +7076,22 @@ class AppLocalizationsTa extends AppLocalizations {
   String get adminPluginsRestart => 'மறுதொடக்கம்';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'உங்கள் தேடலுடன் எந்த செருகுநிரல்களும் பொருந்தவில்லை';
 
   @override
   String get adminPluginsNoneInstalled =>
       'செருகுநிரல்கள் எதுவும் நிறுவப்படவில்லை';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -7065,10 +7065,20 @@ class AppLocalizationsTe extends AppLocalizations {
   String get adminPluginsRestart => 'పునఃప్రారంభించండి';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'మీ శోధనకు సరిపోలే ప్లగిన్‌లు లేవు';
 
   @override
   String get adminPluginsNoneInstalled => 'ప్లగిన్‌లు ఏవీ ఇన్‌స్టాల్ చేయబడలేదు';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -6967,11 +6967,21 @@ class AppLocalizationsTh extends AppLocalizations {
   String get adminPluginsRestart => 'รีสตาร์ท';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'ไม่มีปลั๊กอินที่ตรงกับการค้นหาของคุณ';
 
   @override
   String get adminPluginsNoneInstalled => 'ไม่มีการติดตั้งปลั๊กอิน';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -7094,11 +7094,21 @@ class AppLocalizationsTl extends AppLocalizations {
   String get adminPluginsRestart => 'I-restart';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Walang mga plugin na tumutugma sa iyong paghahanap';
 
   @override
   String get adminPluginsNoneInstalled => 'Walang naka-install na plugin';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -7024,10 +7024,20 @@ class AppLocalizationsTr extends AppLocalizations {
   String get adminPluginsRestart => 'Tekrar başlat';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => 'Aramanızla eşleşen eklenti yok';
 
   @override
   String get adminPluginsNoneInstalled => 'Hiçbir eklenti yüklü değil';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -7035,11 +7035,21 @@ class AppLocalizationsUg extends AppLocalizations {
   String get adminPluginsRestart => 'قايتا قوزغىتىڭ';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'ھېچقانداق قىستۇرما ئىزدىشىڭىزگە ماس كەلمەيدۇ';
 
   @override
   String get adminPluginsNoneInstalled => 'قىستۇرما ئورنىتىلمىدى';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -7064,11 +7064,21 @@ class AppLocalizationsUk extends AppLocalizations {
   String get adminPluginsRestart => 'Перезапустіть';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Жоден плагін не відповідає вашому пошуку';
 
   @override
   String get adminPluginsNoneInstalled => 'Плагіни не встановлено';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -7019,11 +7019,21 @@ class AppLocalizationsVi extends AppLocalizations {
   String get adminPluginsRestart => 'Khởi động lại';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults =>
       'Không có plugin nào phù hợp với tìm kiếm của bạn';
 
   @override
   String get adminPluginsNoneInstalled => 'Không có plugin nào được cài đặt';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -6795,10 +6795,20 @@ class AppLocalizationsYue extends AppLocalizations {
   String get adminPluginsRestart => '重新啟動';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => '沒有符合您搜尋條件的插件';
 
   @override
   String get adminPluginsNoneInstalled => '沒有安裝插件';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -6774,10 +6774,20 @@ class AppLocalizationsZh extends AppLocalizations {
   String get adminPluginsRestart => '重启';
 
   @override
+  String get adminPluginsRestartRequired => 'Restart required';
+
+  @override
   String get adminPluginsNoSearchResults => '未找到符合搜索条件的插件';
 
   @override
   String get adminPluginsNoneInstalled => '未安装插件';
+
+  @override
+  String get adminPluginsNoneActive => 'No active plugins';
+
+  @override
+  String get adminPluginsNoneRequireRestart =>
+      'No plugins require a server restart';
 
   @override
   String adminPluginsUpdateAvailable(String version) {

--- a/lib/ui/screens/admin/plugins/admin_plugins_screen.dart
+++ b/lib/ui/screens/admin/plugins/admin_plugins_screen.dart
@@ -293,14 +293,6 @@ class _InstalledTab extends ConsumerWidget {
               .toList();
         }
 
-        if (filtered.isEmpty) {
-          return Center(
-            child: Text(searchQuery.isNotEmpty
-                ? AppLocalizations.of(context).adminPluginsNoSearchResults
-                : AppLocalizations.of(context).adminPluginsNoneInstalled),
-          );
-        }
-
         return Column(
           children: [
             Padding(
@@ -311,42 +303,63 @@ class _InstalledTab extends ConsumerWidget {
               ),
             ),
             Expanded(
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(12, 4, 12, 80),
-                children: [
-                  adminGlassGroup(
-                    context,
-                    children: [
-                      for (final plugin in filtered)
-                        Builder(
-                          builder: (context) {
-                            final updateInfo =
-                                updateInfoByPluginId[plugin.id] ??
-                                    const _PluginUpdateInfo();
-                            return _InstalledPluginTile(
-                              plugin: plugin,
-                              hasUpdate: updateInfo.latestVersion != null,
-                              latestVersion: updateInfo.latestVersion,
-                              imageUrl: imageUrlsByPluginId[plugin.id],
-                              onUpdate: updateInfo.package != null &&
-                                      updateInfo.latestVersionInfo != null
-                                  ? () => onInstallUpdate(
-                                        plugin,
-                                        updateInfo.package!,
-                                        updateInfo.latestVersionInfo!,
-                                      )
-                                  : null,
-                              onTap: () => context
-                                  .push(Destinations.adminPlugin(plugin.id)),
-                              onToggle: () => onToggle(plugin),
-                              onUninstall: () => onUninstall(plugin),
-                            );
-                          },
+              child: filtered.isEmpty
+                  ? Center(
+                      child: Text(
+                        searchQuery.isNotEmpty
+                            ? AppLocalizations.of(context)
+                                .adminPluginsNoSearchResults
+                            : switch (statusFilter) {
+                                _InstalledPluginFilter.all =>
+                                  AppLocalizations.of(context)
+                                      .adminPluginsNoneInstalled,
+                                _InstalledPluginFilter.active =>
+                                  AppLocalizations.of(context)
+                                      .adminPluginsNoneActive,
+                                _InstalledPluginFilter.restart =>
+                                  AppLocalizations.of(context)
+                                      .adminPluginsNoneRequireRestart,
+                              },
+                      ),
+                    )
+                  : ListView(
+                      padding: const EdgeInsets.fromLTRB(12, 4, 12, 80),
+                      children: [
+                        adminGlassGroup(
+                          context,
+                          children: [
+                            for (final plugin in filtered)
+                              Builder(
+                                builder: (context) {
+                                  final updateInfo =
+                                      updateInfoByPluginId[plugin.id] ??
+                                          const _PluginUpdateInfo();
+                                  return _InstalledPluginTile(
+                                    plugin: plugin,
+                                    hasUpdate:
+                                        updateInfo.latestVersion != null,
+                                    latestVersion: updateInfo.latestVersion,
+                                    imageUrl: imageUrlsByPluginId[plugin.id],
+                                    onUpdate: updateInfo.package != null &&
+                                            updateInfo.latestVersionInfo != null
+                                        ? () => onInstallUpdate(
+                                              plugin,
+                                              updateInfo.package!,
+                                              updateInfo.latestVersionInfo!,
+                                            )
+                                        : null,
+                                    onTap: () => context.push(
+                                      Destinations.adminPlugin(plugin.id),
+                                    ),
+                                    onToggle: () => onToggle(plugin),
+                                    onUninstall: () => onUninstall(plugin),
+                                  );
+                                },
+                              ),
+                          ],
                         ),
-                    ],
-                  ),
-                ],
-              ),
+                      ],
+                    ),
             ),
           ],
         );
@@ -427,7 +440,7 @@ class _InstalledFilterTabs extends StatelessWidget {
             onTap: () => onStatusChanged(_InstalledPluginFilter.active),
           ),
           _InstalledFilterTab(
-            label: AppLocalizations.of(context).adminPluginsRestart,
+            label: AppLocalizations.of(context).adminPluginsRestartRequired,
             selected: statusFilter == _InstalledPluginFilter.restart,
             onTap: () => onStatusChanged(_InstalledPluginFilter.restart),
           ),

--- a/test/ui/screens/admin/admin_plugins_screen_test.dart
+++ b/test/ui/screens/admin/admin_plugins_screen_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/ui/screens/admin/plugins/admin_plugins_screen.dart';
+import 'package:moonfin/ui/screens/admin/providers/admin_user_providers.dart';
+import 'package:server_core/server_core.dart';
+
+class _MockMediaServerClient extends Mock implements MediaServerClient {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    GetIt.instance.registerSingleton<MediaServerClient>(
+      _MockMediaServerClient(),
+    );
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required List<PluginInfo> installedPlugins,
+    List<PackageInfo> availablePackages = const [],
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminInstalledPluginsProvider.overrideWith(
+            (ref) async => installedPlugins,
+          ),
+          adminAvailablePackagesProvider.overrideWith(
+            (ref) async => availablePackages,
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: const Scaffold(body: AdminPluginsScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('installed filters use filter-specific empty states', (
+    tester,
+  ) async {
+    await pumpScreen(tester, installedPlugins: const []);
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+
+    expect(find.text(l10n.adminPluginsNoneInstalled), findsOneWidget);
+
+    await tester.tap(find.text(l10n.adminPluginsActive));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.adminPluginsNoneActive), findsOneWidget);
+
+    await tester.tap(find.text(l10n.adminPluginsRestartRequired));
+    await tester.pumpAndSettle();
+
+    expect(find.text(l10n.all), findsOneWidget);
+    expect(find.text(l10n.adminPluginsActive), findsOneWidget);
+    expect(find.text(l10n.adminPluginsRestartRequired), findsOneWidget);
+    expect(find.text(l10n.adminPluginsNoneRequireRestart), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary

Keeps the installed-plugin filters available when the current filter has no results and replaces misleading generic empty-state copy with filter-specific messages. This prevents users from getting stuck on an empty filter and clarifies that the Restart required filter represents plugin changes awaiting a server restart.

## Related Issues

None.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Keep the All, Active, and Restart required filter controls visible when a filtered list is empty.
- Add distinct empty states for no installed plugins, no active plugins, and no plugins requiring a server restart.
- Add widget regression coverage for navigating among empty installed-plugin filters.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

The focused widget test passes, targeted Dart analysis reports no issues, and the updated Flutter web build was manually verified.

### Test Steps
1. Open Admin > Plugins with no installed plugins.
2. Switch among All, Active, and Restart required.
3. Verify the filter controls remain visible and each filter displays its corresponding empty-state message.

## Screenshots (if applicable)

Not included.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced