### PR TITLE
fix(downloads): honor the server download permission, dispose the service on server switch, and respect the concurrency setting

### DIFF
--- a/lib/auth/repositories/auth_repository.dart
+++ b/lib/auth/repositories/auth_repository.dart
@@ -100,6 +100,7 @@ class AuthRepository {
     final isAdmin = policy?.isAdministrator ?? false;
     final canManageSubtitles = policy?.canFetchRemoteSubtitles ?? false;
     final canManageCollections = policy?.enableCollectionManagement ?? false;
+    final canDownload = policy?.enableContentDownloading ?? false;
 
     if (accessToken == null || userId == null) {
       const state = ApiClientError(error: 'Invalid auth response');
@@ -118,6 +119,7 @@ class AuthRepository {
       lastUsed: DateTime.now(),
       imageTag: imageTag,
       isAdministrator: isAdmin,
+      canDownload: canDownload,
       canManageSubtitles: canManageSubtitles,
       canManageCollections: canManageCollections,
     );

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p;
 import 'package:server_core/server_core.dart';
 import 'package:uuid/uuid.dart';
 
+import '../../auth/repositories/user_repository.dart';
 import '../../platform/ios_storage.dart';
 import '../../playback/subtitle_formats.dart';
 import '../../preference/user_preferences.dart';
@@ -117,6 +118,16 @@ bool looksLikeTlsError(bgd.TaskException? exception) {
 class _NeverStartedException implements Exception {}
 
 enum _DownloadActivityPhase { start, progress, stop }
+
+/// Whether the signed in user may download at all.
+///
+/// The server policy and the platform both have a say, and the two entry
+/// points that offer downloads have to agree or one of them hands out a
+/// button the other would refuse.
+bool userCanDownload() {
+  if (PlatformDetection.isTV) return false;
+  return GetIt.instance<UserRepository>().currentUser?.canDownload ?? false;
+}
 
 class DownloadService extends ChangeNotifier {
   final MediaServerClient _client;
@@ -2042,12 +2053,23 @@ class DownloadService extends ChangeNotifier {
     _completedCount = 0;
     notifyListeners();
 
-    for (final item in items) {
-      if (_cancelAllRequested) break;
-      try {
-        await downloadItem(item, quality: quality);
-      } catch (_) {}
+    // The queue hands the next item to whichever worker frees up, so a slow
+    // download holds up only its own slot rather than everything behind it.
+    final queue = List<AggregatedItem>.from(items);
+    final limit = _prefs.get(UserPreferences.downloadConcurrentCount);
+    final workers = queue.isEmpty ? 1 : limit.clamp(1, queue.length);
+
+    Future<void> drain() async {
+      while (queue.isNotEmpty) {
+        if (_cancelAllRequested) return;
+        final item = queue.removeAt(0);
+        try {
+          await downloadItem(item, quality: quality);
+        } catch (_) {}
+      }
     }
+
+    await Future.wait([for (var i = 0; i < workers; i++) drain()]);
 
     _totalQueued = 0;
     _completedCount = 0;

--- a/lib/di/modules/server_module.dart
+++ b/lib/di/modules/server_module.dart
@@ -78,7 +78,12 @@ void setActiveServerClient(MediaServerClient client) {
   _getIt.registerSingleton<MediaServerClient>(wrapped);
 
   if (_getIt.isRegistered<DownloadService>()) {
-    _getIt.unregister<DownloadService>();
+    // Without this the replaced service keeps its Dio client and error stream
+    // open, and its native tasks keep running for a server nothing is signed
+    // in to any more.
+    _getIt.unregister<DownloadService>(
+      disposingFunction: (service) => service.dispose(),
+    );
   }
   final downloadService = DownloadService(
     rawClient,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3309,7 +3309,7 @@ class _DetailContentState extends State<_DetailContent> {
         isPlaylist && viewModel.canManagePlaylistTracks;
     final canDeleteItem = item.canDelete;
     final canDownloadAll =
-        _canUserDownload() &&
+        userCanDownload() &&
         (item.type == 'MusicAlbum' ||
             item.type == 'AudioBook' ||
             (item.type == 'Playlist' &&
@@ -6335,9 +6335,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         .toList();
 
     final canShowDownloadActions =
-        _isDownloadable(item.type) &&
-        _canUserDownload() &&
-        !PlatformDetection.isTV;
+        _isDownloadable(item.type) && userCanDownload();
 
     final String playButtonLabel;
     if (isPhoto) {
@@ -10143,11 +10141,6 @@ bool _isDownloadable(String? type) {
       type == 'MusicVideo' ||
       type == 'Video' ||
       type == 'MusicAlbum';
-}
-
-bool _canUserDownload() {
-  final user = GetIt.instance<UserRepository>().currentUser;
-  return !PlatformDetection.isTV && (user?.canDownload ?? false);
 }
 
 class _DownloadButton extends StatefulWidget {

--- a/lib/ui/widgets/track_action_dialog.dart
+++ b/lib/ui/widgets/track_action_dialog.dart
@@ -6,7 +6,6 @@ import '../../data/models/aggregated_item.dart';
 import '../../data/repositories/offline_repository.dart';
 import '../../data/services/download_service.dart';
 import '../../l10n/app_localizations.dart';
-import '../../util/platform_detection.dart';
 import 'focusable_dialog_row.dart';
 import 'overlay_sheet.dart';
 
@@ -87,7 +86,7 @@ class TrackActionDialog extends StatelessWidget {
                 offlineItem?.downloadStatus == 2 && offlineItem?.localFilePath != null;
             final isDownloading = downloadService.isDownloading(track.id);
             final supportsOffline =
-              !PlatformDetection.isTV && _supportsOfflineActions(track);
+                userCanDownload() && _supportsOfflineActions(track);
 
             return Dialog(
               backgroundColor: Colors.transparent,

--- a/test/data/services/download_concurrency_test.dart
+++ b/test/data/services/download_concurrency_test.dart
@@ -1,0 +1,183 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/data/database/offline_database.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/data/repositories/offline_repository.dart';
+import 'package:moonfin/data/services/download_notification_service.dart';
+import 'package:moonfin/data/services/download_service.dart';
+import 'package:moonfin/data/services/storage_path_service.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeOfflineRepository extends OfflineRepository {
+  _FakeOfflineRepository(super.db);
+
+  @override
+  Future<void> upsertItem(DownloadedItemsCompanion item) async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeStoragePathService implements StoragePathService {
+  _FakeStoragePathService(this.dir);
+  final Directory dir;
+
+  @override
+  Future<Directory> getOfflineRoot() async => dir;
+
+  @override
+  Future<Directory> getImageCacheDir() async {
+    final imageDir = Directory('${dir.path}/images');
+    if (!await imageDir.exists()) await imageDir.create(recursive: true);
+    return imageDir;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// Holds each metadata fetch open until released, so the peak number of items
+/// in flight at once is observable.
+class _GatedItemsApi implements ItemsApi {
+  final Map<String, dynamic> itemData;
+  _GatedItemsApi(this.itemData);
+
+  int inFlight = 0;
+  int peakInFlight = 0;
+  final gate = Completer<void>();
+
+  @override
+  Future<Map<String, dynamic>> getItem(
+    String itemId, {
+    String? mediaSourceId,
+    String? fields,
+  }) async {
+    inFlight++;
+    if (inFlight > peakInFlight) peakInFlight = inFlight;
+    await gate.future;
+    inFlight--;
+    return {...itemData, 'Id': itemId};
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeClient implements MediaServerClient {
+  _FakeClient(this._itemsApi);
+  final ItemsApi _itemsApi;
+
+  @override
+  ItemsApi get itemsApi => _itemsApi;
+
+  @override
+  String? get accessToken => 'test-token';
+
+  // Unroutable, so every transfer fails immediately once metadata resolves.
+  @override
+  String get baseUrl => 'http://127.0.0.1:1';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late OfflineDatabase db;
+  late Directory tempDir;
+  late _GatedItemsApi itemsApi;
+  late DownloadService service;
+
+  final itemData = <String, dynamic>{
+    'Type': 'Movie',
+    'Name': 'Test Movie',
+    'MediaSources': [
+      {'Id': 'source-1', 'Container': 'mkv', 'Size': 1024},
+    ],
+  };
+
+  Future<void> buildService(int concurrentCount) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'download_concurrent_count': concurrentCount,
+    });
+    final store = PreferenceStore();
+    await store.init();
+
+    tempDir = await Directory.systemTemp.createTemp('moonfin_conc_test');
+    db = OfflineDatabase(DatabaseConnection(NativeDatabase.memory()));
+    itemsApi = _GatedItemsApi(itemData);
+
+    final getIt = GetIt.instance;
+    getIt.registerSingleton<UserPreferences>(UserPreferences(store));
+    getIt.registerSingleton<StoragePathService>(
+      _FakeStoragePathService(tempDir),
+    );
+    getIt.registerSingleton<OfflineRepository>(_FakeOfflineRepository(db));
+
+    service = DownloadService(
+      _FakeClient(itemsApi),
+      DownloadNotificationService(),
+    );
+  }
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+    await db.close();
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  List<AggregatedItem> itemsFor(int count) => [
+    for (var i = 0; i < count; i++)
+      AggregatedItem(
+        id: 'movie-$i',
+        serverId: 'server-1',
+        rawData: {...itemData, 'Id': 'movie-$i'},
+      ),
+  ];
+
+  test('a batch runs no more items at once than the setting allows', () async {
+    await buildService(3);
+
+    final batch = service.downloadItems(itemsFor(8));
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(itemsApi.peakInFlight, 3);
+
+    itemsApi.gate.complete();
+    await batch;
+  });
+
+  test('a setting of one keeps the old single file behaviour', () async {
+    await buildService(1);
+
+    final batch = service.downloadItems(itemsFor(4));
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(itemsApi.peakInFlight, 1);
+
+    itemsApi.gate.complete();
+    await batch;
+  });
+
+  test('a batch smaller than the setting starts only what it has', () async {
+    await buildService(8);
+
+    final batch = service.downloadItems(itemsFor(2));
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(itemsApi.peakInFlight, 2);
+
+    itemsApi.gate.complete();
+    await batch;
+  });
+}

--- a/test/data/services/user_can_download_test.dart
+++ b/test/data/services/user_can_download_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin/auth/models/user.dart';
+import 'package:moonfin/auth/repositories/user_repository.dart';
+import 'package:moonfin/data/services/download_service.dart';
+
+PrivateUser _user({required bool canDownload}) => PrivateUser(
+  id: 'u1',
+  name: 'Test',
+  serverId: 's1',
+  accessToken: 'token',
+  lastUsed: DateTime(2026),
+  canDownload: canDownload,
+);
+
+void main() {
+  late UserRepository users;
+
+  setUp(() {
+    users = UserRepository();
+    GetIt.instance.registerSingleton<UserRepository>(users);
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  test('a user the server allows to download may download', () {
+    users.setCurrentUser(_user(canDownload: true));
+    expect(userCanDownload(), isTrue);
+  });
+
+  test('a user the server forbids may not, whatever the screen offers', () {
+    users.setCurrentUser(_user(canDownload: false));
+    expect(
+      userCanDownload(),
+      isFalse,
+      reason: 'the track dialog used to offer downloads regardless',
+    );
+  });
+
+  test('nobody signed in may not download', () {
+    users.setCurrentUser(null);
+    expect(userCanDownload(), isFalse);
+  });
+}


### PR DESCRIPTION
enforced the download permission at login and in the track menu, disposed the download service on server switch, and honored the concurrent downloads setting