### PR TITLE
fix missing subtitle settings for hdr on androidtv

### DIFF
--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1325,6 +1325,12 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       l10n.verticalOffset,
       keywords: ['position', 'height'],
     ),
+    subtitleStyle.leaf(
+      'subtitles_hdr_separate',
+      l10n.subtitleHdrSeparate,
+      subtitle: l10n.subtitleHdrSeparateSubtitle,
+      keywords: ['hdr', 'brightness', 'grey'],
+    ),
 
     automation.screen(keywords: ['skip intro', 'autoplay', 'queue']),
     automation.leaf(

--- a/lib/ui/screens/settings/subtitle_customization_screen.dart
+++ b/lib/ui/screens/settings/subtitle_customization_screen.dart
@@ -31,7 +31,6 @@ class _SubtitleCustomizationScreenState
   late final PreferenceBinding<double> _offsetBind;
   late final PreferenceBinding<double> _hdrSizeBind;
   late final PreferenceBinding<double> _hdrOffsetBind;
-  late final PreferenceBinding<bool> _hdrSeparateBind;
   late final FocusNode _sizeOuterNode;
   late final FocusNode _sizeInnerNode;
   late final FocusNode _offsetOuterNode;
@@ -73,10 +72,6 @@ class _SubtitleCustomizationScreenState
     _hdrOffsetBind = PreferenceBinding(
       store,
       UserPreferences.subtitlesHdrOffsetPosition,
-    );
-    _hdrSeparateBind = PreferenceBinding(
-      store,
-      UserPreferences.subtitlesHdrSeparate,
     );
     _hdrSizeOuterNode = FocusNode(debugLabel: 'SubtitleHdrSizeOuter');
     _hdrSizeInnerNode = FocusNode(
@@ -146,7 +141,6 @@ class _SubtitleCustomizationScreenState
     _offsetBind.dispose();
     _hdrSizeBind.dispose();
     _hdrOffsetBind.dispose();
-    _hdrSeparateBind.dispose();
     super.dispose();
   }
 
@@ -223,7 +217,6 @@ class _SubtitleCustomizationScreenState
               max: 0.5,
               divisions: 50,
               step: 0.01,
-              swallowDown: true,
               labelBuilder: (v) => l10n.percentValue((v * 100).round()),
             ),
             SwitchPreferenceTile(
@@ -232,9 +225,11 @@ class _SubtitleCustomizationScreenState
               subtitle: l10n.subtitleHdrSeparateSubtitle,
               icon: Icons.hdr_on,
             ),
-            ValueListenableBuilder<bool>(
-              valueListenable: _hdrSeparateBind,
-              builder: (context, separate, _) => separate
+            ListenableBuilder(
+              listenable: GetIt.instance<UserPreferences>(),
+              builder: (context, _) => GetIt.instance<UserPreferences>().get(
+                UserPreferences.subtitlesHdrSeparate,
+              )
                   ? Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [


### PR DESCRIPTION

# Pull Request

## Summary
android tv was missing the separate hdr style settings under subtitle customization.  The slider tile above it was set to swallow down.  Also changed the builder so that it can expand/collapse the separate tiles correctly.  Added a search entry for this since it was missing.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
-remove swallowDown: true on a slider tile, it prevented scrolling the menu past this point to see tiles beyond it 
-removed the PreferenceBinding for _hdrSeparatedBind since it wasn't updating from prefs, and use a ListenableBuilder to build the extra tiles instead
-added a search entry for the separate hdr subtitle style

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. go to subtitle customization
2. verify the separate hdr style setting is visible
3. toggle it to see if the trailing tiles are enabled/disabled

## Screenshots (if applicable)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
