### PR TITLE
Feat: remote subtitle flags and feedback

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1689,6 +1689,14 @@
     "description": "Subtitle for the download subtitles option"
   },
   "downloadSubtitles": "Download Subtitles",
+  "searchingSubtitles": "Searching for subtitles\u2026",
+  "@searchingSubtitles": {
+    "description": "Shown while a remote subtitle search is running"
+  },
+  "downloadingSubtitle": "Downloading subtitle\u2026",
+  "@downloadingSubtitle": {
+    "description": "Shown while a chosen subtitle is downloaded and the server is picking it up"
+  },
   "@downloadSubtitles": {
     "description": "Dialog title for downloading remote subtitles"
   },
@@ -1945,6 +1953,27 @@
   "perfectMatch": "Perfect match",
   "@perfectMatch": {
     "description": "Label for a subtitle that is a hash match"
+  },
+  "aiTranslated": "AI translated",
+  "@aiTranslated": {
+    "description": "Label for a remote subtitle the provider marked as AI translated"
+  },
+  "machineTranslated": "Machine translated",
+  "@machineTranslated": {
+    "description": "Label for a remote subtitle the provider marked as machine translated"
+  },
+  "hearingImpaired": "SDH",
+  "@hearingImpaired": {
+    "description": "Label for a remote subtitle marked as hearing impaired"
+  },
+  "framerateFps": "{rate} fps",
+  "@framerateFps": {
+    "description": "Framerate of a remote subtitle, shown in its detail line",
+    "placeholders": {
+      "rate": {
+        "type": "String"
+      }
+    }
   },
   "channelsCount": "{count}ch",
   "@channelsCount": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1954,11 +1954,11 @@
   "@perfectMatch": {
     "description": "Label for a subtitle that is a hash match"
   },
-  "aiTranslated": "AI translated",
+  "aiTranslated": "AI Translated",
   "@aiTranslated": {
     "description": "Label for a remote subtitle the provider marked as AI translated"
   },
