### PR TITLE
Fix focused Classic row clipping with Aya media bar

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5,7 +5,8 @@ import 'dart:ui' as ui;
 import 'package:collection/collection.dart';
 import 'package:flutter/gestures.dart';
 
-import 'package:flutter/foundation.dart' show kIsWeb, listEquals;
+import 'package:flutter/foundation.dart'
+    show kIsWeb, listEquals, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -78,6 +79,21 @@ Color get _homeBackground => AppColorScheme.background;
 
 /// How far the rows have to scroll before the return is worth offering.
 const _kHomeStartThreshold = 20.0;
+
+/// Clips inactive Classic rows where they pass behind the pinned info area.
+///
+/// The focused row must remain complete: it is the user's active navigation
+/// target, and clipping its artwork can leave only the card metadata visible.
+@visibleForTesting
+double classicHomeRowOverlayClipTop({
+  required bool isFocused,
+  required double rowViewportTop,
+  required double rowExtent,
+  required double overlayBottom,
+}) {
+  if (isFocused) return 0.0;
+  return (overlayBottom - rowViewportTop).clamp(0.0, rowExtent);
+}
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -3797,10 +3813,15 @@ class _ContentRowsState extends State<_ContentRows>
 
     // Get viewport height from scroll controller
     final viewportHeight = _scrollController.position.viewportDimension;
+    final isFocusedRow = focusedRowIndex == rowIndex;
 
     if (!fullScreenRows && !isRowsV2) {
-      final clipTop =
-          (overlayBottom - rowViewportTop).clamp(0.0, rowExtents[rowIndex]);
+      final clipTop = classicHomeRowOverlayClipTop(
+        isFocused: isFocusedRow,
+        rowViewportTop: rowViewportTop,
+        rowExtent: rowExtents[rowIndex],
+        overlayBottom: overlayBottom,
+      );
       if (clipTop <= 0.0) {
         return child;
       }
@@ -3815,7 +3836,6 @@ class _ContentRowsState extends State<_ContentRows>
     final isUnderOverlay = rowViewportBottom <= overlayBottom + 8;
     final rowDistance = (rowIndex - focusedRowIndex).abs();
     final isNeighbor = rowDistance == 1;
-    final isFocusedRow = focusedRowIndex == rowIndex;
     final isFarAway = rowDistance > 1;
 
     // Focused row: always visible

--- a/test/ui/screens/home/classic_home_row_overlay_test.dart
+++ b/test/ui/screens/home/classic_home_row_overlay_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/home/home_screen.dart';
+
+void main() {
+  group('Classic home row overlay clipping', () {
+    test('keeps the focused row fully visible under the info overlay', () {
+      final clipTop = classicHomeRowOverlayClipTop(
+        isFocused: true,
+        rowViewportTop: 120,
+        rowExtent: 300,
+        overlayBottom: 260,
+      );
+
+      expect(clipTop, 0);
+    });
+
+    test('clips the covered portion of an inactive row', () {
+      final clipTop = classicHomeRowOverlayClipTop(
+        isFocused: false,
+        rowViewportTop: 120,
+        rowExtent: 300,
+        overlayBottom: 260,
+      );
+
+      expect(clipTop, 140);
+    });
+
+    test('does not clip an inactive row below the overlay', () {
+      final clipTop = classicHomeRowOverlayClipTop(
+        isFocused: false,
+        rowViewportTop: 280,
+        rowExtent: 300,
+        overlayBottom: 260,
+      );
+
+      expect(clipTop, 0);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Keeps the focused Classic home row fully visible when the pinned information overlay is active. With the Aya media bar, the Classic non-full-screen path could clip the focused row's artwork and leave only its text visible because it applied overlay clipping before the focused-row exemption used by the other row modes.

## Related Issues
None

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Preserve the complete focused Classic row when it intersects the pinned information overlay.
- Continue clipping inactive Classic rows so they do not render through the information area.
- Add regression coverage for focused and inactive row-overlay geometry.

## Platform
- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Manually validated through TestFlight on a physical Apple TV 4K (3rd generation). The Classic home row remained fully visible with the Aya media bar, confirming the reported clipping issue is fixed. The tvOS build completed successfully.

### Test Steps
1. On tvOS, set the media bar to Aya, the home row style to Classic, Full Screen Rows off, and Home Row Info Overlay on.
2. Put a populated Recently Watched row first, return Home, focus the Aya media bar, and navigate down into that row.
3. Verify the focused row's artwork and metadata remain visible while inactive content behind the pinned information area stays clipped.
4. Switch only the home row style to Modern and confirm its existing behavior is unchanged.

## Screenshots (if applicable)
N/A; the fix was verified directly on a physical Apple TV.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [ ] No new warnings introduced
