### PR TITLE
feat(messages): read messages your server admin sends you

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,6 +21,7 @@ import 'data/services/connectivity_service.dart';
 import 'data/services/download_service.dart';
 import 'data/services/seerr_notification_service.dart';
 import 'data/services/plugin_sync_service.dart';
+import 'data/services/server_messages_service.dart';
 import 'data/services/retro_artwork/retro_artwork_data_source.dart';
 import 'data/services/theme_music_service.dart';
 import 'data/services/deep_link_service.dart';
@@ -38,7 +39,9 @@ import 'ui/theme/app_theme.dart';
 import 'ui/theme/app_theme_controller.dart';
 import 'ui/widgets/app_update_banner.dart';
 import 'ui/widgets/cast_mini_player.dart';
+import 'ui/widgets/floating_notification.dart';
 import 'ui/widgets/offline_banner.dart';
+import 'ui/widgets/server_messages_dialog.dart';
 import 'ui/widgets/exit_confirmation_dialog.dart';
 import 'ui/screensaver/screensaver_controller.dart';
 import 'ui/screensaver/screensaver_host.dart';
@@ -55,7 +58,6 @@ import 'ui/widgets/overlay_sheet.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 import 'util/focus/key_event_utils.dart';
 import 'util/focus/gamepad/gamepad_navigation_scope.dart';
-import 'ui/widgets/focus/request_initial_focus.dart';
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 
 class MoonfinApp extends StatefulWidget {
@@ -958,6 +960,11 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
                 );
       }
     }
+    if (GetIt.instance.isRegistered<ServerMessagesService>()) {
+      GetIt.instance<ServerMessagesService>().addListener(
+        _handleServerMessagesChanged,
+      );
+    }
     if (GetIt.instance.isRegistered<DownloadService>()) {
       _downloadErrorSub = GetIt.instance<DownloadService>().errors.listen(
         _handleDownloadError,
@@ -973,6 +980,11 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     if (GetIt.instance.isRegistered<PluginSyncService>()) {
       GetIt.instance<PluginSyncService>().onAdminMessage = null;
       GetIt.instance<PluginSyncService>().onSeerrNotification = null;
+    }
+    if (GetIt.instance.isRegistered<ServerMessagesService>()) {
+      GetIt.instance<ServerMessagesService>().removeListener(
+        _handleServerMessagesChanged,
+      );
     }
     super.dispose();
   }
@@ -1053,20 +1065,38 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     );
   }
 
-  void _handleAdminMessage(String message) {
-    if (!mounted) return;
-
+  BuildContext? _navigatorContext() {
+    if (!mounted) return null;
     final navContext =
         appRouter.routerDelegate.navigatorKey.currentContext ?? context;
-    if (!navContext.mounted) {
-      return;
-    }
+    return navContext.mounted ? navContext : null;
+  }
 
-    showFocusRestoringDialog<void>(
-      context: navContext,
-      barrierDismissible: false,
-      builder: (ctx) => _AdminMessageDialog(message: message),
+  /// A broadcast arrived. It is saved on the server now, so show a small popup
+  /// instead of a blocking dialog and let the menu button carry it from there.
+  void _handleAdminMessage(String message) {
+    final navContext = _navigatorContext();
+    if (navContext == null) return;
+
+    FloatingNotification.show(
+      navContext,
+      AppLocalizations.of(navContext).serverMessages,
+      message,
+      () => showServerMessagesDialog(navContext),
     );
+  }
+
+  /// Opens the messages window for messages the admin marked as "open the
+  /// window". Nothing else opens on its own.
+  void _handleServerMessagesChanged() {
+    final service = GetIt.instance<ServerMessagesService>();
+    if (service.pendingPopups.isEmpty) return;
+
+    final navContext = _navigatorContext();
+    if (navContext == null) return;
+
+    service.markPopupsRead();
+    showServerMessagesDialog(navContext);
   }
 
   /// Fires whenever server reachability flips (either way) so home swaps
@@ -1106,147 +1136,6 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     _wasOnline = isOnline;
 
     return widget.child;
-  }
-}
-
-class _AdminMessageDialog extends StatefulWidget {
-  final String message;
-
-  const _AdminMessageDialog({required this.message});
-
-  @override
-  State<_AdminMessageDialog> createState() => _AdminMessageDialogState();
-}
-
-class _AdminMessageDialogState extends State<_AdminMessageDialog> {
-  final _okFocusNode = FocusNode(debugLabel: 'AdminMessageOkButton');
-  final _dialogScopeNode = FocusScopeNode(
-    debugLabel: 'AdminMessageDialogScope',
-  );
-  bool _focused = false;
-
-  @override
-  void dispose() {
-    _okFocusNode.dispose();
-    _dialogScopeNode.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context);
-    return FocusScope(
-      node: _dialogScopeNode,
-      autofocus: true,
-      onKeyEvent: (node, event) {
-        if (!event.isActionable) {
-          return KeyEventResult.ignored;
-        }
-
-        final key = event.logicalKey;
-        if (key.isDirectional) {
-          if (!_okFocusNode.hasFocus && _okFocusNode.canRequestFocus) {
-            _okFocusNode.requestFocus();
-          }
-          return KeyEventResult.handled;
-        }
-
-        return KeyEventResult.ignored;
-      },
-      child: RequestInitialFocus(
-        targetNode: _okFocusNode,
-        child: Dialog(
-          backgroundColor: Colors.transparent,
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 500),
-            child: Container(
-              padding: const EdgeInsets.all(32),
-              decoration: BoxDecoration(
-                color: AppColorScheme.isGlass
-                    ? const Color(0xD90E1117)
-                    : AppColorScheme.surface,
-                borderRadius: AppRadius.circular(
-                  AppColorScheme.isGlass ? 20 : 16,
-                ),
-                border: Border.fromBorderSide(
-                  AppColorScheme.isGlass
-                      ? const BorderSide(color: Color(0x33FFFFFF), width: 1)
-                      : ThemeRegistry.active.borders.chipBorder,
-                ),
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.campaign_outlined,
-                    size: 40,
-                    color: AppColorScheme.accent,
-                  ),
-                  const SizedBox(height: 24),
-                  Text(
-                    l10n.adminSendMessage,
-                    style: TextStyle(
-                      fontSize: 28,
-                      fontWeight: FontWeight.w600,
-                      color: AppColorScheme.onSurface,
-                      decoration: TextDecoration.none,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  Text(
-                    widget.message,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.w400,
-                      color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-                      decoration: TextDecoration.none,
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  Focus(
-                    focusNode: _okFocusNode,
-                    autofocus: true,
-                    onFocusChange: (f) => setState(() => _focused = f),
-                    onKeyEvent: (node, event) => handleOneShotSelect(event, () {
-                      Navigator.of(context, rootNavigator: true).pop();
-                    }),
-                    child: GestureDetector(
-                      onTap: () {
-                        Navigator.of(context, rootNavigator: true).pop();
-                      },
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 24,
-                          vertical: 12,
-                        ),
-                        decoration: BoxDecoration(
-                          color: _focused
-                              ? AppColorScheme.onSurface
-                              : AppColorScheme.onSurface.withValues(alpha: 0.1),
-                          borderRadius: AppRadius.circular(8),
-                        ),
-                        child: Text(
-                          l10n.ok,
-                          style: TextStyle(
-                            fontSize: 18,
-                            fontWeight: FontWeight.w500,
-                            color: _focused
-                                ? AppColors.black
-                                : AppColorScheme.onSurface,
-                            decoration: TextDecoration.none,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -39,7 +39,6 @@ import 'ui/theme/app_theme.dart';
 import 'ui/theme/app_theme_controller.dart';
 import 'ui/widgets/app_update_banner.dart';
 import 'ui/widgets/cast_mini_player.dart';
-import 'ui/widgets/floating_notification.dart';
 import 'ui/widgets/offline_banner.dart';
 import 'ui/widgets/server_messages_dialog.dart';
 import 'ui/widgets/exit_confirmation_dialog.dart';
@@ -945,7 +944,6 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     final manager = ref.read(syncPlayManagerProvider);
     _syncPlayEventsSub = manager.uiEvents.listen(_handleSyncPlayEvent);
     if (GetIt.instance.isRegistered<PluginSyncService>()) {
-      GetIt.instance<PluginSyncService>().onAdminMessage = _handleAdminMessage;
       if (GetIt.instance.isRegistered<SeerrNotificationService>()) {
         final notificationService =
             GetIt.instance<SeerrNotificationService>();
@@ -978,7 +976,6 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     _syncPlayEventsSub?.cancel();
     _downloadErrorSub?.cancel();
     if (GetIt.instance.isRegistered<PluginSyncService>()) {
-      GetIt.instance<PluginSyncService>().onAdminMessage = null;
       GetIt.instance<PluginSyncService>().onSeerrNotification = null;
     }
     if (GetIt.instance.isRegistered<ServerMessagesService>()) {
@@ -1070,20 +1067,6 @@ class _ConnectivityListenerState extends ConsumerState<_ConnectivityListener>
     final navContext =
         appRouter.routerDelegate.navigatorKey.currentContext ?? context;
     return navContext.mounted ? navContext : null;
-  }
-
-  /// A broadcast arrived. It is saved on the server now, so show a small popup
-  /// instead of a blocking dialog and let the menu button carry it from there.
-  void _handleAdminMessage(String message) {
-    final navContext = _navigatorContext();
-    if (navContext == null) return;
-
-    FloatingNotification.show(
-      navContext,
-      AppLocalizations.of(navContext).serverMessages,
-      message,
-      () => showServerMessagesDialog(navContext),
-    );
   }
 
   /// Opens the messages window for messages the admin marked as "open the

--- a/lib/auth/repositories/session_repository.dart
+++ b/lib/auth/repositories/session_repository.dart
@@ -21,6 +21,7 @@ import '../../data/services/watch_next_service.dart';
 import '../../data/services/media_server_client_factory.dart';
 import '../../data/services/plugin_sync_service.dart';
 import '../../data/services/push_messaging_service.dart';
+import '../../data/services/server_messages_service.dart';
 import '../../data/services/socket_handler.dart';
 import '../../di/modules/app_module.dart';
 import '../../di/modules/playback_module.dart';
@@ -179,6 +180,9 @@ class SessionRepository {
   }) async {
     _setState(SessionState.switching);
     _pluginSyncService.resetState();
+    if (GetIt.instance.isRegistered<ServerMessagesService>()) {
+      GetIt.instance<ServerMessagesService>().clear();
+    }
 
     final server = _serverRepository.getServer(serverId);
     if (server == null) {
@@ -474,6 +478,9 @@ class SessionRepository {
     }
 
     _pluginSyncService.resetState();
+    if (GetIt.instance.isRegistered<ServerMessagesService>()) {
+      GetIt.instance<ServerMessagesService>().clear();
+    }
 
     if (serverId != null && !tokenKnownInvalid) {
       try {

--- a/lib/data/models/server_message.dart
+++ b/lib/data/models/server_message.dart
@@ -1,5 +1,5 @@
-/// How important a message is. Drives its colour in the app.
-enum ServerMessageSeverity { info, warning, critical }
+/// The colour the admin picked for a message.
+enum ServerMessageColor { green, red, yellow, blue, white }
 
 /// How noisy a message should be when it arrives.
 enum ServerMessageDelivery {
@@ -18,7 +18,7 @@ class ServerMessage {
   final String id;
   final String title;
   final String body;
-  final ServerMessageSeverity severity;
+  final ServerMessageColor color;
   final ServerMessageDelivery delivery;
   final bool pinned;
   final String? actionLabel;
@@ -29,7 +29,7 @@ class ServerMessage {
     required this.id,
     required this.title,
     required this.body,
-    this.severity = ServerMessageSeverity.info,
+    this.color = ServerMessageColor.white,
     this.delivery = ServerMessageDelivery.inbox,
     this.pinned = false,
     this.actionLabel,
@@ -72,10 +72,12 @@ class ServerMessage {
       id: id,
       title: title,
       body: body,
-      severity: switch (_string(json, 'severity').toLowerCase()) {
-        'critical' => ServerMessageSeverity.critical,
-        'warning' => ServerMessageSeverity.warning,
-        _ => ServerMessageSeverity.info,
+      color: switch (_string(json, 'color').toLowerCase()) {
+        'green' => ServerMessageColor.green,
+        'red' => ServerMessageColor.red,
+        'yellow' => ServerMessageColor.yellow,
+        'blue' => ServerMessageColor.blue,
+        _ => ServerMessageColor.white,
       },
       delivery: switch (_string(json, 'delivery').toLowerCase()) {
         'popup' => ServerMessageDelivery.popup,
@@ -93,7 +95,7 @@ class ServerMessage {
     'id': id,
     'title': title,
     'body': body,
-    'severity': severity.name,
+    'color': color.name,
     'delivery': delivery.name,
     'pinned': pinned,
     if (actionLabel != null) 'actionLabel': actionLabel,

--- a/lib/data/models/server_message.dart
+++ b/lib/data/models/server_message.dart
@@ -1,0 +1,103 @@
+/// How important a message is. Drives its colour in the app.
+enum ServerMessageSeverity { info, warning, critical }
+
+/// How noisy a message should be when it arrives.
+enum ServerMessageDelivery {
+  /// Only marks the menu button as unread.
+  inbox,
+
+  /// Shows a small popup in the corner.
+  toast,
+
+  /// Opens the message window once, until the user reads it.
+  popup,
+}
+
+/// One message written by a server admin in Moonbase.
+class ServerMessage {
+  final String id;
+  final String title;
+  final String body;
+  final ServerMessageSeverity severity;
+  final ServerMessageDelivery delivery;
+  final bool pinned;
+  final String? actionLabel;
+  final String? actionUrl;
+  final DateTime? createdUtc;
+
+  const ServerMessage({
+    required this.id,
+    required this.title,
+    required this.body,
+    this.severity = ServerMessageSeverity.info,
+    this.delivery = ServerMessageDelivery.inbox,
+    this.pinned = false,
+    this.actionLabel,
+    this.actionUrl,
+    this.createdUtc,
+  });
+
+  bool get hasAction =>
+      (actionUrl?.isNotEmpty ?? false) && (actionLabel?.isNotEmpty ?? false);
+
+  /// Reads a key tolerating PascalCase, since Emby servers capitalize keys.
+  static dynamic _value(Map<String, dynamic> json, String key) =>
+      json[key] ?? json[key[0].toUpperCase() + key.substring(1)];
+
+  static String _string(Map<String, dynamic> json, String key) {
+    final value = _value(json, key);
+    return value is String ? value : '';
+  }
+
+  static String? _nullableString(Map<String, dynamic> json, String key) {
+    final value = _string(json, key).trim();
+    return value.isEmpty ? null : value;
+  }
+
+  static DateTime? _date(Map<String, dynamic> json, String key) {
+    final value = _value(json, key);
+    if (value is! String || value.trim().isEmpty) return null;
+    return DateTime.tryParse(value)?.toUtc();
+  }
+
+  static ServerMessage? fromJson(Map<String, dynamic> json) {
+    final id = _string(json, 'id').trim();
+    if (id.isEmpty) return null;
+
+    final title = _string(json, 'title').trim();
+    final body = _string(json, 'body').trim();
+    if (title.isEmpty && body.isEmpty) return null;
+
+    return ServerMessage(
+      id: id,
+      title: title,
+      body: body,
+      severity: switch (_string(json, 'severity').toLowerCase()) {
+        'critical' => ServerMessageSeverity.critical,
+        'warning' => ServerMessageSeverity.warning,
+        _ => ServerMessageSeverity.info,
+      },
+      delivery: switch (_string(json, 'delivery').toLowerCase()) {
+        'popup' => ServerMessageDelivery.popup,
+        'toast' => ServerMessageDelivery.toast,
+        _ => ServerMessageDelivery.inbox,
+      },
+      pinned: _value(json, 'pinned') == true,
+      actionLabel: _nullableString(json, 'actionLabel'),
+      actionUrl: _nullableString(json, 'actionUrl'),
+      createdUtc: _date(json, 'createdUtc'),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'body': body,
+    'severity': severity.name,
+    'delivery': delivery.name,
+    'pinned': pinned,
+    if (actionLabel != null) 'actionLabel': actionLabel,
+    if (actionUrl != null) 'actionUrl': actionUrl,
+    if (createdUtc != null) 'createdUtc': createdUtc!.toIso8601String(),
+  };
+}

--- a/lib/data/models/server_message.dart
+++ b/lib/data/models/server_message.dart
@@ -44,6 +44,21 @@ class ServerMessage {
     return value is String ? value : '';
   }
 
+  /// The address as sent when it is a web link, otherwise null. The body and
+  /// the action come from the admin as free text and end up in the system
+  /// launcher, so anything that is not http or https is dropped rather than
+  /// handed over.
+  static String? webLink(String? raw) {
+    final value = raw?.trim();
+    if (value == null || value.isEmpty) return null;
+    final uri = Uri.tryParse(value);
+    if (uri == null || uri.host.isEmpty) return null;
+    return switch (uri.scheme) {
+      'http' || 'https' => value,
+      _ => null,
+    };
+  }
+
   static String? _nullableString(Map<String, dynamic> json, String key) {
     final value = _string(json, key).trim();
     return value.isEmpty ? null : value;
@@ -79,7 +94,7 @@ class ServerMessage {
         _ => ServerMessageDelivery.inbox,
       },
       actionLabel: _nullableString(json, 'actionLabel'),
-      actionUrl: _nullableString(json, 'actionUrl'),
+      actionUrl: webLink(_nullableString(json, 'actionUrl')),
       createdUtc: _date(json, 'createdUtc'),
     );
   }

--- a/lib/data/models/server_message.dart
+++ b/lib/data/models/server_message.dart
@@ -3,11 +3,8 @@ enum ServerMessageColor { green, red, yellow, blue, white }
 
 /// How noisy a message should be when it arrives.
 enum ServerMessageDelivery {
-  /// Only marks the menu button as unread.
+  /// Only adds to the unread count on the menu button.
   inbox,
-
-  /// Shows a small popup in the corner.
-  toast,
 
   /// Opens the message window once, until the user reads it.
   popup,
@@ -20,7 +17,6 @@ class ServerMessage {
   final String body;
   final ServerMessageColor color;
   final ServerMessageDelivery delivery;
-  final bool pinned;
   final String? actionLabel;
   final String? actionUrl;
   final DateTime? createdUtc;
@@ -31,7 +27,6 @@ class ServerMessage {
     required this.body,
     this.color = ServerMessageColor.white,
     this.delivery = ServerMessageDelivery.inbox,
-    this.pinned = false,
     this.actionLabel,
     this.actionUrl,
     this.createdUtc,
@@ -81,10 +76,8 @@ class ServerMessage {
       },
       delivery: switch (_string(json, 'delivery').toLowerCase()) {
         'popup' => ServerMessageDelivery.popup,
-        'toast' => ServerMessageDelivery.toast,
         _ => ServerMessageDelivery.inbox,
       },
-      pinned: _value(json, 'pinned') == true,
       actionLabel: _nullableString(json, 'actionLabel'),
       actionUrl: _nullableString(json, 'actionUrl'),
       createdUtc: _date(json, 'createdUtc'),
@@ -97,7 +90,6 @@ class ServerMessage {
     'body': body,
     'color': color.name,
     'delivery': delivery.name,
-    'pinned': pinned,
     if (actionLabel != null) 'actionLabel': actionLabel,
     if (actionUrl != null) 'actionUrl': actionUrl,
     if (createdUtc != null) 'createdUtc': createdUtc!.toIso8601String(),

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -11,6 +11,7 @@ import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:server_core/server_core.dart';
 
 import '../../data/repositories/seerr_repository.dart';
+import 'server_messages_service.dart';
 import 'storage_path_service.dart';
 import 'synced_fields.dart';
 import '../../ui/widgets/navigation_layout.dart';
@@ -36,6 +37,13 @@ class PluginSyncService extends ChangeNotifier {
   final Dio _dio;
 
   SeerrPreferences get _seerrPrefs => GetIt.instance<SeerrPreferences>();
+
+  /// Null when the app has not registered it yet, which is the case in tests
+  /// that only exercise settings sync.
+  ServerMessagesService? get _messages =>
+      GetIt.instance.isRegistered<ServerMessagesService>()
+      ? GetIt.instance<ServerMessagesService>()
+      : null;
 
   bool _pluginAvailable = false;
   bool get pluginAvailable => _pluginAvailable;
@@ -238,6 +246,10 @@ class PluginSyncService extends ChangeNotifier {
       _seerrEnabled = _readBool(pingResult, 'seerrEnabled') ?? false;
       _mdblistAvailable = _readBool(pingResult, 'mdblistAvailable') ?? false;
       _tmdbAvailable = _readBool(pingResult, 'tmdbAvailable') ?? false;
+      // Older plugins leave this out, which reads as false and hides the button.
+      _messages?.setSupported(
+        _readBool(pingResult, 'messagesSupported') ?? false,
+      );
 
       final seerrConfig = await _fetchSeerrConfig(client);
       if (seerrConfig != null) {
@@ -325,6 +337,9 @@ class PluginSyncService extends ChangeNotifier {
       if (availability == _PluginAvailabilityStatus.available) {
         _syncRetryCount = 0;
       }
+
+      // Reads the cache first, so messages are there even with no connection.
+      await _messages?.refresh(client, serverId: serverId);
 
       final syncInitializedPref =
           UserPreferences.pluginSyncInitializedForServer(
@@ -464,6 +479,9 @@ class PluginSyncService extends ChangeNotifier {
     final type = _eventValue(parsed, 'type');
 
     if (type == 'adminMessage') {
+      // The server also saves broadcasts now, so pull the list and let the
+      // messages button and its toast take it from there.
+      await _messages?.refresh(client);
       final text = _eventValue(parsed, 'text');
       if (text is String) {
         final trimmed = text.trim();
@@ -471,6 +489,11 @@ class PluginSyncService extends ChangeNotifier {
           onAdminMessage?.call(trimmed);
         }
       }
+      return;
+    }
+
+    if (type == 'messagesChanged') {
+      await _messages?.refresh(client);
       return;
     }
 

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -69,7 +69,6 @@ class PluginSyncService extends ChangeNotifier {
   bool _tmdbAvailable = false;
   bool get tmdbAvailable => _tmdbAvailable;
   String? _activeThemeCacheServerId;
-  void Function(String message)? onAdminMessage;
   void Function(
     String title,
     String body,
@@ -479,16 +478,9 @@ class PluginSyncService extends ChangeNotifier {
     final type = _eventValue(parsed, 'type');
 
     if (type == 'adminMessage') {
-      // The server also saves broadcasts now, so pull the list and let the
-      // messages button and its toast take it from there.
+      // Broadcasts are saved as messages now, so refreshing is enough: the
+      // stored copy is set to open the window, which the messages service does.
       await _messages?.refresh(client);
-      final text = _eventValue(parsed, 'text');
-      if (text is String) {
-        final trimmed = text.trim();
-        if (trimmed.isNotEmpty) {
-          onAdminMessage?.call(trimmed);
-        }
-      }
       return;
     }
 

--- a/lib/data/services/push_messaging_service.dart
+++ b/lib/data/services/push_messaging_service.dart
@@ -8,6 +8,7 @@ import 'package:server_core/server_core.dart';
 
 import '../../firebase_options.dart';
 import '../../ui/navigation/app_router.dart';
+import '../../ui/widgets/server_messages_dialog.dart';
 import '../../util/platform_detection.dart';
 import 'plugin_sync_service.dart';
 
@@ -207,8 +208,18 @@ class PushMessagingService {
 
   void _navigateFromMessage(RemoteMessage message) {
     final route = message.data['route'];
-    if (route is String && route.trim().isNotEmpty) {
-      appRouter.go(route.trim());
+    if (route is! String) return;
+
+    final trimmed = route.trim();
+    if (trimmed.isEmpty) return;
+
+    // Messages open a window over whatever is on screen, so there is no page to
+    // go to.
+    if (trimmed == serverMessagesPushRoute) {
+      openServerMessagesFromNotification();
+      return;
     }
+
+    appRouter.go(trimmed);
   }
 }

--- a/lib/data/services/server_messages_service.dart
+++ b/lib/data/services/server_messages_service.dart
@@ -36,7 +36,7 @@ class ServerMessagesService extends ChangeNotifier {
   /// True when the server plugin has the messages endpoints.
   bool get supported => _supported;
 
-  /// Messages to show, pinned first then newest.
+  /// Messages to show, in the order the admin arranged them in Moonbase.
   List<ServerMessage> get messages => _messages;
 
   int get unreadCount =>
@@ -168,15 +168,6 @@ class ServerMessagesService extends ChangeNotifier {
       final message = ServerMessage.fromJson(Map<String, dynamic>.from(entry));
       if (message != null) messages.add(message);
     }
-
-    // The server already sorts, but a cached file may be older than that.
-    messages.sort((a, b) {
-      if (a.pinned != b.pinned) return a.pinned ? -1 : 1;
-      final aDate = a.createdUtc;
-      final bDate = b.createdUtc;
-      if (aDate == null || bDate == null) return 0;
-      return bDate.compareTo(aDate);
-    });
 
     return messages;
   }

--- a/lib/data/services/server_messages_service.dart
+++ b/lib/data/services/server_messages_service.dart
@@ -44,17 +44,8 @@ class ServerMessagesService extends ChangeNotifier {
 
   bool isRead(String id) => _readIds.contains(id);
 
-  /// The colour the menu button should use, or null when nothing is unread.
-  ServerMessageSeverity? get highestUnreadSeverity {
-    ServerMessageSeverity? highest;
-    for (final message in _messages) {
-      if (_readIds.contains(message.id)) continue;
-      if (highest == null || message.severity.index > highest.index) {
-        highest = message.severity;
-      }
-    }
-    return highest;
-  }
+  /// True when at least one message has not been read yet.
+  bool get hasUnread => unreadCount > 0;
 
   /// Unread messages the admin marked as "open the window".
   List<ServerMessage> get pendingPopups => _messages

--- a/lib/data/services/server_messages_service.dart
+++ b/lib/data/services/server_messages_service.dart
@@ -1,0 +1,260 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:server_core/server_core.dart';
+
+import '../models/server_message.dart';
+import 'storage_path_service.dart';
+
+/// Holds the admin messages for the server the user is signed in to, and which
+/// ones this user has already read.
+/// Messages are cached on disk so the list still opens offline, and so a message
+/// posted while the app was closed is there on the next launch. The live event
+/// only reaches clients that are running.
+class ServerMessagesService extends ChangeNotifier {
+  final PreferenceStore _store;
+  final Dio _dio;
+
+  List<ServerMessage> _messages = const [];
+  Set<String> _readIds = <String>{};
+  String? _scopeKey;
+  bool _supported = false;
+
+  ServerMessagesService(this._store, {@visibleForTesting Dio? dio})
+    : _dio = dio ?? Dio() {
+    if (dio == null) {
+      configureServerDio(_dio);
+      _dio.interceptors.add(redirectInterceptor(_dio));
+    }
+  }
+
+  /// True when the server plugin has the messages endpoints.
+  bool get supported => _supported;
+
+  /// Messages to show, pinned first then newest.
+  List<ServerMessage> get messages => _messages;
+
+  int get unreadCount =>
+      _messages.where((message) => !_readIds.contains(message.id)).length;
+
+  bool isRead(String id) => _readIds.contains(id);
+
+  /// The colour the menu button should use, or null when nothing is unread.
+  ServerMessageSeverity? get highestUnreadSeverity {
+    ServerMessageSeverity? highest;
+    for (final message in _messages) {
+      if (_readIds.contains(message.id)) continue;
+      if (highest == null || message.severity.index > highest.index) {
+        highest = message.severity;
+      }
+    }
+    return highest;
+  }
+
+  /// Unread messages the admin marked as "open the window".
+  List<ServerMessage> get pendingPopups => _messages
+      .where(
+        (message) =>
+            message.delivery == ServerMessageDelivery.popup &&
+            !_readIds.contains(message.id),
+      )
+      .toList();
+
+  void setSupported(bool value) {
+    if (_supported == value) return;
+    _supported = value;
+    notifyListeners();
+  }
+
+  /// Loads the cached list, then asks the server for a fresh one.
+  Future<void> refresh(MediaServerClient client, {String? serverId}) async {
+    _scopeKey = _scopeKeyFor(client, serverId: serverId);
+    _readIds = _loadReadIds();
+
+    if (_messages.isEmpty) {
+      final cached = await _readCache();
+      if (cached.isNotEmpty) {
+        _messages = cached;
+        notifyListeners();
+      }
+    }
+
+    if (!_supported) {
+      // No plugin, or one without the messages endpoints. The cache above is all
+      // we can show.
+      return;
+    }
+
+    final fetched = await _fetch(client);
+    if (fetched == null) {
+      // Server unreachable. Keep whatever the cache gave us.
+      return;
+    }
+
+    _messages = fetched;
+    _pruneReadIds();
+    await _writeCache(fetched);
+    notifyListeners();
+  }
+
+  Future<void> markRead(String id) async {
+    if (_readIds.contains(id)) return;
+    _readIds = {..._readIds, id};
+    await _saveReadIds();
+    notifyListeners();
+  }
+
+  /// Marks the "open the window" messages as read in one go. Showing them counts
+  /// as reading them, otherwise the window would open again on every refresh.
+  Future<void> markPopupsRead() async {
+    final ids = pendingPopups.map((message) => message.id).toSet();
+    if (ids.isEmpty) return;
+    _readIds = {..._readIds, ...ids};
+    await _saveReadIds();
+    notifyListeners();
+  }
+
+  Future<void> markAllRead() async {
+    final all = _messages.map((message) => message.id).toSet();
+    if (all.difference(_readIds).isEmpty) return;
+    _readIds = {..._readIds, ...all};
+    await _saveReadIds();
+    notifyListeners();
+  }
+
+  /// Forgets everything. Called on sign out, so the next user does not inherit
+  /// another user's messages.
+  void clear() {
+    _messages = const [];
+    _readIds = <String>{};
+    _scopeKey = null;
+    _supported = false;
+    notifyListeners();
+  }
+
+  // Network
+  Future<List<ServerMessage>?> _fetch(MediaServerClient client) async {
+    final token = client.accessToken;
+    if (token == null || token.isEmpty) return null;
+
+    try {
+      final response = await _dio.get(
+        '${client.baseUrl}/Moonfin/Messages',
+        options: Options(
+          headers: {
+            'Authorization': buildServerAuthorizationHeader(
+              scheme: 'MediaBrowser',
+              deviceInfo: client.deviceInfo,
+              accessToken: token,
+            ),
+          },
+        ),
+      );
+
+      return _parse(response.data);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static List<ServerMessage> _parse(dynamic payload) {
+    final raw = switch (payload) {
+      List() => payload,
+      Map() => payload['items'] ?? payload['Items'] ?? const [],
+      _ => const [],
+    };
+
+    if (raw is! List) return const [];
+
+    final messages = <ServerMessage>[];
+    for (final entry in raw) {
+      if (entry is! Map) continue;
+      final message = ServerMessage.fromJson(Map<String, dynamic>.from(entry));
+      if (message != null) messages.add(message);
+    }
+
+    // The server already sorts, but a cached file may be older than that.
+    messages.sort((a, b) {
+      if (a.pinned != b.pinned) return a.pinned ? -1 : 1;
+      final aDate = a.createdUtc;
+      final bDate = b.createdUtc;
+      if (aDate == null || bDate == null) return 0;
+      return bDate.compareTo(aDate);
+    });
+
+    return messages;
+  }
+
+  // Read state
+  /// One key per server and user, so messages read on one server do not look
+  /// read on another.
+  String _scopeKeyFor(MediaServerClient client, {String? serverId}) {
+    final resolvedServer = (serverId?.trim().isNotEmpty ?? false)
+        ? serverId!.trim()
+        : client.baseUrl.toLowerCase().trim().replaceAll(
+            RegExp(r'[^a-z0-9]+'),
+            '_',
+          );
+    final userId = (_store.getString('pref_last_user_id') ?? '').trim();
+    return userId.isEmpty ? resolvedServer : '${resolvedServer}_$userId';
+  }
+
+  String get _readIdsKey => 'pref_server_messages_read_$_scopeKey';
+
+  Set<String> _loadReadIds() {
+    if (_scopeKey == null) return <String>{};
+    return (_store.getStringList(_readIdsKey) ?? const <String>[]).toSet();
+  }
+
+  Future<void> _saveReadIds() async {
+    if (_scopeKey == null) return;
+    await _store.setStringList(_readIdsKey, _readIds.toList());
+  }
+
+  /// Drops read IDs for messages the server no longer sends, so the list does
+  /// not grow forever.
+  void _pruneReadIds() {
+    final live = _messages.map((message) => message.id).toSet();
+    final kept = _readIds.intersection(live);
+    if (kept.length == _readIds.length) return;
+    _readIds = kept;
+    unawaited(_saveReadIds());
+  }
+
+  // Disk cache
+  Future<File?> _cacheFile() async {
+    if (_scopeKey == null) return null;
+    try {
+      final dir = await GetIt.instance<StoragePathService>()
+          .getMessageCacheDir();
+      return File('${dir.path}/$_scopeKey.json');
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<List<ServerMessage>> _readCache() async {
+    try {
+      final file = await _cacheFile();
+      if (file == null || !await file.exists()) return const [];
+      return _parse(jsonDecode(await file.readAsString()));
+    } catch (_) {
+      return const [];
+    }
+  }
+
+  Future<void> _writeCache(List<ServerMessage> messages) async {
+    try {
+      final file = await _cacheFile();
+      if (file == null) return;
+      await file.writeAsString(
+        jsonEncode(messages.map((message) => message.toJson()).toList()),
+      );
+    } catch (_) {}
+  }
+}

--- a/lib/data/services/storage_path_service.dart
+++ b/lib/data/services/storage_path_service.dart
@@ -186,4 +186,18 @@ class StoragePathService {
     if (!await dir.exists()) await dir.create(recursive: true);
     return dir;
   }
+
+  Future<Directory> getMessageCacheDir() async {
+    if (PlatformDetection.isAndroid && _useMediaStore) {
+      final support = await getApplicationSupportDirectory();
+      final dir = Directory('${support.path}/Moonfin/messages');
+      if (!await dir.exists()) await dir.create(recursive: true);
+      return dir;
+    }
+
+    final root = await getOfflineRoot();
+    final dir = Directory('${root.path}/messages');
+    if (!await dir.exists()) await dir.create(recursive: true);
+    return dir;
+  }
 }

--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -297,6 +297,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('showDescriptionOnPause', UserPreferences.showDescriptionOnPause, SyncCodec.boolean),
   SyncedField('showMediaDetailsOnLibraryPage', UserPreferences.showMediaDetailsOnLibraryPage, SyncCodec.boolean),
   SyncedField('showSeerrButton', UserPreferences.showSeerrButton, SyncCodec.boolean),
+  SyncedField('showServerMessagesButton', UserPreferences.showServerMessagesButton, SyncCodec.boolean),
   SyncedField('sinceYouWatched1Enabled', UserPreferences.sinceYouWatched1Enabled, SyncCodec.boolean),
   SyncedField('sinceYouWatched2Enabled', UserPreferences.sinceYouWatched2Enabled, SyncCodec.boolean),
   SyncedField('sinceYouWatched3Enabled', UserPreferences.sinceYouWatched3Enabled, SyncCodec.boolean),

--- a/lib/di/modules/app_module.dart
+++ b/lib/di/modules/app_module.dart
@@ -29,6 +29,7 @@ import '../../data/services/cast/google_cast_provider.dart';
 import '../../data/services/cast/native_cast_channel.dart';
 import '../../data/services/cast/remote_session_cast_provider.dart';
 import '../../data/services/plugin_sync_service.dart';
+import '../../data/services/server_messages_service.dart';
 import '../../data/services/retro_artwork/retro_artwork_activity_gate.dart';
 import '../../data/services/retro_artwork/retro_artwork_cache.dart';
 import '../../data/services/retro_artwork/retro_artwork_disk_cache.dart';
@@ -135,6 +136,10 @@ void registerAppModule() {
   );
   _getIt.registerLazySingleton(
     () => PluginSyncService(_getIt<UserPreferences>(), _getIt()),
+  );
+  _getIt.registerLazySingleton(
+    () => ServerMessagesService(_getIt<PreferenceStore>()),
+    dispose: (service) => service.dispose(),
   );
   _getIt.registerLazySingleton(
     () => SeerrPreferences(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9841,5 +9841,25 @@
   "runSetupAgain": "Run setup again",
   "@runSetupAgain": {
     "description": "Starts the first-run setup wizard again from settings"
+  },
+  "serverMessages": "Messages",
+  "@serverMessages": {
+    "description": "Menu button and window title for messages sent by the server admin"
+  },
+  "serverMessagesEmpty": "No messages from your server yet",
+  "@serverMessagesEmpty": {
+    "description": "Shown in the messages window when the server has sent nothing"
+  },
+  "serverMessagesMarkAllRead": "Mark all as read",
+  "@serverMessagesMarkAllRead": {
+    "description": "Button in the messages window that marks every message as read"
+  },
+  "serverMessagesShowButton": "Show messages button",
+  "@serverMessagesShowButton": {
+    "description": "Setting that shows or hides the messages button in the menu"
+  },
+  "serverMessagesShowButtonSubtitle": "Adds a button to the menu for messages sent by your server admin",
+  "@serverMessagesShowButtonSubtitle": {
+    "description": "Explains the setting that shows or hides the messages button"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -19719,6 +19719,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Run setup again'**
   String get runSetupAgain;
+
+  /// Menu button and window title for messages sent by the server admin
+  ///
+  /// In en, this message translates to:
+  /// **'Messages'**
+  String get serverMessages;
+
+  /// Shown in the messages window when the server has sent nothing
+  ///
+  /// In en, this message translates to:
+  /// **'No messages from your server yet'**
+  String get serverMessagesEmpty;
+
+  /// Button in the messages window that marks every message as read
+  ///
+  /// In en, this message translates to:
+  /// **'Mark all as read'**
+  String get serverMessagesMarkAllRead;
+
+  /// Setting that shows or hides the messages button in the menu
+  ///
+  /// In en, this message translates to:
+  /// **'Show messages button'**
+  String get serverMessagesShowButton;
+
+  /// Explains the setting that shows or hides the messages button
+  ///
+  /// In en, this message translates to:
+  /// **'Adds a button to the menu for messages sent by your server admin'**
+  String get serverMessagesShowButtonSubtitle;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -11076,4 +11076,20 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -11053,4 +11053,20 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -11141,4 +11141,20 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -11179,4 +11179,20 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -11050,4 +11050,20 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -11243,4 +11243,20 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11114,4 +11114,20 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -11131,4 +11131,20 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11067,4 +11067,20 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11225,4 +11225,20 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -11243,4 +11243,20 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10987,6 +10987,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -11062,4 +11062,20 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11192,6 +11192,22 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -11080,4 +11080,20 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -11008,4 +11008,20 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -11102,4 +11102,20 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11215,4 +11215,20 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Relancer la configuration';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -11217,4 +11217,20 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -10929,4 +10929,20 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -11043,4 +11043,20 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -11296,4 +11296,20 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -11168,4 +11168,20 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -11072,4 +11072,20 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11160,4 +11160,20 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -10756,4 +10756,20 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -11119,4 +11119,20 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -11142,4 +11142,20 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -10751,4 +10751,20 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -11135,4 +11135,20 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -11135,4 +11135,20 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -11150,4 +11150,20 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -11195,4 +11195,20 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -11092,4 +11092,20 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -11064,4 +11064,20 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11131,4 +11131,20 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -11031,4 +11031,20 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -11352,4 +11352,20 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Uruchom konfigurację ponownie';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11157,6 +11157,22 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11163,4 +11163,20 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -11151,4 +11151,20 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -11063,4 +11063,20 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -11143,4 +11143,20 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -11137,4 +11137,20 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -11168,4 +11168,20 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -11284,4 +11284,20 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11081,4 +11081,20 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -11156,4 +11156,20 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -11156,4 +11156,20 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -11143,4 +11143,20 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -10994,4 +10994,20 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -11187,4 +11187,20 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -11085,4 +11085,20 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Kurulumu yeniden çalıştır';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -11105,4 +11105,20 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -11160,4 +11160,20 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -11075,4 +11075,20 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -10670,6 +10670,22 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -10629,6 +10629,22 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get runSetupAgain => 'Run setup again';
+
+  @override
+  String get serverMessages => 'Messages';
+
+  @override
+  String get serverMessagesEmpty => 'No messages from your server yet';
+
+  @override
+  String get serverMessagesMarkAllRead => 'Mark all as read';
+
+  @override
+  String get serverMessagesShowButton => 'Show messages button';
+
+  @override
+  String get serverMessagesShowButtonSubtitle =>
+      'Adds a button to the menu for messages sent by your server admin';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -383,6 +383,7 @@ class UserPreferences extends ChangeNotifier {
     'poster_size_playlist',
     'pref_home_rows_fullscreen',
     'pref_show_seerr_button',
+    'pref_show_server_messages_button',
     'pref_show_media_details_on_library_page',
     'pref_use_detailed_sub_headings',
     'pref_hide_backdrops_in_libraries',
@@ -1364,6 +1365,11 @@ class UserPreferences extends ChangeNotifier {
 
   static final showSeerrButton = Preference(
     key: 'pref_show_seerr_button',
+    defaultValue: true,
+  );
+
+  static final showServerMessagesButton = Preference(
+    key: 'pref_show_server_messages_button',
     defaultValue: true,
   );
 

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1368,9 +1368,11 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: true,
   );
 
+  /// Off by default. An admin who wants it on for everyone can set it in the
+  /// Moonbase default settings.
   static final showServerMessagesButton = Preference(
     key: 'pref_show_server_messages_button',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   static final adminDrawerOrder = Preference(

--- a/lib/ui/screens/settings/panel/navigation_category_screen.dart
+++ b/lib/ui/screens/settings/panel/navigation_category_screen.dart
@@ -154,6 +154,13 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
                     ),
                     onChanged: _pushPersonalizationSync,
                   ),
+                SwitchPreferenceTile(
+                  preference: UserPreferences.showServerMessagesButton,
+                  title: l10n.serverMessagesShowButton,
+                  subtitle: l10n.serverMessagesShowButtonSubtitle,
+                  icon: Icons.info_outline_rounded,
+                  onChanged: _pushPersonalizationSync,
+                ),
               ],
             ),
           ],

--- a/lib/ui/widgets/expandable_icon_button.dart
+++ b/lib/ui/widgets/expandable_icon_button.dart
@@ -26,6 +26,10 @@ class ExpandableIconButton extends StatefulWidget {
   final ValueChanged<bool>? onFocusChanged;
   final Color? baseColor;
 
+  /// Tints the button background when it is neither focused nor hovered. Used to
+  /// flag the button as needing attention without moving anything around it.
+  final Color? glowColor;
+
   /// When true, the label stays visible even when unfocused/unhovered instead
   /// of collapsing to an icon-only button. Drives the "always expand navbar
   /// labels" preference.
@@ -42,6 +46,7 @@ class ExpandableIconButton extends StatefulWidget {
     this.onKeyEvent,
     this.onFocusChanged,
     this.baseColor,
+    this.glowColor,
     this.forceExpanded = false,
   });
 
@@ -177,7 +182,7 @@ class _ExpandableIconButtonState extends State<ExpandableIconButton> {
         ? AppColorScheme.onSurface
         : (focusVisible || hoverActive)
         ? focusColor.withValues(alpha: 0.18)
-        : Colors.transparent;
+        : (widget.glowColor ?? Colors.transparent);
 
     final fgColor = leanbackFocused
       ? AppColors.black

--- a/lib/ui/widgets/expandable_icon_button.dart
+++ b/lib/ui/widgets/expandable_icon_button.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import 'unread_badge.dart';
+
 import '../../preference/user_preferences.dart';
 import '../../util/focus/dpad_keys.dart';
 import '../../util/focus/input_mode_tracker.dart';
@@ -26,9 +28,8 @@ class ExpandableIconButton extends StatefulWidget {
   final ValueChanged<bool>? onFocusChanged;
   final Color? baseColor;
 
-  /// Tints the button background when it is neither focused nor hovered. Used to
-  /// flag the button as needing attention without moving anything around it.
-  final Color? glowColor;
+  /// Unread count drawn as a small red circle on the icon. Zero draws nothing.
+  final int badgeCount;
 
   /// When true, the label stays visible even when unfocused/unhovered instead
   /// of collapsing to an icon-only button. Drives the "always expand navbar
@@ -46,7 +47,7 @@ class ExpandableIconButton extends StatefulWidget {
     this.onKeyEvent,
     this.onFocusChanged,
     this.baseColor,
-    this.glowColor,
+    this.badgeCount = 0,
     this.forceExpanded = false,
   });
 
@@ -182,7 +183,7 @@ class _ExpandableIconButtonState extends State<ExpandableIconButton> {
         ? AppColorScheme.onSurface
         : (focusVisible || hoverActive)
         ? focusColor.withValues(alpha: 0.18)
-        : (widget.glowColor ?? Colors.transparent);
+        : Colors.transparent;
 
     final fgColor = leanbackFocused
       ? AppColors.black
@@ -233,8 +234,12 @@ class _ExpandableIconButtonState extends State<ExpandableIconButton> {
               mainAxisSize: MainAxisSize.min,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                widget.iconBuilder?.call(iconSize, fgColor) ??
-                    Icon(widget.icon, size: iconSize, color: fgColor),
+                UnreadBadge(
+                  count: widget.badgeCount,
+                  child:
+                      widget.iconBuilder?.call(iconSize, fgColor) ??
+                      Icon(widget.icon, size: iconSize, color: fgColor),
+                ),
                 if (isExpanded) ...[
                   const SizedBox(width: _kSpacing),
                   Flexible(

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -31,6 +31,8 @@ import 'settings/settings_panel.dart';
 import '../screens/syncplay/syncplay_screen.dart';
 import '../screens/settings/settings_side_panel.dart';
 import 'seerr_icons.dart';
+import 'server_messages_dialog.dart';
+import 'server_messages_nav_slot.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
 
@@ -78,6 +80,9 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
   final _sidebarFocus = FocusScopeNode(debugLabel: 'LeftSidebar');
   final _homeFocusNode = FocusNode(debugLabel: 'LeftSidebarHome');
   final _settingsFocusNode = FocusNode(debugLabel: 'LeftSidebarSettings');
+  final _serverMessagesFocusNode = FocusNode(
+    debugLabel: 'LeftSidebarServerMessages',
+  );
   final _profileFocusNode = FocusNode(debugLabel: 'LeftSidebarProfile');
   final _musicCardFocusNode = FocusNode(debugLabel: 'SidebarMusicCard');
   late final VoidCallback _focusNavbarCallback;
@@ -218,6 +223,7 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     _librariesReloadDebounce?.cancel();
     _homeFocusNode.dispose();
     _settingsFocusNode.dispose();
+    _serverMessagesFocusNode.dispose();
     _profileFocusNode.dispose();
     _musicCardFocusNode.dispose();
     _sidebarFocus.dispose();
@@ -1065,6 +1071,22 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                         : const SizedBox.shrink(),
                   ),
                 ],
+                ServerMessagesNavSlot(
+                  builder: (context) => _SidebarItem(
+                    key: const ValueKey('sidebar-server-messages'),
+                    icon: Icons.info_outline_rounded,
+                    label: l10n.serverMessages,
+                    focusNode: _serverMessagesFocusNode,
+                    showLabel: _showLabels,
+                    onPressed: () async {
+                      _onNavigate();
+                      await showServerMessagesDialog(context);
+                      if (!mounted) return;
+                      _markNavigationAwayFromSidebar();
+                      _serverMessagesFocusNode.requestFocus();
+                    },
+                  ),
+                ),
                 _SidebarItem(
                   key: const ValueKey('sidebar-settings'),
                   icon: Icons.settings_rounded,

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -1072,10 +1072,11 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                   ),
                 ],
                 ServerMessagesNavSlot(
-                  builder: (context) => _SidebarItem(
+                  builder: (context, glow) => _SidebarItem(
                     key: const ValueKey('sidebar-server-messages'),
                     icon: Icons.info_outline_rounded,
                     label: l10n.serverMessages,
+                    glowColor: glow,
                     focusNode: _serverMessagesFocusNode,
                     showLabel: _showLabels,
                     onPressed: () async {
@@ -1300,6 +1301,10 @@ class _SidebarItem extends StatefulWidget {
   final FocusNode? focusNode;
   final Color? baseColor;
 
+  /// Tints the row when it is neither focused nor hovered, to flag it as
+  /// needing attention.
+  final Color? glowColor;
+
   const _SidebarItem({
     super.key,
     this.icon,
@@ -1310,6 +1315,7 @@ class _SidebarItem extends StatefulWidget {
     this.trailing,
     this.focusNode,
     this.baseColor,
+    this.glowColor,
   });
 
   @override
@@ -1408,7 +1414,7 @@ class _SidebarItemState extends State<_SidebarItem> {
                     ? (useBaseForFocus
                           ? baseColor.withValues(alpha: 0.12)
                           : focusColor.withValues(alpha: 0.12))
-                    : Colors.transparent,
+                    : (widget.glowColor ?? Colors.transparent),
                 borderRadius: PlatformDetection.isTV
                     ? AppRadius.circular(24)
                     : BorderRadius.zero,

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -804,6 +804,32 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     );
   }
 
+  /// The messages row, or nothing when there is nothing to show. The nav colour
+  /// is passed in so the caller decides which palette slot it takes.
+  Widget _serverMessagesSidebarItem({
+    required Color? navColor,
+    required String label,
+  }) {
+    return ServerMessagesNavSlot(
+      builder: (context, glow) => _SidebarItem(
+        key: const ValueKey('sidebar-server-messages'),
+        icon: Icons.info_outline_rounded,
+        label: label,
+        baseColor: navColor,
+        glowColor: glow,
+        focusNode: _serverMessagesFocusNode,
+        showLabel: _showLabels,
+        onPressed: () async {
+          _onNavigate();
+          await showServerMessagesDialog(context);
+          if (!mounted) return;
+          _markNavigationAwayFromSidebar();
+          _serverMessagesFocusNode.requestFocus();
+        },
+      ),
+    );
+  }
+
   Widget _buildContent() {
     final l10n = AppLocalizations.of(context);
     final showShuffle = _prefs.get(UserPreferences.showShuffleButton);
@@ -1071,22 +1097,12 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                         : const SizedBox.shrink(),
                   ),
                 ],
-                ServerMessagesNavSlot(
-                  builder: (context, glow) => _SidebarItem(
-                    key: const ValueKey('sidebar-server-messages'),
-                    icon: Icons.info_outline_rounded,
-                    label: l10n.serverMessages,
-                    glowColor: glow,
-                    focusNode: _serverMessagesFocusNode,
-                    showLabel: _showLabels,
-                    onPressed: () async {
-                      _onNavigate();
-                      await showServerMessagesDialog(context);
-                      if (!mounted) return;
-                      _markNavigationAwayFromSidebar();
-                      _serverMessagesFocusNode.requestFocus();
-                    },
-                  ),
+                // The slot is taken here rather than inside the builder, so the
+                // settings row keeps its colour whether or not there are any
+                // messages to show.
+                _serverMessagesSidebarItem(
+                  navColor: nextMainSidebarColor(),
+                  label: l10n.serverMessages,
                 ),
                 _SidebarItem(
                   key: const ValueKey('sidebar-settings'),

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -33,6 +33,7 @@ import '../screens/settings/settings_side_panel.dart';
 import 'seerr_icons.dart';
 import 'server_messages_dialog.dart';
 import 'server_messages_nav_slot.dart';
+import 'unread_badge.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
 
@@ -811,12 +812,12 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     required String label,
   }) {
     return ServerMessagesNavSlot(
-      builder: (context, glow) => _SidebarItem(
+      builder: (context, unread) => _SidebarItem(
         key: const ValueKey('sidebar-server-messages'),
         icon: Icons.info_outline_rounded,
         label: label,
         baseColor: navColor,
-        glowColor: glow,
+        badgeCount: unread,
         focusNode: _serverMessagesFocusNode,
         showLabel: _showLabels,
         onPressed: () async {
@@ -1317,9 +1318,8 @@ class _SidebarItem extends StatefulWidget {
   final FocusNode? focusNode;
   final Color? baseColor;
 
-  /// Tints the row when it is neither focused nor hovered, to flag it as
-  /// needing attention.
-  final Color? glowColor;
+  /// Unread count drawn as a small red circle on the icon. Zero draws nothing.
+  final int badgeCount;
 
   const _SidebarItem({
     super.key,
@@ -1331,7 +1331,7 @@ class _SidebarItem extends StatefulWidget {
     this.trailing,
     this.focusNode,
     this.baseColor,
-    this.glowColor,
+    this.badgeCount = 0,
   });
 
   @override
@@ -1430,7 +1430,7 @@ class _SidebarItemState extends State<_SidebarItem> {
                     ? (useBaseForFocus
                           ? baseColor.withValues(alpha: 0.12)
                           : focusColor.withValues(alpha: 0.12))
-                    : (widget.glowColor ?? Colors.transparent),
+                    : Colors.transparent,
                 borderRadius: PlatformDetection.isTV
                     ? AppRadius.circular(24)
                     : BorderRadius.zero,
@@ -1439,15 +1439,18 @@ class _SidebarItemState extends State<_SidebarItem> {
                 children: [
                   SizedBox(
                     width: iconSlotWidth,
-                    child:
-                        widget.iconBuilder?.call(iconSize, fgColor) ??
-                        (widget.icon != null
-                            ? AdaptiveIcon(
-                                widget.icon!,
-                                size: iconSize,
-                                color: fgColor,
-                              )
-                            : const SizedBox.shrink()),
+                    child: UnreadBadge(
+                      count: widget.badgeCount,
+                      child:
+                          widget.iconBuilder?.call(iconSize, fgColor) ??
+                          (widget.icon != null
+                              ? AdaptiveIcon(
+                                  widget.icon!,
+                                  size: iconSize,
+                                  color: fgColor,
+                                )
+                              : const SizedBox.shrink()),
+                    ),
                   ),
                   if (widget.showLabel) ...[
                     const SizedBox(width: 12),

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -27,6 +27,7 @@ import 'seerr_icons.dart';
 import 'server_messages_dialog.dart';
 import 'settings/settings_panel.dart';
 import 'shuffle_overlay.dart';
+import 'unread_badge.dart';
 import 'user_menu_dialog.dart';
 
 const double _kBarHeight = 54.0;
@@ -58,7 +59,9 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     _prefs.addListener(_onPrefsChanged);
     _viewsRepo.addListener(_onViewsChanged);
     GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
-    GetIt.instance<ServerMessagesService>().addListener(_onPrefsChanged);
+    GetIt.instance<ServerMessagesService>().addListener(
+      _onServerMessagesChanged,
+    );
     _userSub = _userRepo.currentUserStream.listen((_) => _loadUserImage());
     _loadUserImage();
     _loadLibraries();
@@ -68,7 +71,9 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
   void dispose() {
     try {
       GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
-      GetIt.instance<ServerMessagesService>().removeListener(_onPrefsChanged);
+      GetIt.instance<ServerMessagesService>().removeListener(
+        _onServerMessagesChanged,
+      );
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     try {
@@ -83,6 +88,11 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     if (!mounted) return;
     _scheduleLibrariesReload();
     setState(() {});
+  }
+
+  // Only the button changes, so the libraries are left alone.
+  void _onServerMessagesChanged() {
+    if (mounted) setState(() {});
   }
 
   void _onViewsChanged() {
@@ -320,7 +330,8 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     return _BottomNavAction(
       icon: Icons.info_outline_rounded,
       label: l10n.serverMessages,
-      isActive: service.unreadCount > 0,
+      isActive: false,
+      badgeCount: service.unreadCount,
       onTap: () => showServerMessagesDialog(context),
     );
   }
@@ -580,10 +591,14 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
   Widget _icon(_BottomNavAction action, {required Color color}) {
     final icon = action.icon;
-    return action.iconBuilder?.call(_kIconSize, color) ??
-        (icon != null
-            ? AdaptiveIcon(icon, size: _kIconSize, color: color)
-            : const SizedBox.shrink());
+    return UnreadBadge(
+      count: action.badgeCount,
+      child:
+          action.iconBuilder?.call(_kIconSize, color) ??
+          (icon != null
+              ? AdaptiveIcon(icon, size: _kIconSize, color: color)
+              : const SizedBox.shrink()),
+    );
   }
 
   Widget _buildTab(BuildContext context, _BottomNavAction action,
@@ -728,12 +743,16 @@ class _BottomNavAction {
   final bool isActive;
   final VoidCallback onTap;
 
+  /// Unread count drawn as a small red circle on the icon. Zero draws nothing.
+  final int badgeCount;
+
   const _BottomNavAction({
     this.icon,
     this.iconBuilder,
     required this.label,
     required this.isActive,
     required this.onTap,
+    this.badgeCount = 0,
   });
 }
 

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -11,6 +11,7 @@ import '../../data/models/aggregated_library.dart';
 import '../../data/repositories/multi_server_repository.dart';
 import '../../data/repositories/user_views_repository.dart';
 import '../../data/services/plugin_sync_service.dart';
+import '../../data/services/server_messages_service.dart';
 import '../../l10n/app_localizations.dart';
 import '../../preference/seerr_preferences.dart';
 import '../../preference/user_preferences.dart';
@@ -23,6 +24,7 @@ import '../screens/syncplay/syncplay_screen.dart';
 import 'adaptive/adaptive_glass.dart';
 import 'adaptive/sf_symbol.dart';
 import 'seerr_icons.dart';
+import 'server_messages_dialog.dart';
 import 'settings/settings_panel.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
@@ -56,6 +58,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     _prefs.addListener(_onPrefsChanged);
     _viewsRepo.addListener(_onViewsChanged);
     GetIt.instance<PluginSyncService>().addListener(_onPrefsChanged);
+    GetIt.instance<ServerMessagesService>().addListener(_onPrefsChanged);
     _userSub = _userRepo.currentUserStream.listen((_) => _loadUserImage());
     _loadUserImage();
     _loadLibraries();
@@ -65,6 +68,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
   void dispose() {
     try {
       GetIt.instance<PluginSyncService>().removeListener(_onPrefsChanged);
+      GetIt.instance<ServerMessagesService>().removeListener(_onPrefsChanged);
     } catch (_) {}
     _prefs.removeListener(_onPrefsChanged);
     try {
@@ -300,6 +304,25 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     } catch (_) {
       return false;
     }
+  }
+
+  /// The messages entry, or null when the user turned it off or the server has
+  /// no messages.
+  _BottomNavAction? _serverMessagesAction(
+    BuildContext context,
+    AppLocalizations l10n,
+  ) {
+    if (!_prefs.get(UserPreferences.showServerMessagesButton)) return null;
+
+    final service = GetIt.instance<ServerMessagesService>();
+    if (service.messages.isEmpty) return null;
+
+    return _BottomNavAction(
+      icon: Icons.info_outline_rounded,
+      label: l10n.serverMessages,
+      isActive: service.unreadCount > 0,
+      onTap: () => showServerMessagesDialog(context),
+    );
   }
 
   _BottomNavAction _settingsAction(
@@ -620,8 +643,9 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final content = _contentActions(context, l10n);
+    final messages = _serverMessagesAction(context, l10n);
     final settings = _settingsAction(context, l10n);
-    final actions = <_BottomNavAction>[...content, settings];
+    final actions = <_BottomNavAction>[...content, ?messages, settings];
 
     const maxInline = 5;
     final List<_BottomNavAction> tabs;

--- a/lib/ui/widgets/server_messages_dialog.dart
+++ b/lib/ui/widgets/server_messages_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
@@ -8,6 +10,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../data/models/server_message.dart';
 import '../../data/services/server_messages_service.dart';
 import '../../l10n/app_localizations.dart';
+import '../../util/focus/dpad_keys.dart';
 import '../../util/focus/key_event_utils.dart';
 import '../../util/overview_text.dart';
 import '../navigation/app_router.dart';
@@ -40,9 +43,15 @@ void openServerMessagesFromNotification() {
 Future<void> showServerMessagesDialog(BuildContext context) {
   final service = GetIt.instance<ServerMessagesService>();
 
+  // The shared default of 440 leaves a long message in a narrow column, which
+  // reads badly on a TV. Never go under the 340 the dialog asks for, or the
+  // constraints stop being valid on a small phone.
+  final width = MediaQuery.sizeOf(context).width;
+
   return showStyledPlayerDialog<void>(
     context,
     title: AppLocalizations.of(context).serverMessages,
+    maxWidth: math.max(340.0, math.min(width - 80, 720.0)),
     builder: (dialogContext) => _ServerMessagesBody(service: service),
   );
 }
@@ -129,10 +138,24 @@ class _MessageCard extends StatefulWidget {
 }
 
 class _MessageCardState extends State<_MessageCard> {
+  final _cardFocus = FocusNode(debugLabel: 'ServerMessageCard');
+  final _actionFocus = FocusNode(debugLabel: 'ServerMessageAction');
   bool _expanded = false;
   bool _focused = false;
 
+  @override
+  void dispose() {
+    _cardFocus.dispose();
+    _actionFocus.dispose();
+    super.dispose();
+  }
+
   void _toggle() {
+    // Collapsing takes the button away, so pull focus back to the card first
+    // or it lands nowhere.
+    if (_expanded && _actionFocus.hasFocus) {
+      _cardFocus.requestFocus();
+    }
     setState(() => _expanded = !_expanded);
     if (_expanded && !widget.read) {
       widget.onRead();
@@ -145,9 +168,29 @@ class _MessageCardState extends State<_MessageCard> {
     final color = serverMessageColor(message.color);
     final body = cleanOverview(message.body);
 
+    final canEnterAction = _expanded && message.hasAction;
+
     return Focus(
+      focusNode: _cardFocus,
       onFocusChange: (focused) => setState(() => _focused = focused),
-      onKeyEvent: (node, event) => handleOneShotSelect(event, _toggle),
+      onKeyEvent: (node, event) {
+        // The card wraps its button, so the button sits inside the card's own
+        // rectangle and never counts as being below it. Without this, pressing
+        // down skips to the next message and the button cannot be reached with
+        // a remote.
+        //
+        // Only when the card itself holds focus. Key events travel up from the
+        // button to here, so without that check pressing down on the button
+        // would send focus straight back to it and trap the remote.
+        if (canEnterAction &&
+            _cardFocus.hasPrimaryFocus &&
+            event.isActionable &&
+            event.logicalKey.isDownKey) {
+          _actionFocus.requestFocus();
+          return KeyEventResult.handled;
+        }
+        return handleOneShotSelect(event, _toggle);
+      },
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: GestureDetector(
@@ -237,6 +280,8 @@ class _MessageCardState extends State<_MessageCard> {
                         if (_expanded && message.hasAction) ...[
                           const SizedBox(height: 10),
                           _DialogTextButton(
+                            focusNode: _actionFocus,
+                            onFocusUp: _cardFocus.requestFocus,
                             label: message.actionLabel!,
                             onPressed: () => showQrOrLaunch(
                               context,
@@ -263,8 +308,18 @@ class _MessageCardState extends State<_MessageCard> {
 class _DialogTextButton extends StatefulWidget {
   final String label;
   final VoidCallback onPressed;
+  final FocusNode? focusNode;
 
-  const _DialogTextButton({required this.label, required this.onPressed});
+  /// Called when the remote presses up, so the card that owns this button can
+  /// take focus back instead of the list jumping past it.
+  final VoidCallback? onFocusUp;
+
+  const _DialogTextButton({
+    required this.label,
+    required this.onPressed,
+    this.focusNode,
+    this.onFocusUp,
+  });
 
   @override
   State<_DialogTextButton> createState() => _DialogTextButtonState();
@@ -276,8 +331,16 @@ class _DialogTextButtonState extends State<_DialogTextButton> {
   @override
   Widget build(BuildContext context) {
     return Focus(
+      focusNode: widget.focusNode,
       onFocusChange: (focused) => setState(() => _focused = focused),
-      onKeyEvent: (node, event) => handleOneShotSelect(event, widget.onPressed),
+      onKeyEvent: (node, event) {
+        final goUp = widget.onFocusUp;
+        if (goUp != null && event.isActionable && event.logicalKey.isUpKey) {
+          goUp();
+          return KeyEventResult.handled;
+        }
+        return handleOneShotSelect(event, widget.onPressed);
+      },
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: GestureDetector(

--- a/lib/ui/widgets/server_messages_dialog.dart
+++ b/lib/ui/widgets/server_messages_dialog.dart
@@ -1,0 +1,308 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../data/models/server_message.dart';
+import '../../data/services/server_messages_service.dart';
+import '../../l10n/app_localizations.dart';
+import '../../util/focus/key_event_utils.dart';
+import '../../util/overview_text.dart';
+import '../navigation/app_router.dart';
+import 'support_dialog.dart';
+import 'track_selector_dialog.dart';
+
+/// Colour used for a message and for the menu button when it is unread.
+Color serverMessageColor(ServerMessageSeverity severity) => switch (severity) {
+  ServerMessageSeverity.critical => AppColorScheme.statusError,
+  ServerMessageSeverity.warning => AppColorScheme.statusPending,
+  ServerMessageSeverity.info => AppColorScheme.statusAvailable,
+};
+
+IconData _severityIcon(ServerMessageSeverity severity) => switch (severity) {
+  ServerMessageSeverity.critical => Icons.error_outline_rounded,
+  ServerMessageSeverity.warning => Icons.warning_amber_rounded,
+  ServerMessageSeverity.info => Icons.info_outline_rounded,
+};
+
+/// Route the server sends with a message push. Not a page: it tells the app to
+/// open the messages window.
+const serverMessagesPushRoute = 'messages';
+
+/// Opens the messages window after a tap on a notification, where there is no
+/// widget context to hand in.
+void openServerMessagesFromNotification() {
+  final context = appRouter.routerDelegate.navigatorKey.currentContext;
+  if (context == null || !context.mounted) return;
+  showServerMessagesDialog(context);
+}
+
+/// Opens the window listing the messages the server admin sent.
+Future<void> showServerMessagesDialog(BuildContext context) {
+  final service = GetIt.instance<ServerMessagesService>();
+
+  return showStyledPlayerDialog<void>(
+    context,
+    title: AppLocalizations.of(context).serverMessages,
+    builder: (dialogContext) => _ServerMessagesBody(service: service),
+  );
+}
+
+class _ServerMessagesBody extends StatelessWidget {
+  final ServerMessagesService service;
+
+  const _ServerMessagesBody({required this.service});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return ListenableBuilder(
+      listenable: service,
+      builder: (context, _) {
+        final messages = service.messages;
+
+        if (messages.isEmpty) {
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(24, 12, 24, 20),
+            child: Text(
+              l10n.serverMessagesEmpty,
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+              ),
+            ),
+          );
+        }
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.fromLTRB(16, 4, 16, 4),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    for (final message in messages)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: _MessageCard(
+                          key: ValueKey(message.id),
+                          message: message,
+                          read: service.isRead(message.id),
+                          onRead: () => service.markRead(message.id),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            if (service.unreadCount > 0)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                child: _DialogTextButton(
+                  label: l10n.serverMessagesMarkAllRead,
+                  onPressed: service.markAllRead,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _MessageCard extends StatefulWidget {
+  final ServerMessage message;
+  final bool read;
+  final VoidCallback onRead;
+
+  const _MessageCard({
+    super.key,
+    required this.message,
+    required this.read,
+    required this.onRead,
+  });
+
+  @override
+  State<_MessageCard> createState() => _MessageCardState();
+}
+
+class _MessageCardState extends State<_MessageCard> {
+  bool _expanded = false;
+  bool _focused = false;
+
+  void _toggle() {
+    setState(() => _expanded = !_expanded);
+    if (_expanded && !widget.read) {
+      widget.onRead();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final message = widget.message;
+    final color = serverMessageColor(message.severity);
+    final body = cleanOverview(message.body);
+
+    return Focus(
+      onFocusChange: (focused) => setState(() => _focused = focused),
+      onKeyEvent: (node, event) => handleOneShotSelect(event, _toggle),
+      child: GestureDetector(
+        onTap: _toggle,
+        child: GlassSurface(
+          cornerRadius: 16,
+          reinforced: true,
+          fallbackColor: AppColorScheme.surfaceVariant.withValues(alpha: 0.95),
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: AppRadius.circular(16),
+              border: Border.fromBorderSide(
+                _focused
+                    ? BorderSide(color: color, width: 2)
+                    : BorderSide(color: color.withValues(alpha: 0.35)),
+              ),
+            ),
+            padding: const EdgeInsets.all(14),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(_severityIcon(message.severity), size: 22, color: color),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              message.title.isNotEmpty
+                                  ? message.title
+                                  : AppLocalizations.of(
+                                      context,
+                                    ).serverMessages,
+                              style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.w600,
+                                color: AppColorScheme.onSurface,
+                              ),
+                            ),
+                          ),
+                          if (!widget.read)
+                            Container(
+                              width: 8,
+                              height: 8,
+                              margin: const EdgeInsets.only(left: 8),
+                              decoration: BoxDecoration(
+                                color: color,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                        ],
+                      ),
+                      if (message.createdUtc != null) ...[
+                        const SizedBox(height: 2),
+                        Text(
+                          DateFormat.yMMMd().add_jm().format(
+                            message.createdUtc!.toLocal(),
+                          ),
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: AppColorScheme.onSurface.withValues(
+                              alpha: 0.5,
+                            ),
+                          ),
+                        ),
+                      ],
+                      if (body.isNotEmpty) ...[
+                        const SizedBox(height: 6),
+                        AnimatedSize(
+                          duration: const Duration(milliseconds: 150),
+                          alignment: Alignment.topLeft,
+                          child: Text(
+                            body,
+                            maxLines: _expanded ? null : 2,
+                            overflow: _expanded
+                                ? TextOverflow.visible
+                                : TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 13,
+                              height: 1.35,
+                              color: AppColorScheme.onSurface.withValues(
+                                alpha: 0.75,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                      if (_expanded && message.hasAction) ...[
+                        const SizedBox(height: 10),
+                        _DialogTextButton(
+                          label: message.actionLabel!,
+                          onPressed: () => showQrOrLaunch(
+                            context,
+                            url: message.actionUrl!,
+                            title: message.actionLabel!,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small button used inside the messages window. Focusable so a remote can
+/// reach it.
+class _DialogTextButton extends StatefulWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const _DialogTextButton({required this.label, required this.onPressed});
+
+  @override
+  State<_DialogTextButton> createState() => _DialogTextButtonState();
+}
+
+class _DialogTextButtonState extends State<_DialogTextButton> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      onFocusChange: (focused) => setState(() => _focused = focused),
+      onKeyEvent: (node, event) =>
+          handleOneShotSelect(event, widget.onPressed),
+      child: GestureDetector(
+        onTap: widget.onPressed,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            color: _focused
+                ? AppColorScheme.accent
+                : AppColorScheme.accent.withValues(alpha: 0.16),
+            borderRadius: AppRadius.circular(8),
+          ),
+          child: Text(
+            widget.label,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+              color: _focused
+                  ? AppColorScheme.onAccent
+                  : AppColorScheme.onSurface,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/server_messages_dialog.dart
+++ b/lib/ui/widgets/server_messages_dialog.dart
@@ -39,8 +39,15 @@ void openServerMessagesFromNotification() {
   showServerMessagesDialog(context);
 }
 
+bool _dialogOpen = false;
+
 /// Opens the window listing the messages the server admin sent.
+///
+/// Only one at a time. The window follows the service, so a message that
+/// arrives while it is open shows up in place, and opening another over it
+/// would just stack two copies of the same list.
 Future<void> showServerMessagesDialog(BuildContext context) {
+  if (_dialogOpen) return Future<void>.value();
   final service = GetIt.instance<ServerMessagesService>();
 
   // The shared default of 440 leaves a long message in a narrow column, which
@@ -48,12 +55,13 @@ Future<void> showServerMessagesDialog(BuildContext context) {
   // constraints stop being valid on a small phone.
   final width = MediaQuery.sizeOf(context).width;
 
+  _dialogOpen = true;
   return showStyledPlayerDialog<void>(
     context,
     title: AppLocalizations.of(context).serverMessages,
     maxWidth: math.max(340.0, math.min(width - 80, 720.0)),
     builder: (dialogContext) => _ServerMessagesBody(service: service),
-  );
+  ).whenComplete(() => _dialogOpen = false);
 }
 
 class _ServerMessagesBody extends StatelessWidget {
@@ -416,8 +424,9 @@ class _MessageBody extends StatelessWidget {
       selectable: false,
       imageBuilder: (_, _, _) => const SizedBox.shrink(),
       onTapLink: (text, href, title) {
-        if (href == null || href.isEmpty) return;
-        showQrOrLaunch(context, url: href, title: text.isEmpty ? href : text);
+        final url = ServerMessage.webLink(href);
+        if (url == null) return;
+        showQrOrLaunch(context, url: url, title: text.isEmpty ? url : text);
       },
       // Based on the app theme so every element the parser can produce gets a
       // readable colour, not just the handful spelled out below.

--- a/lib/ui/widgets/server_messages_dialog.dart
+++ b/lib/ui/widgets/server_messages_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:markdown/markdown.dart' as md;
 import 'package:intl/intl.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
@@ -12,17 +14,14 @@ import '../navigation/app_router.dart';
 import 'support_dialog.dart';
 import 'track_selector_dialog.dart';
 
-/// Colour used for a message and for the menu button when it is unread.
-Color serverMessageColor(ServerMessageSeverity severity) => switch (severity) {
-  ServerMessageSeverity.critical => AppColorScheme.statusError,
-  ServerMessageSeverity.warning => AppColorScheme.statusPending,
-  ServerMessageSeverity.info => AppColorScheme.statusAvailable,
-};
-
-IconData _severityIcon(ServerMessageSeverity severity) => switch (severity) {
-  ServerMessageSeverity.critical => Icons.error_outline_rounded,
-  ServerMessageSeverity.warning => Icons.warning_amber_rounded,
-  ServerMessageSeverity.info => Icons.info_outline_rounded,
+/// The colour the admin picked, as drawn in the app. Fixed values rather than
+/// theme tokens, so a message marked blue looks blue on every theme.
+Color serverMessageColor(ServerMessageColor color) => switch (color) {
+  ServerMessageColor.green => const Color(0xFF4CAF6D),
+  ServerMessageColor.red => const Color(0xFFE05260),
+  ServerMessageColor.yellow => const Color(0xFFE0B040),
+  ServerMessageColor.blue => const Color(0xFF4A9EE0),
+  ServerMessageColor.white => const Color(0xFFE8EAED),
 };
 
 /// Route the server sends with a message push. Not a page: it tells the app to
@@ -143,115 +142,114 @@ class _MessageCardState extends State<_MessageCard> {
   @override
   Widget build(BuildContext context) {
     final message = widget.message;
-    final color = serverMessageColor(message.severity);
+    final color = serverMessageColor(message.color);
     final body = cleanOverview(message.body);
 
     return Focus(
       onFocusChange: (focused) => setState(() => _focused = focused),
       onKeyEvent: (node, event) => handleOneShotSelect(event, _toggle),
-      child: GestureDetector(
-        onTap: _toggle,
-        child: GlassSurface(
-          cornerRadius: 16,
-          reinforced: true,
-          fallbackColor: AppColorScheme.surfaceVariant.withValues(alpha: 0.95),
-          child: Container(
-            decoration: BoxDecoration(
-              borderRadius: AppRadius.circular(16),
-              border: Border.fromBorderSide(
-                _focused
-                    ? BorderSide(color: color, width: 2)
-                    : BorderSide(color: color.withValues(alpha: 0.35)),
-              ),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: _toggle,
+          child: GlassSurface(
+            cornerRadius: 16,
+            reinforced: true,
+            fallbackColor: AppColorScheme.surfaceVariant.withValues(
+              alpha: 0.95,
             ),
-            padding: const EdgeInsets.all(14),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Icon(_severityIcon(message.severity), size: 22, color: color),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Expanded(
-                            child: Text(
-                              message.title.isNotEmpty
-                                  ? message.title
-                                  : AppLocalizations.of(
-                                      context,
-                                    ).serverMessages,
-                              style: TextStyle(
-                                fontSize: 15,
-                                fontWeight: FontWeight.w600,
-                                color: AppColorScheme.onSurface,
-                              ),
-                            ),
-                          ),
-                          if (!widget.read)
-                            Container(
-                              width: 8,
-                              height: 8,
-                              margin: const EdgeInsets.only(left: 8),
-                              decoration: BoxDecoration(
-                                color: color,
-                                shape: BoxShape.circle,
-                              ),
-                            ),
-                        ],
-                      ),
-                      if (message.createdUtc != null) ...[
-                        const SizedBox(height: 2),
-                        Text(
-                          DateFormat.yMMMd().add_jm().format(
-                            message.createdUtc!.toLocal(),
-                          ),
-                          style: TextStyle(
-                            fontSize: 11,
-                            color: AppColorScheme.onSurface.withValues(
-                              alpha: 0.5,
-                            ),
-                          ),
-                        ),
-                      ],
-                      if (body.isNotEmpty) ...[
-                        const SizedBox(height: 6),
-                        AnimatedSize(
-                          duration: const Duration(milliseconds: 150),
-                          alignment: Alignment.topLeft,
-                          child: Text(
-                            body,
-                            maxLines: _expanded ? null : 2,
-                            overflow: _expanded
-                                ? TextOverflow.visible
-                                : TextOverflow.ellipsis,
-                            style: TextStyle(
-                              fontSize: 13,
-                              height: 1.35,
-                              color: AppColorScheme.onSurface.withValues(
-                                alpha: 0.75,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                      if (_expanded && message.hasAction) ...[
-                        const SizedBox(height: 10),
-                        _DialogTextButton(
-                          label: message.actionLabel!,
-                          onPressed: () => showQrOrLaunch(
-                            context,
-                            url: message.actionUrl!,
-                            title: message.actionLabel!,
-                          ),
-                        ),
-                      ],
-                    ],
-                  ),
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: AppRadius.circular(16),
+                border: Border.fromBorderSide(
+                  _focused
+                      ? BorderSide(color: color, width: 2)
+                      : BorderSide(color: color.withValues(alpha: 0.35)),
                 ),
-              ],
+              ),
+              padding: const EdgeInsets.all(14),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.info_outline_rounded, size: 22, color: color),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                message.title.isNotEmpty
+                                    ? message.title
+                                    : AppLocalizations.of(
+                                        context,
+                                      ).serverMessages,
+                                style: TextStyle(
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w600,
+                                  color: AppColorScheme.onSurface,
+                                ),
+                              ),
+                            ),
+                            if (!widget.read)
+                              Container(
+                                width: 8,
+                                height: 8,
+                                margin: const EdgeInsets.only(left: 8),
+                                decoration: BoxDecoration(
+                                  color: color,
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                          ],
+                        ),
+                        if (message.createdUtc != null) ...[
+                          const SizedBox(height: 2),
+                          Text(
+                            DateFormat.yMMMd().add_jm().format(
+                              message.createdUtc!.toLocal(),
+                            ),
+                            style: TextStyle(
+                              fontSize: 11,
+                              color: AppColorScheme.onSurface.withValues(
+                                alpha: 0.5,
+                              ),
+                            ),
+                          ),
+                        ],
+                        if (body.isNotEmpty) ...[
+                          const SizedBox(height: 6),
+                          AnimatedSize(
+                            duration: const Duration(milliseconds: 150),
+                            alignment: Alignment.topLeft,
+                            child: _expanded
+                                ? _MessageBody(markdown: body)
+                                : Text(
+                                    stripMarkdown(body),
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: _bodyTextStyle,
+                                  ),
+                          ),
+                        ],
+                        if (_expanded && message.hasAction) ...[
+                          const SizedBox(height: 10),
+                          _DialogTextButton(
+                            label: message.actionLabel!,
+                            onPressed: () => showQrOrLaunch(
+                              context,
+                              url: message.actionUrl!,
+                              title: message.actionLabel!,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -279,29 +277,128 @@ class _DialogTextButtonState extends State<_DialogTextButton> {
   Widget build(BuildContext context) {
     return Focus(
       onFocusChange: (focused) => setState(() => _focused = focused),
-      onKeyEvent: (node, event) =>
-          handleOneShotSelect(event, widget.onPressed),
-      child: GestureDetector(
-        onTap: widget.onPressed,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
-          decoration: BoxDecoration(
-            color: _focused
-                ? AppColorScheme.accent
-                : AppColorScheme.accent.withValues(alpha: 0.16),
-            borderRadius: AppRadius.circular(8),
-          ),
-          child: Text(
-            widget.label,
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w600,
+      onKeyEvent: (node, event) => handleOneShotSelect(event, widget.onPressed),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: widget.onPressed,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+            decoration: BoxDecoration(
               color: _focused
-                  ? AppColorScheme.onAccent
-                  : AppColorScheme.onSurface,
+                  ? AppColorScheme.accent
+                  : AppColorScheme.accent.withValues(alpha: 0.16),
+              borderRadius: AppRadius.circular(8),
+            ),
+            child: Text(
+              widget.label,
+              style: TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: _focused
+                    ? AppColorScheme.onAccent
+                    : AppColorScheme.onSurface,
+              ),
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+final _bodyTextStyle = TextStyle(
+  fontSize: 13,
+  height: 1.35,
+  color: AppColorScheme.onSurface.withValues(alpha: 0.75),
+);
+
+/// Markdown syntax to drop from the one-line preview on a collapsed card, so it
+/// reads as a sentence instead of showing asterisks and hashes.
+final _markdownNoise = RegExp(
+  r'^\s{0,3}#{1,6}\s+|^\s{0,3}>\s?|^\s{0,3}[-*+]\s+',
+  multiLine: true,
+);
+final _markdownEmphasis = RegExp(r'(\*{1,3}|_{1,3}|`)');
+final _markdownLink = RegExp(r'\[([^\]]*)\]\([^)]*\)');
+
+/// Flattens markdown to plain text for the collapsed preview.
+String stripMarkdown(String source) => source
+    .replaceAll(_markdownNoise, '')
+    .replaceAllMapped(_markdownLink, (m) => m[1] ?? '')
+    .replaceAll(_markdownEmphasis, '')
+    .replaceAll(RegExp(r'\n{2,}'), '\n')
+    .trim();
+
+/// The formatted body of an opened message.
+///
+/// Images are dropped on purpose: the body is admin free text, and loading a
+/// remote image from it would reach out to whatever host it names.
+class _MessageBody extends StatelessWidget {
+  final String markdown;
+
+  const _MessageBody({required this.markdown});
+
+  @override
+  Widget build(BuildContext context) {
+    final muted = AppColorScheme.onSurface.withValues(alpha: 0.75);
+
+    return MarkdownBody(
+      data: markdown,
+      shrinkWrap: true,
+      // The package defaults to GitHub flavour, which adds tables and task lists.
+      // Those do not fit a narrow card, so this keeps to plain CommonMark:
+      // headings, bold, italic, lists, quotes, code and links.
+      extensionSet: md.ExtensionSet.commonMark,
+      selectable: false,
+      imageBuilder: (_, _, _) => const SizedBox.shrink(),
+      onTapLink: (text, href, title) {
+        if (href == null || href.isEmpty) return;
+        showQrOrLaunch(context, url: href, title: text.isEmpty ? href : text);
+      },
+      // Based on the app theme so every element the parser can produce gets a
+      // readable colour, not just the handful spelled out below.
+      styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+        p: _bodyTextStyle,
+        h1: TextStyle(
+          fontSize: 17,
+          fontWeight: FontWeight.w700,
+          color: AppColorScheme.onSurface,
+        ),
+        h2: TextStyle(
+          fontSize: 15,
+          fontWeight: FontWeight.w700,
+          color: AppColorScheme.onSurface,
+        ),
+        h3: TextStyle(
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+          color: AppColorScheme.onSurface,
+        ),
+        strong: TextStyle(
+          fontWeight: FontWeight.w700,
+          color: AppColorScheme.onSurface,
+        ),
+        em: const TextStyle(fontStyle: FontStyle.italic),
+        a: TextStyle(color: AppColorScheme.accent),
+        listBullet: _bodyTextStyle,
+        blockquote: _bodyTextStyle,
+        code: TextStyle(fontFamily: 'monospace', fontSize: 12, color: muted),
+        del: _bodyTextStyle.copyWith(decoration: TextDecoration.lineThrough),
+        codeblockDecoration: BoxDecoration(
+          color: AppColorScheme.onSurface.withValues(alpha: 0.07),
+          borderRadius: AppRadius.circular(6),
+        ),
+        blockquoteDecoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              color: AppColorScheme.onSurface.withValues(alpha: 0.25),
+              width: 3,
+            ),
+          ),
+        ),
+        blockquotePadding: const EdgeInsets.only(left: 10),
+        blockSpacing: 6,
       ),
     );
   }

--- a/lib/ui/widgets/server_messages_nav_slot.dart
+++ b/lib/ui/widgets/server_messages_nav_slot.dart
@@ -4,16 +4,16 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../data/services/server_messages_service.dart';
 import '../../preference/user_preferences.dart';
-import 'server_messages_dialog.dart';
 
 /// Wraps the messages button for a nav bar.
 ///
 /// Renders nothing when the user turned the button off or the server has no
 /// messages, so the menu never shows a button that does nothing. Unread
-/// messages put a soft glow behind the icon in the colour of the most important
-/// one. The icon itself keeps the normal menu colour.
+/// messages get a faint plate behind the icon. The colour an admin picks for a
+/// message is only used inside the messages window, not here, so the menu stays
+/// calm no matter what was posted.
 class ServerMessagesNavSlot extends StatelessWidget {
-  final WidgetBuilder builder;
+  final Widget Function(BuildContext context, Color? glow) builder;
 
   const ServerMessagesNavSlot({super.key, required this.builder});
 
@@ -34,38 +34,13 @@ class ServerMessagesNavSlot extends StatelessWidget {
           return const SizedBox.shrink();
         }
 
-        final button = builder(context);
-        final severity = service.highestUnreadSeverity;
-        if (severity == null) {
-          return button;
-        }
-
-        // Sits behind the button and follows its size, so it keeps up with the
-        // label opening and closing. The inset keeps the glow smaller than the
-        // button so it reads as a hint rather than a filled disc.
-        final glow = serverMessageColor(severity);
-        return Stack(
-          children: [
-            Positioned.fill(
-              child: Padding(
-                padding: const EdgeInsets.all(9),
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: AppRadius.circular(999),
-                    color: glow.withValues(alpha: 0.07),
-                    boxShadow: [
-                      BoxShadow(
-                        color: glow.withValues(alpha: 0.20),
-                        blurRadius: 7,
-                        spreadRadius: -2,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            button,
-          ],
+        // The button paints this itself, so it lines up with the icon and keeps
+        // up with the label opening and closing.
+        return builder(
+          context,
+          service.hasUnread
+              ? AppColorScheme.onSurface.withValues(alpha: 0.16)
+              : null,
         );
       },
     );

--- a/lib/ui/widgets/server_messages_nav_slot.dart
+++ b/lib/ui/widgets/server_messages_nav_slot.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../data/services/server_messages_service.dart';
+import '../../preference/user_preferences.dart';
+import 'server_messages_dialog.dart';
+
+/// Wraps the messages button for a nav bar.
+///
+/// Renders nothing when the user turned the button off or the server has no
+/// messages, so the menu never shows a button that does nothing. Unread
+/// messages put a soft glow behind the icon in the colour of the most important
+/// one. The icon itself keeps the normal menu colour.
+class ServerMessagesNavSlot extends StatelessWidget {
+  final WidgetBuilder builder;
+
+  const ServerMessagesNavSlot({super.key, required this.builder});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!GetIt.instance<UserPreferences>().get(
+      UserPreferences.showServerMessagesButton,
+    )) {
+      return const SizedBox.shrink();
+    }
+
+    final service = GetIt.instance<ServerMessagesService>();
+
+    return ListenableBuilder(
+      listenable: service,
+      builder: (context, _) {
+        if (service.messages.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        final button = builder(context);
+        final severity = service.highestUnreadSeverity;
+        if (severity == null) {
+          return button;
+        }
+
+        // Sits behind the button and follows its size, so it keeps up with the
+        // label opening and closing. The inset keeps the glow smaller than the
+        // button so it reads as a hint rather than a filled disc.
+        final glow = serverMessageColor(severity);
+        return Stack(
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.all(9),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    borderRadius: AppRadius.circular(999),
+                    color: glow.withValues(alpha: 0.07),
+                    boxShadow: [
+                      BoxShadow(
+                        color: glow.withValues(alpha: 0.20),
+                        blurRadius: 7,
+                        spreadRadius: -2,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            button,
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/widgets/server_messages_nav_slot.dart
+++ b/lib/ui/widgets/server_messages_nav_slot.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
-import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../data/services/server_messages_service.dart';
 import '../../preference/user_preferences.dart';
@@ -8,12 +7,11 @@ import '../../preference/user_preferences.dart';
 /// Wraps the messages button for a nav bar.
 ///
 /// Renders nothing when the user turned the button off or the server has no
-/// messages, so the menu never shows a button that does nothing. Unread
-/// messages get a faint plate behind the icon. The colour an admin picks for a
-/// message is only used inside the messages window, not here, so the menu stays
-/// calm no matter what was posted.
+/// messages, so the menu never shows a button that does nothing. Hands the
+/// builder the number of unread messages, which the button draws as a red
+/// circle on its icon.
 class ServerMessagesNavSlot extends StatelessWidget {
-  final Widget Function(BuildContext context, Color? glow) builder;
+  final Widget Function(BuildContext context, int unread) builder;
 
   const ServerMessagesNavSlot({super.key, required this.builder});
 
@@ -34,14 +32,7 @@ class ServerMessagesNavSlot extends StatelessWidget {
           return const SizedBox.shrink();
         }
 
-        // The button paints this itself, so it lines up with the icon and keeps
-        // up with the label opening and closing.
-        return builder(
-          context,
-          service.hasUnread
-              ? AppColorScheme.onSurface.withValues(alpha: 0.16)
-              : null,
-        );
+        return builder(context, service.unreadCount);
       },
     );
   }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -1110,19 +1110,13 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
               _gap(),
               _orderButton(
                 order: 98,
-                child: ServerMessagesNavSlot(
-                  builder: (context, glow) => ExpandableIconButton(
-                    key: const ValueKey('toolbar_server_messages'),
-                    forceExpanded: alwaysExpanded,
-                    icon: Icons.info_outline_rounded,
-                    label: l10n.serverMessages,
-                    glowColor: glow,
-                    focusNode: _serverMessagesFocus,
-                    onPressed: () async {
-                      await showServerMessagesDialog(context);
-                      if (mounted) _serverMessagesFocus.requestFocus();
-                    },
-                  ),
+                // The slot is taken here rather than inside the builder, so the
+                // settings icon keeps its colour whether or not there are any
+                // messages to show.
+                child: _buildServerMessagesButton(
+                  navColor: nextNavColor(),
+                  alwaysExpanded: alwaysExpanded,
+                  label: l10n.serverMessages,
                 ),
               ),
               _orderButton(
@@ -1282,6 +1276,30 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
           );
         }
       },
+    );
+  }
+
+  /// The messages button, or nothing when there is nothing to show. The nav
+  /// colour is passed in so the caller decides which palette slot it takes.
+  Widget _buildServerMessagesButton({
+    required Color? navColor,
+    required bool alwaysExpanded,
+    required String label,
+  }) {
+    return ServerMessagesNavSlot(
+      builder: (context, glow) => ExpandableIconButton(
+        key: const ValueKey('toolbar_server_messages'),
+        forceExpanded: alwaysExpanded,
+        icon: Icons.info_outline_rounded,
+        label: label,
+        baseColor: navColor,
+        glowColor: glow,
+        focusNode: _serverMessagesFocus,
+        onPressed: () async {
+          await showServerMessagesDialog(context);
+          if (mounted) _serverMessagesFocus.requestFocus();
+        },
+      ),
     );
   }
 

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -1111,11 +1111,12 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
               _orderButton(
                 order: 98,
                 child: ServerMessagesNavSlot(
-                  builder: (context) => ExpandableIconButton(
+                  builder: (context, glow) => ExpandableIconButton(
                     key: const ValueKey('toolbar_server_messages'),
                     forceExpanded: alwaysExpanded,
                     icon: Icons.info_outline_rounded,
                     label: l10n.serverMessages,
+                    glowColor: glow,
                     focusNode: _serverMessagesFocus,
                     onPressed: () async {
                       await showServerMessagesDialog(context);

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -1281,24 +1281,32 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
 
   /// The messages button, or nothing when there is nothing to show. The nav
   /// colour is passed in so the caller decides which palette slot it takes.
+  /// The gap to the next button travels with it, so it only takes up room when
+  /// the button is there.
   Widget _buildServerMessagesButton({
     required Color? navColor,
     required bool alwaysExpanded,
     required String label,
   }) {
     return ServerMessagesNavSlot(
-      builder: (context, unread) => ExpandableIconButton(
-        key: const ValueKey('toolbar_server_messages'),
-        forceExpanded: alwaysExpanded,
-        icon: Icons.info_outline_rounded,
-        label: label,
-        baseColor: navColor,
-        badgeCount: unread,
-        focusNode: _serverMessagesFocus,
-        onPressed: () async {
-          await showServerMessagesDialog(context);
-          if (mounted) _serverMessagesFocus.requestFocus();
-        },
+      builder: (context, unread) => Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ExpandableIconButton(
+            key: const ValueKey('toolbar_server_messages'),
+            forceExpanded: alwaysExpanded,
+            icon: Icons.info_outline_rounded,
+            label: label,
+            baseColor: navColor,
+            badgeCount: unread,
+            focusNode: _serverMessagesFocus,
+            onPressed: () async {
+              await showServerMessagesDialog(context);
+              if (mounted) _serverMessagesFocus.requestFocus();
+            },
+          ),
+          _gap(),
+        ],
       ),
     );
   }

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -1287,13 +1287,13 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     required String label,
   }) {
     return ServerMessagesNavSlot(
-      builder: (context, glow) => ExpandableIconButton(
+      builder: (context, unread) => ExpandableIconButton(
         key: const ValueKey('toolbar_server_messages'),
         forceExpanded: alwaysExpanded,
         icon: Icons.info_outline_rounded,
         label: label,
         baseColor: navColor,
-        glowColor: glow,
+        badgeCount: unread,
         focusNode: _serverMessagesFocus,
         onPressed: () async {
           await showServerMessagesDialog(context);

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -31,6 +31,8 @@ import 'settings/settings_panel.dart';
 import '../screens/settings/settings_side_panel.dart';
 import '../screens/syncplay/syncplay_screen.dart';
 import 'seerr_icons.dart';
+import 'server_messages_dialog.dart';
+import 'server_messages_nav_slot.dart';
 import 'shuffle_overlay.dart';
 import 'user_menu_dialog.dart';
 
@@ -110,6 +112,9 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
   final _avatarFocus = FocusNode();
   final _homeFocus = FocusNode(debugLabel: 'TopToolbarHome');
   final _settingsFocus = FocusNode(debugLabel: 'TopToolbarSettings');
+  final _serverMessagesFocus = FocusNode(
+    debugLabel: 'TopToolbarServerMessages',
+  );
   final _inlineLibrariesTriggerFocus = FocusNode(
     debugLabel: 'TopToolbarInlineLibrariesTrigger',
   );
@@ -232,6 +237,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     _avatarFocus.dispose();
     _homeFocus.dispose();
     _settingsFocus.dispose();
+    _serverMessagesFocus.dispose();
     _inlineLibrariesTriggerFocus.dispose();
     _musicBarFocusNode.dispose();
     _userSub?.cancel();
@@ -1102,6 +1108,22 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                 ),
               ],
               _gap(),
+              _orderButton(
+                order: 98,
+                child: ServerMessagesNavSlot(
+                  builder: (context) => ExpandableIconButton(
+                    key: const ValueKey('toolbar_server_messages'),
+                    forceExpanded: alwaysExpanded,
+                    icon: Icons.info_outline_rounded,
+                    label: l10n.serverMessages,
+                    focusNode: _serverMessagesFocus,
+                    onPressed: () async {
+                      await showServerMessagesDialog(context);
+                      if (mounted) _serverMessagesFocus.requestFocus();
+                    },
+                  ),
+                ),
+              ),
               _orderButton(
                 order: 99,
                 child: ExpandableIconButton(

--- a/lib/ui/widgets/unread_badge.dart
+++ b/lib/ui/widgets/unread_badge.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+/// A small red circle with a count, sitting on the top right corner of [child].
+///
+/// Draws nothing when [count] is zero, so callers can pass the count straight
+/// through without checking first. Counts above 9 show as "9+" to keep the
+/// circle small enough for a collapsed navbar icon.
+class UnreadBadge extends StatelessWidget {
+  final int count;
+  final Widget child;
+
+  const UnreadBadge({super.key, required this.count, required this.child});
+
+  static const _badgeRed = Color(0xFFE03B36);
+
+  @override
+  Widget build(BuildContext context) {
+    if (count <= 0) return child;
+
+    final label = count > 9 ? '9+' : '$count';
+
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        child,
+        Positioned(
+          top: -5,
+          right: -8,
+          child: Container(
+            constraints: const BoxConstraints(minWidth: 16, minHeight: 16),
+            padding: const EdgeInsets.symmetric(horizontal: 4),
+            alignment: Alignment.center,
+            decoration: const BoxDecoration(
+              color: _badgeRed,
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              label,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 10,
+                height: 1.2,
+                fontWeight: FontWeight.w700,
+                decoration: TextDecoration.none,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -704,6 +704,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_markdown_plus:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown_plus
+      sha256: fce641d6c2106cc495de1cd603f97a4f9d615a97a64011928ded380dbdade935
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.12"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1151,6 +1159,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: "direct main"
+    description:
+      name: markdown
+      sha256: ee85086ad7698b42522c6ad42fe195f1b9898e4d974a1af4576c1a3a176cada9
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.1"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -188,6 +188,8 @@ dependencies:
   firebase_core: ^4.11.0
   firebase_messaging: ^16.4.1
   pointer_interceptor: ^0.10.1+2
+  flutter_markdown_plus: ^1.0.12
+  markdown: ^7.3.1
 
 dev_dependencies:
   flutter_test:

--- a/test/data/services/server_messages_service_test.dart
+++ b/test/data/services/server_messages_service_test.dart
@@ -46,7 +46,6 @@ Map<String, dynamic> _message(
   String id, {
   String color = 'white',
   String delivery = 'inbox',
-  bool pinned = false,
   String createdUtc = '2026-08-24T12:00:00Z',
 }) => {
   'id': id,
@@ -54,7 +53,6 @@ Map<String, dynamic> _message(
   'body': 'Body $id',
   'color': color,
   'delivery': delivery,
-  'pinned': pinned,
   'createdUtc': createdUtc,
 };
 
@@ -104,16 +102,12 @@ void main() {
     expect(service.messages, isEmpty);
   });
 
-  test('pinned messages come first, then the newest', () async {
-    adapter.items = [
-      _message('old', createdUtc: '2026-08-01T12:00:00Z'),
-      _message('new', createdUtc: '2026-08-20T12:00:00Z'),
-      _message('pin', pinned: true, createdUtc: '2026-07-01T12:00:00Z'),
-    ];
+  test('messages keep the order the server sent them', () async {
+    adapter.items = [_message('c'), _message('a'), _message('b')];
 
     await service.refresh(client);
 
-    expect(service.messages.map((m) => m.id), ['pin', 'new', 'old']);
+    expect(service.messages.map((m) => m.id), ['c', 'a', 'b']);
   });
 
   test('the unread flag clears once everything is read', () async {
@@ -169,7 +163,6 @@ void main() {
   test('only popup messages are pending, and marking them clears them', () async {
     adapter.items = [
       _message('quiet', delivery: 'inbox'),
-      _message('toast', delivery: 'toast'),
       _message('loud', delivery: 'popup'),
     ];
     await service.refresh(client);
@@ -180,7 +173,7 @@ void main() {
 
     expect(service.pendingPopups, isEmpty);
     expect(service.isRead('loud'), isTrue);
-    expect(service.isRead('toast'), isFalse, reason: 'only popups were marked');
+    expect(service.isRead('quiet'), isFalse, reason: 'only popups were marked');
   });
 
   test('a failed request keeps the messages already loaded', () async {
@@ -215,14 +208,12 @@ void main() {
         'Body': 'World',
         'Color': 'red',
         'Delivery': 'popup',
-        'Pinned': true,
       });
 
       expect(message, isNotNull);
       expect(message!.title, 'Hello');
       expect(message.color, ServerMessageColor.red);
       expect(message.delivery, ServerMessageDelivery.popup);
-      expect(message.pinned, isTrue);
     });
 
     test('unknown colour and delivery fall back to the quiet defaults', () {

--- a/test/data/services/server_messages_service_test.dart
+++ b/test/data/services/server_messages_service_test.dart
@@ -44,7 +44,7 @@ class _MessagesAdapter implements HttpClientAdapter {
 
 Map<String, dynamic> _message(
   String id, {
-  String severity = 'info',
+  String color = 'white',
   String delivery = 'inbox',
   bool pinned = false,
   String createdUtc = '2026-08-24T12:00:00Z',
@@ -52,7 +52,7 @@ Map<String, dynamic> _message(
   'id': id,
   'title': 'Title $id',
   'body': 'Body $id',
-  'severity': severity,
+  'color': color,
   'delivery': delivery,
   'pinned': pinned,
   'createdUtc': createdUtc,
@@ -116,24 +116,18 @@ void main() {
     expect(service.messages.map((m) => m.id), ['pin', 'new', 'old']);
   });
 
-  test('the button colour follows the most important unread message', () async {
-    adapter.items = [
-      _message('info', severity: 'info'),
-      _message('warn', severity: 'warning'),
-      _message('crit', severity: 'critical'),
-    ];
+  test('the unread flag clears once everything is read', () async {
+    adapter.items = [_message('a'), _message('b')];
     await service.refresh(client);
 
-    expect(service.highestUnreadSeverity, ServerMessageSeverity.critical);
+    expect(service.hasUnread, isTrue);
+    expect(service.unreadCount, 2);
 
-    await service.markRead('crit');
-    expect(service.highestUnreadSeverity, ServerMessageSeverity.warning);
+    await service.markRead('a');
+    expect(service.hasUnread, isTrue);
 
-    await service.markRead('warn');
-    expect(service.highestUnreadSeverity, ServerMessageSeverity.info);
-
-    await service.markRead('info');
-    expect(service.highestUnreadSeverity, isNull);
+    await service.markRead('b');
+    expect(service.hasUnread, isFalse);
     expect(service.unreadCount, 0);
   });
 
@@ -219,27 +213,27 @@ void main() {
         'Id': 'x',
         'Title': 'Hello',
         'Body': 'World',
-        'Severity': 'critical',
+        'Color': 'red',
         'Delivery': 'popup',
         'Pinned': true,
       });
 
       expect(message, isNotNull);
       expect(message!.title, 'Hello');
-      expect(message.severity, ServerMessageSeverity.critical);
+      expect(message.color, ServerMessageColor.red);
       expect(message.delivery, ServerMessageDelivery.popup);
       expect(message.pinned, isTrue);
     });
 
-    test('unknown severity and delivery fall back to the quiet defaults', () {
+    test('unknown colour and delivery fall back to the quiet defaults', () {
       final message = ServerMessage.fromJson({
         'id': 'x',
         'title': 'Hello',
-        'severity': 'apocalyptic',
+        'color': 'chartreuse',
         'delivery': 'smoke-signal',
       });
 
-      expect(message!.severity, ServerMessageSeverity.info);
+      expect(message!.color, ServerMessageColor.white);
       expect(message.delivery, ServerMessageDelivery.inbox);
     });
 

--- a/test/data/services/server_messages_service_test.dart
+++ b/test/data/services/server_messages_service_test.dart
@@ -252,5 +252,43 @@ void main() {
       });
       expect(labelOnly!.hasAction, isFalse);
     });
+
+    test('an action link has to be a web address', () {
+      ServerMessage parse(String url) => ServerMessage.fromJson({
+        'id': 'x',
+        'title': 'T',
+        'actionLabel': 'Open',
+        'actionUrl': url,
+      })!;
+
+      expect(parse('https://example.com/a').hasAction, isTrue);
+      expect(parse('http://example.com').hasAction, isTrue);
+
+      // Anything else would go straight to the system launcher.
+      for (final url in [
+        'javascript:alert(1)',
+        'file:///etc/passwd',
+        'moonfin://server/item/1',
+        'intent://x#Intent;scheme=http;end',
+        'data:text/html,hi',
+        'example.com',
+        'ht tp://broken',
+        ':::',
+      ]) {
+        expect(parse(url).hasAction, isFalse, reason: url);
+        expect(parse(url).actionUrl, isNull, reason: url);
+      }
+    });
+
+    test('links inside the body are held to the same rule', () {
+      expect(ServerMessage.webLink('https://a.test/x'), 'https://a.test/x');
+      expect(ServerMessage.webLink('  https://a.test/x  '), 'https://a.test/x');
+      expect(ServerMessage.webLink('javascript:alert(1)'), isNull);
+      expect(ServerMessage.webLink('moonfin://x'), isNull);
+      expect(ServerMessage.webLink('http://[bad'), isNull);
+      expect(ServerMessage.webLink('https://'), isNull);
+      expect(ServerMessage.webLink(''), isNull);
+      expect(ServerMessage.webLink(null), isNull);
+    });
   });
 }

--- a/test/data/services/server_messages_service_test.dart
+++ b/test/data/services/server_messages_service_test.dart
@@ -1,0 +1,271 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/models/server_message.dart';
+import 'package:moonfin/data/services/server_messages_service.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockClient extends Mock implements MediaServerClient {}
+
+/// Serves whatever the test puts in [items] from /Moonfin/Messages.
+class _MessagesAdapter implements HttpClientAdapter {
+  List<Map<String, dynamic>> items = [];
+  int status = 200;
+  int calls = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    calls++;
+    if (status != 200) {
+      return ResponseBody.fromString('', status);
+    }
+    return ResponseBody.fromString(
+      jsonEncode({'items': items}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _message(
+  String id, {
+  String severity = 'info',
+  String delivery = 'inbox',
+  bool pinned = false,
+  String createdUtc = '2026-08-24T12:00:00Z',
+}) => {
+  'id': id,
+  'title': 'Title $id',
+  'body': 'Body $id',
+  'severity': severity,
+  'delivery': delivery,
+  'pinned': pinned,
+  'createdUtc': createdUtc,
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MessagesAdapter adapter;
+  late ServerMessagesService service;
+  late _MockClient client;
+  late PreferenceStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({'pref_last_user_id': 'user1'});
+    store = PreferenceStore();
+    await store.init();
+
+    client = _MockClient();
+    when(() => client.baseUrl).thenReturn('http://plugin.test');
+    when(() => client.accessToken).thenReturn('token');
+    when(() => client.deviceInfo).thenReturn(
+      const DeviceInfo(
+        id: 'dev1',
+        name: 'test',
+        appName: 'moonfin',
+        appVersion: '0.0.0',
+      ),
+    );
+
+    adapter = _MessagesAdapter();
+    final dio = Dio();
+    dio.httpClientAdapter = adapter;
+    service = ServerMessagesService(store, dio: dio);
+    service.setSupported(true);
+  });
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  test('no request is made when the plugin does not support messages', () async {
+    service.setSupported(false);
+    adapter.items = [_message('a')];
+
+    await service.refresh(client);
+
+    expect(adapter.calls, 0);
+    expect(service.messages, isEmpty);
+  });
+
+  test('pinned messages come first, then the newest', () async {
+    adapter.items = [
+      _message('old', createdUtc: '2026-08-01T12:00:00Z'),
+      _message('new', createdUtc: '2026-08-20T12:00:00Z'),
+      _message('pin', pinned: true, createdUtc: '2026-07-01T12:00:00Z'),
+    ];
+
+    await service.refresh(client);
+
+    expect(service.messages.map((m) => m.id), ['pin', 'new', 'old']);
+  });
+
+  test('the button colour follows the most important unread message', () async {
+    adapter.items = [
+      _message('info', severity: 'info'),
+      _message('warn', severity: 'warning'),
+      _message('crit', severity: 'critical'),
+    ];
+    await service.refresh(client);
+
+    expect(service.highestUnreadSeverity, ServerMessageSeverity.critical);
+
+    await service.markRead('crit');
+    expect(service.highestUnreadSeverity, ServerMessageSeverity.warning);
+
+    await service.markRead('warn');
+    expect(service.highestUnreadSeverity, ServerMessageSeverity.info);
+
+    await service.markRead('info');
+    expect(service.highestUnreadSeverity, isNull);
+    expect(service.unreadCount, 0);
+  });
+
+  test('read state survives a reload of the service', () async {
+    adapter.items = [_message('a'), _message('b')];
+    await service.refresh(client);
+    await service.markRead('a');
+
+    final reloaded = ServerMessagesService(store, dio: Dio()..httpClientAdapter = adapter);
+    reloaded.setSupported(true);
+    await reloaded.refresh(client);
+
+    expect(reloaded.isRead('a'), isTrue);
+    expect(reloaded.isRead('b'), isFalse);
+    expect(reloaded.unreadCount, 1);
+  });
+
+  test('read IDs for deleted messages are dropped', () async {
+    adapter.items = [_message('a'), _message('b')];
+    await service.refresh(client);
+    await service.markRead('a');
+    await service.markRead('b');
+
+    // The admin deletes both and posts a new one.
+    adapter.items = [_message('c')];
+    await service.refresh(client);
+
+    expect(service.unreadCount, 1);
+    expect(service.isRead('a'), isFalse);
+
+    // The stored list was really trimmed, not just filtered in memory: a fresh
+    // service reading the same preferences also sees "a" as unread.
+    final readKey = store.keys
+        .where((key) => key.startsWith('pref_server_messages_read_'))
+        .single;
+    expect(store.getStringList(readKey), isEmpty);
+  });
+
+  test('only popup messages are pending, and marking them clears them', () async {
+    adapter.items = [
+      _message('quiet', delivery: 'inbox'),
+      _message('toast', delivery: 'toast'),
+      _message('loud', delivery: 'popup'),
+    ];
+    await service.refresh(client);
+
+    expect(service.pendingPopups.map((m) => m.id), ['loud']);
+
+    await service.markPopupsRead();
+
+    expect(service.pendingPopups, isEmpty);
+    expect(service.isRead('loud'), isTrue);
+    expect(service.isRead('toast'), isFalse, reason: 'only popups were marked');
+  });
+
+  test('a failed request keeps the messages already loaded', () async {
+    adapter.items = [_message('a')];
+    await service.refresh(client);
+    expect(service.messages, hasLength(1));
+
+    adapter.status = 500;
+    await service.refresh(client);
+
+    expect(service.messages, hasLength(1));
+  });
+
+  test('clear forgets everything so the next user starts fresh', () async {
+    adapter.items = [_message('a')];
+    await service.refresh(client);
+    await service.markRead('a');
+
+    service.clear();
+
+    expect(service.messages, isEmpty);
+    expect(service.unreadCount, 0);
+    expect(service.isRead('a'), isFalse);
+    expect(service.supported, isFalse);
+  });
+
+  group('parsing', () {
+    test('PascalCase keys from Emby are read', () {
+      final message = ServerMessage.fromJson({
+        'Id': 'x',
+        'Title': 'Hello',
+        'Body': 'World',
+        'Severity': 'critical',
+        'Delivery': 'popup',
+        'Pinned': true,
+      });
+
+      expect(message, isNotNull);
+      expect(message!.title, 'Hello');
+      expect(message.severity, ServerMessageSeverity.critical);
+      expect(message.delivery, ServerMessageDelivery.popup);
+      expect(message.pinned, isTrue);
+    });
+
+    test('unknown severity and delivery fall back to the quiet defaults', () {
+      final message = ServerMessage.fromJson({
+        'id': 'x',
+        'title': 'Hello',
+        'severity': 'apocalyptic',
+        'delivery': 'smoke-signal',
+      });
+
+      expect(message!.severity, ServerMessageSeverity.info);
+      expect(message.delivery, ServerMessageDelivery.inbox);
+    });
+
+    test('a message with no ID or no text is skipped', () {
+      expect(ServerMessage.fromJson({'title': 'No id'}), isNull);
+      expect(
+        ServerMessage.fromJson({'id': 'x', 'title': '  ', 'body': ''}),
+        isNull,
+      );
+    });
+
+    test('an action needs both a label and a link to count', () {
+      final full = ServerMessage.fromJson({
+        'id': 'x',
+        'title': 'T',
+        'actionLabel': 'Open',
+        'actionUrl': 'https://example.com',
+      });
+      expect(full!.hasAction, isTrue);
+
+      final labelOnly = ServerMessage.fromJson({
+        'id': 'y',
+        'title': 'T',
+        'actionLabel': 'Open',
+      });
+      expect(labelOnly!.hasAction, isFalse);
+    });
+  });
+}

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -206,6 +206,7 @@ void main() {
     'showLibrariesInToolbar',
     'showMediaDetailsOnLibraryPage',
     'showSeerrButton',
+    'showServerMessagesButton',
     'showShuffleButton',
     'showSyncPlayButton',
     'shuffleContentType',

--- a/test/ui/widgets/server_message_markdown_test.dart
+++ b/test/ui/widgets/server_message_markdown_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/server_messages_dialog.dart';
+
+void main() {
+  group('stripMarkdown', () {
+    test('drops heading, quote and list markers', () {
+      expect(stripMarkdown('## Maintenance'), 'Maintenance');
+      expect(stripMarkdown('> heads up'), 'heads up');
+      expect(stripMarkdown('- first\n- second'), 'first\nsecond');
+      expect(stripMarkdown('* starred'), 'starred');
+    });
+
+    test('drops emphasis and code marks but keeps the words', () {
+      expect(stripMarkdown('**bold** and *italic*'), 'bold and italic');
+      expect(stripMarkdown('__strong__ and _thin_'), 'strong and thin');
+      expect(stripMarkdown('use `curl` here'), 'use curl here');
+    });
+
+    test('keeps the link text and drops the URL', () {
+      expect(
+        stripMarkdown('see [the notes](https://example.com/a_b)'),
+        'see the notes',
+      );
+    });
+
+    test('collapses blank lines so the preview stays on few lines', () {
+      expect(stripMarkdown('one\n\n\ntwo'), 'one\ntwo');
+    });
+
+    test('leaves plain text alone', () {
+      expect(
+        stripMarkdown('Server reboot at 2am, sorry for the noise.'),
+        'Server reboot at 2am, sorry for the noise.',
+      );
+    });
+
+    test('a hash inside a sentence is not a heading', () {
+      expect(stripMarkdown('issue #1234 is fixed'), 'issue #1234 is fixed');
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Server admins had no way to tell their users anything that lasts. The plugin could already broadcast a line of text, but it was not saved and only reached people who had the app open at that moment, and it landed as a popup you could not dismiss without losing it. This adds a messages button to the menu and a window to read them, so a message waits for you.

## Related Issues
- Closes #
- Fixes #
- Related to [Plugin `feat/server-messages`](https://github.com/Moonfin-Client/Plugin/pull/258)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Features
- A messages button in the menu, next to the settings gear. It shows up in the top bar and the left sidebar. I'm wondering if we could move it to the user icon settings (servers, quickconnect, etc) on the top left corner, under a new entry below "Saved Medias".
- A red circle on the button with the number of messages you have not read.
- A window listing the messages. A card shows the title and the first two lines. Open it to read the full message.
- Message text can use Markdown, so an admin can write headings, bold, italic, lists and links.
- Each message carries the colour the admin picked: white, green, blue, yellow or red.
- An optional button at the end of a message that opens a link. On a TV it shows a QR code instead.
- Messages are cached, so the list still opens with no connection, and a message posted while the app was closed is there the next time you open it.
- The admin decides how loud each message is: a count on the button, or the window opening on its own once.
- The button is off by default. You can turn it on in Settings > Navigation, and an admin can turn it on for everyone from Moonbase default settings.

## Changes Made
- New `ServerMessagesService`: reads its cache first and then asks the server, so the list works offline. Which messages you have read is stored per server and per user, so reading one on one server does not mark it read on another.
- New messages window, built on the same dialog frame as the app update dialog. Cards open in place. Bodies render CommonMark through `flutter_markdown_plus`. Images and raw HTML are not rendered.
- New `UnreadBadge`, drawn by the button itself so it lines up with the icon and follows the label opening and closing.
- Broadcasts are saved as messages now, so the window handles them and nothing is lost if you miss it.
- Messages appear in the order the admin arranged them in Moonbase. The app does not sort them.
- Two new packages: `flutter_markdown_plus` for rendering and `markdown` for limiting what is parsed to CommonMark.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

macOS 26.3.1 on Apple Silicon, Android TV emulator, Android phone emulator, and the web build served by the plugin. Against a live Jellyfin 10.11 with the matching Moonbase build.

### Test Steps
1. With no messages on the server, the button is absent. Post one and it appears with a red cicle with 1 inside. ("Show messages button" setting needs to be enabled)
2. Open a message: the count drops and the circle goes away.
3. Post a message set to open the window, with the app closed. Open the app and the window comes up on its own, once.
4. Write a message with a heading, bold text, a list and a link. The closed card shows a plain sentence, the open one shows the formatting.
5. Kill the app and reopen it: the messages are still listed.
6. Move a message in Moonbase with the arrows. The app follows the same order.
7. On a TV, walk the list with the D-pad. Down from an open message reaches its link button, up goes back to the card, and the link shows a QR code.
8. Sign in as another user. You only see the messages meant for you.

## Screenshots (if applicable)
<img width="2032" height="1162" alt="Screenshot 2026-08-25 at 11 46 44" src="https://github.com/user-attachments/assets/355ad71e-d822-48af-af19-0c4bbbabdb3e" />
<img width="1840" height="1196" alt="Screenshot 2026-08-25 at 10 23 47" src="https://github.com/user-attachments/assets/1c438356-649e-4548-bac5-046050d1be86" />
<img width="1076" height="628" alt="Screenshot 2026-08-25 at 11 50 59" src="https://github.com/user-attachments/assets/b96e4692-77f0-4ea5-85ca-d33ecaae1162" />
<img width="1076" height="628" alt="Screenshot 2026-08-24 at 17 32 16" src="https://github.com/user-attachments/assets/0f5f5452-8139-4272-99ef-93b30c57fb09" />
<img width="1076" height="628" alt="Screenshot 2026-08-24 at 17 52 18" src="https://github.com/user-attachments/assets/063551db-8d7e-4653-a754-c8a7156c8e58" />
<img width="519" height="1034" alt="Screenshot 2026-08-24 at 17 53 10" src="https://github.com/user-attachments/assets/ef50dddf-a86c-480c-9eb9-7d3555dc8bfe" />
<img width="2032" height="1162" alt="Screenshot 2026-08-25 at 11 43 38" src="https://github.com/user-attachments/assets/f75dfe4b-1456-4313-9f0c-025746bfd2bf" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