-  "machineTranslated": "Machine translated",
+  "machineTranslated": "Machine Translated",
   "@machineTranslated": {
     "description": "Label for a remote subtitle the provider marked as machine translated"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2689,13 +2689,13 @@ abstract class AppLocalizations {
   /// Label for a remote subtitle the provider marked as AI translated
   ///
   /// In en, this message translates to:
-  /// **'AI translated'**
+  /// **'AI Translated'**
   String get aiTranslated;
 
   /// Label for a remote subtitle the provider marked as machine translated
   ///
   /// In en, this message translates to:
-  /// **'Machine translated'**
+  /// **'Machine Translated'**
   String get machineTranslated;
 
   /// Label for a remote subtitle marked as hearing impaired

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2422,6 +2422,18 @@ abstract class AppLocalizations {
   /// **'Download Subtitles'**
   String get downloadSubtitles;
 
+  /// Shown while a remote subtitle search is running
+  ///
+  /// In en, this message translates to:
+  /// **'Searching for subtitles…'**
+  String get searchingSubtitles;
+
+  /// Shown while a chosen subtitle is downloaded and the server is picking it up
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading subtitle…'**
+  String get downloadingSubtitle;
+
   /// Error message when a selected subtitle is invalid
   ///
   /// In en, this message translates to:
@@ -2673,6 +2685,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Perfect match'**
   String get perfectMatch;
+
+  /// Label for a remote subtitle the provider marked as AI translated
+  ///
+  /// In en, this message translates to:
+  /// **'AI translated'**
+  String get aiTranslated;
+
+  /// Label for a remote subtitle the provider marked as machine translated
+  ///
+  /// In en, this message translates to:
+  /// **'Machine translated'**
+  String get machineTranslated;
+
+  /// Label for a remote subtitle marked as hearing impaired
+  ///
+  /// In en, this message translates to:
+  /// **'SDH'**
+  String get hearingImpaired;
+
+  /// Framerate of a remote subtitle, shown in its detail line
+  ///
+  /// In en, this message translates to:
+  /// **'{rate} fps'**
+  String framerateFps(String rate);
 
   /// Audio channel count label
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsAf extends AppLocalizations {
   String get downloadSubtitles => 'Laai onderskrifte af';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Die geselekteerde onderskrif is ongeldig.';
 
@@ -1432,6 +1438,20 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekte pasmaat';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1440,10 +1440,10 @@ class AppLocalizationsAf extends AppLocalizations {
   String get perfectMatch => 'Perfekte pasmaat';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1449,10 +1449,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get perfectMatch => 'مباراة مثالية';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1264,6 +1264,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get downloadSubtitles => 'تحميل ترجمات';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'العنوان الفرعي المحدد غير صالح.';
 
   @override
@@ -1441,6 +1447,20 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get perfectMatch => 'مباراة مثالية';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1443,10 +1443,10 @@ class AppLocalizationsBe extends AppLocalizations {
   String get perfectMatch => 'Ідэальны матч';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1261,6 +1261,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get downloadSubtitles => 'Спампаваць субтытры';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Выбраны несапраўдны субтытр.';
 
   @override
@@ -1435,6 +1441,20 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Ідэальны матч';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get downloadSubtitles => 'Изтегляне на субтитри';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Избраният субтитър е невалиден.';
 
   @override
@@ -1427,6 +1433,20 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Перфектно съвпадение';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1435,10 +1435,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get perfectMatch => 'Перфектно съвпадение';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1252,6 +1252,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get downloadSubtitles => 'সাবটাইটেল ডাউনলোড করুন';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'নির্বাচিত সাবটাইটেলটি অবৈধ৷';
 
   @override
@@ -1421,6 +1427,20 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get perfectMatch => 'নিখুঁত ম্যাচ';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1429,10 +1429,10 @@ class AppLocalizationsBn extends AppLocalizations {
   String get perfectMatch => 'নিখুঁত ম্যাচ';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1443,10 +1443,10 @@ class AppLocalizationsCa extends AppLocalizations {
   String get perfectMatch => 'Coincidència perfecte';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1265,6 +1265,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get downloadSubtitles => 'Descarrega els subtítols';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'El subtítol seleccionat no és vàlid.';
 
   @override
@@ -1435,6 +1441,20 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Coincidència perfecte';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1445,10 +1445,10 @@ class AppLocalizationsCs extends AppLocalizations {
   String get perfectMatch => 'Perfektní shoda';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1264,6 +1264,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get downloadSubtitles => 'Stáhnout titulky';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Vybrané titulky jsou neplatné.';
 
   @override
@@ -1437,6 +1443,20 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfektní shoda';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1452,10 +1452,10 @@ class AppLocalizationsCy extends AppLocalizations {
   String get perfectMatch => 'Cydweddiad perffaith';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1265,6 +1265,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get downloadSubtitles => 'Lawrlwythwch Isdeitlau';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Mae\'r is-deitl a ddewiswyd yn annilys.';
 
@@ -1444,6 +1450,20 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Cydweddiad perffaith';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1432,10 +1432,10 @@ class AppLocalizationsDa extends AppLocalizations {
   String get perfectMatch => 'Perfekt match';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1255,6 +1255,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get downloadSubtitles => 'Download undertekster';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Den valgte undertekst er ugyldig.';
 
   @override
@@ -1424,6 +1430,20 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekt match';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1506,10 +1506,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get perfectMatch => 'Exakte Übereinstimmung';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1331,6 +1331,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get downloadSubtitles => 'Untertitel herunterladen';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Die ausgewählten Untertitel sind ungültig.';
 
@@ -1498,6 +1504,20 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Exakte Übereinstimmung';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1268,6 +1268,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get downloadSubtitles => 'Κατεβάστε υπότιτλους';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Ο επιλεγμένος υπότιτλος δεν είναι έγκυρος.';
 
@@ -1441,6 +1447,20 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Τέλειο ταίρι';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1449,10 +1449,10 @@ class AppLocalizationsEl extends AppLocalizations {
   String get perfectMatch => 'Τέλειο ταίρι';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1251,6 +1251,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get downloadSubtitles => 'Download Subtitles';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'The selected subtitle is invalid.';
 
   @override
@@ -1420,6 +1426,20 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfect match';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1428,10 +1428,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get perfectMatch => 'Perfect match';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1433,10 +1433,10 @@ class AppLocalizationsEo extends AppLocalizations {
   String get perfectMatch => 'Perfekta matĉo';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1255,6 +1255,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get downloadSubtitles => 'Elŝutu Subtekstojn';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'La elektita subteksto estas malvalida.';
 
@@ -1425,6 +1431,20 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekta matĉo';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1442,10 +1442,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get perfectMatch => 'Coincidencia perfecta';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get downloadSubtitles => 'Descargar subtítulos';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'El subtítulo seleccionado no es válido.';
 
@@ -1434,6 +1440,20 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Coincidencia perfecta';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1259,6 +1259,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get downloadSubtitles => 'Laadige alla subtiitrid';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Valitud alapealkiri on kehtetu.';
 
   @override
@@ -1430,6 +1436,20 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Ideaalne sobivus';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1438,10 +1438,10 @@ class AppLocalizationsEt extends AppLocalizations {
   String get perfectMatch => 'Ideaalne sobivus';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1428,10 +1428,10 @@ class AppLocalizationsFa extends AppLocalizations {
   String get perfectMatch => 'تطابق کامل';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1251,6 +1251,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get downloadSubtitles => 'دانلود زیرنویس';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'زیرنویس انتخاب شده نامعتبر است.';
 
   @override
@@ -1420,6 +1426,20 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get perfectMatch => 'تطابق کامل';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get downloadSubtitles => 'Lataa tekstitykset';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Valittu tekstitys on virheellinen.';
 
   @override
@@ -1431,6 +1437,20 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Täydellinen ottelu';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1439,10 +1439,10 @@ class AppLocalizationsFi extends AppLocalizations {
   String get perfectMatch => 'Täydellinen ottelu';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get downloadSubtitles => 'Télécharger des sous-titres';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Le sous-titre sélectionné n\'est pas valide.';
 
@@ -1441,6 +1447,20 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Correspondance parfaite';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1449,10 +1449,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get perfectMatch => 'Correspondance parfaite';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1447,10 +1447,10 @@ class AppLocalizationsGl extends AppLocalizations {
   String get perfectMatch => 'Combinación perfecta';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1266,6 +1266,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get downloadSubtitles => 'Descargar subtítulos';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'O subtítulo seleccionado non é válido.';
 
@@ -1439,6 +1445,20 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Combinación perfecta';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1425,10 +1425,10 @@ class AppLocalizationsHe extends AppLocalizations {
   String get perfectMatch => 'התאמה מושלמת';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1246,6 +1246,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get downloadSubtitles => 'הורד כתוביות';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'הכתובית שנבחרה אינה חוקית.';
 
   @override
@@ -1417,6 +1423,20 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get perfectMatch => 'התאמה מושלמת';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1254,6 +1254,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get downloadSubtitles => 'उपशीर्षक डाउनलोड करें';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'चयनित उपशीर्षक अमान्य है.';
 
   @override
@@ -1424,6 +1430,20 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get perfectMatch => 'बहतरीन मैच';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1432,10 +1432,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get perfectMatch => 'बहतरीन मैच';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1519,10 +1519,10 @@ class AppLocalizationsHr extends AppLocalizations {
   String get perfectMatch => 'Savršen spoj';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1324,6 +1324,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get downloadSubtitles => 'Preuzmite titlove';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Odabrani podnaslov je nevažeći.';
 
   @override
@@ -1511,6 +1517,20 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Savršen spoj';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1439,10 +1439,10 @@ class AppLocalizationsHu extends AppLocalizations {
   String get perfectMatch => 'Tökéletes párosítás';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1262,6 +1262,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get downloadSubtitles => 'Feliratok letöltése';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'A kiválasztott felirat érvénytelen.';
 
   @override
@@ -1431,6 +1437,20 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Tökéletes párosítás';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get downloadSubtitles => 'Unduh Subtitle';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Subtitle yang dipilih tidak valid.';
 
   @override
@@ -1429,6 +1435,20 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Cocok sempurna';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1437,10 +1437,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get perfectMatch => 'Cocok sempurna';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1437,10 +1437,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get perfectMatch => 'Corrispondenza perfetta';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1259,6 +1259,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get downloadSubtitles => 'Scarica Sottotitoli';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'Il sottotitolo selezionato non è valido.';
 
@@ -1429,6 +1435,20 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Corrispondenza perfetta';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1224,6 +1224,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get downloadSubtitles => '字幕をダウンロードする';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => '選択された字幕は無効です。';
 
   @override
@@ -1393,6 +1399,20 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get perfectMatch => '完璧に一致';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1401,10 +1401,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get perfectMatch => '完璧に一致';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1257,6 +1257,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get downloadSubtitles => 'Субтитрлерді жүктеп алыңыз';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Таңдалған субтитр жарамсыз.';
 
   @override
@@ -1426,6 +1432,20 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Керемет сәйкестік';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1434,10 +1434,10 @@ class AppLocalizationsKk extends AppLocalizations {
   String get perfectMatch => 'Керемет сәйкестік';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1436,10 +1436,10 @@ class AppLocalizationsKn extends AppLocalizations {
   String get perfectMatch => 'ಪರಿಪೂರ್ಣ ಹೊಂದಾಣಿಕೆ';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1258,6 +1258,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get downloadSubtitles => 'ಉಪಶೀರ್ಷಿಕೆಗಳನ್ನು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'ಆಯ್ಕೆಮಾಡಿದ ಉಪಶೀರ್ಷಿಕೆ ಅಮಾನ್ಯವಾಗಿದೆ.';
 
   @override
@@ -1428,6 +1434,20 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get perfectMatch => 'ಪರಿಪೂರ್ಣ ಹೊಂದಾಣಿಕೆ';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1403,10 +1403,10 @@ class AppLocalizationsKo extends AppLocalizations {
   String get perfectMatch => '완벽한 일치';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1226,6 +1226,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get downloadSubtitles => '자막 다운로드';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => '선택한 자막이 잘못되었습니다.';
 
   @override
@@ -1395,6 +1401,20 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get perfectMatch => '완벽한 일치';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1259,6 +1259,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get downloadSubtitles => 'Atsisiųsti subtitrus';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Pasirinkti subtitrai netinkami.';
 
   @override
@@ -1432,6 +1438,20 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Tobulas atitikimas';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1440,10 +1440,10 @@ class AppLocalizationsLt extends AppLocalizations {
   String get perfectMatch => 'Tobulas atitikimas';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1444,10 +1444,10 @@ class AppLocalizationsLv extends AppLocalizations {
   String get perfectMatch => 'Perfekta sakritība';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get downloadSubtitles => 'Lejupielādēt subtitrus';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Atlasītie subtitri nav derīgi.';
 
   @override
@@ -1436,6 +1442,20 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekta sakritība';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1439,10 +1439,10 @@ class AppLocalizationsMk extends AppLocalizations {
   String get perfectMatch => 'Совршен натпревар';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get downloadSubtitles => 'Преземете преводи';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Избраниот титл е неважечки.';
 
   @override
@@ -1431,6 +1437,20 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Совршен натпревар';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1442,10 +1442,10 @@ class AppLocalizationsMl extends AppLocalizations {
   String get perfectMatch => 'തികഞ്ഞ പൊരുത്തം';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get downloadSubtitles => 'സബ്‌ടൈറ്റിലുകൾ ഡൗൺലോഡ് ചെയ്യുക';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'തിരഞ്ഞെടുത്ത സബ്ടൈറ്റിൽ അസാധുവാണ്.';
 
   @override
@@ -1434,6 +1440,20 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'തികഞ്ഞ പൊരുത്തം';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1433,10 +1433,10 @@ class AppLocalizationsMn extends AppLocalizations {
   String get perfectMatch => 'Төгс тохирох';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsMn extends AppLocalizations {
   String get downloadSubtitles => 'Хадмал орчуулгыг татаж авах';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Сонгосон хадмал орчуулга буруу байна.';
 
   @override
@@ -1425,6 +1431,20 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Төгс тохирох';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get downloadSubtitles => 'Last ned undertekster';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Den valgte underteksten er ugyldig.';
 
   @override
@@ -1425,6 +1431,20 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekt match';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1433,10 +1433,10 @@ class AppLocalizationsNb extends AppLocalizations {
   String get perfectMatch => 'Perfekt match';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1259,6 +1259,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get downloadSubtitles => 'Ondertitels downloaden';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid =>
       'De geselecteerde ondertitel is ongeldig.';
 
@@ -1430,6 +1436,20 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfecte wedstrijd';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1438,10 +1438,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get perfectMatch => 'Perfecte wedstrijd';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1434,10 +1434,10 @@ class AppLocalizationsPa extends AppLocalizations {
   String get perfectMatch => 'ਸੰਪੂਰਣ ਮੈਚ';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get downloadSubtitles => 'ਉਪਸਿਰਲੇਖ ਡਾਊਨਲੋਡ ਕਰੋ';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'ਚੁਣਿਆ ਉਪਸਿਰਲੇਖ ਅਵੈਧ ਹੈ।';
 
   @override
@@ -1426,6 +1432,20 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get perfectMatch => 'ਸੰਪੂਰਣ ਮੈਚ';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1536,10 +1536,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get perfectMatch => 'Idealne dopasowanie';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1339,6 +1339,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get downloadSubtitles => 'Pobierz napisy';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Wybrane napisy są nieprawidłowe.';
 
   @override
@@ -1528,6 +1534,20 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Idealne dopasowanie';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1438,10 +1438,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get perfectMatch => 'Correspondência perfeita';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1259,6 +1259,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get downloadSubtitles => 'Baixar Legendas';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'A legenda selecionada é inválida.';
 
   @override
@@ -1430,6 +1436,20 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Correspondência perfeita';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1442,10 +1442,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get perfectMatch => 'Potrivire perfectă';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1262,6 +1262,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get downloadSubtitles => 'Descărcați subtitrări';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Subtitrarea selectată este nevalidă.';
 
   @override
@@ -1434,6 +1440,20 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Potrivire perfectă';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1447,10 +1447,10 @@ class AppLocalizationsRu extends AppLocalizations {
   String get perfectMatch => 'Идеальное совпадение';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1264,6 +1264,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get downloadSubtitles => 'Скачать субтитры';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Выбранный субтитр недействителен.';
 
   @override
@@ -1439,6 +1445,20 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Идеальное совпадение';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1251,6 +1251,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get downloadSubtitles => 'උපසිරැසි බාගන්න';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'තෝරාගත් උපසිරැසිය වලංගු නොවේ.';
 
   @override
@@ -1420,6 +1426,20 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get perfectMatch => 'පරිපූර්ණ ගැලපීම';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1428,10 +1428,10 @@ class AppLocalizationsSi extends AppLocalizations {
   String get perfectMatch => 'පරිපූර්ණ ගැලපීම';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1268,6 +1268,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get downloadSubtitles => 'Stiahnite si titulky';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Vybraté titulky sú neplatné.';
 
   @override
@@ -1441,6 +1447,20 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfektná zhoda';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1449,10 +1449,10 @@ class AppLocalizationsSk extends AppLocalizations {
   String get perfectMatch => 'Perfektná zhoda';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1448,10 +1448,10 @@ class AppLocalizationsSl extends AppLocalizations {
   String get perfectMatch => 'Popolno ujemanje';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1265,6 +1265,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get downloadSubtitles => 'Prenesi podnapise';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Izbrani podnaslov je neveljaven.';
 
   @override
@@ -1440,6 +1446,20 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Popolno ujemanje';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1264,6 +1264,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get downloadSubtitles => 'Shkarko titrat';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Titra e zgjedhur është e pavlefshme.';
 
   @override
@@ -1433,6 +1439,20 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Ndeshje perfekte';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1441,10 +1441,10 @@ class AppLocalizationsSq extends AppLocalizations {
   String get perfectMatch => 'Ndeshje perfekte';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1518,10 +1518,10 @@ class AppLocalizationsSr extends AppLocalizations {
   String get perfectMatch => 'Савршено подударање';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1323,6 +1323,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get downloadSubtitles => 'Довнлоад Субтитлес';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Изабрани титл је неважећи.';
 
   @override
@@ -1510,6 +1516,20 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Савршено подударање';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1433,10 +1433,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get perfectMatch => 'Perfekt matchning';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get downloadSubtitles => 'Ladda ner undertexter';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Den valda undertexten är ogiltig.';
 
   @override
@@ -1425,6 +1431,20 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perfekt matchning';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1266,6 +1266,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get downloadSubtitles => 'Pakua Manukuu';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Manukuu yaliyochaguliwa ni batili.';
 
   @override
@@ -1435,6 +1441,20 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Mechi kamili';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1443,10 +1443,10 @@ class AppLocalizationsSw extends AppLocalizations {
   String get perfectMatch => 'Mechi kamili';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1442,10 +1442,10 @@ class AppLocalizationsTa extends AppLocalizations {
   String get perfectMatch => 'சரியான போட்டி';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get downloadSubtitles => 'வசனங்களைப் பதிவிறக்கவும்';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'தேர்ந்தெடுக்கப்பட்ட வசனம் தவறானது.';
 
   @override
@@ -1434,6 +1440,20 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get perfectMatch => 'சரியான போட்டி';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1437,10 +1437,10 @@ class AppLocalizationsTe extends AppLocalizations {
   String get perfectMatch => 'పర్ఫెక్ట్ మ్యాచ్';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get downloadSubtitles => 'ఉపశీర్షికలను డౌన్‌లోడ్ చేయండి';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'ఎంచుకున్న ఉపశీర్షిక చెల్లదు.';
 
   @override
@@ -1429,6 +1435,20 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get perfectMatch => 'పర్ఫెక్ట్ మ్యాచ్';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1425,10 +1425,10 @@ class AppLocalizationsTh extends AppLocalizations {
   String get perfectMatch => 'คู่ที่สมบูรณ์แบบ';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1248,6 +1248,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get downloadSubtitles => 'ดาวน์โหลดคำบรรยาย';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'คำบรรยายที่เลือกไม่ถูกต้อง';
 
   @override
@@ -1417,6 +1423,20 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get perfectMatch => 'คู่ที่สมบูรณ์แบบ';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get downloadSubtitles => 'Mag-download ng Mga Subtitle';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Ang napiling subtitle ay hindi wasto.';
 
   @override
@@ -1435,6 +1441,20 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Perpektong tugma';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1443,10 +1443,10 @@ class AppLocalizationsTl extends AppLocalizations {
   String get perfectMatch => 'Perpektong tugma';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get downloadSubtitles => 'Altyazıları İndir';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Seçilen altyazı geçersiz.';
 
   @override
@@ -1426,6 +1432,20 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Mükemmel eşleşme';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1434,10 +1434,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get perfectMatch => 'Mükemmel eşleşme';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1433,10 +1433,10 @@ class AppLocalizationsUg extends AppLocalizations {
   String get perfectMatch => 'مۇكەممەل ماسلاشتۇرۇش';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1256,6 +1256,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get downloadSubtitles => 'Subtitles نى چۈشۈرۈڭ';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'تاللانغان تارماق ئىناۋەتسىز.';
 
   @override
@@ -1425,6 +1431,20 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get perfectMatch => 'مۇكەممەل ماسلاشتۇرۇش';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1445,10 +1445,10 @@ class AppLocalizationsUk extends AppLocalizations {
   String get perfectMatch => 'Ідеальний матч';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1263,6 +1263,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get downloadSubtitles => 'Завантажити субтитри';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Вибрані субтитри недійсні.';
 
   @override
@@ -1437,6 +1443,20 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Ідеальний матч';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1260,6 +1260,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get downloadSubtitles => 'Tải xuống phụ đề';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => 'Phụ đề đã chọn không hợp lệ.';
 
   @override
@@ -1429,6 +1435,20 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get perfectMatch => 'Kết hợp hoàn hảo';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1437,10 +1437,10 @@ class AppLocalizationsVi extends AppLocalizations {
   String get perfectMatch => 'Kết hợp hoàn hảo';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1394,10 +1394,10 @@ class AppLocalizationsYue extends AppLocalizations {
   String get perfectMatch => '完美搭配';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1217,6 +1217,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get downloadSubtitles => '下載字幕';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => '所選的字幕無效。';
 
   @override
@@ -1386,6 +1392,20 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get perfectMatch => '完美搭配';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1215,6 +1215,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get downloadSubtitles => '下载字幕';
 
   @override
+  String get searchingSubtitles => 'Searching for subtitles…';
+
+  @override
+  String get downloadingSubtitle => 'Downloading subtitle…';
+
+  @override
   String get selectedSubtitleInvalid => '所选的字幕无效。';
 
   @override
@@ -1384,6 +1390,20 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get perfectMatch => '完全匹配';
+
+  @override
+  String get aiTranslated => 'AI translated';
+
+  @override
+  String get machineTranslated => 'Machine translated';
+
+  @override
+  String get hearingImpaired => 'SDH';
+
+  @override
+  String framerateFps(String rate) {
+    return '$rate fps';
+  }
 
   @override
   String channelsCount(int count) {

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1392,10 +1392,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get perfectMatch => '完全匹配';
 
   @override
-  String get aiTranslated => 'AI translated';
+  String get aiTranslated => 'AI Translated';
 
   @override
-  String get machineTranslated => 'Machine translated';
+  String get machineTranslated => 'Machine Translated';
 
   @override
   String get hearingImpaired => 'SDH';

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -594,6 +594,16 @@ class AppleTvBackend implements PlayerBackend {
     await _invoke<void>('showRemoteSubtitles', {'results': results});
   }
 
+  Future<void> showSubtitleProgress(String message) async {
+    await _invoke<void>('showSubtitleProgress', {'message': message});
+  }
+
+  /// Pass a message to leave the viewer with something to acknowledge, or null
+  /// when the subtitle arrived and the progress alert can just go away.
+  Future<void> hideSubtitleProgress({String? message}) async {
+    await _invoke<void>('hideSubtitleProgress', {'message': message});
+  }
+
   Future<void> setThemeConfig({
     required bool isGlass,
     required int accentARGB,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -9268,8 +9268,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         !isAudio;
   }
 
-
-
   /// Waits for a freshly downloaded subtitle to show up on the item.
   ///
   /// The wait asks the item endpoint for the media streams alone rather than
@@ -9298,7 +9296,6 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     }
     return found;
   }
-
 
   Future<void> _downloadRemoteSubtitles(
     BuildContext context,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -9321,7 +9321,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if (!context.mounted) {
         return;
       }
-      messenger.showSnackBar(
+      trySnackBar(
+        messenger,
         SnackBar(
           content: Text(
             remoteSubtitleErrorMessage(
@@ -9339,7 +9340,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       return;
     }
     if (results.isEmpty) {
-      messenger.showSnackBar(
+      trySnackBar(
+        messenger,
         SnackBar(
           content: Text(
             AppLocalizations.of(context).noRemoteSubtitlesFound(language),
@@ -9362,6 +9364,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         return TrackOption(
           label: label,
           subtitle: subtitleText.isNotEmpty ? subtitleText : null,
+          subtitleMaxLines: 2,
+          badges: remoteSubtitleFlags(subtitle, l10n),
         );
       }).toList(),
     );
@@ -9372,7 +9376,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
     final subtitleId = results[result]['Id']?.toString();
     if (subtitleId == null || subtitleId.isEmpty) {
-      messenger.showSnackBar(
+      trySnackBar(
+        messenger,
         SnackBar(
           content: Text(AppLocalizations.of(context).selectedSubtitleInvalid),
         ),
@@ -9400,7 +9405,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
       if (newStream != null) {
         setState(() => _selectedSubtitleIndex = newStream['Index'] as int?);
-        messenger.showSnackBar(
+        trySnackBar(
+          messenger,
           SnackBar(
             content: Text(
               AppLocalizations.of(context).subtitleDownloadedSelected(
@@ -9415,7 +9421,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         return;
       }
 
-      messenger.showSnackBar(
+      trySnackBar(
+        messenger,
         SnackBar(
           content: Text(AppLocalizations.of(context).subtitleDownloadedPending),
         ),
@@ -9424,7 +9431,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       if (!context.mounted) {
         return;
       }
-      messenger.showSnackBar(
+      trySnackBar(
+        messenger,
         SnackBar(
           content: Text(
             remoteSubtitleErrorMessage(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -4,7 +4,6 @@ import 'dart:ui';
 import '../../widgets/offline_aware_image.dart';
 import '../../widgets/identify_dialog.dart';
 import '../../widgets/focus/context_action.dart' show canIdentifyItemType;
-import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -39,6 +38,9 @@ import 'modern/modern_detail_content.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../widgets/progress_snack_bar.dart';
+import '../../../util/remote_subtitle_labels.dart';
+import '../../../util/subtitle_appearance_schedule.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../preference/seerr_preferences.dart';
@@ -9266,153 +9268,37 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         !isAudio;
   }
 
-  String _remoteSubtitleErrorMessage(Object error, {required String action}) {
-    final l10n = AppLocalizations.of(context);
-    if (error is DioException) {
-      final status = error.response?.statusCode;
-      if (status == 403) {
-        return l10n.remoteSubtitlePermissionError(action);
-      }
-      if (status == 404) {
-        return l10n.remoteSubtitleNotFoundError(action);
-      }
 
-      final data = error.response?.data;
-      String? detail;
-      if (data is Map) {
-        detail =
-            (data['message'] ??
-                    data['Message'] ??
-                    data['error'] ??
-                    data['Error'])
-                as String?;
-      } else if (data is String && data.trim().isNotEmpty) {
-        detail = data.trim();
-      }
 
-      if (detail != null && detail.isNotEmpty) {
-        return l10n.remoteSubtitleDetailError(action, detail);
-      }
-      if (status != null) {
-        return l10n.remoteSubtitleHttpError(action, status);
-      }
-    }
-
-    return l10n.remoteSubtitleGenericError(action);
-  }
-
-  String _remoteSubtitleLanguage(
-    List<Map<String, dynamic>> subtitleStreams,
-    List<Map<String, dynamic>> audioStreams,
-  ) {
-    final preferred = GetIt.instance<UserPreferences>()
-        .get(UserPreferences.defaultSubtitleLanguage)
-        .trim();
-    if (preferred.isNotEmpty) {
-      return preferred;
-    }
-
-    for (final stream in [...subtitleStreams, ...audioStreams]) {
-      final language = (stream['Language'] as String?)?.trim();
-      if (language != null && language.isNotEmpty) {
-        return language;
-      }
-    }
-
-    return 'eng';
-  }
-
-  String _remoteSubtitleOptionSubtitle(Map<String, dynamic> subtitle) {
-    final details = <String>[];
-    final language =
-        (subtitle['ThreeLetterISOLanguageName'] as String?)?.trim() ??
-        (subtitle['Language'] as String?)?.trim();
-    final provider = subtitle['ProviderName'] as String?;
-    final format = subtitle['Format'] as String?;
-    final downloadCount = subtitle['DownloadCount'] as num?;
-    final rating = subtitle['CommunityRating'] as num?;
-    final isHashMatch = subtitle['IsHashMatch'] == true;
-
-    if (language != null && language.isNotEmpty) {
-      details.add(language.toUpperCase());
-    }
-
-    if (provider != null && provider.isNotEmpty) {
-      details.add(provider);
-    }
-    if (format != null && format.isNotEmpty) {
-      details.add(format.toUpperCase());
-    }
-    if (rating != null) {
-      details.add('${rating.toStringAsFixed(1)}★');
-    }
-    if (downloadCount != null) {
-      details.add(
-        AppLocalizations.of(context).downloadsCount(downloadCount.toInt()),
-      );
-    }
-    if (isHashMatch) {
-      details.add(AppLocalizations.of(context).perfectMatch);
-    }
-
-    return details.join(' | ');
-  }
-
-  Future<List<Map<String, dynamic>>> _refreshSubtitleStreams(
+  /// Waits for a freshly downloaded subtitle to show up on the item.
+  ///
+  /// The wait asks the item endpoint for the media streams alone rather than
+  /// reloading the view model: a view model load blanks the screen behind a
+  /// loading overlay and fans out into ratings, similar items, features and
+  /// Seerr, none of which say anything about whether the subtitle has landed.
+  /// One reload happens at the end, when there is something new to show.
+  Future<Map<String, dynamic>?> _awaitDownloadedSubtitle(
     AggregatedItem currentItem,
+    MediaServerClient client,
     Set<int> existingIndexes,
   ) async {
-    const attempts = 8;
-    const delay = Duration(milliseconds: 500);
-    List<Map<String, dynamic>> latestStreams = currentItem.mediaStreams
-        .where((stream) => stream['Type'] == 'Subtitle')
-        .toList(growable: false);
+    final found = await awaitNewSubtitleStream(
+      client: client,
+      item: currentItem,
+      existingIndexes: existingIndexes,
+      streamsOf: (refreshed) => mediaStreamsForItem(
+        refreshed,
+        selectedMediaSourceForItem(refreshed, widget.selectedMediaSourceId),
+      ),
+      keepGoing: () => mounted,
+    );
 
-    for (var attempt = 0; attempt < attempts; attempt++) {
+    if (found != null) {
       await viewModel.load();
-      if (!mounted) {
-        return latestStreams;
-      }
-
-      final refreshedItem = viewModel.item;
-      if (refreshedItem != null) {
-        final mediaSource = selectedMediaSourceForItem(
-          refreshedItem,
-          widget.selectedMediaSourceId,
-        );
-        latestStreams = mediaStreamsForItem(refreshedItem, mediaSource)
-            .where((stream) => stream['Type'] == 'Subtitle')
-            .toList(growable: false);
-        final hasNewStream = latestStreams.any((stream) {
-          final index = stream['Index'] as int?;
-          return index != null && !existingIndexes.contains(index);
-        });
-        if (hasNewStream) {
-          return latestStreams;
-        }
-      }
-
-      if (attempt < attempts - 1) {
-        await Future.delayed(delay);
-      }
     }
-
-    return latestStreams;
+    return found;
   }
 
-  Map<String, dynamic>? _findNewSubtitleStream(
-    Set<int> existingIndexes,
-    List<Map<String, dynamic>> after,
-  ) {
-    for (final stream in after) {
-      final index = stream['Index'] as int?;
-      if (index != null && !existingIndexes.contains(index)) {
-        return stream;
-      }
-    }
-
-    return null;
-  }
 
   Future<void> _downloadRemoteSubtitles(
     BuildContext context,
@@ -9422,13 +9308,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   ) async {
     final messenger = ScaffoldMessenger.of(context);
     final client = GetIt.instance<MediaServerClient>();
-    final language = _remoteSubtitleLanguage(subtitleStreams, audioStreams);
+    final language = remoteSubtitleLanguage(subtitleStreams, audioStreams);
 
     List<Map<String, dynamic>> results;
     try {
-      results = await client.itemsApi.searchRemoteSubtitles(
-        item.id,
-        language: language,
+      results = await withProgressSnackBar(
+        messenger,
+        AppLocalizations.of(context).searchingSubtitles,
+        () => client.itemsApi.searchRemoteSubtitles(item.id, language: language),
       );
     } catch (error) {
       if (!context.mounted) {
@@ -9437,8 +9324,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       messenger.showSnackBar(
         SnackBar(
           content: Text(
-            _remoteSubtitleErrorMessage(
+            remoteSubtitleErrorMessage(
               error,
+              AppLocalizations.of(context),
               action: AppLocalizations.of(context).search,
             ),
           ),
@@ -9461,16 +9349,16 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       return;
     }
 
+    final l10n = AppLocalizations.of(context);
     final result = await TrackSelectorDialog.show(
       context,
-      title: AppLocalizations.of(context).downloadSubtitles,
+      title: l10n.downloadSubtitles,
       options: results.map((subtitle) {
-        final l10n = AppLocalizations.of(context);
         final label =
             subtitle['Name'] as String? ??
             subtitle['Author'] as String? ??
             l10n.subtitles;
-        final subtitleText = _remoteSubtitleOptionSubtitle(subtitle);
+        final subtitleText = remoteSubtitleDetails(subtitle, l10n);
         return TrackOption(
           label: label,
           subtitle: subtitleText.isNotEmpty ? subtitleText : null,
@@ -9492,29 +9380,23 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       return;
     }
 
+    final existingIndexes = subtitleStreams
+        .map((stream) => stream['Index'] as int?)
+        .whereType<int>()
+        .toSet();
+
     try {
-      await client.itemsApi.downloadRemoteSubtitle(item.id, subtitleId);
-      if (!context.mounted) {
-        return;
-      }
-
-      final existingIndexes = subtitleStreams
-          .map((stream) => stream['Index'] as int?)
-          .whereType<int>()
-          .toSet();
-
-      final refreshedSubtitleStreams = await _refreshSubtitleStreams(
-        item,
-        existingIndexes,
+      final newStream = await withProgressSnackBar(
+        messenger,
+        AppLocalizations.of(context).downloadingSubtitle,
+        () async {
+          await client.itemsApi.downloadRemoteSubtitle(item.id, subtitleId);
+          return _awaitDownloadedSubtitle(item, client, existingIndexes);
+        },
       );
       if (!context.mounted) {
         return;
       }
-
-      final newStream = _findNewSubtitleStream(
-        existingIndexes,
-        refreshedSubtitleStreams,
-      );
 
       if (newStream != null) {
         setState(() => _selectedSubtitleIndex = newStream['Index'] as int?);
@@ -9545,8 +9427,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       messenger.showSnackBar(
         SnackBar(
           content: Text(
-            _remoteSubtitleErrorMessage(
+            remoteSubtitleErrorMessage(
               error,
+              AppLocalizations.of(context),
               action: AppLocalizations.of(context).download,
             ),
           ),

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -815,7 +815,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
             return {
               'id': id,
               'label': label,
-              'subtitle': remoteSubtitleDetails(s, l10n),
+              'subtitle': remoteSubtitleSummary(s, l10n),
             };
           })
           .where((m) => (m['id']?.toString() ?? '').isNotEmpty)

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -27,6 +27,8 @@ import '../../navigation/destinations.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../../util/remote_subtitle_labels.dart';
+import '../../../util/subtitle_appearance_schedule.dart';
 import '../../../util/episode_playability.dart';
 import '../../../util/play_method_label.dart';
 import 'appletv_playback_prompt_controller.dart';
@@ -750,40 +752,6 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         !isAudio;
   }
 
-  String _remoteSubtitleLanguage(
-    List<Map<String, dynamic>> subtitleStreams,
-    List<Map<String, dynamic>> audioStreams,
-  ) {
-    final preferred = GetIt.instance<UserPreferences>()
-        .get(UserPreferences.defaultSubtitleLanguage)
-        .trim()
-        .toLowerCase();
-    if (preferred.isNotEmpty && preferred != 'auto' && preferred != 'none') {
-      return preferred;
-    }
-    for (final stream in [...subtitleStreams, ...audioStreams]) {
-      final language = (stream['Language'] as String?)?.trim();
-      if (language != null && language.isNotEmpty) return language;
-    }
-    return 'eng';
-  }
-
-  String _remoteSubtitleOptionSubtitle(Map<String, dynamic> subtitle) {
-    final details = <String>[];
-    final language =
-        (subtitle['ThreeLetterISOLanguageName'] as String?)?.trim() ??
-        (subtitle['Language'] as String?)?.trim();
-    final provider = subtitle['ProviderName'] as String?;
-    final format = subtitle['Format'] as String?;
-    final rating = subtitle['CommunityRating'] as num?;
-    if (language != null && language.isNotEmpty) {
-      details.add(language.toUpperCase());
-    }
-    if (provider != null && provider.isNotEmpty) details.add(provider);
-    if (format != null && format.isNotEmpty) details.add(format.toUpperCase());
-    if (rating != null) details.add('${rating.toStringAsFixed(1)}*');
-    return details.join(' · ');
-  }
 
   void _searchRemoteSubtitles() {
     final manager = _manager;
@@ -806,31 +774,54 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         .where((s) => s['Type'] == 'Subtitle')
         .toList();
     final audioStreams = allStreams.where((s) => s['Type'] == 'Audio').toList();
-    final language = _remoteSubtitleLanguage(subtitleStreams, audioStreams);
+    final language = remoteSubtitleLanguage(subtitleStreams, audioStreams);
+    final l10n = AppLocalizations.of(context);
     () async {
-      var results = const <Map<String, dynamic>>[];
+      // The search alert is raised from here rather than from Swift so that a
+      // refused or failed search can end on the reason. Left to itself the
+      // native side could only fall through to "No Subtitles Found", which told
+      // the viewer the film had none when the truth was a rejected request.
+      await backend.showSubtitleProgress(l10n.searchingSubtitles);
+
+      List<Map<String, dynamic>> results;
       try {
         results = await client.itemsApi.searchRemoteSubtitles(
           item.id,
           language: language,
         );
-      } catch (_) {}
-      if (!mounted) return;
+      } catch (error) {
+        await backend.hideSubtitleProgress(
+          message: remoteSubtitleErrorMessage(
+            error,
+            l10n,
+            action: l10n.search,
+          ),
+        );
+        return;
+      }
+
+      if (!mounted) {
+        await backend.hideSubtitleProgress();
+        return;
+      }
+
       final mapped = results
           .map((s) {
             final id = (s['Id']?.toString()) ?? '';
             final label =
                 (s['Name'] as String?) ??
                 (s['Author'] as String?) ??
-                'Subtitle';
+                l10n.subtitles;
             return {
               'id': id,
               'label': label,
-              'subtitle': _remoteSubtitleOptionSubtitle(s),
+              'subtitle': remoteSubtitleDetails(s, l10n),
             };
           })
           .where((m) => (m['id']?.toString() ?? '').isNotEmpty)
           .toList();
+
+      await backend.hideSubtitleProgress();
       backend.showRemoteSubtitles(mapped);
     }();
   }
@@ -849,7 +840,15 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
             .map((s) => s['Index'] as int?)
             .whereType<int>()
             .toSet();
+    final backend = _backend;
+    final l10n = AppLocalizations.of(context);
     () async {
+      // The wait after the press is the server queueing a metadata refresh, so
+      // it can run to twenty seconds. Every ending says something: swallowing
+      // them left the viewer staring at a player that had gone back to normal
+      // with no idea whether the subtitle was coming.
+      await backend?.showSubtitleProgress(l10n.downloadingSubtitle);
+      String? outcome;
       try {
         await client.itemsApi.downloadRemoteSubtitle(item.id, subtitleId);
         final newStream = await _refreshAndFindSubtitle(
@@ -860,9 +859,17 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         final index = newStream?['Index'] as int?;
         if (index != null) {
           await manager.changeSubtitleTrack(index);
+        } else {
+          outcome = l10n.subtitleDownloadedPending;
         }
-      } catch (_) {
+      } catch (error) {
+        outcome = remoteSubtitleErrorMessage(
+          error,
+          l10n,
+          action: l10n.download,
+        );
       } finally {
+        await backend?.hideSubtitleProgress(message: outcome);
         if (mounted) _pushMetadata();
       }
     }();
@@ -872,26 +879,13 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     AggregatedItem item,
     MediaServerClient client,
     Set<int> existingIndexes,
-  ) async {
-    for (var attempt = 0; attempt < 8; attempt++) {
-      try {
-        final raw = await client.itemsApi.getItem(item.id);
-        if (!mounted) return null;
-        final refreshed = AggregatedItem(
-          id: item.id,
-          serverId: item.serverId,
-          rawData: raw,
-        );
-        for (final s in refreshed.mediaStreams.where(
-          (s) => s['Type'] == 'Subtitle',
-        )) {
-          final index = s['Index'] as int?;
-          if (index != null && !existingIndexes.contains(index)) return s;
-        }
-      } catch (_) {}
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-    }
-    return null;
+  ) {
+    return awaitNewSubtitleStream(
+      client: client,
+      item: item,
+      existingIndexes: existingIndexes,
+      keepGoing: () => mounted,
+    );
   }
 
   void _toggleFavorite(dynamic item) {

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -752,7 +752,6 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         !isAudio;
   }
 
-
   void _searchRemoteSubtitles() {
     final manager = _manager;
     final backend = _backend;
@@ -821,7 +820,9 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
           .where((m) => (m['id']?.toString() ?? '').isNotEmpty)
           .toList();
 
-      await backend.hideSubtitleProgress();
+      // The results sheet takes the progress alert down itself and waits for
+      // the dismissal before presenting. Hiding it here instead leaves the
+      // sheet presenting over an alert still animating out, which tvOS drops.
       backend.showRemoteSubtitles(mapped);
     }();
   }

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -499,6 +499,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         return TrackOption(
           label: label,
           subtitle: subtitleText.isNotEmpty ? subtitleText : null,
+          subtitleMaxLines: 2,
+          badges: remoteSubtitleFlags(subtitle, l10n),
         );
       }).toList(),
     );

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -427,8 +427,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         !isAudio;
   }
 
-
-
   Future<Map<String, dynamic>?> _awaitDownloadedSubtitle(
     AggregatedItem currentItem,
     Set<int> existingIndexes,
@@ -440,7 +438,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       keepGoing: () => mounted,
     );
   }
-
 
   Future<void> _downloadRemoteSubtitles(
     AggregatedItem item,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:dio/dio.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -73,6 +72,9 @@ import '../../widgets/playback/stream_info_dialog.dart';
 import '../../widgets/syncplay/syncplay_player_button.dart';
 import '../../../syncplay/syncplay_manager.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../widgets/progress_snack_bar.dart';
+import '../../../util/remote_subtitle_labels.dart';
+import '../../../util/subtitle_appearance_schedule.dart';
 import '../../../playback/media3_player_backend.dart';
 import '../../../playback/tizen_player_backend.dart';
 import 'playback_takeover.dart';
@@ -425,153 +427,20 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         !isAudio;
   }
 
-  String _remoteSubtitleErrorMessage(Object error, {required String action}) {
-    final l10n = AppLocalizations.of(context);
-    if (error is DioException) {
-      final status = error.response?.statusCode;
-      if (status == 403) {
-        return l10n.remoteSubtitlePermissionError(action);
-      }
-      if (status == 404) {
-        return l10n.remoteSubtitleNotFoundError(action);
-      }
 
-      final data = error.response?.data;
-      String? detail;
-      if (data is Map) {
-        detail =
-            (data['message'] ??
-                    data['Message'] ??
-                    data['error'] ??
-                    data['Error'])
-                as String?;
-      } else if (data is String && data.trim().isNotEmpty) {
-        detail = data.trim();
-      }
 
-      if (detail != null && detail.isNotEmpty) {
-        return l10n.remoteSubtitleDetailError(action, detail);
-      }
-      if (status != null) {
-        return l10n.remoteSubtitleHttpError(action, status);
-      }
-    }
-
-    return l10n.remoteSubtitleGenericError(action);
-  }
-
-  String _remoteSubtitleLanguage(
-    List<Map<String, dynamic>> subtitleStreams,
-    List<Map<String, dynamic>> audioStreams,
-  ) {
-    final preferred = _prefs
-        .get(UserPreferences.defaultSubtitleLanguage)
-        .trim();
-    if (preferred.isNotEmpty) {
-      return preferred;
-    }
-
-    for (final stream in [...subtitleStreams, ...audioStreams]) {
-      final language = (stream['Language'] as String?)?.trim();
-      if (language != null && language.isNotEmpty) {
-        return language;
-      }
-    }
-
-    return 'eng';
-  }
-
-  String _remoteSubtitleOptionSubtitle(Map<String, dynamic> subtitle) {
-    final details = <String>[];
-    final language =
-        (subtitle['ThreeLetterISOLanguageName'] as String?)?.trim() ??
-        (subtitle['Language'] as String?)?.trim();
-    final provider = subtitle['ProviderName'] as String?;
-    final format = subtitle['Format'] as String?;
-    final downloadCount = subtitle['DownloadCount'] as num?;
-    final rating = subtitle['CommunityRating'] as num?;
-    final isHashMatch = subtitle['IsHashMatch'] == true;
-
-    if (language != null && language.isNotEmpty) {
-      details.add(language.toUpperCase());
-    }
-    if (provider != null && provider.isNotEmpty) {
-      details.add(provider);
-    }
-    if (format != null && format.isNotEmpty) {
-      details.add(format.toUpperCase());
-    }
-    if (rating != null) {
-      details.add('${rating.toStringAsFixed(1)}★');
-    }
-    if (downloadCount != null) {
-      details.add(
-        AppLocalizations.of(context).downloadsCount(downloadCount.toInt()),
-      );
-    }
-    if (isHashMatch) {
-      details.add(AppLocalizations.of(context).perfectMatch);
-    }
-
-    return details.join(' | ');
-  }
-
-  Future<List<Map<String, dynamic>>> _refreshSubtitleStreams(
+  Future<Map<String, dynamic>?> _awaitDownloadedSubtitle(
     AggregatedItem currentItem,
     Set<int> existingIndexes,
-  ) async {
-    const attempts = 8;
-    const delay = Duration(milliseconds: 500);
-    final client = _clientForItem(currentItem);
-
-    List<Map<String, dynamic>> latestStreams = currentItem.mediaStreams
-        .where((stream) => stream['Type'] == 'Subtitle')
-        .toList(growable: false);
-
-    for (var attempt = 0; attempt < attempts; attempt++) {
-      try {
-        final refreshedRaw = await client.itemsApi.getItem(currentItem.id);
-        if (!mounted) return latestStreams;
-        final refreshedItem = AggregatedItem(
-          id: currentItem.id,
-          serverId: currentItem.serverId,
-          rawData: refreshedRaw,
-        );
-        latestStreams = refreshedItem.mediaStreams
-            .where((stream) => stream['Type'] == 'Subtitle')
-            .toList(growable: false);
-
-        final hasNewStream = latestStreams.any((stream) {
-          final index = stream['Index'] as int?;
-          return index != null && !existingIndexes.contains(index);
-        });
-        if (hasNewStream) {
-          return latestStreams;
-        }
-      } catch (_) {
-        break;
-      }
-
-      if (attempt < attempts - 1) {
-        await Future.delayed(delay);
-      }
-    }
-
-    return latestStreams;
-  }
-
-  Map<String, dynamic>? _findNewSubtitleStream(
-    Set<int> existingIndexes,
-    List<Map<String, dynamic>> after,
   ) {
-    for (final stream in after) {
-      final index = stream['Index'] as int?;
-      if (index != null && !existingIndexes.contains(index)) {
-        return stream;
-      }
-    }
-    return null;
+    return awaitNewSubtitleStream(
+      client: _clientForItem(currentItem),
+      item: currentItem,
+      existingIndexes: existingIndexes,
+      keepGoing: () => mounted,
+    );
   }
+
 
   Future<void> _downloadRemoteSubtitles(
     AggregatedItem item,
@@ -580,19 +449,26 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   ) async {
     final messenger = ScaffoldMessenger.of(context);
     final client = _clientForItem(item);
-    final language = _remoteSubtitleLanguage(subtitleStreams, audioStreams);
+    final language = remoteSubtitleLanguage(subtitleStreams, audioStreams);
 
     List<Map<String, dynamic>> results;
     try {
-      results = await client.itemsApi.searchRemoteSubtitles(
-        item.id,
-        language: language,
+      results = await withProgressSnackBar(
+        messenger,
+        AppLocalizations.of(context).searchingSubtitles,
+        () => client.itemsApi.searchRemoteSubtitles(item.id, language: language),
       );
     } catch (error) {
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text(_remoteSubtitleErrorMessage(error, action: 'search')),
+          content: Text(
+            remoteSubtitleErrorMessage(
+              error,
+              AppLocalizations.of(context),
+              action: AppLocalizations.of(context).search,
+            ),
+          ),
         ),
       );
       return;
@@ -610,15 +486,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return;
     }
 
+    final l10n = AppLocalizations.of(context);
     final result = await TrackSelectorDialog.show(
       context,
-      title: AppLocalizations.of(context).downloadSubtitles,
+      title: l10n.downloadSubtitles,
       options: results.map((subtitle) {
         final label =
             subtitle['Name'] as String? ??
             subtitle['Author'] as String? ??
-            'Subtitle';
-        final subtitleText = _remoteSubtitleOptionSubtitle(subtitle);
+            l10n.subtitles;
+        final subtitleText = remoteSubtitleDetails(subtitle, l10n);
         return TrackOption(
           label: label,
           subtitle: subtitleText.isNotEmpty ? subtitleText : null,
@@ -638,25 +515,22 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return;
     }
 
+    final existingIndexes = subtitleStreams
+        .map((stream) => stream['Index'] as int?)
+        .whereType<int>()
+        .toSet();
+
     try {
-      await client.itemsApi.downloadRemoteSubtitle(item.id, subtitleId);
-      if (!mounted) return;
-
-      final existingIndexes = subtitleStreams
-          .map((stream) => stream['Index'] as int?)
-          .whereType<int>()
-          .toSet();
-
-      final refreshedSubtitleStreams = await _refreshSubtitleStreams(
-        item,
-        existingIndexes,
+      final newStream = await withProgressSnackBar(
+        messenger,
+        AppLocalizations.of(context).downloadingSubtitle,
+        () async {
+          await client.itemsApi.downloadRemoteSubtitle(item.id, subtitleId);
+          return _awaitDownloadedSubtitle(item, existingIndexes);
+        },
       );
       if (!mounted) return;
 
-      final newStream = _findNewSubtitleStream(
-        existingIndexes,
-        refreshedSubtitleStreams,
-      );
       if (newStream != null) {
         final streamIndex = newStream['Index'] as int?;
         if (streamIndex != null) {
@@ -693,7 +567,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       if (!mounted) return;
       messenger.showSnackBar(
         SnackBar(
-          content: Text(_remoteSubtitleErrorMessage(error, action: 'download')),
+          content: Text(
+            remoteSubtitleErrorMessage(
+              error,
+              AppLocalizations.of(context),
+              action: AppLocalizations.of(context).download,
+            ),
+          ),
         ),
       );
     }

--- a/lib/ui/widgets/progress_snack_bar.dart
+++ b/lib/ui/widgets/progress_snack_bar.dart
@@ -22,21 +22,44 @@ SnackBar _progressSnackBar(String message) {
   );
 }
 
+/// Shows [snackBar], or gives up on saying anything at all.
+///
+/// A messenger walks every Scaffold registered with it on the way to putting a
+/// message up, and one Scaffold that has since been deactivated makes that walk
+/// throw. Telling the user about a piece of work is never worth taking the work
+/// itself down with it, so a messenger in that state costs the message and
+/// nothing more.
+ScaffoldFeatureController<SnackBar, SnackBarClosedReason>? trySnackBar(
+  ScaffoldMessengerState messenger,
+  SnackBar snackBar,
+) {
+  try {
+    return messenger.showSnackBar(snackBar);
+  } catch (_) {
+    return null;
+  }
+}
+
 /// Runs [work] with a progress snack bar up, and takes that snack bar down
 /// however the work ends.
 ///
-/// Closing the controller this returns is what makes it safe: hiding "whatever
-/// is on screen" would just as happily dismiss an unrelated message, and every
-/// early return would have to remember to do it.
+/// Closing the controller is what makes it safe: hiding "whatever is on screen"
+/// would just as happily dismiss an unrelated message, and every early return
+/// would have to remember to do it.
 Future<T> withProgressSnackBar<T>(
   ScaffoldMessengerState messenger,
   String message,
   Future<T> Function() work,
 ) async {
-  final controller = messenger.showSnackBar(_progressSnackBar(message));
+  final controller = trySnackBar(messenger, _progressSnackBar(message));
   try {
     return await work();
   } finally {
-    controller.close();
+    try {
+      controller?.close();
+    } catch (_) {
+      // The messenger stopped taking messages while the work ran; the snack
+      // bar went down with it and there is nothing left to close.
+    }
   }
 }

--- a/lib/ui/widgets/progress_snack_bar.dart
+++ b/lib/ui/widgets/progress_snack_bar.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// A snack bar that sits there with a spinner while something is still
+/// running, instead of the silence a remote subtitle search and download used
+/// to leave behind. The caller takes it down when the work it describes is
+/// over, so the duration below is only a backstop for a screen that goes away
+/// mid-flight.
+SnackBar _progressSnackBar(String message) {
+  return SnackBar(
+    duration: const Duration(seconds: 45),
+    content: Row(
+      children: <Widget>[
+        const SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        const SizedBox(width: 16),
+        Expanded(child: Text(message)),
+      ],
+    ),
+  );
+}
+
+/// Runs [work] with a progress snack bar up, and takes that snack bar down
+/// however the work ends.
+///
+/// Closing the controller this returns is what makes it safe: hiding "whatever
+/// is on screen" would just as happily dismiss an unrelated message, and every
+/// early return would have to remember to do it.
+Future<T> withProgressSnackBar<T>(
+  ScaffoldMessengerState messenger,
+  String message,
+  Future<T> Function() work,
+) async {
+  final controller = messenger.showSnackBar(_progressSnackBar(message));
+  try {
+    return await work();
+  } finally {
+    controller.close();
+  }
+}

--- a/lib/ui/widgets/track_selector_dialog.dart
+++ b/lib/ui/widgets/track_selector_dialog.dart
@@ -112,6 +112,16 @@ class TrackOption {
   final String label;
   final String? subtitle;
   final int? labelMaxLines;
+
+  /// Lines the detail line may run to before it is cut short. One is right for
+  /// a track's own description; a remote subtitle result carries enough - the
+  /// format, the rating, the framerate - that one line loses the end of it.
+  final int subtitleMaxLines;
+
+  /// Short labels shown as pills under the detail line. What goes here is what
+  /// decides the choice rather than describes it, so it survives however narrow
+  /// the row gets instead of being the first thing cut off the end.
+  final List<String> badges;
   final bool scrollLabel;
   final bool scrollSubtitle;
 
@@ -119,6 +129,8 @@ class TrackOption {
     required this.label,
     this.subtitle,
     this.labelMaxLines = 1,
+    this.subtitleMaxLines = 1,
+    this.badges = const <String>[],
     this.scrollLabel = false,
     this.scrollSubtitle = false,
   });
@@ -270,13 +282,62 @@ class _TrackRowState extends State<_TrackRow> {
                                 fontSize: 12,
                                 color: subtitleColor,
                               ),
-                              maxLines: 1,
+                              maxLines: widget.option.subtitleMaxLines,
                               overflow: TextOverflow.ellipsis,
                             )),
+                    if (widget.option.badges.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 6),
+                        child: Wrap(
+                          spacing: 6,
+                          runSpacing: 6,
+                          children: widget.option.badges
+                              .map((badge) => _OptionBadge(
+                                    label: badge,
+                                    dimmed: widget.dimmed,
+                                  ))
+                              .toList(growable: false),
+                        ),
+                      ),
                   ],
                 ),
               ),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A pill under a track row, in the same shape as the audio quality badge so
+/// the two read as the same kind of mark.
+class _OptionBadge extends StatelessWidget {
+  final String label;
+  final bool dimmed;
+
+  const _OptionBadge({required this.label, required this.dimmed});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = AppColorScheme.accent;
+    final alpha = dimmed ? 0.3 : 0.55;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppColorScheme.onSurface.withValues(alpha: 0.10),
+        borderRadius: AppRadius.circular(11),
+        border: Border.all(color: accent.withValues(alpha: alpha), width: 1),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.3,
+          color: Color.alphaBlend(
+            accent.withValues(alpha: dimmed ? 0.5 : 0.85),
+            Colors.white,
           ),
         ),
       ),

--- a/lib/util/remote_subtitle_labels.dart
+++ b/lib/util/remote_subtitle_labels.dart
@@ -4,13 +4,40 @@ import 'package:get_it/get_it.dart';
 import '../l10n/app_localizations.dart';
 import '../preference/user_preferences.dart';
 
-/// Builds the one line of detail shown under a remote subtitle search result.
+/// The flags the provider sets on an upload - machine or AI translated,
+/// hearing impaired, forced, a hash match against this exact file.
 ///
-/// The flags OpenSubtitles sets on an upload - machine or AI translated,
-/// hearing impaired, forced - are the part that decides whether a result is
-/// worth taking at all, so they come first. Everything after them is the
-/// provider's own bookkeeping, and the row is a single line that gets cut off
-/// well before the end on a phone.
+/// These decide whether a result is worth taking at all, so they are kept apart
+/// from the detail line and shown as badges: run in with the rest they were the
+/// first thing to fall off the end of the row.
+List<String> remoteSubtitleFlags(
+  Map<String, dynamic> subtitle,
+  AppLocalizations l10n,
+) {
+  return <String>[
+    if (subtitle['AiTranslated'] == true) l10n.aiTranslated,
+    if (subtitle['MachineTranslated'] == true) l10n.machineTranslated,
+    if (subtitle['HearingImpaired'] == true) l10n.hearingImpaired,
+    if (subtitle['Forced'] == true) l10n.forced,
+    if (subtitle['IsHashMatch'] == true) l10n.perfectMatch,
+  ];
+}
+
+/// Flags and detail as a single string, for a surface that can only take text.
+///
+/// The tvOS sheet is a native action sheet whose rows are one title each, so it
+/// has nowhere to put a badge.
+String remoteSubtitleSummary(
+  Map<String, dynamic> subtitle,
+  AppLocalizations l10n,
+) {
+  final parts = <String>[
+    ...remoteSubtitleFlags(subtitle, l10n),
+    remoteSubtitleDetails(subtitle, l10n),
+  ]..removeWhere((part) => part.isEmpty);
+  return parts.join(' | ');
+}
+/// The provider's own bookkeeping, as one line under the release name.
 String remoteSubtitleDetails(
   Map<String, dynamic> subtitle,
   AppLocalizations l10n,
@@ -22,22 +49,6 @@ String remoteSubtitleDetails(
       (subtitle['Language'] as String?)?.trim();
   if (language != null && language.isNotEmpty) {
     details.add(language.toUpperCase());
-  }
-
-  if (subtitle['AiTranslated'] == true) {
-    details.add(l10n.aiTranslated);
-  }
-  if (subtitle['MachineTranslated'] == true) {
-    details.add(l10n.machineTranslated);
-  }
-  if (subtitle['HearingImpaired'] == true) {
-    details.add(l10n.hearingImpaired);
-  }
-  if (subtitle['Forced'] == true) {
-    details.add(l10n.forced);
-  }
-  if (subtitle['IsHashMatch'] == true) {
-    details.add(l10n.perfectMatch);
   }
 
   final provider = (subtitle['ProviderName'] as String?)?.trim();

--- a/lib/util/remote_subtitle_labels.dart
+++ b/lib/util/remote_subtitle_labels.dart
@@ -1,0 +1,144 @@
+import 'package:dio/dio.dart';
+import 'package:get_it/get_it.dart';
+
+import '../l10n/app_localizations.dart';
+import '../preference/user_preferences.dart';
+
+/// Builds the one line of detail shown under a remote subtitle search result.
+///
+/// The flags OpenSubtitles sets on an upload - machine or AI translated,
+/// hearing impaired, forced - are the part that decides whether a result is
+/// worth taking at all, so they come first. Everything after them is the
+/// provider's own bookkeeping, and the row is a single line that gets cut off
+/// well before the end on a phone.
+String remoteSubtitleDetails(
+  Map<String, dynamic> subtitle,
+  AppLocalizations l10n,
+) {
+  final details = <String>[];
+
+  final language =
+      (subtitle['ThreeLetterISOLanguageName'] as String?)?.trim() ??
+      (subtitle['Language'] as String?)?.trim();
+  if (language != null && language.isNotEmpty) {
+    details.add(language.toUpperCase());
+  }
+
+  if (subtitle['AiTranslated'] == true) {
+    details.add(l10n.aiTranslated);
+  }
+  if (subtitle['MachineTranslated'] == true) {
+    details.add(l10n.machineTranslated);
+  }
+  if (subtitle['HearingImpaired'] == true) {
+    details.add(l10n.hearingImpaired);
+  }
+  if (subtitle['Forced'] == true) {
+    details.add(l10n.forced);
+  }
+  if (subtitle['IsHashMatch'] == true) {
+    details.add(l10n.perfectMatch);
+  }
+
+  final provider = (subtitle['ProviderName'] as String?)?.trim();
+  if (provider != null && provider.isNotEmpty) {
+    details.add(provider);
+  }
+
+  final format = (subtitle['Format'] as String?)?.trim();
+  if (format != null && format.isNotEmpty) {
+    details.add(format.toUpperCase());
+  }
+
+  final rating = subtitle['CommunityRating'] as num?;
+  if (rating != null) {
+    details.add('${rating.toStringAsFixed(1)}★');
+  }
+
+  final downloadCount = subtitle['DownloadCount'] as num?;
+  if (downloadCount != null) {
+    details.add(l10n.downloadsCount(downloadCount.toInt()));
+  }
+
+  final frameRate = subtitle['FrameRate'] as num?;
+  if (frameRate != null && frameRate > 0) {
+    details.add(l10n.framerateFps(_frameRateLabel(frameRate)));
+  }
+
+  return details.join(' | ');
+}
+
+// 23.976 stays as it is, 25.000 reads better as 25.
+final RegExp _trailingZeros = RegExp(r'\.?0+$');
+
+String _frameRateLabel(num value) =>
+    value.toStringAsFixed(3).replaceFirst(_trailingZeros, '');
+
+/// Turns a failed search or download into something worth reading.
+///
+/// Lifted out of the screens because all three want the same wording, and the
+/// tvOS copy had gone without any of it - a failure there used to be swallowed
+/// whole. [action] is the localized verb the messages are built around.
+String remoteSubtitleErrorMessage(
+  Object error,
+  AppLocalizations l10n, {
+  required String action,
+}) {
+  if (error is DioException) {
+    final status = error.response?.statusCode;
+    if (status == 403) {
+      return l10n.remoteSubtitlePermissionError(action);
+    }
+    if (status == 404) {
+      return l10n.remoteSubtitleNotFoundError(action);
+    }
+
+    final data = error.response?.data;
+    String? detail;
+    if (data is Map) {
+      detail =
+          (data['message'] ?? data['Message'] ?? data['error'] ?? data['Error'])
+              as String?;
+    } else if (data is String && data.trim().isNotEmpty) {
+      detail = data.trim();
+    }
+
+    if (detail != null && detail.isNotEmpty) {
+      return l10n.remoteSubtitleDetailError(action, detail);
+    }
+    if (status != null) {
+      return l10n.remoteSubtitleHttpError(action, status);
+    }
+  }
+
+  return l10n.remoteSubtitleGenericError(action);
+}
+
+/// Which language to ask the providers for.
+///
+/// The preference wins when it names one; otherwise the languages already on
+/// the item are the best guess at what the viewer wants, and English is the
+/// last resort. This was copied into all three screens and had drifted - only
+/// the tvOS copy screened out the sentinel values - so the strict reading is
+/// the one kept here.
+String remoteSubtitleLanguage(
+  List<Map<String, dynamic>> subtitleStreams,
+  List<Map<String, dynamic>> audioStreams,
+) {
+  final preferred = GetIt.instance<UserPreferences>()
+      .get(UserPreferences.defaultSubtitleLanguage)
+      .trim()
+      .toLowerCase();
+  if (preferred.isNotEmpty && preferred != 'auto' && preferred != 'none') {
+    return preferred;
+  }
+
+  for (final stream in [...subtitleStreams, ...audioStreams]) {
+    final language = (stream['Language'] as String?)?.trim();
+    if (language != null && language.isNotEmpty) {
+      return language;
+    }
+  }
+
+  return 'eng';
+}

--- a/lib/util/remote_subtitle_labels.dart
+++ b/lib/util/remote_subtitle_labels.dart
@@ -37,6 +37,7 @@ String remoteSubtitleSummary(
   ]..removeWhere((part) => part.isEmpty);
   return parts.join(' | ');
 }
+
 /// The provider's own bookkeeping, as one line under the release name.
 String remoteSubtitleDetails(
   Map<String, dynamic> subtitle,

--- a/lib/util/subtitle_appearance_schedule.dart
+++ b/lib/util/subtitle_appearance_schedule.dart
@@ -1,0 +1,108 @@
+import 'package:server_core/server_core.dart';
+
+import '../data/models/aggregated_item.dart';
+
+/// How long to wait between checks while a freshly downloaded subtitle makes
+/// its way into the item.
+///
+/// The server saves the file and then queues a metadata refresh, so the new
+/// stream turns up some time after the download call has already returned. The
+/// old schedule was eight fixed half-second checks: four seconds, which a busy
+/// server misses more often than not, and the wait then ended on "it may take a
+/// moment" with nothing left watching. These steps start tight so a quick
+/// server still feels instant, then stretch out to cover about twenty seconds
+/// without hammering the item endpoint the whole time.
+const List<Duration> subtitleAppearanceDelays = <Duration>[
+  Duration(milliseconds: 300),
+  Duration(milliseconds: 300),
+  Duration(milliseconds: 500),
+  Duration(milliseconds: 700),
+  Duration(seconds: 1),
+  Duration(seconds: 1),
+  Duration(milliseconds: 1500),
+  Duration(seconds: 2),
+  Duration(seconds: 2),
+  Duration(seconds: 3),
+  Duration(seconds: 3),
+  Duration(seconds: 4),
+];
+
+/// Runs [probe] against the schedule above until it turns something up.
+///
+/// The three screens that download a subtitle all want the same thing - keep
+/// asking the server until the new stream is listed - and differ only in how
+/// they fetch and what they consider a hit, so the loop lives here with the
+/// delays rather than being written out three times. [keepGoing] is the
+/// caller's chance to stop early, which a screen that has been disposed does.
+Future<T?> pollForSubtitleAppearance<T>(
+  Future<T?> Function() probe, {
+  bool Function()? keepGoing,
+}) async {
+  for (var attempt = 0; ; attempt++) {
+    if (keepGoing != null && !keepGoing()) {
+      return null;
+    }
+
+    final found = await probe();
+
+    // Asked again after the probe as well as before it, so a screen that went
+    // away mid-request doesn't have to check for itself in every prober.
+    if (keepGoing != null && !keepGoing()) {
+      return null;
+    }
+    if (found != null) {
+      return found;
+    }
+
+    if (attempt >= subtitleAppearanceDelays.length) {
+      return null;
+    }
+    await Future<void>.delayed(subtitleAppearanceDelays[attempt]);
+  }
+}
+
+/// Only what the wait actually reads. The default item request pulls people,
+/// chapters, trickplay tiles and the overview along with it, which is a lot of
+/// payload to fetch thirteen times over for a look at the subtitle list - and
+/// on two of the three screens it happens while a video is playing.
+const String _subtitlePollFields = 'MediaSources,MediaStreams';
+
+/// Waits for a subtitle whose index isn't in [existingIndexes] to appear on
+/// [item], and hands back the stream itself.
+///
+/// [streamsOf] is for a caller that has to pick the streams out of a chosen
+/// media source rather than off the item; the rest get the item's own list.
+Future<Map<String, dynamic>?> awaitNewSubtitleStream({
+  required MediaServerClient client,
+  required AggregatedItem item,
+  required Set<int> existingIndexes,
+  List<Map<String, dynamic>> Function(AggregatedItem refreshed)? streamsOf,
+  bool Function()? keepGoing,
+}) {
+  return pollForSubtitleAppearance<Map<String, dynamic>>(() async {
+    try {
+      final raw = await client.itemsApi.getItem(
+        item.id,
+        fields: _subtitlePollFields,
+      );
+      final refreshed = AggregatedItem(
+        id: item.id,
+        serverId: item.serverId,
+        rawData: raw,
+      );
+      final streams = streamsOf?.call(refreshed) ?? refreshed.mediaStreams;
+      for (final stream in streams) {
+        if (stream['Type'] != 'Subtitle') {
+          continue;
+        }
+        final index = stream['Index'] as int?;
+        if (index != null && !existingIndexes.contains(index)) {
+          return stream;
+        }
+      }
+    } catch (_) {
+      // A server that hiccups mid-wait gets another go on the next tick.
+    }
+    return null;
+  }, keepGoing: keepGoing);
+}

--- a/test/util/remote_subtitle_labels_test.dart
+++ b/test/util/remote_subtitle_labels_test.dart
@@ -6,7 +6,7 @@ void main() {
   final l10n = AppLocalizationsEn();
 
   group('remoteSubtitleDetails', () {
-    test('shows the AI translated flag the provider set', () {
+    test('keeps the flags out of the detail line', () {
       final details = remoteSubtitleDetails(<String, dynamic>{
         'ThreeLetterISOLanguageName': 'eng',
         'AiTranslated': true,
@@ -14,31 +14,7 @@ void main() {
         'Format': 'srt',
       }, l10n);
 
-      expect(details, 'ENG | AI translated | Open Subtitles | SRT');
-    });
-
-    test('shows machine translated, SDH and forced flags', () {
-      final details = remoteSubtitleDetails(<String, dynamic>{
-        'MachineTranslated': true,
-        'HearingImpaired': true,
-        'Forced': true,
-      }, l10n);
-
-      expect(details, 'Machine translated | SDH | Forced');
-    });
-
-    test('puts the flags before the provider bookkeeping', () {
-      final details = remoteSubtitleDetails(<String, dynamic>{
-        'ThreeLetterISOLanguageName': 'fre',
-        'ProviderName': 'Open Subtitles',
-        'DownloadCount': 12,
-        'AiTranslated': true,
-      }, l10n);
-
-      expect(
-        details.indexOf('AI translated'),
-        lessThan(details.indexOf('Open Subtitles')),
-      );
+      expect(details, 'ENG | Open Subtitles | SRT');
     });
 
     test('keeps a fractional framerate and trims a whole one', () {
@@ -62,14 +38,15 @@ void main() {
       );
     });
 
-    test('leaves out flags that are absent or false', () {
+    test('keeps the flags out of the detail line', () {
       final details = remoteSubtitleDetails(<String, dynamic>{
         'ThreeLetterISOLanguageName': 'eng',
-        'AiTranslated': false,
-        'Forced': null,
+        'AiTranslated': true,
+        'ProviderName': 'Open Subtitles',
+        'Format': 'srt',
       }, l10n);
 
-      expect(details, 'ENG');
+      expect(details, 'ENG | Open Subtitles | SRT');
     });
 
     test('falls back to the Language key when Emby sends that instead', () {
@@ -79,14 +56,76 @@ void main() {
       );
     });
 
-    test('keeps rating, downloads and hash match', () {
+    test('keeps rating and downloads', () {
       final details = remoteSubtitleDetails(<String, dynamic>{
-        'IsHashMatch': true,
         'CommunityRating': 8.5,
         'DownloadCount': 3421,
       }, l10n);
 
-      expect(details, 'Perfect match | 8.5★ | 3421 downloads');
+      expect(details, '8.5★ | 3421 downloads');
+    });
+  });
+
+  group('remoteSubtitleFlags', () {
+    test('returns every flag the provider set, in reading order', () {
+      final flags = remoteSubtitleFlags(<String, dynamic>{
+        'AiTranslated': true,
+        'MachineTranslated': true,
+        'HearingImpaired': true,
+        'Forced': true,
+        'IsHashMatch': true,
+      }, l10n);
+
+      expect(flags, <String>[
+        'AI Translated',
+        'Machine Translated',
+        'SDH',
+        'Forced',
+        'Perfect match',
+      ]);
+    });
+
+    test('leaves out flags that are absent or false', () {
+      final flags = remoteSubtitleFlags(<String, dynamic>{
+        'AiTranslated': false,
+        'Forced': null,
+        'HearingImpaired': true,
+      }, l10n);
+
+      expect(flags, <String>['SDH']);
+    });
+
+    test('is empty when the provider set nothing', () {
+      expect(
+        remoteSubtitleFlags(<String, dynamic>{'Format': 'srt'}, l10n),
+        isEmpty,
+      );
+    });
+  });
+
+  group('remoteSubtitleSummary', () {
+    test('runs the flags back in for a text-only surface', () {
+      final summary = remoteSubtitleSummary(<String, dynamic>{
+        'ThreeLetterISOLanguageName': 'eng',
+        'AiTranslated': true,
+        'Format': 'srt',
+      }, l10n);
+
+      expect(summary, 'AI Translated | ENG | SRT');
+    });
+
+    test('is just the detail line when there are no flags', () {
+      expect(
+        remoteSubtitleSummary(<String, dynamic>{'Format': 'srt'}, l10n),
+        'SRT',
+      );
+    });
+
+    test('is just the flags when there is no detail', () {
+      expect(
+        remoteSubtitleSummary(<String, dynamic>{'Forced': true}, l10n),
+        'Forced',
+      );
     });
   });
 }

--- a/test/util/remote_subtitle_labels_test.dart
+++ b/test/util/remote_subtitle_labels_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/l10n/app_localizations_en.dart';
+import 'package:moonfin/util/remote_subtitle_labels.dart';
+
+void main() {
+  final l10n = AppLocalizationsEn();
+
+  group('remoteSubtitleDetails', () {
+    test('shows the AI translated flag the provider set', () {
+      final details = remoteSubtitleDetails(<String, dynamic>{
+        'ThreeLetterISOLanguageName': 'eng',
+        'AiTranslated': true,
+        'ProviderName': 'Open Subtitles',
+        'Format': 'srt',
+      }, l10n);
+
+      expect(details, 'ENG | AI translated | Open Subtitles | SRT');
+    });
+
+    test('shows machine translated, SDH and forced flags', () {
+      final details = remoteSubtitleDetails(<String, dynamic>{
+        'MachineTranslated': true,
+        'HearingImpaired': true,
+        'Forced': true,
+      }, l10n);
+
+      expect(details, 'Machine translated | SDH | Forced');
+    });
+
+    test('puts the flags before the provider bookkeeping', () {
+      final details = remoteSubtitleDetails(<String, dynamic>{
+        'ThreeLetterISOLanguageName': 'fre',
+        'ProviderName': 'Open Subtitles',
+        'DownloadCount': 12,
+        'AiTranslated': true,
+      }, l10n);
+
+      expect(
+        details.indexOf('AI translated'),
+        lessThan(details.indexOf('Open Subtitles')),
+      );
+    });
+
+    test('keeps a fractional framerate and trims a whole one', () {
+      expect(
+        remoteSubtitleDetails(<String, dynamic>{'FrameRate': 23.976}, l10n),
+        '23.976 fps',
+      );
+      expect(
+        remoteSubtitleDetails(<String, dynamic>{'FrameRate': 25.0}, l10n),
+        '25 fps',
+      );
+    });
+
+    test('leaves out a framerate the provider did not report', () {
+      expect(
+        remoteSubtitleDetails(<String, dynamic>{
+          'FrameRate': 0,
+          'Format': 'srt',
+        }, l10n),
+        'SRT',
+      );
+    });
+
+    test('leaves out flags that are absent or false', () {
+      final details = remoteSubtitleDetails(<String, dynamic>{
+        'ThreeLetterISOLanguageName': 'eng',
+        'AiTranslated': false,
+        'Forced': null,
+      }, l10n);
+
+      expect(details, 'ENG');
+    });
+
+    test('falls back to the Language key when Emby sends that instead', () {
+      expect(
+        remoteSubtitleDetails(<String, dynamic>{'Language': 'ger'}, l10n),
+        'GER',
+      );
+    });
+
+    test('keeps rating, downloads and hash match', () {
+      final details = remoteSubtitleDetails(<String, dynamic>{
+        'IsHashMatch': true,
+        'CommunityRating': 8.5,
+        'DownloadCount': 3421,
+      }, l10n);
+
+      expect(details, 'Perfect match | 8.5★ | 3421 downloads');
+    });
+  });
+}

--- a/test/util/remote_subtitle_labels_test.dart
+++ b/test/util/remote_subtitle_labels_test.dart
@@ -1,8 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:moonfin/l10n/app_localizations_en.dart';
+import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/util/remote_subtitle_labels.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   final l10n = AppLocalizationsEn();
 
   group('remoteSubtitleDetails', () {
@@ -36,17 +41,6 @@ void main() {
         }, l10n),
         'SRT',
       );
-    });
-
-    test('keeps the flags out of the detail line', () {
-      final details = remoteSubtitleDetails(<String, dynamic>{
-        'ThreeLetterISOLanguageName': 'eng',
-        'AiTranslated': true,
-        'ProviderName': 'Open Subtitles',
-        'Format': 'srt',
-      }, l10n);
-
-      expect(details, 'ENG | Open Subtitles | SRT');
     });
 
     test('falls back to the Language key when Emby sends that instead', () {
@@ -126,6 +120,64 @@ void main() {
         remoteSubtitleSummary(<String, dynamic>{'Forced': true}, l10n),
         'Forced',
       );
+    });
+  });
+
+  group('remoteSubtitleLanguage', () {
+    late UserPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(const <String, Object>{});
+      final store = PreferenceStore();
+      await store.init();
+      prefs = UserPreferences(store);
+      GetIt.instance.registerSingleton<UserPreferences>(prefs);
+    });
+
+    tearDown(() => GetIt.instance.unregister<UserPreferences>());
+
+    test('the preference wins when it names a language', () async {
+      await prefs.set(UserPreferences.defaultSubtitleLanguage, 'ger');
+
+      expect(
+        remoteSubtitleLanguage(
+          [<String, dynamic>{'Language': 'fre'}],
+          const [],
+        ),
+        'ger',
+      );
+    });
+
+    test('auto and none are not languages to search for', () async {
+      for (final sentinel in ['auto', 'None']) {
+        await prefs.set(UserPreferences.defaultSubtitleLanguage, sentinel);
+
+        expect(
+          remoteSubtitleLanguage(
+            [<String, dynamic>{'Language': 'fre'}],
+            const [],
+          ),
+          'fre',
+          reason: '$sentinel names a setting, not a language to search for',
+        );
+      }
+    });
+
+    test('falls back to what the item already carries', () async {
+      await prefs.set(UserPreferences.defaultSubtitleLanguage, '');
+
+      expect(
+        remoteSubtitleLanguage(const [], [
+          <String, dynamic>{'Language': 'jpn'},
+        ]),
+        'jpn',
+      );
+    });
+
+    test('is English when nothing else says otherwise', () async {
+      await prefs.set(UserPreferences.defaultSubtitleLanguage, '');
+
+      expect(remoteSubtitleLanguage(const [], const []), 'eng');
     });
   });
 }

--- a/test/util/subtitle_appearance_schedule_test.dart
+++ b/test/util/subtitle_appearance_schedule_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/subtitle_appearance_schedule.dart';
+
+void main() {
+  group('subtitleAppearanceDelays', () {
+    test('waits long enough for a queued metadata refresh', () {
+      // The old fixed schedule gave up after four seconds, which a busy server
+      // misses. Anything under fifteen is back to guessing.
+      final window = subtitleAppearanceDelays.fold(
+        Duration.zero,
+        (total, delay) => total + delay,
+      );
+      expect(window.inSeconds, greaterThanOrEqualTo(15));
+      expect(window.inSeconds, lessThanOrEqualTo(30));
+    });
+
+    test('starts tight so a quick server still feels instant', () {
+      expect(subtitleAppearanceDelays.first.inMilliseconds, lessThan(500));
+      final firstThree = subtitleAppearanceDelays
+          .take(3)
+          .fold(Duration.zero, (total, delay) => total + delay);
+      expect(firstThree.inMilliseconds, lessThan(1500));
+    });
+
+    test('never steps back down', () {
+      for (var i = 1; i < subtitleAppearanceDelays.length; i++) {
+        expect(
+          subtitleAppearanceDelays[i],
+          greaterThanOrEqualTo(subtitleAppearanceDelays[i - 1]),
+          reason: 'delay $i is shorter than the one before it',
+        );
+      }
+    });
+
+    test('does not hammer the item endpoint', () {
+      expect(subtitleAppearanceDelays.length + 1, lessThanOrEqualTo(15));
+    });
+  });
+
+  group('pollForSubtitleAppearance', () {
+    test('returns the first thing the probe turns up', () async {
+      var calls = 0;
+      final found = await pollForSubtitleAppearance<String>(() async {
+        calls++;
+        return calls >= 2 ? 'found' : null;
+      });
+
+      expect(found, 'found');
+      expect(calls, 2);
+    });
+
+    test('stops when the caller asks it to', () async {
+      var calls = 0;
+      final found = await pollForSubtitleAppearance<String>(() async {
+        calls++;
+        return null;
+      }, keepGoing: () => calls < 3);
+
+      expect(found, isNull);
+      expect(calls, 3);
+    });
+
+    test('stops before probing when the caller has gone away', () async {
+      var calls = 0;
+      final found = await pollForSubtitleAppearance<String>(() async {
+        calls++;
+        return 'found';
+      }, keepGoing: () => false);
+
+      expect(found, isNull);
+      expect(calls, 0);
+    });
+  });
+}

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -63,7 +63,10 @@ final class AppleTvPlayerViewController: UIViewController {
     private var canFavorite = false
     private var isFavorite = false
     private var canDownloadSubtitles = false
-    private weak var subtitleSearchingAlert: UIAlertController?
+    /// The searching / downloading alert. Dart raises and clears it, so both
+    /// halves of the flow report their own ending instead of the search one
+    /// falling through to "No Subtitles Found" whatever went wrong.
+    private weak var subtitleProgressAlert: UIAlertController?
     /// The buttons the player button settings left switched on, in the order
     /// the user put them in. Nil until the Dart side sends one, and the row
     /// offers everything until then.
@@ -2328,12 +2331,40 @@ final class AppleTvPlayerViewController: UIViewController {
     }
 
     private func beginSubtitleSearch() {
-        let alert = UIAlertController(
-            title: "Searching for Subtitles\u{2026}", message: nil,
-            preferredStyle: .alert)
-        subtitleSearchingAlert = alert
-        present(alert, animated: true)
         onSearchSubtitles?()
+    }
+
+    /// Put up a spinner-less "working on it" alert for the stretch between
+    /// picking a subtitle and the server listing it. Without this the sheet just
+    /// closes and nothing happens for as long as the refresh takes, which reads
+    /// as the press having been ignored.
+    func showSubtitleProgress(_ message: String) {
+        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        subtitleProgressAlert = alert
+        present(alert, animated: true)
+    }
+
+    /// Take the progress alert down. A message turns it into an alert the viewer
+    /// has to acknowledge, which is how a failure or a subtitle that never
+    /// turned up gets reported instead of being swallowed.
+    func hideSubtitleProgress(message: String?) {
+        dismissSubtitleProgress { [weak self] in
+            guard let self, let message, !message.isEmpty else { return }
+            let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .cancel))
+            self.present(alert, animated: true)
+        }
+    }
+
+    /// Dismissal is asynchronous, so whatever comes next has to wait for the
+    /// completion rather than be presented on top of an alert on its way out.
+    private func dismissSubtitleProgress(then next: @escaping () -> Void) {
+        guard let existing = subtitleProgressAlert else {
+            next()
+            return
+        }
+        subtitleProgressAlert = nil
+        existing.dismiss(animated: true) { next() }
     }
 
     func presentRemoteSubtitleResults(_ results: [[String: Any]]) {
@@ -2361,12 +2392,7 @@ final class AppleTvPlayerViewController: UIViewController {
             sheet.addAction(UIAlertAction(title: "Cancel", style: .cancel))
             self.present(sheet, animated: true)
         }
-        if let searching = subtitleSearchingAlert {
-            subtitleSearchingAlert = nil
-            searching.dismiss(animated: true) { show() }
-        } else {
-            show()
-        }
+        dismissSubtitleProgress { show() }
     }
 
     private func presentChapterMenu() {

--- a/tvos/Runner/Playback/AppleTvVideoChannel.swift
+++ b/tvos/Runner/Playback/AppleTvVideoChannel.swift
@@ -104,6 +104,10 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
         case "showRemoteSubtitles":
             let results = (args["results"] as? [[String: Any]]) ?? []
             playerVC?.presentRemoteSubtitleResults(results)
+        case "showSubtitleProgress":
+            playerVC?.showSubtitleProgress((args["message"] as? String) ?? "Working\u{2026}")
+        case "hideSubtitleProgress":
+            playerVC?.hideSubtitleProgress(message: args["message"] as? String)
         case "configureSubtitleStyle":
             lastSubtitleStyle = args
             applySubtitleStyle(args)


### PR DESCRIPTION
# Pull Request

## Summary
Remote subtitle search results were missing the flags the provider sets on an upload — an AI-translated subtitle looked identical to a hand-checked one — and the whole search → download → appear flow gave no feedback at all, so a press was followed by an unexplained pause. This surfaces the flags as badges under each result, holds a progress indicator for as long as the work runs on all three surfaces, and widens the wait for the server to list the new subtitle from ~4s to ~19s because the old window usually expired before the metadata refresh completed.

Along the way the three screens that own this flow (item detail, video player, Apple TV host) had copied the label builder, error formatter, language picker and polling loop between them, and the copies had drifted. Those are now shared.

## Related Issues
No tracked issue — found while using the OpenSubtitles plugin from the app.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactor
- [x] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Show the provider's flags.** `AiTranslated`, `MachineTranslated`, `HearingImpaired`, `Forreturned by the API and ignored. They now render as pills under each result, in the same shape as `AudioQualityBadge`, with `Wrap` so several stack instead of overflowing. Wording matches `jellyfin-web` (`AI Translated`, `Machine Translated`, `Perfect match`).
- **Say something while it works.** Searching and downloading now hold a snack bar (and on tvduration, cleared on every exit path including errors and unmount.
- **Wait long enough.** The server queues a metadata refresh after saving the file, so the new stream appears some time after the download call returns. The old poll was 8 fixed 500 ms checks (~4 s) and usually
gave up first, ending on "it may take a moment" with nothing still watching. Replaced with a ts tight and stretches to ~19 s.
- **Stop pulling the whole item 13 times.** The poll now requests `fields: 'MediaSources,MediaStreams'` instead of the default `kItemFields` (People, Chapters, Trickplay, Overview…). The detail screen was doing
this through a full `viewModel.load()` that blanked the screen behind a loading overlay and filar/Seerr on every attempt; it now does one light request per attempt and reloads once, atthe end.
- **Fix the tvOS search reporting.** A refused or failed search fell through to the native "Ntelling the viewer the film had no subtitles when the request had been rejected. Dart now owns both alerts and every ending carries its reason.
- **Share the duplicated code.** New `lib/util/remote_subtitle_labels.dart` (label builder, f language picker), `lib/util/subtitle_appearance_schedule.dart` (delay schedule, poll loop,stream wait) and `lib/ui/widgets/progress_snack_bar.dart`. Removes `_findNewSubtitleStream` ×2, `_remoteSubtitleErrorMessage` ×2, `_remoteSubtitleLanguage` ×3, `_remoteSubtitleOptionSubtitle` ×3 and three copies
of the polling loop. The language picker had already drifted — only the tvOS copy screened ou
- **`TrackOption` gains `badges` and `subtitleMaxLines`**, both defaulted so no other caller of the dialog changes behaviour.

## Platform
- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator / simulator (Apple TV)
- [x] Tested on physical device
- [x] Manual testing completed
- [] Not tested (explain why):

### Test Steps
1. Open any movie or episode → three-dot menu → **Download Subtitles**. A "Searching for subtitles…" snack bar with a spinner should appear while the search runs.
2. In the results list, confirm each row shows the release name, a detail line (`ENG | Open Sds | 23.976 fps`) and — where the provider set them — pills reading **AI Translated**,**Machine Translated**, **SDH**, **Forced** or **Perfect match**.
3. Pick a result. A "Downloading subtitle…" snack bar should stay up through the download *anced by "Subtitle downloaded and selected: …". On a busy server this can take upward of 10 s;it should not give up early.
4. Repeat from inside the player (same flow, snack bars over the video).
5. **Still needed:** repeat on Apple TV. Confirm the "Downloading Subtitle…" alert appears, that a successful download dismisses it and switches the track, and that revoking subtitle permissions produces an error
alert rather than "No Subtitles Found".

## Screenshots (if applicable)

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced