### PR TITLE
Add trickplay display modes, prefetching, and configurable preview (#143)

### DIFF
--- a/lib/data/models/trickplay_info.dart
+++ b/lib/data/models/trickplay_info.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Rect;
+
 class TrickplayInfo {
   final int width;
   final int height;
@@ -21,6 +23,33 @@ class TrickplayInfo {
       interval > 0;
 
   int get tilesPerImage => tileWidth * tileHeight;
+
+  TrickplayTileResolution resolveTile(Duration position) {
+    final positionMs = position.inMilliseconds;
+    final tileIndex = positionMs ~/ interval;
+    final perImage = tilesPerImage;
+    final tileOffset = tileIndex % perImage;
+    final imageIndex = tileIndex ~/ perImage;
+
+    final col = tileOffset % tileWidth;
+    final row = tileOffset ~/ tileWidth;
+    final offsetX = (col * width).toDouble();
+    final offsetY = (row * height).toDouble();
+
+    return TrickplayTileResolution(
+      imageIndex: imageIndex,
+      sourceRect: Rect.fromLTWH(
+        offsetX,
+        offsetY,
+        width.toDouble(),
+        height.toDouble(),
+      ),
+      thumbWidth: width.toDouble(),
+      thumbHeight: height.toDouble(),
+      tileWidth: tileWidth,
+      tileHeight: tileHeight,
+    );
+  }
 
   static TrickplayInfo? fromItemData(
     Map<String, dynamic> rawData, {
@@ -50,4 +79,40 @@ class TrickplayInfo {
       interval: (info['Interval'] as num?)?.toInt() ?? 0,
     );
   }
+}
+
+class TrickplayTileResolution {
+  final int imageIndex;
+  final Rect sourceRect;
+  final double thumbWidth;
+  final double thumbHeight;
+  final int tileWidth;
+  final int tileHeight;
+
+  const TrickplayTileResolution({
+    required this.imageIndex,
+    required this.sourceRect,
+    required this.thumbWidth,
+    required this.thumbHeight,
+    required this.tileWidth,
+    required this.tileHeight,
+  });
+}
+
+class TrickplayTile {
+  final String url;
+  final Map<String, String> headers;
+  final TrickplayTileResolution resolution;
+
+  const TrickplayTile({
+    required this.url,
+    required this.headers,
+    required this.resolution,
+  });
+
+  Rect get sourceRect => resolution.sourceRect;
+  double get thumbWidth => resolution.thumbWidth;
+  double get thumbHeight => resolution.thumbHeight;
+  int get tileWidth => resolution.tileWidth;
+  int get tileHeight => resolution.tileHeight;
 }

--- a/lib/data/models/trickplay_prefetch_planner.dart
+++ b/lib/data/models/trickplay_prefetch_planner.dart
@@ -1,0 +1,44 @@
+import 'trickplay_info.dart';
+
+class TrickplayPrefetchPlanner {
+  const TrickplayPrefetchPlanner._();
+
+  static int _lastSheetIndex(TrickplayInfo info, Duration totalDuration) {
+    final lastMs = (totalDuration.inMilliseconds - 1).clamp(
+      0,
+      totalDuration.inMilliseconds,
+    );
+    return info.resolveTile(Duration(milliseconds: lastMs)).imageIndex;
+  }
+
+  static List<int> planImageIndexes({
+    required TrickplayInfo info,
+    required Duration position,
+    required Duration totalDuration,
+    required bool directionForward,
+    int sheetsAhead = 2,
+  }) {
+    final currentIndex = info.resolveTile(position).imageIndex;
+    final lastIndex = _lastSheetIndex(info, totalDuration);
+    final indexes = <int>[];
+    for (var i = 1; i <= sheetsAhead; i++) {
+      final target = directionForward ? currentIndex + i : currentIndex - i;
+      if (target < 0 || target > lastIndex) break;
+      indexes.add(target);
+    }
+    return indexes;
+  }
+
+  static List<int> planAllImageIndexes({
+    required TrickplayInfo info,
+    required Duration position,
+    required Duration totalDuration,
+    int maxSheets = 128,
+  }) {
+    final currentIndex = info.resolveTile(position).imageIndex;
+    final lastIndex = _lastSheetIndex(info, totalDuration);
+    final all = List.generate(lastIndex + 1, (i) => i);
+    all.sort((a, b) => (a - currentIndex).abs().compareTo((b - currentIndex).abs()));
+    return all.length > maxSheets ? all.sublist(0, maxSheets) : all;
+  }
+}

--- a/lib/data/models/trickplay_preview_layout.dart
+++ b/lib/data/models/trickplay_preview_layout.dart
@@ -1,5 +1,7 @@
 import 'dart:math' as math;
 
+import 'trickplay_strip_resolution.dart';
+
 class TrickplayPreviewLayout {
   const TrickplayPreviewLayout._();
 
@@ -84,6 +86,73 @@ class TrickplayPreviewLayout {
     return percent * math.max(maxTravel, 0.0);
   }
 
+  static TrickplayPreviewPlan plan({
+    required double trackWidth,
+    required int scalePercent,
+    required double aspect,
+    required double maxHeightBudget,
+    required double positionMs,
+    required double durationMs,
+    required bool followScrub,
+    required int verticalPositionPercent,
+    required bool isStrip,
+    required double spacing,
+    required double overflowMargin,
+    required Duration seekPosition,
+    required Duration totalDuration,
+    required int stepMs,
+  }) {
+    final tileSize = resolveTileSize(
+      trackWidth: trackWidth,
+      scalePercent: scalePercent,
+      aspect: aspect,
+      maxHeightBudget: maxHeightBudget,
+    );
+    final verticalTravel = resolveVerticalTravel(
+      verticalPositionPercent,
+      maxTravel: resolveVerticalTravelMax(
+        rawMaxTravel: maxHeightBudget - tileSize.height,
+        trackWidth: trackWidth,
+      ),
+    );
+    final mainTileLeft = resolveSingleLeft(
+      positionMs: positionMs,
+      durationMs: durationMs,
+      trackWidth: trackWidth,
+      tileWidth: tileSize.width,
+      followScrub: followScrub,
+    );
+    final strip = isStrip
+        ? resolveStrip(
+            mainTileLeft: mainTileLeft,
+            trackWidth: trackWidth,
+            tileWidth: tileSize.width,
+            spacing: spacing,
+            overflowMargin: overflowMargin,
+          )
+        : TrickplayStripLayout(
+            leftCount: 0,
+            rightCount: 0,
+            leftOffset: mainTileLeft,
+          );
+    final slots = TrickplayStripResolver.resolve(
+      fakeTimelinePosition: seekPosition,
+      totalDuration: totalDuration,
+      stepMs: stepMs,
+      slotCount: strip.slotCount,
+      highlightIndex: strip.highlightIndex,
+    );
+    return TrickplayPreviewPlan(
+      tileWidth: tileSize.width,
+      tileHeight: tileSize.height,
+      verticalTravel: verticalTravel,
+      leftOffset: strip.leftOffset,
+      leftCount: strip.leftCount,
+      rightCount: strip.rightCount,
+      slotsByIndex: {for (final slot in slots) slot.slotIndex: slot},
+    );
+  }
+
   static TrickplayTileSize resolveTileSize({
     required double trackWidth,
     required int scalePercent,
@@ -100,6 +169,28 @@ class TrickplayPreviewLayout {
     final height = math.min(desiredHeight, safeTrackWidth * aspect);
     return TrickplayTileSize(width: height / aspect, height: height);
   }
+}
+
+/// Everything a preview needs to draw itself, worked out once here so the
+/// player and the settings preview do not drift apart.
+class TrickplayPreviewPlan {
+  final double tileWidth;
+  final double tileHeight;
+  final double verticalTravel;
+  final double leftOffset;
+  final int leftCount;
+  final int rightCount;
+  final Map<int, TrickplayStripSlot> slotsByIndex;
+
+  const TrickplayPreviewPlan({
+    required this.tileWidth,
+    required this.tileHeight,
+    required this.verticalTravel,
+    required this.leftOffset,
+    required this.leftCount,
+    required this.rightCount,
+    required this.slotsByIndex,
+  });
 }
 
 class TrickplayTileSize {

--- a/lib/data/models/trickplay_preview_layout.dart
+++ b/lib/data/models/trickplay_preview_layout.dart
@@ -1,0 +1,125 @@
+import 'dart:math' as math;
+
+class TrickplayPreviewLayout {
+  const TrickplayPreviewLayout._();
+
+  static const seekThumbRadius = 7.0;
+
+  static double trackXForPosition({
+    required double positionMs,
+    required double durationMs,
+    required double trackWidth,
+  }) {
+    final fraction = durationMs > 0
+        ? (positionMs / durationMs).clamp(0.0, 1.0)
+        : 0.0;
+    return seekThumbRadius +
+        fraction * math.max(trackWidth - 2 * seekThumbRadius, 0.0);
+  }
+
+  static double resolveSingleLeft({
+    required double positionMs,
+    required double durationMs,
+    required double trackWidth,
+    required double tileWidth,
+    required bool followScrub,
+  }) {
+    if (!followScrub) return (trackWidth - tileWidth) / 2;
+    final thumbX = trackXForPosition(
+      positionMs: positionMs,
+      durationMs: durationMs,
+      trackWidth: trackWidth,
+    );
+    return (thumbX - tileWidth / 2)
+        .clamp(0.0, math.max(0.0, trackWidth - tileWidth))
+        .toDouble();
+  }
+
+  static TrickplayStripLayout resolveStrip({
+    required double mainTileLeft,
+    required double trackWidth,
+    required double tileWidth,
+    required double spacing,
+    int maxSlotsPerSide = 500,
+    double overflowMargin = 0,
+  }) {
+    final step = tileWidth + spacing;
+    if (step <= 0) {
+      return TrickplayStripLayout(
+        leftCount: 0,
+        rightCount: 0,
+        leftOffset: mainTileLeft,
+      );
+    }
+    final leftCount = (((mainTileLeft + overflowMargin) / step).floor() + 1)
+        .clamp(0, maxSlotsPerSide);
+    final rightCount =
+        (((trackWidth + overflowMargin - mainTileLeft - tileWidth) / step)
+                .floor() +
+            1)
+            .clamp(0, maxSlotsPerSide);
+    return TrickplayStripLayout(
+      leftCount: leftCount,
+      rightCount: rightCount,
+      leftOffset: mainTileLeft - leftCount * step,
+    );
+  }
+
+  static const verticalTravelBottomMargin = 150.0;
+
+  static const verticalTravelTopMargin = 120.0;
+
+  static double resolveVerticalTravelMax({
+    required double rawMaxTravel,
+    required double trackWidth,
+  }) {
+    return math.max(math.min(rawMaxTravel, trackWidth), 0.0);
+  }
+
+  static double resolveVerticalTravel(
+    int verticalPositionPercent, {
+    required double maxTravel,
+  }) {
+    final percent = verticalPositionPercent.clamp(0, 100) / 100;
+    return percent * math.max(maxTravel, 0.0);
+  }
+
+  static TrickplayTileSize resolveTileSize({
+    required double trackWidth,
+    required int scalePercent,
+    required double aspect,
+    required double maxHeightBudget,
+  }) {
+    final scale = 0.5 + (scalePercent.clamp(10, 100) - 10) / 90 * 1.5;
+    final safeHeightBudget = math.max(maxHeightBudget, 32.0);
+    final safeTrackWidth = math.max(trackWidth, 24.0);
+    final desiredHeight = (safeHeightBudget * (scale / 2.0)).clamp(
+      24.0,
+      safeHeightBudget,
+    );
+    final height = math.min(desiredHeight, safeTrackWidth * aspect);
+    return TrickplayTileSize(width: height / aspect, height: height);
+  }
+}
+
+class TrickplayTileSize {
+  final double width;
+  final double height;
+
+  const TrickplayTileSize({required this.width, required this.height});
+}
+
+class TrickplayStripLayout {
+  final int leftCount;
+  final int rightCount;
+  final double leftOffset;
+
+  const TrickplayStripLayout({
+    required this.leftCount,
+    required this.rightCount,
+    required this.leftOffset,
+  });
+
+  int get slotCount => leftCount + 1 + rightCount;
+  int get highlightIndex => leftCount;
+}

--- a/lib/data/models/trickplay_strip_resolution.dart
+++ b/lib/data/models/trickplay_strip_resolution.dart
@@ -1,0 +1,40 @@
+class TrickplayStripResolver {
+  const TrickplayStripResolver._();
+
+  static List<TrickplayStripSlot> resolve({
+    required Duration fakeTimelinePosition,
+    required Duration totalDuration,
+    required int stepMs,
+    int slotCount = 5,
+    int? highlightIndex,
+  }) {
+    assert(slotCount > 0);
+    final highlight = (highlightIndex ?? slotCount ~/ 2).clamp(
+      0,
+      slotCount - 1,
+    );
+    return List.generate(slotCount, (i) {
+      final slotIndex = i - highlight;
+      final targetMs =
+          fakeTimelinePosition.inMilliseconds + slotIndex * stepMs;
+      final inRange = targetMs >= 0 && targetMs <= totalDuration.inMilliseconds;
+      return TrickplayStripSlot(
+        slotIndex: slotIndex,
+        targetPosition: inRange ? Duration(milliseconds: targetMs) : null,
+        inRange: inRange,
+      );
+    }, growable: false);
+  }
+}
+
+class TrickplayStripSlot {
+  final int slotIndex;
+  final Duration? targetPosition;
+  final bool inRange;
+
+  const TrickplayStripSlot({
+    required this.slotIndex,
+    required this.targetPosition,
+    required this.inRange,
+  });
+}

--- a/lib/di/injection.dart
+++ b/lib/di/injection.dart
@@ -363,16 +363,9 @@ Future<void> migrateAudioPassthroughMode(PreferenceStore store) async {
 }
 
 const _legacyTrickPlayEnabledKey = 'trick_play_enabled';
-const _legacyTrickPlayDisplayStyleKey = 'trickplay_display_style';
-const _legacyTrickPlayReplaceVideoWhileScrubbingKey =
-    'trickplay_replace_video_while_scrubbing';
-const _legacyTrickPlayVerticalOffsetPxKey = 'trickplay_vertical_offset_px';
 
-/// Consolidates the legacy trickPlayEnabled/trickPlayDisplayStyle/
-/// trickPlayReplaceVideoWhileScrubbing prefs into the single trickPlayMode
-/// enum, and converts the vertical offset from px into the 0-100 percent
-/// Vertical Position now uses. Public (like [migrateAudioPreferenceSplit])
-/// so its mapping logic is unit-testable.
+/// The old on/off switch became the trickPlayMode enum. Only an explicit off
+/// is carried over, since the new default is on.
 Future<void> migrateTrickplayPreferenceConsolidation(
   PreferenceStore store,
 ) async {
@@ -381,43 +374,12 @@ Future<void> migrateTrickplayPreferenceConsolidation(
     return;
   }
 
-  if (!store.containsKey(UserPreferences.trickPlayMode.key)) {
-    final TrickplayMode migratedMode;
-    if (store.containsKey(_legacyTrickPlayEnabledKey) &&
-        store.getBool(_legacyTrickPlayEnabledKey) == false) {
-      // Only an explicit legacy "off" overrides the new default (single/on).
-      migratedMode = TrickplayMode.disabled;
-    } else if (store.getString(_legacyTrickPlayDisplayStyleKey) == 'strip') {
-      // Checked ahead of the legacy replace-video-while-scrubbing bool: if
-      // a user had both set, strip wins (issue #143's filmstrip was the
-      // primary display choice; replace-video was the secondary one).
-      migratedMode = TrickplayMode.strip;
-    } else if (store.getBool(_legacyTrickPlayReplaceVideoWhileScrubbingKey) ==
-        true) {
-      migratedMode = TrickplayMode.full;
-    } else {
-      migratedMode = TrickplayMode.single;
-    }
-    await store.setString(UserPreferences.trickPlayMode.key, migratedMode.name);
-  }
-
-  if (!store.containsKey(
-    UserPreferences.trickPlayVerticalPositionPercent.key,
-  )) {
-    final legacyOffsetPx = store.getInt(_legacyTrickPlayVerticalOffsetPxKey);
-    if (legacyOffsetPx != null) {
-      // Old range was -80..80px; negatives clamp to the new 0% floor (the
-      // default), so only a positive travel is worth writing.
-      final migratedPercent = (legacyOffsetPx / 80.0 * 100)
-          .clamp(0, 100)
-          .round();
-      if (migratedPercent > 0) {
-        await store.setInt(
-          UserPreferences.trickPlayVerticalPositionPercent.key,
-          migratedPercent,
-        );
-      }
-    }
+  if (!store.containsKey(UserPreferences.trickPlayMode.key) &&
+      store.getBool(_legacyTrickPlayEnabledKey) == false) {
+    await store.setString(
+      UserPreferences.trickPlayMode.key,
+      TrickplayMode.disabled.name,
+    );
   }
 
   await store.setBool(migrationKey, true);

--- a/lib/di/injection.dart
+++ b/lib/di/injection.dart
@@ -362,6 +362,67 @@ Future<void> migrateAudioPassthroughMode(PreferenceStore store) async {
   await store.setBool(UserPreferences.audioModeMigrated.key, true);
 }
 
+const _legacyTrickPlayEnabledKey = 'trick_play_enabled';
+const _legacyTrickPlayDisplayStyleKey = 'trickplay_display_style';
+const _legacyTrickPlayReplaceVideoWhileScrubbingKey =
+    'trickplay_replace_video_while_scrubbing';
+const _legacyTrickPlayVerticalOffsetPxKey = 'trickplay_vertical_offset_px';
+
+/// Consolidates the legacy trickPlayEnabled/trickPlayDisplayStyle/
+/// trickPlayReplaceVideoWhileScrubbing prefs into the single trickPlayMode
+/// enum, and converts the vertical offset from px into the 0-100 percent
+/// Vertical Position now uses. Public (like [migrateAudioPreferenceSplit])
+/// so its mapping logic is unit-testable.
+Future<void> migrateTrickplayPreferenceConsolidation(
+  PreferenceStore store,
+) async {
+  const migrationKey = 'pref_trickplay_consolidation_v1';
+  if (store.getBool(migrationKey) == true) {
+    return;
+  }
+
+  if (!store.containsKey(UserPreferences.trickPlayMode.key)) {
+    final TrickplayMode migratedMode;
+    if (store.containsKey(_legacyTrickPlayEnabledKey) &&
+        store.getBool(_legacyTrickPlayEnabledKey) == false) {
+      // Only an explicit legacy "off" overrides the new default (single/on).
+      migratedMode = TrickplayMode.disabled;
+    } else if (store.getString(_legacyTrickPlayDisplayStyleKey) == 'strip') {
+      // Checked ahead of the legacy replace-video-while-scrubbing bool: if
+      // a user had both set, strip wins (issue #143's filmstrip was the
+      // primary display choice; replace-video was the secondary one).
+      migratedMode = TrickplayMode.strip;
+    } else if (store.getBool(_legacyTrickPlayReplaceVideoWhileScrubbingKey) ==
+        true) {
+      migratedMode = TrickplayMode.full;
+    } else {
+      migratedMode = TrickplayMode.single;
+    }
+    await store.setString(UserPreferences.trickPlayMode.key, migratedMode.name);
+  }
+
+  if (!store.containsKey(
+    UserPreferences.trickPlayVerticalPositionPercent.key,
+  )) {
+    final legacyOffsetPx = store.getInt(_legacyTrickPlayVerticalOffsetPxKey);
+    if (legacyOffsetPx != null) {
+      // Old range was -80..80px; negatives clamp to the new 0% floor (the
+      // default), so only a positive travel is worth writing.
+      final migratedPercent = (legacyOffsetPx / 80.0 * 100)
+          .clamp(0, 100)
+          .round();
+      if (migratedPercent > 0) {
+        await store.setInt(
+          UserPreferences.trickPlayVerticalPositionPercent.key,
+          migratedPercent,
+        );
+      }
+    }
+  }
+
+  await store.setBool(migrationKey, true);
+}
+
 // Minimal DI for background isolates like the Watch Next worker. This must not
 // call registerPlaybackModule: constructing Media3PlayerBackend subscribes to
 // the process-global moonfin/media3_video_events channel and would hijack the
@@ -400,6 +461,7 @@ Future<void> configureDependencies() async {
   await _migrateAndroidMobileAudioDefaults(preferenceStore);
   await migrateAudioPreferenceSplit(preferenceStore);
   await migrateAudioPassthroughMode(preferenceStore);
+  await migrateTrickplayPreferenceConsolidation(preferenceStore);
 
   var deviceId = preferenceStore.getString('device_id');
   if (deviceId == null) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3451,6 +3451,38 @@
   "@showPreviewThumbnailsWhenSeeking": {
     "description": "Description for trick play"
   },
+  "trickplayDisplayStyleSingle": "Single Thumbnail",
+  "@trickplayDisplayStyleSingle": {
+    "description": "Trickplay display style option: one thumbnail at the scrub position"
+  },
+  "trickplayDisplayStyleStrip": "Filmstrip",
+  "@trickplayDisplayStyleStrip": {
+    "description": "Trickplay display style option: a row of 5 thumbnails around the scrub position"
+  },
+  "trickplayModeFull": "Full Screen",
+  "@trickplayModeFull": {
+    "description": "Trickplay mode option: temporarily replaces the video with the trickplay image while scrubbing"
+  },
+  "trickplaySettingsPreviewHint": "Drag the slider to preview scrubbing",
+  "@trickplaySettingsPreviewHint": {
+    "description": "Hint shown below the live trickplay settings preview"
+  },
+  "trickplayPreviewScale": "Preview Size",
+  "@trickplayPreviewScale": {
+    "description": "Setting for the size of the trickplay seek preview"
+  },
+  "trickplayVerticalOffset": "Distance From Seekbar",
+  "@trickplayVerticalOffset": {
+    "description": "Setting for the vertical position of the trickplay seek preview relative to the seekbar"
+  },
+  "trickplayFollowScrubPosition": "Follow Scrub Position",
+  "@trickplayFollowScrubPosition": {
+    "description": "Setting for whether the trickplay preview horizontally tracks the scrub handle"
+  },
+  "trickplayFollowScrubPositionSubtitle": "Preview slides along the seekbar as you scrub, instead of staying centered",
+  "@trickplayFollowScrubPositionSubtitle": {
+    "description": "Description for the trickplay follow-scrub-position setting"
+  },
   "showDescriptionOnPause": "Show Description on Pause",
   "@showDescriptionOnPause": {
     "description": "Setting for showing description on pause"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4456,6 +4456,54 @@ abstract class AppLocalizations {
   /// **'Show preview thumbnails when seeking'**
   String get showPreviewThumbnailsWhenSeeking;
 
+  /// Trickplay display style option: one thumbnail at the scrub position
+  ///
+  /// In en, this message translates to:
+  /// **'Single Thumbnail'**
+  String get trickplayDisplayStyleSingle;
+
+  /// Trickplay display style option: a row of 5 thumbnails around the scrub position
+  ///
+  /// In en, this message translates to:
+  /// **'Filmstrip'**
+  String get trickplayDisplayStyleStrip;
+
+  /// Trickplay mode option: temporarily replaces the video with the trickplay image while scrubbing
+  ///
+  /// In en, this message translates to:
+  /// **'Full Screen'**
+  String get trickplayModeFull;
+
+  /// Hint shown below the live trickplay settings preview
+  ///
+  /// In en, this message translates to:
+  /// **'Drag the slider to preview scrubbing'**
+  String get trickplaySettingsPreviewHint;
+
+  /// Setting for the size of the trickplay seek preview
+  ///
+  /// In en, this message translates to:
+  /// **'Preview Size'**
+  String get trickplayPreviewScale;
+
+  /// Setting for the vertical position of the trickplay seek preview relative to the seekbar
+  ///
+  /// In en, this message translates to:
+  /// **'Distance From Seekbar'**
+  String get trickplayVerticalOffset;
+
+  /// Setting for whether the trickplay preview horizontally tracks the scrub handle
+  ///
+  /// In en, this message translates to:
+  /// **'Follow Scrub Position'**
+  String get trickplayFollowScrubPosition;
+
+  /// Description for the trickplay follow-scrub-position setting
+  ///
+  /// In en, this message translates to:
+  /// **'Preview slides along the seekbar as you scrub, instead of staying centered'**
+  String get trickplayFollowScrubPositionSubtitle;
+
   /// Setting for showing description on pause
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2467,6 +2467,32 @@ class AppLocalizationsAf extends AppLocalizations {
       'Wys voorskou-kleinkiekies wanneer jy soek';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Wys beskrywing op pouse';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsAr extends AppLocalizations {
       'إظهار الصور المصغرة للمعاينة عند البحث';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'إظهار الوصف عند الإيقاف المؤقت';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsBe extends AppLocalizations {
       'Паказваць мініяцюры папярэдняга прагляду пры пошуку';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Паказаць апісанне на паўзе';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2473,6 +2473,32 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на миниатюри за визуализация при търсене';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Показване на описание на пауза';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2454,6 +2454,32 @@ class AppLocalizationsBn extends AppLocalizations {
       'খোঁজার সময় পূর্বরূপ থাম্বনেল দেখান';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'পজ এ বর্ণনা দেখান';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2495,6 +2495,32 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra les miniatures de previsualització quan cerques';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Mostra la descripció a Pausa';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsCs extends AppLocalizations {
       'Při hledání zobrazovat náhledy';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Zobrazit popis při pauze';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2488,6 +2488,32 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dangos mân-luniau rhagolwg wrth geisio';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Dangos Disgrifiad ar Saib';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2463,6 +2463,32 @@ class AppLocalizationsDa extends AppLocalizations {
       'Vis forhåndsvisningsminiaturer, når du søger';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Vis beskrivelse på pause';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2548,6 +2548,32 @@ class AppLocalizationsDe extends AppLocalizations {
       'Vorschaubilder beim Spulen anzeigen';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Beschreibung bei Pause anzeigen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2492,6 +2492,32 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση μικρογραφιών προεπισκόπησης κατά την αναζήτηση';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Εμφάνιση Περιγραφής σε Παύση';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2451,6 +2451,32 @@ class AppLocalizationsEn extends AppLocalizations {
       'Show preview thumbnails when seeking';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Show Description on Pause';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2461,6 +2461,32 @@ class AppLocalizationsEo extends AppLocalizations {
       'Montru antaŭrigardajn bildetojn dum serĉado';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Montri Priskribon ĉe Paŭzo';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2479,6 +2479,32 @@ class AppLocalizationsEs extends AppLocalizations {
       'Mostrar miniaturas de vista previa al buscar';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Mostrar descripción al pausar';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2469,6 +2469,32 @@ class AppLocalizationsEt extends AppLocalizations {
       'Kuva otsimisel eelvaate pisipildid';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Kuva kirjeldus pausil';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2449,6 +2449,32 @@ class AppLocalizationsFa extends AppLocalizations {
       'هنگام جستجو، تصاویر کوچک پیش‌نمایش را نشان دهید';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'نمایش توضیحات در حالت مکث';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2472,6 +2472,32 @@ class AppLocalizationsFi extends AppLocalizations {
       'Näytä esikatselupikkukuvat etsiessäsi';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Näytä kuvaus tauolla';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2495,6 +2495,32 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher les miniatures d’aperçu pendant la recherche';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Afficher la description en pause';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2491,6 +2491,32 @@ class AppLocalizationsGl extends AppLocalizations {
       'Mostrar miniaturas de vista previa ao buscar';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Mostrar a descrición en pausa';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2445,6 +2445,32 @@ class AppLocalizationsHe extends AppLocalizations {
       'הצג תמונות ממוזערות של תצוגה מקדימה בעת חיפוש';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'הצג תיאור בהשהיה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2454,6 +2454,32 @@ class AppLocalizationsHi extends AppLocalizations {
       'मांगते समय पूर्वावलोकन थंबनेल दिखाएं';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'विराम पर विवरण दिखाएँ';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2579,6 +2579,32 @@ class AppLocalizationsHr extends AppLocalizations {
       'Prikaži sličice pregleda prilikom traženja';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Prikaži opis na pauzi';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsHu extends AppLocalizations {
       'Az előnézeti bélyegképek megjelenítése kereséskor';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Leírás megjelenítése szüneteltetéskor';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2465,6 +2465,32 @@ class AppLocalizationsId extends AppLocalizations {
       'Tampilkan thumbnail pratinjau saat seek';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Tampilkan Deskripsi saat Jeda';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2474,6 +2474,32 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra miniature di anteprima durante lo scorrimento';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Mostra Descrizione in Pausa';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2415,6 +2415,32 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showPreviewThumbnailsWhenSeeking => 'シーク時にプレビューのサムネイルを表示する';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => '一時停止時に説明を表示';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2470,6 +2470,32 @@ class AppLocalizationsKk extends AppLocalizations {
       'Іздеу кезінде алдын ала қарау нобайларын көрсетіңіз';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Сипаттаманы кідіртуде көрсету';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2474,6 +2474,32 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಹುಡುಕುತ್ತಿರುವಾಗ ಪೂರ್ವವೀಕ್ಷಣೆ ಥಂಬ್‌ನೇಲ್‌ಗಳನ್ನು ತೋರಿಸಿ';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'ವಿರಾಮದಲ್ಲಿ ವಿವರಣೆಯನ್ನು ತೋರಿಸಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2413,6 +2413,32 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showPreviewThumbnailsWhenSeeking => '검색 시 미리보기 썸네일 표시';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => '일시중지 시 설명 표시';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2474,6 +2474,32 @@ class AppLocalizationsLt extends AppLocalizations {
       'Ieškant rodyti peržiūros miniatiūras';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Rodyti aprašą pauzėje';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2479,6 +2479,32 @@ class AppLocalizationsLv extends AppLocalizations {
       'Rādīt priekšskatījuma sīktēlus, kad meklējat';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Rādīt aprakstu pauzē';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsMk extends AppLocalizations {
       'Прикажи преглед на сликички кога барате';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Прикажи опис на пауза';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2475,6 +2475,32 @@ class AppLocalizationsMl extends AppLocalizations {
       'തിരയുമ്പോൾ പ്രിവ്യൂ ലഘുചിത്രങ്ങൾ കാണിക്കുക';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause =>
       'താൽക്കാലികമായി നിർത്തുന്നതിൽ വിവരണം കാണിക്കുക';
 

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2464,6 +2464,32 @@ class AppLocalizationsMn extends AppLocalizations {
       'Хайх үед урьдчилан харах өнгөц зургийг харуул';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Түр зогсолт дээр тайлбарыг харуулах';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2461,6 +2461,32 @@ class AppLocalizationsNb extends AppLocalizations {
       'Vis forhåndsvisningsminiatyrer når du søker';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Vis beskrivelse på pause';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2477,6 +2477,32 @@ class AppLocalizationsNl extends AppLocalizations {
       'Toon voorbeeldminiaturen tijdens het zoeken';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Beschrijving weergeven bij pauze';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2458,6 +2458,32 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਮੰਗਣ ਵੇਲੇ ਝਲਕ ਦੇ ਥੰਬਨੇਲ ਦਿਖਾਓ';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'ਵਿਰਾਮ \'ਤੇ ਵਰਣਨ ਦਿਖਾਓ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2605,6 +2605,32 @@ class AppLocalizationsPl extends AppLocalizations {
       'Pokazuj podgląd klatek podczas przewijania';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Pokazuj opis podczas pauzy';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2473,6 +2473,32 @@ class AppLocalizationsPt extends AppLocalizations {
       'Mostrar miniaturas de pré-visualização ao avançar';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Mostrar Descrição ao Pausar';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2480,6 +2480,32 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișați miniaturile de previzualizare când căutați';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Afișați descrierea în pauză';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2486,6 +2486,32 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать миниатюры предварительного просмотра при поиске';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Показать описание на паузе';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2460,6 +2460,32 @@ class AppLocalizationsSi extends AppLocalizations {
       'සොයන විට පෙරදසුන් සිඟිති රූ පෙන්වන්න';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'විරාමය මත විස්තරය පෙන්වන්න';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2484,6 +2484,32 @@ class AppLocalizationsSk extends AppLocalizations {
       'Pri vyhľadávaní zobraziť miniatúry ukážky';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Zobraziť popis pri pozastavení';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2486,6 +2486,32 @@ class AppLocalizationsSl extends AppLocalizations {
       'Pri iskanju prikaži predogled sličic';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Prikaži opis ob premoru';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2480,6 +2480,32 @@ class AppLocalizationsSq extends AppLocalizations {
       'Shfaq miniaturën e pamjes paraprake kur kërkon';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Shfaq përshkrimin në pauzë';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2580,6 +2580,32 @@ class AppLocalizationsSr extends AppLocalizations {
       'Прикажи сличице за преглед када тражите';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Прикажи опис на паузи';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2469,6 +2469,32 @@ class AppLocalizationsSv extends AppLocalizations {
       'Visa förhandsgranskningsminiatyrer när du söker';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Visa beskrivning på paus';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2479,6 +2479,32 @@ class AppLocalizationsSw extends AppLocalizations {
       'Onyesha vijipicha vya kukagua unapotafuta';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Onyesha Maelezo kuhusu Kusitisha';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2479,6 +2479,32 @@ class AppLocalizationsTa extends AppLocalizations {
       'தேடும் போது முன்னோட்ட சிறுபடங்களைக் காட்டு';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'இடைநிறுத்தத்தில் விளக்கத்தைக் காட்டு';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2475,6 +2475,32 @@ class AppLocalizationsTe extends AppLocalizations {
       'కోరుతున్నప్పుడు ప్రివ్యూ థంబ్‌నెయిల్‌లను చూపండి';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'పాజ్‌లో వివరణను చూపు';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2444,6 +2444,32 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showPreviewThumbnailsWhenSeeking => 'แสดงภาพตัวอย่างเมื่อค้นหา';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'แสดงคำอธิบายเมื่อหยุดชั่วคราว';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2481,6 +2481,32 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ipakita ang mga thumbnail ng preview kapag naghahanap';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Ipakita ang Paglalarawan sa I-pause';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2459,6 +2459,32 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sararken önizleme küçük resimlerini göster';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Duraklatıldığında Açıklamayı Göster';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2466,6 +2466,32 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئىزدىگەندە ئالدىن كۆرۈش كىچىك كۆرۈنۈشىنى كۆرسىتىڭ';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'توختاپ قېلىشنى چۈشەندۈرۈڭ';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2484,6 +2484,32 @@ class AppLocalizationsUk extends AppLocalizations {
       'Показувати мініатюри попереднього перегляду під час пошуку';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Показати опис на паузі';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2467,6 +2467,32 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị hình thu nhỏ xem trước khi tìm kiếm';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => 'Hiển thị mô tả khi tạm dừng';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2401,6 +2401,32 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showPreviewThumbnailsWhenSeeking => '搜尋時顯示預覽縮圖';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => '顯示暫停說明';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2399,6 +2399,32 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showPreviewThumbnailsWhenSeeking => '拖动进度时显示预览缩略图';
 
   @override
+  String get trickplayDisplayStyleSingle => 'Single Thumbnail';
+
+  @override
+  String get trickplayDisplayStyleStrip => 'Filmstrip';
+
+  @override
+  String get trickplayModeFull => 'Full Screen';
+
+  @override
+  String get trickplaySettingsPreviewHint =>
+      'Drag the slider to preview scrubbing';
+
+  @override
+  String get trickplayPreviewScale => 'Preview Size';
+
+  @override
+  String get trickplayVerticalOffset => 'Distance From Seekbar';
+
+  @override
+  String get trickplayFollowScrubPosition => 'Follow Scrub Position';
+
+  @override
+  String get trickplayFollowScrubPositionSubtitle =>
+      'Preview slides along the seekbar as you scrub, instead of staying centered';
+
+  @override
   String get showDescriptionOnPause => '暂停时显示简介';
 
   @override

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -320,6 +320,16 @@ const double kBannerAspectRatio = 1000 / 185;
 /// keep resizing banners with no way to change them.
 const double kBannerCardHeight = 110;
 
+/// [strip] shows a Netflix-style filmstrip spanning the scrub position.
+/// [full] temporarily replaces the video with the trickplay image while
+/// scrubbing.
+enum TrickplayMode {
+  disabled,
+  single,
+  strip,
+  full,
+}
+
 enum ImageType {
   poster,
   thumb,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1594,8 +1594,24 @@ class UserPreferences extends ChangeNotifier {
     values: DesktopScrollWheelAction.values,
   );
 
-  static final trickPlayEnabled = Preference(
-    key: 'trick_play_enabled',
+  static final trickPlayMode = EnumPreference(
+    key: 'trickplay_mode',
+    defaultValue: TrickplayMode.single,
+    values: TrickplayMode.values,
+  );
+
+  static final trickPlayPreviewScalePercent = Preference<int>(
+    key: 'trickplay_preview_scale_percent',
+    defaultValue: 30,
+  );
+
+  static final trickPlayVerticalPositionPercent = Preference<int>(
+    key: 'trickplay_vertical_position_percent',
+    defaultValue: 0,
+  );
+
+  static final trickPlayFollowScrubPosition = Preference<bool>(
+    key: 'trickplay_follow_scrub_position',
     defaultValue: true,
   );
 

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -53,6 +53,8 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
   MediaSegmentService? _segmentService;
   String? _segmentsLoadedForItemId;
   StreamSubscription<Duration>? _positionSub;
+  UserPreferences? _prefsListened;
+  String _lastTrickplayPrefs = '';
   SyncPlayManager? _syncPlay;
   AppThemeController? _themeController;
   ScreensaverController? _screensaverController;
@@ -120,6 +122,9 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         queueSnapshot: _queueSnapshot,
         segmentService: () => _segmentService,
       );
+      _prefsListened = prefs;
+      _lastTrickplayPrefs = _trickplayPrefsSnapshot(prefs);
+      prefs.addListener(_onPrefsChanged);
     } catch (_) {}
     _loadSegmentsForCurrentItem();
     if (GetIt.instance.isRegistered<SyncPlayManager>()) {
@@ -591,14 +596,13 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     dynamic item,
     PlaybackManager manager,
   ) {
+    final UserPreferences prefs;
     try {
-      if (GetIt.instance<UserPreferences>().get(
-            UserPreferences.trickPlayMode,
-          ) ==
-          TrickplayMode.disabled) {
-        return null;
-      }
+      prefs = GetIt.instance<UserPreferences>();
     } catch (_) {
+      return null;
+    }
+    if (prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
       return null;
     }
     final raw = _rawDataForQueueItem(item);
@@ -638,7 +642,31 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
       'cols': info.tileWidth,
       'rows': info.tileHeight,
       'intervalMs': info.interval,
+      'mode': prefs.get(UserPreferences.trickPlayMode).name,
+      'scalePercent': prefs.get(UserPreferences.trickPlayPreviewScalePercent),
+      'verticalPositionPercent': prefs.get(
+        UserPreferences.trickPlayVerticalPositionPercent,
+      ),
+      'followScrub': prefs.get(UserPreferences.trickPlayFollowScrubPosition),
     };
+  }
+
+  // The native player reads these once per metadata push, so a change made
+  // while a video is playing has to be sent over again.
+  String _trickplayPrefsSnapshot(UserPreferences prefs) => [
+    prefs.get(UserPreferences.trickPlayMode).name,
+    prefs.get(UserPreferences.trickPlayPreviewScalePercent),
+    prefs.get(UserPreferences.trickPlayVerticalPositionPercent),
+    prefs.get(UserPreferences.trickPlayFollowScrubPosition),
+  ].join('|');
+
+  void _onPrefsChanged() {
+    final prefs = _prefsListened;
+    if (prefs == null) return;
+    final next = _trickplayPrefsSnapshot(prefs);
+    if (next == _lastTrickplayPrefs) return;
+    _lastTrickplayPrefs = next;
+    _pushMetadata();
   }
 
   List<Map<String, dynamic>> _mapPeople(
@@ -1410,6 +1438,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     _screensaverController?.setPlaybackActive(false);
     _syncPlay?.removeListener(_onSyncPlayChanged);
     _themeController?.removeListener(_onThemeChanged);
+    _prefsListened?.removeListener(_onPrefsChanged);
     unawaited(_backend?.dismissPlayer() ?? Future<void>.value());
     try {
       final manager = GetIt.instance<PlaybackManager>();

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -592,9 +592,10 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     PlaybackManager manager,
   ) {
     try {
-      if (!GetIt.instance<UserPreferences>().get(
-        UserPreferences.trickPlayEnabled,
-      )) {
+      if (GetIt.instance<UserPreferences>().get(
+            UserPreferences.trickPlayMode,
+          ) ==
+          TrickplayMode.disabled) {
         return null;
       }
     } catch (_) {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -22,6 +23,7 @@ import '../../../util/scroll_sensitivity_binding.dart';
 import '../../widgets/player_volume_control.dart';
 import '../../widgets/playback/playback_time_row.dart';
 import '../../widgets/playback/seek_icons.dart';
+import '../../widgets/playback/trickplay.dart';
 import '../../widgets/playback/trickplay_tile_image.dart';
 
 import '../../../playback/html_video_backend.dart';
@@ -36,6 +38,9 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/item_mutation_repository.dart';
 import '../../../data/models/media_segment.dart';
 import '../../../data/models/trickplay_info.dart';
+import '../../../data/models/trickplay_prefetch_planner.dart';
+import '../../../data/models/trickplay_preview_layout.dart';
+import '../../../data/models/trickplay_strip_resolution.dart';
 import '../../../data/services/cast/cast_service.dart';
 import '../../../data/services/cast/cast_target.dart';
 import '../../../data/services/cast/native_airplay_channel.dart';
@@ -90,7 +95,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   static const _tvTemporarySpeedHoldDelay = Duration(milliseconds: 420);
   static const _seekPromptSuppressionDuration = Duration(milliseconds: 1200);
   static const _seekDragPromptSuppressionDuration = Duration(seconds: 4);
-  static const _scrubSeekDebounceDuration = Duration(milliseconds: 250);
+  static const _scrubSeekConvergeTolerance = Duration(milliseconds: 800);
+  static const _scrubSeekConvergeTimeout = Duration(seconds: 2);
 
   final _manager = GetIt.instance<PlaybackManager>();
   // media_kit isn't registered on platforms that run a different backend, so
@@ -140,8 +146,20 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Timer? _endsAtTicker;
   bool _isSeeking = false;
   double _seekValue = 0;
-  Timer? _scrubSeekDebounceTimer;
   Duration? _pendingScrubSeekTarget;
+  Duration? _lastScrubCommitTarget;
+  int _scrubSeekCommitId = 0;
+  bool _wasPlayingBeforeScrubPause = false;
+  // True for a paused scrub session's whole lifetime; unlike
+  // _wasPlayingBeforeScrubPause, doesn't imply resuming afterward.
+  bool _isPausedScrubActive = false;
+  final Set<int> _prefetchedTrickplayIndexes = {};
+  bool _touchTrickplayPrefetchStarted = false;
+  Duration? _hoverPosition;
+  double? _topOverlayHeight;
+  double? _bottomOverlayHeight;
+  final GlobalKey _topOverlayKey = GlobalKey();
+  final GlobalKey _bottomOverlayKey = GlobalKey();
   late ZoomMode _zoomMode;
   double _audioDelay = 0.0;
   double _subtitleDelay = 0.0;
@@ -982,8 +1000,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _skipSegmentAutoHideTimer?.cancel();
     _displayPlayingDebounce?.cancel();
     _endsAtTicker?.cancel();
-    _scrubSeekDebounceTimer?.cancel();
-    _scrubSeekDebounceTimer = null;
     _volumeOverlayTimer?.cancel();
     _brightnessOverlayTimer?.cancel();
     _zoomModeToastTimer?.cancel();
@@ -2120,6 +2136,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       rawData,
       mediaSourceId: mediaSourceId,
     );
+    _prefetchedTrickplayIndexes.clear();
+    _touchTrickplayPrefetchStarted = false;
     if (mounted) {
       setState(() {
         _trickplayInfo = info;
@@ -2138,12 +2156,109 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
+  void _handleTrickplayAmbientPrefetch(Duration position) {
+    if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
+      return;
+    }
+    final info = _trickplayInfo;
+    if (info == null || !info.isValid) return;
+    final duration = _state.duration;
+    if (duration <= Duration.zero) return;
+
+    if (!PlatformDetection.isTV) {
+      _startTouchTrickplayPrefetch(info, position, duration);
+    }
+
+    _precacheTrickplayIndexes(
+      TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: position,
+        totalDuration: duration,
+        directionForward: true,
+        sheetsAhead: 1,
+      ),
+    );
+  }
+
+  void _startTouchTrickplayPrefetch(
+    TrickplayInfo info,
+    Duration position,
+    Duration duration,
+  ) {
+    if (_touchTrickplayPrefetchStarted) return;
+    _touchTrickplayPrefetchStarted = true;
+    _precacheTrickplayIndexes(
+      TrickplayPrefetchPlanner.planAllImageIndexes(
+        info: info,
+        position: position,
+        totalDuration: duration,
+      ),
+    );
+  }
+
+  void _prefetchTrickplayDirectional(
+    Duration position, {
+    required bool forward,
+  }) {
+    if (!PlatformDetection.isTV) return;
+    if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
+      return;
+    }
+    final info = _trickplayInfo;
+    final duration = _state.duration;
+    if (info == null || !info.isValid || duration <= Duration.zero) return;
+    _precacheTrickplayIndexes(
+      TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: position,
+        totalDuration: duration,
+        directionForward: forward,
+        sheetsAhead: 2,
+      ),
+    );
+  }
+
+  void _precacheTrickplayIndexes(List<int> indexes) {
+    if (indexes.isEmpty) return;
+    final info = _trickplayInfo;
+    if (info == null) return;
+    final item = _queue.currentItem;
+    final itemId = _itemIdForQueueItem(item);
+    if (itemId == null || itemId.isEmpty) return;
+    final client = _clientForQueueItem(item);
+    final token = client.accessToken;
+    final headers = <String, String>{
+      if (token != null && token.isNotEmpty)
+        'Authorization': 'MediaBrowser Token="$token"',
+    };
+    for (final index in indexes) {
+      if (!_prefetchedTrickplayIndexes.add(index)) continue;
+      if (!mounted) return;
+      final url = client.imageApi.getTrickplayTileImageUrl(
+        itemId,
+        width: info.width,
+        index: index,
+        mediaSourceId: _trickplayMediaSourceId,
+      );
+      unawaited(
+        precacheImage(
+          CachedNetworkImageProvider(
+            url,
+            headers: headers.isEmpty ? null : headers,
+          ),
+          context,
+        ).catchError((_) {}),
+      );
+    }
+  }
+
   void _onPositionUpdate(Duration position) {
     if (!mounted || _isSeeking || _isRestoringPosition) return;
     if (PlatformDetection.useNativeVideoSurface) {
       _syncSubtitleActive();
     }
     _refreshTrickplayIfNeeded();
+    _handleTrickplayAmbientPrefetch(position);
     _syncAirPlayPlaybackState(position: position);
     if (PlatformDetection.isIOS) {
       _pipService.updateIosTimeline(
@@ -2777,49 +2892,149 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
-  void _seekRelativeDebounced(int ms, {bool showControls = true}) {
+  void _seekRelativeAccumulate(int ms) {
     _suppressSeekPrompts();
-    final basePosition = _pendingScrubSeekTarget ?? _state.position;
+    // While a released commit is still converging, the pending target is
+    // already null but _state.position still reads pre-seek - basing a quick
+    // follow-up press on it would jump back to the old position.
+    final basePosition = _pendingScrubSeekTarget ??
+        (_isSeeking ? _lastScrubCommitTarget : null) ??
+        _state.position;
     final target = basePosition + Duration(milliseconds: ms);
-    _scheduleDebouncedScrubSeek(target, showControls: showControls);
+    _prefetchTrickplayDirectional(basePosition, forward: ms > 0);
+    _accumulateScrub(target);
   }
 
-  void _scheduleDebouncedScrubSeek(
-    Duration target, {
-    bool showControls = true,
-  }) {
+  bool get _hasTrickplayPreview =>
+      _prefs.get(UserPreferences.trickPlayMode) != TrickplayMode.disabled &&
+      (_trickplayInfo?.isValid ?? false);
+
+  // Pauses playback once per scrub session so the trickplay preview has a
+  // stable frozen reference; without a preview, scrubbing leaves playback
+  // untouched. The Slider path resumes after its committed seek converges;
+  // the D-pad path stays paused until the user presses play. Callers gate
+  // this on
+  // _pendingScrubSeekTarget being null (see _accumulateScrub), not on
+  // _isSeeking - _isSeeking can still be true from an OLDER commit that
+  // hasn't finished converging yet when a brand new gesture starts (release,
+  // then press again quickly), and that stale state must not block this new
+  // gesture's own setup.
+  void _beginScrub() {
+    // Dragging fires PointerMoveEvents, not hover events, so stale
+    // _hoverPosition must be cleared or it flashes the wrong preview on drag end.
+    _hoverPosition = null;
+    // Invalidates any older in-flight _commitScrubSeek the moment a new
+    // gesture starts (not just when a new gesture commits) - otherwise that
+    // old commit's eventual convergence can clear _isSeeking (or fire
+    // resume()) out from under this new, still-active gesture, snapping the
+    // frozen timeline back to live position mid-hold.
+    _scrubSeekCommitId++;
+    if (_hasTrickplayPreview) {
+      _isPausedScrubActive = true;
+      // If an earlier still-resolving commit already paused playback for
+      // this chain of overlapping gestures, _wasPlayingBeforeScrubPause is
+      // already correctly true - re-reading _state.isPlaying now would see
+      // "paused" and wrongly conclude nothing needs resuming later.
+      if (!_wasPlayingBeforeScrubPause) {
+        _wasPlayingBeforeScrubPause = _state.isPlaying;
+        if (_wasPlayingBeforeScrubPause) {
+          _manager.pause();
+        }
+      }
+    }
+  }
+
+  // Purely visual - moves the frozen scrub target without touching the
+  // backend; the session's one real seek fires in _commitPendingScrub.
+  void _accumulateScrub(Duration target, {bool showControls = true}) {
     final clamped = Duration(
       milliseconds: target.inMilliseconds.clamp(
         0,
         _state.duration.inMilliseconds,
       ),
     );
+    if (_pendingScrubSeekTarget == null) {
+      _beginScrub();
+    }
     setState(() {
       _pendingScrubSeekTarget = clamped;
       _isSeeking = true;
       _seekValue = clamped.inMilliseconds.toDouble();
-    });
-    _scrubSeekDebounceTimer?.cancel();
-    _scrubSeekDebounceTimer = Timer(_scrubSeekDebounceDuration, () {
-      final pendingTarget = _pendingScrubSeekTarget;
-      if (pendingTarget != null) {
-        _pendingScrubSeekTarget = null;
-        _scrubSeekDebounceTimer = null;
-        unawaited(_manager.seekTo(pendingTarget));
-        _lastSeekTime = DateTime.now();
-        if (mounted) {
-          setState(() {
-            _isSeeking = false;
-          });
-        }
-      }
     });
     if (showControls) {
       _showControls();
     }
   }
 
+  /// Commits whatever scrub target is pending as the one real seek for this
+  /// session. Called on Slider drag-end and on play during a paused D-pad
+  /// scrub session - the actual "go" signals, not a timer guess.
+  void _commitPendingScrub() {
+    _isPausedScrubActive = false;
+    final pendingTarget = _pendingScrubSeekTarget;
+    if (pendingTarget == null) return;
+    _pendingScrubSeekTarget = null;
+    _lastScrubCommitTarget = pendingTarget;
+    unawaited(_commitScrubSeek(pendingTarget));
+  }
+
+  // _isSeeking gates the seekbar between the frozen scrub target and the
+  // live position stream (see _buildSeekbar). That stream only updates on
+  // the backend's own periodic push, not on seekTo completion, so clearing
+  // _isSeeking as soon as the seek is dispatched shows a stale pre-seek
+  // position for one frame, then jumps again once the real update arrives.
+  //
+  // A second commit can still start before an earlier one's wait finishes
+  // (e.g. a new gesture beginning right after the previous one committed).
+  // Two failure modes if that overlap isn't handled explicitly:
+  //  1. positionStream events aren't selective - during overlap the next
+  //     one can be a stale event left over from an OLDER, already-abandoned
+  //     commit, unrelated to this commit's own target. Waiting for a
+  //     reading actually close to *this* target avoids that.
+  //  2. An abandoned older commit reaching its resume()/isSeeking-clear
+  //     after a newer commit has already taken over must not act at all -
+  //     otherwise it can resume playback (or drop the freeze) on the newer
+  //     commit's behalf, mid-seek. Checking commitId before every side
+  //     effect (not just the final setState) prevents that.
+  Future<void> _commitScrubSeek(Duration target) async {
+    final commitId = ++_scrubSeekCommitId;
+    try {
+      await _manager.seekTo(target);
+      _lastSeekTime = DateTime.now();
+      // .timeout keeps this a real wall-clock deadline: while Strip mode
+      // holds the player paused the position stream can go completely
+      // silent, and a deadline only checked when an event arrives would
+      // never fire.
+      await _state.positionStream
+          .firstWhere(
+            (p) =>
+                commitId != _scrubSeekCommitId ||
+                (p - target).abs() <= _scrubSeekConvergeTolerance,
+          )
+          .timeout(_scrubSeekConvergeTimeout);
+    } catch (_) {
+      // Seek failed, or the real position never converged in time; fall
+      // through so the UI doesn't stay frozen on the scrub target forever.
+    }
+    if (commitId != _scrubSeekCommitId) return;
+    if (_wasPlayingBeforeScrubPause) {
+      _wasPlayingBeforeScrubPause = false;
+      unawaited(_manager.resume());
+    }
+    if (mounted) {
+      setState(() => _isSeeking = false);
+    }
+  }
+
   Future<void> _resumeWithConfiguredRewind() async {
+    // Every resume control funnels through here. During a paused scrub
+    // session, play means "commit the scrubbed target and go" (#1025's
+    // press-play-to-continue), not resume-at-the-old-position.
+    if (_isPausedScrubActive) {
+      _wasPlayingBeforeScrubPause = true;
+      _commitPendingScrub();
+      return;
+    }
     final rewindMs = _prefs.get(UserPreferences.unpauseRewindDuration);
     if (rewindMs > 0) {
       final rewind = Duration(milliseconds: rewindMs);
@@ -3167,6 +3382,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       if (event.logicalKey == LogicalKeyboardKey.arrowLeft ||
           event.logicalKey == LogicalKeyboardKey.arrowRight) {
         _resetSeekAcceleration();
+        // With a trickplay preview up, the session survives key-release -
+        // the preview stays on the paused frame and play is what commits
+        // (#1025). With nothing to browse, release commits directly.
+        if (!_hasTrickplayPreview) {
+          _commitPendingScrub();
+        }
       }
       return KeyEventResult.ignored;
     }
@@ -3571,6 +3792,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                       const Positioned.fill(
                         child: ColoredBox(color: Colors.transparent),
                       ), // Workaround for a Flutter web issue where the video surface can block pointer events.
+                    _buildTrickplayVideoCover(),
                     _buildBringupOverlay(context),
                     if (_isRestoringPosition)
                       const Positioned.fill(
@@ -3581,11 +3803,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                         !_isOsdLocked &&
                         !hideOsdForPreroll) ...[
                       _buildTopOverlay(context),
-                      _buildBottomOverlay(context),
                       if (!PlatformDetection.useLeanbackUi)
                         Positioned.fill(
                           child: Center(child: _buildCenterTransportControls()),
                         ),
+                      _buildBottomOverlay(context),
                     ],
                     _buildBufferingIndicator(),
                     _buildVolumeOverlay(),
@@ -3683,6 +3905,29 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         if (retryIdx == null || retryIdx < 0) return;
         await _manager.changeSubtitleTrack(retryIdx, userInitiated: false);
       }),
+    );
+  }
+
+  Widget _buildTrickplayVideoCover() {
+    if (!_isSeeking) return const SizedBox.shrink();
+    if (_prefs.get(UserPreferences.trickPlayMode) != TrickplayMode.full) {
+      return const SizedBox.shrink();
+    }
+    final seekPosition = Duration(milliseconds: _seekValue.round());
+    final tile = _getTrickplayTile(seekPosition);
+    if (tile == null) return const SizedBox.shrink();
+    return Positioned.fill(
+      child: Trickplay(
+        fillFrame: true,
+        content: (_) => FittedBox(
+          fit: _zoomToFit(_zoomMode),
+          child: SizedBox(
+            width: tile.thumbWidth,
+            height: tile.thumbHeight,
+            child: _trickplayTileImage(tile),
+          ),
+        ),
+      ),
     );
   }
 
@@ -4001,7 +4246,29 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     return null;
   }
 
+  void _scheduleOverlayMeasurement() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final topBox =
+          _topOverlayKey.currentContext?.findRenderObject() as RenderBox?;
+      final bottomBox =
+          _bottomOverlayKey.currentContext?.findRenderObject() as RenderBox?;
+      final newTop = topBox?.hasSize == true ? topBox!.size.height : null;
+      final newBottom = bottomBox?.hasSize == true
+          ? bottomBox!.size.height
+          : null;
+      if ((newTop != null && newTop != _topOverlayHeight) ||
+          (newBottom != null && newBottom != _bottomOverlayHeight)) {
+        setState(() {
+          if (newTop != null) _topOverlayHeight = newTop;
+          if (newBottom != null) _bottomOverlayHeight = newBottom;
+        });
+      }
+    });
+  }
+
   Widget _buildTopOverlay(BuildContext context) {
+    _scheduleOverlayMeasurement();
     final l10n = AppLocalizations.of(context);
     final padding = MediaQuery.of(context).padding;
     return Positioned(
@@ -4009,6 +4276,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       left: 0,
       right: 0,
       child: Container(
+        key: _topOverlayKey,
         padding: EdgeInsets.only(
           top: padding.top + AppSpacing.spaceSm,
           left: AppSpacing.spaceLg,
@@ -4293,27 +4561,41 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       bottom: 0,
       left: 0,
       right: 0,
-      child: Container(
-        padding: EdgeInsets.only(
-          bottom: padding.bottom + AppSpacing.spaceSm,
-          left: AppSpacing.spaceLg,
-          right: AppSpacing.spaceLg,
-        ),
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.bottomCenter,
-            end: Alignment.topCenter,
-            colors: [Colors.black87, Colors.transparent],
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              left: AppSpacing.spaceLg,
+              right: AppSpacing.spaceLg,
+            ),
+            child: _buildTrickplaySeekPreview(),
           ),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildSeekbar(),
-            const SizedBox(height: AppSpacing.spaceXs),
-            _buildSecondaryControlsRow(),
-          ],
-        ),
+          Container(
+            key: _bottomOverlayKey,
+            padding: EdgeInsets.only(
+              bottom: padding.bottom + AppSpacing.spaceSm,
+              left: AppSpacing.spaceLg,
+              right: AppSpacing.spaceLg,
+            ),
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [Colors.black87, Colors.transparent],
+              ),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildSeekbar(),
+                const SizedBox(height: AppSpacing.spaceXs),
+                _buildSecondaryControlsRow(),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -4324,27 +4606,41 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       bottom: 0,
       left: 0,
       right: 0,
-      child: Container(
-        padding: EdgeInsets.only(
-          bottom: padding.bottom + AppSpacing.spaceSm,
-          left: AppSpacing.spaceLg,
-          right: AppSpacing.spaceLg,
-        ),
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.bottomCenter,
-            end: Alignment.topCenter,
-            colors: [Colors.black87, Colors.transparent],
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              left: AppSpacing.spaceLg,
+              right: AppSpacing.spaceLg,
+            ),
+            child: _buildTrickplaySeekPreview(),
           ),
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildSeekbar(),
-            const SizedBox(height: AppSpacing.spaceXs),
-            _buildTvBottomControlsRow(),
-          ],
-        ),
+          Container(
+            key: _bottomOverlayKey,
+            padding: EdgeInsets.only(
+              bottom: padding.bottom + AppSpacing.spaceSm,
+              left: AppSpacing.spaceLg,
+              right: AppSpacing.spaceLg,
+            ),
+            decoration: const BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.bottomCenter,
+                end: Alignment.topCenter,
+                colors: [Colors.black87, Colors.transparent],
+              ),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildSeekbar(),
+                const SizedBox(height: AppSpacing.spaceXs),
+                _buildTvBottomControlsRow(),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -4409,159 +4705,166 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     aboveLeft.isNotEmpty ||
                     aboveCenter.isNotEmpty ||
                     aboveRight.isNotEmpty;
-                final trickplayTile = _isSeeking
-                    ? _getTrickplayTile(seekPosition)
-                    : null;
 
-                return Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (trickplayTile != null)
-                      Padding(
-                        padding: const EdgeInsets.only(
-                          bottom: AppSpacing.spaceSm,
-                        ),
-                        child: _buildSeekPreviewThumbnail(
-                          imageUrl: trickplayTile.url,
-                          headers: trickplayTile.headers,
-                          position: seekPosition,
-                          sourceRect: trickplayTile.sourceRect,
-                          thumbWidth: trickplayTile.thumbWidth,
-                          thumbHeight: trickplayTile.thumbHeight,
-                          tileWidth: trickplayTile.tileWidth,
-                          tileHeight: trickplayTile.tileHeight,
-                        ),
-                      ),
-                    if (hasAboveRow)
-                      Padding(
-                        padding: const EdgeInsets.only(
-                          bottom: AppSpacing.spaceXs,
-                        ),
-                        child: _buildTimeSlotRow(
-                          left: aboveLeft,
-                          center: aboveCenter,
-                          right: aboveRight,
-                          bold: true,
-                        ),
-                      ),
-                    Focus(
-                      focusNode: _tvSeekbarFocus,
-                      onKeyEvent: (node, event) {
-                        if (!PlatformDetection.isTV ||
-                            (event is! KeyDownEvent &&
-                                event is! KeyRepeatEvent)) {
-                          return KeyEventResult.ignored;
-                        }
-                        switch (event.logicalKey) {
-                          case LogicalKeyboardKey.arrowLeft:
-                            _seekRelativeDebounced(
-                              -_prefs.get(UserPreferences.skipBackLength),
-                            );
-                            return KeyEventResult.handled;
-                          case LogicalKeyboardKey.arrowRight:
-                            _seekRelativeDebounced(
-                              _prefs.get(UserPreferences.skipForwardLength),
-                            );
-                            return KeyEventResult.handled;
-                          case LogicalKeyboardKey.arrowUp:
-                            return KeyEventResult.handled;
-                          case LogicalKeyboardKey.arrowDown:
-                            if (_tvBottomPrimaryFocus.context != null) {
-                              _tvBottomPrimaryFocus.requestFocus();
-                            }
-                            return KeyEventResult.handled;
-                          case LogicalKeyboardKey.select:
-                          case LogicalKeyboardKey.enter:
-                            _togglePlayPause();
-                            _showControls(focusSeekbar: true);
-                            return KeyEventResult.handled;
-                          default:
-                            return KeyEventResult.ignored;
-                        }
-                      },
-                      child: ExcludeFocus(
-                        excluding: PlatformDetection.isTV,
-                        child: SliderTheme(
-                          data: SliderThemeData(
-                            trackHeight: 4,
-                            thumbShape: const RoundSliderThumbShape(
-                              enabledThumbRadius: 7,
+                return LayoutBuilder(
+                  builder: (context, seekbarConstraints) {
+                    final trackWidth = seekbarConstraints.maxWidth;
+
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (hasAboveRow)
+                          Padding(
+                            padding: const EdgeInsets.only(
+                              bottom: AppSpacing.spaceXs,
                             ),
-                            overlayShape: const RoundSliderOverlayShape(
-                              overlayRadius: 14,
-                            ),
-                            activeTrackColor: AppColorScheme.rangeProgress,
-                            secondaryActiveTrackColor: AppColorScheme.rangeTrack
-                                .withValues(alpha: 0.8),
-                            inactiveTrackColor: AppColorScheme.rangeTrack,
-                            thumbColor:
-                                (PlatformDetection.isTV && _seekbarFocused)
-                                ? Colors.white
-                                : AppColorScheme.rangeThumb,
-                            overlayColor: AppColorScheme.rangeThumb.withValues(
-                              alpha: 0.2,
+                            child: _buildTimeSlotRow(
+                              left: aboveLeft,
+                              center: aboveCenter,
+                              right: aboveRight,
+                              bold: true,
                             ),
                           ),
-                          child: Slider(
-                            value: positionMs.clamp(0.0, durationMs),
-                            secondaryTrackValue: bufferMs.clamp(
-                              0.0,
-                              durationMs,
+                        MouseRegion(
+                          opaque: false,
+                          onHover: PlatformDetection.useDesktopUi
+                              ? (event) => _handleSeekbarHover(
+                                  event,
+                                  trackWidth: trackWidth,
+                                  duration: duration,
+                                )
+                              : null,
+                          onExit: PlatformDetection.useDesktopUi
+                              ? (_) => _clearSeekbarHover()
+                              : null,
+                          child: Focus(
+                            focusNode: _tvSeekbarFocus,
+                            onKeyEvent: (node, event) {
+                              if (!PlatformDetection.isTV ||
+                                  (event is! KeyDownEvent &&
+                                      event is! KeyRepeatEvent)) {
+                                return KeyEventResult.ignored;
+                              }
+                              switch (event.logicalKey) {
+                                case LogicalKeyboardKey.arrowLeft:
+                                  _seekRelativeAccumulate(
+                                    -_prefs.get(UserPreferences.skipBackLength),
+                                  );
+                                  return KeyEventResult.handled;
+                                case LogicalKeyboardKey.arrowRight:
+                                  _seekRelativeAccumulate(
+                                    _prefs.get(
+                                      UserPreferences.skipForwardLength,
+                                    ),
+                                  );
+                                  return KeyEventResult.handled;
+                                case LogicalKeyboardKey.arrowUp:
+                                  return KeyEventResult.handled;
+                                case LogicalKeyboardKey.arrowDown:
+                                  if (_tvBottomPrimaryFocus.context != null) {
+                                    _tvBottomPrimaryFocus.requestFocus();
+                                  }
+                                  return KeyEventResult.handled;
+                                case LogicalKeyboardKey.select:
+                                case LogicalKeyboardKey.enter:
+                                  _togglePlayPause();
+                                  _showControls(focusSeekbar: true);
+                                  return KeyEventResult.handled;
+                                default:
+                                  return KeyEventResult.ignored;
+                              }
+                            },
+                            child: ExcludeFocus(
+                              excluding: PlatformDetection.isTV,
+                              child: SliderTheme(
+                                data: SliderThemeData(
+                                  trackHeight: 4,
+                                  thumbShape: const RoundSliderThumbShape(
+                                    enabledThumbRadius:
+                                        TrickplayPreviewLayout.seekThumbRadius,
+                                  ),
+                                  overlayShape: const RoundSliderOverlayShape(
+                                    overlayRadius: 14,
+                                  ),
+                                  activeTrackColor:
+                                      AppColorScheme.rangeProgress,
+                                  secondaryActiveTrackColor: AppColorScheme
+                                      .rangeTrack
+                                      .withValues(alpha: 0.8),
+                                  inactiveTrackColor: AppColorScheme.rangeTrack,
+                                  thumbColor:
+                                      (PlatformDetection.isTV &&
+                                          _seekbarFocused)
+                                      ? Colors.white
+                                      : AppColorScheme.rangeThumb,
+                                  overlayColor: AppColorScheme.rangeThumb
+                                      .withValues(alpha: 0.2),
+                                ),
+                                child: Slider(
+                                  value: positionMs.clamp(0.0, durationMs),
+                                  secondaryTrackValue: bufferMs.clamp(
+                                    0.0,
+                                    durationMs,
+                                  ),
+                                  max: durationMs,
+                                  onChangeStart: (v) {
+                                    _suppressSeekPrompts(
+                                      duration:
+                                          _seekDragPromptSuppressionDuration,
+                                    );
+                                    _pendingScrubSeekTarget = null;
+                                    _beginScrub();
+                                    setState(() {
+                                      _isSeeking = true;
+                                      _seekValue = v;
+                                    });
+                                    _hideTimer?.cancel();
+                                  },
+                                  onChanged: (v) {
+                                    _suppressSeekPrompts(
+                                      duration:
+                                          _seekDragPromptSuppressionDuration,
+                                      dismissVisiblePrompts: false,
+                                    );
+                                    setState(() => _seekValue = v);
+                                  },
+                                  onChangeEnd: (v) {
+                                    _suppressSeekPrompts();
+                                    _accumulateScrub(
+                                      Duration(milliseconds: v.round()),
+                                      showControls: false,
+                                    );
+                                    _commitPendingScrub();
+                                    _scheduleHide();
+                                  },
+                                ),
+                              ),
                             ),
-                            max: durationMs,
-                            onChangeStart: (v) {
-                              _suppressSeekPrompts(
-                                duration: _seekDragPromptSuppressionDuration,
-                              );
-                              _scrubSeekDebounceTimer?.cancel();
-                              _scrubSeekDebounceTimer = null;
-                              _pendingScrubSeekTarget = null;
-                              setState(() {
-                                _isSeeking = true;
-                                _seekValue = v;
-                              });
-                              _hideTimer?.cancel();
-                            },
-                            onChanged: (v) {
-                              _suppressSeekPrompts(
-                                duration: _seekDragPromptSuppressionDuration,
-                                dismissVisiblePrompts: false,
-                              );
-                              setState(() => _seekValue = v);
-                            },
-                            onChangeEnd: (v) {
-                              _suppressSeekPrompts();
-                              _scheduleDebouncedScrubSeek(
-                                Duration(milliseconds: v.round()),
-                                showControls: false,
-                              );
-                              _scheduleHide();
-                            },
                           ),
                         ),
-                      ),
-                    ),
-                    _buildTimeSlotRow(
-                      left: _timeSlotLabel(
-                        belowLeftSlot,
-                        position: livePosition,
-                        duration: duration,
-                        use24Hour: use24Hour,
-                      ),
-                      center: _timeSlotLabel(
-                        belowCenterSlot,
-                        position: livePosition,
-                        duration: duration,
-                        use24Hour: use24Hour,
-                      ),
-                      right: _timeSlotLabel(
-                        belowRightSlot,
-                        position: livePosition,
-                        duration: duration,
-                        use24Hour: use24Hour,
-                      ),
-                    ),
-                  ],
+                        _buildTimeSlotRow(
+                          left: _timeSlotLabel(
+                            belowLeftSlot,
+                            position: livePosition,
+                            duration: duration,
+                            use24Hour: use24Hour,
+                          ),
+                          center: _timeSlotLabel(
+                            belowCenterSlot,
+                            position: livePosition,
+                            duration: duration,
+                            use24Hour: use24Hour,
+                          ),
+                          right: _timeSlotLabel(
+                            belowRightSlot,
+                            position: livePosition,
+                            duration: duration,
+                            use24Hour: use24Hour,
+                          ),
+                        ),
+                      ],
+                    );
+                  },
                 );
               },
             );
@@ -4571,71 +4874,217 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     );
   }
 
-  Widget _buildSeekPreviewThumbnail({
-    required String imageUrl,
-    required Map<String, String> headers,
-    required Duration position,
-    required Rect sourceRect,
-    required double thumbWidth,
-    required double thumbHeight,
-    required int tileWidth,
-    required int tileHeight,
+  Duration _durationForTrackX(
+    double localX,
+    double trackWidth,
+    Duration duration,
+  ) {
+    const thumbRadius = TrickplayPreviewLayout.seekThumbRadius;
+    final usable = math.max(trackWidth - 2 * thumbRadius, 1.0);
+    final fraction = ((localX - thumbRadius) / usable).clamp(0.0, 1.0);
+    return Duration(milliseconds: (fraction * duration.inMilliseconds).round());
+  }
+
+  void _handleSeekbarHover(
+    PointerHoverEvent event, {
+    required double trackWidth,
+    required Duration duration,
   }) {
-    final screenWidth = MediaQuery.sizeOf(context).width;
-    final displayWidth = (screenWidth * 0.4).clamp(240.0, 520.0).toDouble();
-    final displayHeight = displayWidth * (thumbHeight / thumbWidth);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: displayWidth,
-          height: displayHeight,
-          decoration: BoxDecoration(
-            color: Colors.black,
-            borderRadius: AppRadius.circular(10),
-            border: Border.fromBorderSide(
-              ThemeRegistry.active.borders.cardBorder,
-            ),
-          ),
-          child: ClipRRect(
-            borderRadius: AppRadius.circular(9),
-            child: TrickplayTileImage(
-              sheet: NetworkImage(
-                imageUrl,
-                headers: headers.isEmpty ? null : headers,
-              ),
-              sourceRect: sourceRect,
-              thumbWidth: thumbWidth,
-              thumbHeight: thumbHeight,
-              tileWidth: tileWidth,
-              tileHeight: tileHeight,
-            ),
-          ),
-        ),
-        const SizedBox(height: AppSpacing.spaceXs),
-        Text(
-          formatPlaybackDuration(position),
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: AppTypography.fontSizeXs,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-      ],
+    if (_isSeeking || duration <= Duration.zero) return;
+    final position = _durationForTrackX(
+      event.localPosition.dx,
+      trackWidth,
+      duration,
+    );
+    if (position != _hoverPosition) setState(() => _hoverPosition = position);
+  }
+
+  void _clearSeekbarHover() {
+    if (_hoverPosition != null) setState(() => _hoverPosition = null);
+  }
+
+  Widget _buildTrickplaySeekPreview() {
+    return StreamBuilder<Duration>(
+      stream: _state.durationStream,
+      initialData: _state.duration,
+      builder: (context, durSnap) {
+        final duration = durSnap.data ?? Duration.zero;
+        final durationMs = math.max(duration.inMilliseconds, 1).toDouble();
+        final trickplayMode = _prefs.get(UserPreferences.trickPlayMode);
+        final coverActive = _isSeeking && trickplayMode == TrickplayMode.full;
+        final hoverActive =
+            !_isSeeking &&
+            PlatformDetection.useDesktopUi &&
+            _hoverPosition != null &&
+            trickplayMode != TrickplayMode.disabled &&
+            trickplayMode != TrickplayMode.full;
+        final previewPosition = _isSeeking
+            ? Duration(milliseconds: _seekValue.round())
+            : (hoverActive ? _hoverPosition : null);
+        final previewTile = previewPosition != null && !coverActive
+            ? _getTrickplayTile(previewPosition)
+            : null;
+        if (previewTile == null) return const SizedBox.shrink();
+
+        return LayoutBuilder(
+          builder: (context, constraints) {
+            return _buildTrickplayPreviewArea(
+              referenceTile: previewTile,
+              isStrip: trickplayMode == TrickplayMode.strip,
+              seekPosition: previewPosition!,
+              totalDuration: duration,
+              positionMs: previewPosition.inMilliseconds.toDouble(),
+              durationMs: durationMs,
+              trackWidth: constraints.maxWidth,
+              showTimeLabel: !_isSeeking,
+            );
+          },
+        );
+      },
     );
   }
 
-  ({
-    String url,
-    Map<String, String> headers,
-    Rect sourceRect,
-    double thumbWidth,
-    double thumbHeight,
-    int tileWidth,
-    int tileHeight,
-  })?
-  _getTrickplayTile(Duration position) {
-    if (!_prefs.get(UserPreferences.trickPlayEnabled)) return null;
+  Widget _buildTrickplayPreviewArea({
+    required TrickplayTile referenceTile,
+    required bool isStrip,
+    required Duration seekPosition,
+    required Duration totalDuration,
+    required double positionMs,
+    required double durationMs,
+    required double trackWidth,
+    required bool showTimeLabel,
+  }) {
+    final timeLabel = showTimeLabel ? formatPlaybackDuration(seekPosition) : null;
+    final scalePercent = _prefs.get(
+      UserPreferences.trickPlayPreviewScalePercent,
+    );
+    final followScrub = _prefs.get(
+      UserPreferences.trickPlayFollowScrubPosition,
+    );
+
+    final resolvedBottomMargin =
+        _bottomOverlayHeight ?? TrickplayPreviewLayout.verticalTravelBottomMargin;
+    final resolvedTopMargin =
+        _topOverlayHeight ?? TrickplayPreviewLayout.verticalTravelTopMargin;
+
+    final maxHeightBudget =
+        MediaQuery.sizeOf(context).height -
+        resolvedBottomMargin -
+        resolvedTopMargin;
+    final tileSize = TrickplayPreviewLayout.resolveTileSize(
+      trackWidth: trackWidth,
+      scalePercent: scalePercent,
+      aspect: referenceTile.thumbHeight / referenceTile.thumbWidth,
+      maxHeightBudget: maxHeightBudget,
+    );
+    final tileWidth = tileSize.width;
+    final tileHeight = tileSize.height;
+    final previewHeight = tileHeight;
+    final verticalTravel = TrickplayPreviewLayout.resolveVerticalTravel(
+      _prefs.get(UserPreferences.trickPlayVerticalPositionPercent),
+      maxTravel: TrickplayPreviewLayout.resolveVerticalTravelMax(
+        rawMaxTravel:
+            MediaQuery.sizeOf(context).height -
+            previewHeight -
+            resolvedBottomMargin -
+            resolvedTopMargin,
+        trackWidth: trackWidth,
+      ),
+    );
+    final mainTileLeft = TrickplayPreviewLayout.resolveSingleLeft(
+      positionMs: positionMs,
+      durationMs: durationMs,
+      trackWidth: trackWidth,
+      tileWidth: tileWidth,
+      followScrub: followScrub,
+    );
+
+    const spacing = AppSpacing.spaceXs;
+    final stripLayout = isStrip
+        ? TrickplayPreviewLayout.resolveStrip(
+            mainTileLeft: mainTileLeft,
+            trackWidth: trackWidth,
+            tileWidth: tileWidth,
+            spacing: spacing,
+            overflowMargin: AppSpacing.spaceLg,
+          )
+        : TrickplayStripLayout(
+            leftCount: 0,
+            rightCount: 0,
+            leftOffset: mainTileLeft,
+          );
+    final leftOffset = stripLayout.leftOffset;
+    final resolvedSlots = TrickplayStripResolver.resolve(
+      fakeTimelinePosition: seekPosition,
+      totalDuration: totalDuration,
+      stepMs: math.max(_prefs.get(UserPreferences.skipForwardLength), 1),
+      slotCount: stripLayout.slotCount,
+      highlightIndex: stripLayout.highlightIndex,
+    );
+    final slotsByIndex = {
+      for (final slot in resolvedSlots) slot.slotIndex: slot,
+    };
+    final previewWidget = Trickplay(
+      leftCount: stripLayout.leftCount,
+      rightCount: stripLayout.rightCount,
+      timeLabel: timeLabel,
+      tileWidth: tileWidth,
+      tileHeight: tileHeight,
+      slotSpacing: spacing,
+      content: (slotIndex) {
+        if (slotIndex == 0) return _trickplayTileImage(referenceTile);
+        final target = slotsByIndex[slotIndex]?.targetPosition;
+        if (target == null) return null;
+        final tile = _getTrickplayTile(target);
+        return tile == null ? null : _trickplayTileImage(tile);
+      },
+    );
+
+    final allowOverflow = isStrip;
+
+    final positioned = Transform.translate(
+      offset: Offset(leftOffset, 0),
+      child: previewWidget,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.spaceSm),
+      child: Transform.translate(
+        offset: Offset(0, -verticalTravel),
+        child: SizedBox(
+          width: trackWidth > 0 ? trackWidth : null,
+          height: previewHeight,
+          child: allowOverflow
+              ? OverflowBox(
+                  minWidth: 0,
+                  maxWidth: double.infinity,
+                  alignment: Alignment.topLeft,
+                  child: positioned,
+                )
+              : Align(alignment: Alignment.topLeft, child: positioned),
+        ),
+      ),
+    );
+  }
+
+  Widget _trickplayTileImage(TrickplayTile tile) {
+    return TrickplayTileImage(
+      sheet: CachedNetworkImageProvider(
+        tile.url,
+        headers: tile.headers.isEmpty ? null : tile.headers,
+      ),
+      sourceRect: tile.sourceRect,
+      thumbWidth: tile.thumbWidth,
+      thumbHeight: tile.thumbHeight,
+      tileWidth: tile.tileWidth,
+      tileHeight: tile.tileHeight,
+    );
+  }
+
+  TrickplayTile? _getTrickplayTile(Duration position) {
+    if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
+      return null;
+    }
 
     final info = _trickplayInfo;
     if (info == null || !info.isValid) return null;
@@ -4644,22 +5093,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final itemId = _itemIdForQueueItem(item);
     if (itemId == null || itemId.isEmpty) return null;
 
-    final positionMs = position.inMilliseconds;
-    final tileIndex = positionMs ~/ info.interval;
-    final tilesPerImage = info.tilesPerImage;
-    final tileOffset = tileIndex % tilesPerImage;
-    final imageIndex = tileIndex ~/ tilesPerImage;
-
-    final col = tileOffset % info.tileWidth;
-    final row = tileOffset ~/ info.tileWidth;
-    final offsetX = (col * info.width).toDouble();
-    final offsetY = (row * info.height).toDouble();
-
+    final duration = _state.duration;
+    final resolvePosition = duration > Duration.zero && position >= duration
+        ? Duration(milliseconds: duration.inMilliseconds - 1)
+        : position;
+    final resolution = info.resolveTile(resolvePosition);
     final trickplayClient = _clientForQueueItem(item);
     final url = trickplayClient.imageApi.getTrickplayTileImageUrl(
       itemId,
       width: info.width,
-      index: imageIndex,
+      index: resolution.imageIndex,
       mediaSourceId: _trickplayMediaSourceId,
     );
     final token = trickplayClient.accessToken;
@@ -4669,20 +5112,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         'Authorization': 'MediaBrowser Token="$token"',
     };
 
-    return (
-      url: url,
-      headers: headers,
-      sourceRect: Rect.fromLTWH(
-        offsetX,
-        offsetY,
-        info.width.toDouble(),
-        info.height.toDouble(),
-      ),
-      thumbWidth: info.width.toDouble(),
-      thumbHeight: info.height.toDouble(),
-      tileWidth: info.tileWidth,
-      tileHeight: info.tileHeight,
-    );
+    return TrickplayTile(url: url, headers: headers, resolution: resolution);
   }
 
   Widget _buildTvTransportRow() {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -40,7 +40,6 @@ import '../../../data/models/media_segment.dart';
 import '../../../data/models/trickplay_info.dart';
 import '../../../data/models/trickplay_prefetch_planner.dart';
 import '../../../data/models/trickplay_preview_layout.dart';
-import '../../../data/models/trickplay_strip_resolution.dart';
 import '../../../data/services/cast/cast_service.dart';
 import '../../../data/services/cast/cast_target.dart';
 import '../../../data/services/cast/native_airplay_channel.dart';
@@ -2165,10 +2164,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final duration = _state.duration;
     if (duration <= Duration.zero) return;
 
-    if (!PlatformDetection.isTV) {
-      _startTouchTrickplayPrefetch(info, position, duration);
-    }
-
     _precacheTrickplayIndexes(
       TrickplayPrefetchPlanner.planImageIndexes(
         info: info,
@@ -2180,12 +2175,17 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     );
   }
 
-  void _startTouchTrickplayPrefetch(
-    TrickplayInfo info,
-    Duration position,
-    Duration duration,
-  ) {
-    if (_touchTrickplayPrefetchStarted) return;
+  // Every sheet, nearest first. Held back until the first scrub or hover so
+  // a video that is only ever watched costs nothing here, and skipped on TV
+  // where the D-pad direction says which sheets are worth having.
+  void _prefetchAllTrickplaySheets(Duration position) {
+    if (PlatformDetection.isTV || _touchTrickplayPrefetchStarted) return;
+    if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
+      return;
+    }
+    final info = _trickplayInfo;
+    final duration = _state.duration;
+    if (info == null || !info.isValid || duration <= Duration.zero) return;
     _touchTrickplayPrefetchStarted = true;
     _precacheTrickplayIndexes(
       TrickplayPrefetchPlanner.planAllImageIndexes(
@@ -2350,7 +2350,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         return;
       }
       if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
-        unawaited(_manager.seekTo(result.skipTo!));
+        unawaited(_seekDirect(result.skipTo!));
         _presentNextUpOverlay();
         return;
       }
@@ -2358,7 +2358,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         unawaited(_exitPlayback());
         return;
       }
-      _manager.seekTo(result.skipTo!);
+      _seekDirect(result.skipTo!);
       _clearSkipSegment();
       return;
     }
@@ -2602,7 +2602,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     if (replaceSkipOutroWithNextUp && isOutro && _shouldShowNextUpOverlay()) {
       final skipTo = _skipTo;
       if (skipTo != null) {
-        unawaited(_manager.seekTo(skipTo));
+        unawaited(_seekDirect(skipTo));
       }
       _presentNextUpOverlay();
       return;
@@ -2613,7 +2613,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
 
     if (_skipTo != null) {
-      _manager.seekTo(_skipTo!);
+      _seekDirect(_skipTo!);
     }
     _resetSkipSegmentAutoHide();
     setState(() {
@@ -2876,6 +2876,23 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     return dismissed;
   }
 
+  // A skip, a chapter jump or a segment skip lands somewhere the scrub
+  // session knows nothing about. Left alone, the session would commit its
+  // stale target the next time play is pressed, so it is dropped here and
+  // the seek goes straight through.
+  Future<void> _seekDirect(Duration target) {
+    if (_pendingScrubSeekTarget != null || _isPausedScrubActive || _isSeeking) {
+      _scrubSeekCommitId++;
+      _pendingScrubSeekTarget = null;
+      _isPausedScrubActive = false;
+      final resume = _wasPlayingBeforeScrubPause;
+      _wasPlayingBeforeScrubPause = false;
+      if (resume) unawaited(_manager.resume());
+      if (mounted) setState(() => _isSeeking = false);
+    }
+    return _manager.seekTo(target);
+  }
+
   void _seekRelative(int ms, {bool showControls = true}) {
     _suppressSeekPrompts();
     final target = _state.position + Duration(milliseconds: ms);
@@ -2885,7 +2902,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _state.duration.inMilliseconds,
       ),
     );
-    _manager.seekTo(clamped);
+    _seekDirect(clamped);
     _lastSeekTime = DateTime.now();
     if (showControls) {
       _showControls();
@@ -2930,6 +2947,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     // frozen timeline back to live position mid-hold.
     _scrubSeekCommitId++;
     if (_hasTrickplayPreview) {
+      _prefetchAllTrickplaySheets(_state.position);
       _isPausedScrubActive = true;
       // If an earlier still-resolving commit already paused playback for
       // this chain of overlapping gestures, _wasPlayingBeforeScrubPause is
@@ -3332,7 +3350,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             return KeyEventResult.handled;
 
           case LogicalKeyboardKey.mediaRewind:
-            unawaited(_manager.seekTo(Duration.zero));
+            unawaited(_seekDirect(Duration.zero));
             _lastSeekTime = DateTime.now();
             unawaited(_manager.resume());
             return KeyEventResult.handled;
@@ -4896,6 +4914,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       trackWidth,
       duration,
     );
+    if (_hoverPosition == null) _prefetchAllTrickplaySheets(position);
     if (position != _hoverPosition) setState(() => _hoverPosition = position);
   }
 
@@ -4967,73 +4986,41 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final resolvedTopMargin =
         _topOverlayHeight ?? TrickplayPreviewLayout.verticalTravelTopMargin;
 
-    final maxHeightBudget =
-        MediaQuery.sizeOf(context).height -
-        resolvedBottomMargin -
-        resolvedTopMargin;
-    final tileSize = TrickplayPreviewLayout.resolveTileSize(
+    const spacing = AppSpacing.spaceXs;
+    final plan = TrickplayPreviewLayout.plan(
       trackWidth: trackWidth,
       scalePercent: scalePercent,
       aspect: referenceTile.thumbHeight / referenceTile.thumbWidth,
-      maxHeightBudget: maxHeightBudget,
-    );
-    final tileWidth = tileSize.width;
-    final tileHeight = tileSize.height;
-    final previewHeight = tileHeight;
-    final verticalTravel = TrickplayPreviewLayout.resolveVerticalTravel(
-      _prefs.get(UserPreferences.trickPlayVerticalPositionPercent),
-      maxTravel: TrickplayPreviewLayout.resolveVerticalTravelMax(
-        rawMaxTravel:
-            MediaQuery.sizeOf(context).height -
-            previewHeight -
-            resolvedBottomMargin -
-            resolvedTopMargin,
-        trackWidth: trackWidth,
-      ),
-    );
-    final mainTileLeft = TrickplayPreviewLayout.resolveSingleLeft(
+      maxHeightBudget:
+          MediaQuery.sizeOf(context).height -
+          resolvedBottomMargin -
+          resolvedTopMargin,
       positionMs: positionMs,
       durationMs: durationMs,
-      trackWidth: trackWidth,
-      tileWidth: tileWidth,
       followScrub: followScrub,
-    );
-
-    const spacing = AppSpacing.spaceXs;
-    final stripLayout = isStrip
-        ? TrickplayPreviewLayout.resolveStrip(
-            mainTileLeft: mainTileLeft,
-            trackWidth: trackWidth,
-            tileWidth: tileWidth,
-            spacing: spacing,
-            overflowMargin: AppSpacing.spaceLg,
-          )
-        : TrickplayStripLayout(
-            leftCount: 0,
-            rightCount: 0,
-            leftOffset: mainTileLeft,
-          );
-    final leftOffset = stripLayout.leftOffset;
-    final resolvedSlots = TrickplayStripResolver.resolve(
-      fakeTimelinePosition: seekPosition,
+      verticalPositionPercent: _prefs.get(
+        UserPreferences.trickPlayVerticalPositionPercent,
+      ),
+      isStrip: isStrip,
+      spacing: spacing,
+      overflowMargin: AppSpacing.spaceLg,
+      seekPosition: seekPosition,
       totalDuration: totalDuration,
       stepMs: math.max(_prefs.get(UserPreferences.skipForwardLength), 1),
-      slotCount: stripLayout.slotCount,
-      highlightIndex: stripLayout.highlightIndex,
     );
-    final slotsByIndex = {
-      for (final slot in resolvedSlots) slot.slotIndex: slot,
-    };
+    final previewHeight = plan.tileHeight;
+    final verticalTravel = plan.verticalTravel;
+    final leftOffset = plan.leftOffset;
     final previewWidget = Trickplay(
-      leftCount: stripLayout.leftCount,
-      rightCount: stripLayout.rightCount,
+      leftCount: plan.leftCount,
+      rightCount: plan.rightCount,
       timeLabel: timeLabel,
-      tileWidth: tileWidth,
-      tileHeight: tileHeight,
+      tileWidth: plan.tileWidth,
+      tileHeight: plan.tileHeight,
       slotSpacing: spacing,
       content: (slotIndex) {
         if (slotIndex == 0) return _trickplayTileImage(referenceTile);
-        final target = slotsByIndex[slotIndex]?.targetPosition;
+        final target = plan.slotsByIndex[slotIndex]?.targetPosition;
         if (target == null) return null;
         final tile = _getTrickplayTile(target);
         return tile == null ? null : _trickplayTileImage(tile);
@@ -6972,7 +6959,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       final ch = chapters[result];
       final ticks = ch['StartPositionTicks'] as int? ?? 0;
       _suppressSeekPrompts();
-      _manager.seekTo(Duration(microseconds: ticks ~/ 10));
+      _seekDirect(Duration(microseconds: ticks ~/ 10));
     }());
     _showControls();
   }

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1118,10 +1118,16 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       keywords: ['music', 'song', 'track'],
     ),
     video.leaf(
-      'trick_play_enabled',
+      'trickplay_mode',
       l10n.trickPlay,
       subtitle: l10n.showPreviewThumbnailsWhenSeeking,
-      keywords: ['scrubbing', 'seek thumbnails'],
+      keywords: [
+        'scrubbing',
+        'seek thumbnails',
+        'preview size',
+        'distance from seekbar',
+        'follow scrub',
+      ],
     ),
     if (PlatformDetection.useDesktopUi)
       video.leaf(

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -41,12 +41,6 @@ class _VideoPlaybackScreen extends StatelessWidget {
                   const _PlaybackTimeLayoutScreen(),
                 ),
               ),
-              SwitchPreferenceTile(
-                preference: UserPreferences.trickPlayEnabled,
-                title: l10n.trickPlay,
-                subtitle: l10n.showPreviewThumbnailsWhenSeeking,
-                icon: Icons.image_search,
-              ),
               if (PlatformDetection.useDesktopUi)
                 EnumPreferenceTile<DesktopScrollWheelAction>(
                   preference: UserPreferences.desktopScrollWheelAction,
@@ -138,6 +132,49 @@ class _VideoPlaybackScreen extends StatelessWidget {
                 subtitle: Text(l10n.osdButtonsDescription),
                 onTap: () =>
                     context.pushSettingsScreen(const _OsdButtonsScreen()),
+              ),
+            ],
+          ),
+
+          _SectionHeader(l10n.trickPlay),
+          adaptiveListSection(
+            children: [
+              const TrickplaySettingsPreview(),
+              EnumPreferenceTile<TrickplayMode>(
+                preference: UserPreferences.trickPlayMode,
+                title: l10n.trickPlay,
+                description: l10n.showPreviewThumbnailsWhenSeeking,
+                icon: Icons.image_search,
+                labelOf: (v) => switch (v) {
+                  TrickplayMode.disabled => l10n.disabled,
+                  TrickplayMode.single => l10n.trickplayDisplayStyleSingle,
+                  TrickplayMode.strip => l10n.trickplayDisplayStyleStrip,
+                  TrickplayMode.full => l10n.trickplayModeFull,
+                },
+              ),
+              SliderPreferenceTile(
+                preference: UserPreferences.trickPlayPreviewScalePercent,
+                title: l10n.trickplayPreviewScale,
+                icon: Icons.photo_size_select_large_outlined,
+                min: 10,
+                max: 100,
+                divisions: 18,
+                labelOf: (v) => l10n.percentValue(v),
+              ),
+              SliderPreferenceTile(
+                preference: UserPreferences.trickPlayVerticalPositionPercent,
+                title: l10n.trickplayVerticalOffset,
+                icon: Icons.height,
+                min: 0,
+                max: 100,
+                divisions: 20,
+                labelOf: (v) => l10n.percentValue(v),
+              ),
+              SwitchPreferenceTile(
+                preference: UserPreferences.trickPlayFollowScrubPosition,
+                title: l10n.trickplayFollowScrubPosition,
+                subtitle: l10n.trickplayFollowScrubPositionSubtitle,
+                icon: Icons.swipe,
               ),
             ],
           ),

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -63,6 +63,7 @@ import '../../widgets/settings/settings_panel.dart';
 import '../../widgets/settings/settings_section_header.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/support_dialog.dart';
+import '../../widgets/trickplay_settings_preview.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../home/home_view_model.dart';
 import 'appearance_theme_screen.dart';

--- a/lib/ui/widgets/playback/trickplay.dart
+++ b/lib/ui/widgets/playback/trickplay.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../../preference/preference_constants.dart';
+
+BoxFit zoomModeToBoxFit(ZoomMode mode) => switch (mode) {
+  ZoomMode.fit => BoxFit.contain,
+  ZoomMode.autoCrop => BoxFit.cover,
+  ZoomMode.stretch => BoxFit.fill,
+};
+
+class Trickplay extends StatelessWidget {
+  final Widget? Function(int slotIndex) content;
+
+  final int leftCount;
+  final int rightCount;
+
+  final String? timeLabel;
+
+  final double tileWidth;
+  final double tileHeight;
+  final double slotSpacing;
+
+  final bool fillFrame;
+
+  const Trickplay({
+    super.key,
+    required this.content,
+    this.leftCount = 0,
+    this.rightCount = 0,
+    this.timeLabel,
+    this.tileWidth = 0,
+    this.tileHeight = 0,
+    this.slotSpacing = AppSpacing.spaceXs,
+    this.fillFrame = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (fillFrame) {
+      return _TrickplayTileChrome(
+        content: content(0),
+        width: null,
+        height: null,
+        active: true,
+        fillFrame: true,
+      );
+    }
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        for (var slotIndex = -leftCount; slotIndex <= rightCount; slotIndex++) ...[
+          if (slotIndex > -leftCount) SizedBox(width: slotSpacing),
+          _TrickplayTileChrome(
+            key: ValueKey(slotIndex),
+            content: content(slotIndex),
+            width: tileWidth,
+            height: tileHeight,
+            active: slotIndex == 0,
+            label: slotIndex == 0 ? timeLabel : null,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _TrickplayTileChrome extends StatelessWidget {
+  final Widget? content;
+  final double? width;
+  final double? height;
+  final bool active;
+  final bool fillFrame;
+
+  final String? label;
+
+  const _TrickplayTileChrome({
+    super.key,
+    required this.content,
+    required this.width,
+    required this.height,
+    required this.active,
+    this.fillFrame = false,
+    this.label,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final borderTokens = ThemeRegistry.active.borders;
+    final decorated = Container(
+      width: width,
+      height: height,
+      decoration: fillFrame
+          ? const BoxDecoration(color: Colors.black)
+          : BoxDecoration(
+              color: Colors.black,
+              borderRadius: AppRadius.circular(8),
+              border: active
+                  ? Border.all(color: AppColorScheme.accent, width: 2)
+                  : Border.fromBorderSide(borderTokens.cardBorder),
+              boxShadow: active && borderTokens.focusGlow.isNotEmpty
+                  ? borderTokens.focusGlow
+                  : null,
+            ),
+      child: content == null
+          ? null
+          : (fillFrame
+                ? ClipRect(child: content)
+                : ClipRRect(
+                    borderRadius: AppRadius.circular(7),
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        content!,
+                        if (label != null)
+                          Positioned(
+                            left: 0,
+                            right: 0,
+                            bottom: 0,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.topCenter,
+                                  end: Alignment.bottomCenter,
+                                  colors: [
+                                    Colors.transparent,
+                                    Colors.black.withValues(alpha: 0.75),
+                                  ],
+                                ),
+                              ),
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: AppSpacing.spaceXs,
+                                ),
+                                child: Text(
+                                  label!,
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(
+                                    color: Colors.white70,
+                                    fontSize: AppTypography.fontSizeXs,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  )),
+    );
+    if (fillFrame) return decorated;
+    return Opacity(opacity: content == null ? 0 : 1, child: decorated);
+  }
+}

--- a/lib/ui/widgets/playback/trickplay_tile_image.dart
+++ b/lib/ui/widgets/playback/trickplay_tile_image.dart
@@ -53,7 +53,11 @@ class TrickplayTileImage extends StatelessWidget {
           child: Image(
             image: sheet,
             fit: BoxFit.fill,
-            filterQuality: FilterQuality.medium,
+            // High rather than medium: this tile can be upscaled a lot
+            // (e.g. the Full Screen mode's video cover), and a better
+            // resampling filter is the only lever available for that - the
+            // source pixels are still a low-res thumbnail.
+            filterQuality: FilterQuality.high,
             errorBuilder: (_, _, _) => Container(
               color: Colors.white.withValues(alpha: 0.08),
               alignment: Alignment.center,

--- a/lib/ui/widgets/trickplay_settings_preview.dart
+++ b/lib/ui/widgets/trickplay_settings_preview.dart
@@ -7,7 +7,6 @@ import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../data/models/trickplay_preview_layout.dart';
-import '../../data/models/trickplay_strip_resolution.dart';
 import '../../l10n/app_localizations.dart';
 import '../../preference/preference_constants.dart';
 import '../../preference/user_preferences.dart';
@@ -144,7 +143,7 @@ class _TrickplaySettingsPreviewState extends State<TrickplaySettingsPreview> {
                   final frameTopMargin =
                       TrickplayPreviewLayout.verticalTravelTopMargin *
                       previewScale;
-                  final tileSize = TrickplayPreviewLayout.resolveTileSize(
+                  final plan = TrickplayPreviewLayout.plan(
                     trackWidth: trackWidth,
                     scalePercent: scalePercent,
                     aspect: 9 / 16,
@@ -152,65 +151,33 @@ class _TrickplaySettingsPreviewState extends State<TrickplaySettingsPreview> {
                       videoHeight - floorReserved - frameTopMargin,
                       32.0,
                     ),
-                  );
-                  final tileWidth = tileSize.width;
-                  final tileHeight = tileSize.height;
-                  final previewHeight = tileHeight;
-                  final mainTileLeft = TrickplayPreviewLayout.resolveSingleLeft(
                     positionMs: _positionMs,
                     durationMs: _fakeDurationMs,
-                    trackWidth: trackWidth,
-                    tileWidth: tileWidth,
                     followScrub: followScrub,
-                  );
-                  final maxTravel = TrickplayPreviewLayout.resolveVerticalTravelMax(
-                    rawMaxTravel:
-                        videoHeight - floorReserved - previewHeight - frameTopMargin,
-                    trackWidth: trackWidth,
-                  );
-                  final verticalTravel =
-                      TrickplayPreviewLayout.resolveVerticalTravel(
-                        verticalPositionPercent,
-                        maxTravel: maxTravel,
-                      );
-
-                  final stripLayout = mode == TrickplayMode.strip
-                      ? TrickplayPreviewLayout.resolveStrip(
-                          mainTileLeft: mainTileLeft,
-                          trackWidth: trackWidth,
-                          tileWidth: tileWidth,
-                          spacing: AppSpacing.spaceXs,
-                          overflowMargin: _sliderInset,
-                        )
-                      : TrickplayStripLayout(
-                          leftCount: 0,
-                          rightCount: 0,
-                          leftOffset: mainTileLeft,
-                        );
-                  final leftOffset = stripLayout.leftOffset;
-                  final resolvedSlots = TrickplayStripResolver.resolve(
-                    fakeTimelinePosition: position,
+                    verticalPositionPercent: verticalPositionPercent,
+                    isStrip: mode == TrickplayMode.strip,
+                    spacing: AppSpacing.spaceXs,
+                    overflowMargin: _sliderInset,
+                    seekPosition: position,
                     totalDuration: const Duration(
                       milliseconds: _fakeDurationMsInt,
                     ),
                     stepMs: _fakeStepMs,
-                    slotCount: stripLayout.slotCount,
-                    highlightIndex: stripLayout.highlightIndex,
                   );
-                  final slotsByIndex = {
-                    for (final slot in resolvedSlots) slot.slotIndex: slot,
-                  };
+                  final previewHeight = plan.tileHeight;
+                  final verticalTravel = plan.verticalTravel;
+                  final leftOffset = plan.leftOffset;
                   final previewTile =
                       mode == TrickplayMode.strip ||
                           mode == TrickplayMode.single
                       ? Trickplay(
-                          leftCount: stripLayout.leftCount,
-                          rightCount: stripLayout.rightCount,
-                          tileWidth: tileWidth,
-                          tileHeight: tileHeight,
+                          leftCount: plan.leftCount,
+                          rightCount: plan.rightCount,
+                          tileWidth: plan.tileWidth,
+                          tileHeight: plan.tileHeight,
                           content: (slotIndex) {
                             final target =
-                                slotsByIndex[slotIndex]?.targetPosition;
+                                plan.slotsByIndex[slotIndex]?.targetPosition;
                             return target == null
                                 ? null
                                 : _fakeTileContent(

--- a/lib/ui/widgets/trickplay_settings_preview.dart
+++ b/lib/ui/widgets/trickplay_settings_preview.dart
@@ -1,0 +1,404 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:get_it/get_it.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../data/models/trickplay_preview_layout.dart';
+import '../../data/models/trickplay_strip_resolution.dart';
+import '../../l10n/app_localizations.dart';
+import '../../preference/preference_constants.dart';
+import '../../preference/user_preferences.dart';
+import 'playback/trickplay.dart';
+
+class TrickplaySettingsPreview extends StatefulWidget {
+  const TrickplaySettingsPreview({super.key});
+
+  @override
+  State<TrickplaySettingsPreview> createState() =>
+      _TrickplaySettingsPreviewState();
+}
+
+class _TrickplaySettingsPreviewState extends State<TrickplaySettingsPreview> {
+  static const _fakeDurationMsInt = 3600000; // 60:00
+  static const _fakeDurationMs = 3600000.0;
+  static const _sliderInset = 8.0;
+
+  static const _realSliderVisualHeight = 28.0;
+  static const _realControlsRowExtent = 48.0;
+
+  final UserPreferences _prefs = GetIt.instance<UserPreferences>();
+  double _positionMs = _fakeDurationMs * 0.5;
+
+  late final FocusNode _sliderOuterFocusNode;
+  late final FocusNode _sliderInternalFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _prefs.addListener(_onPrefsChanged);
+    _sliderOuterFocusNode = FocusNode(debugLabel: 'TrickplayPreviewSlider');
+    _sliderInternalFocusNode = FocusNode(
+      debugLabel: 'TrickplayPreviewSliderInner',
+      canRequestFocus: false,
+      skipTraversal: true,
+    );
+  }
+
+  @override
+  void dispose() {
+    _prefs.removeListener(_onPrefsChanged);
+    _sliderOuterFocusNode.dispose();
+    _sliderInternalFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _onPrefsChanged() {
+    if (mounted) setState(() {});
+  }
+
+  int get _fakeStepMs =>
+      math.max(_prefs.get(UserPreferences.skipForwardLength), 1);
+
+  KeyEventResult _onSliderKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    switch (event.logicalKey) {
+      case LogicalKeyboardKey.arrowUp:
+        node.previousFocus();
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowDown:
+        node.nextFocus();
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowLeft:
+        setState(
+          () => _positionMs = (_positionMs - _fakeStepMs).clamp(
+            0.0,
+            _fakeDurationMs,
+          ),
+        );
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowRight:
+        setState(
+          () => _positionMs = (_positionMs + _fakeStepMs).clamp(
+            0.0,
+            _fakeDurationMs,
+          ),
+        );
+        return KeyEventResult.handled;
+      default:
+        return KeyEventResult.ignored;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mode = _prefs.get(UserPreferences.trickPlayMode);
+    if (mode == TrickplayMode.disabled) return const SizedBox.shrink();
+    final scalePercent = _prefs.get(
+      UserPreferences.trickPlayPreviewScalePercent,
+    );
+    final verticalPositionPercent = _prefs.get(
+      UserPreferences.trickPlayVerticalPositionPercent,
+    );
+    final followScrub = _prefs.get(
+      UserPreferences.trickPlayFollowScrubPosition,
+    );
+    final position = Duration(milliseconds: _positionMs.round());
+
+    final screenSize = MediaQuery.sizeOf(context);
+    final longSide = math.max(screenSize.width, screenSize.height);
+    final shortSide = math.min(screenSize.width, screenSize.height);
+    final rawAspectRatio = shortSide > 0 ? longSide / shortSide : 16 / 9;
+    final deviceAspectRatio = rawAspectRatio.clamp(16 / 9, 21 / 9);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      child: Column(
+        children: [
+          AspectRatio(
+            aspectRatio: deviceAspectRatio,
+            child: ClipRRect(
+              borderRadius: AppRadius.circular(8),
+              child: LayoutBuilder(
+                builder: (context, videoConstraints) {
+                  final videoWidth = videoConstraints.maxWidth;
+                  final videoHeight = videoConstraints.maxHeight;
+                  final trackWidth = math.max(
+                    videoWidth - _sliderInset * 2,
+                    0.0,
+                  );
+                  final previewScale = (trackWidth / screenSize.width).clamp(
+                    0.2,
+                    1.0,
+                  );
+                  final sliderReservedHeight = _realSliderVisualHeight;
+                  final controlsRowGap = AppSpacing.spaceXs * previewScale;
+                  final controlsRowExtent =
+                      _realControlsRowExtent * previewScale;
+                  final floorReserved =
+                      sliderReservedHeight + controlsRowGap + controlsRowExtent;
+                  final frameTopMargin =
+                      TrickplayPreviewLayout.verticalTravelTopMargin *
+                      previewScale;
+                  final tileSize = TrickplayPreviewLayout.resolveTileSize(
+                    trackWidth: trackWidth,
+                    scalePercent: scalePercent,
+                    aspect: 9 / 16,
+                    maxHeightBudget: math.max(
+                      videoHeight - floorReserved - frameTopMargin,
+                      32.0,
+                    ),
+                  );
+                  final tileWidth = tileSize.width;
+                  final tileHeight = tileSize.height;
+                  final previewHeight = tileHeight;
+                  final mainTileLeft = TrickplayPreviewLayout.resolveSingleLeft(
+                    positionMs: _positionMs,
+                    durationMs: _fakeDurationMs,
+                    trackWidth: trackWidth,
+                    tileWidth: tileWidth,
+                    followScrub: followScrub,
+                  );
+                  final maxTravel = TrickplayPreviewLayout.resolveVerticalTravelMax(
+                    rawMaxTravel:
+                        videoHeight - floorReserved - previewHeight - frameTopMargin,
+                    trackWidth: trackWidth,
+                  );
+                  final verticalTravel =
+                      TrickplayPreviewLayout.resolveVerticalTravel(
+                        verticalPositionPercent,
+                        maxTravel: maxTravel,
+                      );
+
+                  final stripLayout = mode == TrickplayMode.strip
+                      ? TrickplayPreviewLayout.resolveStrip(
+                          mainTileLeft: mainTileLeft,
+                          trackWidth: trackWidth,
+                          tileWidth: tileWidth,
+                          spacing: AppSpacing.spaceXs,
+                          overflowMargin: _sliderInset,
+                        )
+                      : TrickplayStripLayout(
+                          leftCount: 0,
+                          rightCount: 0,
+                          leftOffset: mainTileLeft,
+                        );
+                  final leftOffset = stripLayout.leftOffset;
+                  final resolvedSlots = TrickplayStripResolver.resolve(
+                    fakeTimelinePosition: position,
+                    totalDuration: const Duration(
+                      milliseconds: _fakeDurationMsInt,
+                    ),
+                    stepMs: _fakeStepMs,
+                    slotCount: stripLayout.slotCount,
+                    highlightIndex: stripLayout.highlightIndex,
+                  );
+                  final slotsByIndex = {
+                    for (final slot in resolvedSlots) slot.slotIndex: slot,
+                  };
+                  final previewTile =
+                      mode == TrickplayMode.strip ||
+                          mode == TrickplayMode.single
+                      ? Trickplay(
+                          leftCount: stripLayout.leftCount,
+                          rightCount: stripLayout.rightCount,
+                          tileWidth: tileWidth,
+                          tileHeight: tileHeight,
+                          content: (slotIndex) {
+                            final target =
+                                slotsByIndex[slotIndex]?.targetPosition;
+                            return target == null
+                                ? null
+                                : _fakeTileContent(
+                                    _fakeIndex(
+                                      target.inMilliseconds.toDouble(),
+                                    ),
+                                  );
+                          },
+                        )
+                      : null;
+
+                  return Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      Container(
+                        color: AppColorScheme.scrim,
+                        alignment: Alignment.center,
+                        child: Icon(
+                          Icons.play_arrow,
+                          color: Colors.white.withValues(alpha: 0.4),
+                          size: 36,
+                        ),
+                      ),
+                      if (mode == TrickplayMode.full)
+                        Positioned.fill(
+                          child: Trickplay(
+                            fillFrame: true,
+                            content: (_) => FittedBox(
+                              fit: zoomModeToBoxFit(
+                                _prefs.get(UserPreferences.playerZoomMode),
+                              ),
+                              child: SizedBox(
+                                width: 160,
+                                height: 90,
+                                child: _fakeTileContent(
+                                  _fakeIndex(_positionMs),
+                                  large: true,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      if (previewTile != null)
+                        Positioned(
+                          left: _sliderInset,
+                          bottom: floorReserved + verticalTravel,
+                          height: previewHeight,
+                          width: trackWidth,
+                          child: OverflowBox(
+                            minWidth: 0,
+                            maxWidth: double.infinity,
+                            alignment: Alignment.topLeft,
+                            child: Transform.translate(
+                              offset: Offset(leftOffset, 0),
+                              child: previewTile,
+                            ),
+                          ),
+                        ),
+                      Positioned(
+                        left: _sliderInset,
+                        right: _sliderInset,
+                        bottom: 0,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Focus(
+                              focusNode: _sliderOuterFocusNode,
+                              onKeyEvent: _onSliderKeyEvent,
+                              child: SliderTheme(
+                                data: SliderThemeData(
+                                  trackHeight: 4,
+                                  thumbShape: const RoundSliderThumbShape(
+                                    enabledThumbRadius:
+                                        TrickplayPreviewLayout.seekThumbRadius,
+                                  ),
+                                  overlayShape: const RoundSliderOverlayShape(
+                                    overlayRadius: 14,
+                                  ),
+                                  activeTrackColor:
+                                      AppColorScheme.rangeProgress,
+                                  secondaryActiveTrackColor:
+                                      AppColorScheme.rangeTrack.withValues(
+                                        alpha: 0.8,
+                                      ),
+                                  inactiveTrackColor:
+                                      AppColorScheme.rangeTrack,
+                                  thumbColor: AppColorScheme.rangeThumb,
+                                  overlayColor: AppColorScheme.rangeThumb
+                                      .withValues(alpha: 0.2),
+                                ),
+                                child: Slider(
+                                  focusNode: _sliderInternalFocusNode,
+                                  value: _positionMs.clamp(
+                                    0.0,
+                                    _fakeDurationMs,
+                                  ),
+                                  max: _fakeDurationMs,
+                                  onChanged: (v) =>
+                                      setState(() => _positionMs = v),
+                                ),
+                              ),
+                            ),
+                            SizedBox(height: controlsRowGap),
+                            SizedBox(height: controlsRowExtent),
+                          ],
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.spaceXs),
+          Text(
+            AppLocalizations.of(context).trickplaySettingsPreviewHint,
+            textAlign: TextAlign.center,
+            style: TextStyle(
+              color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+              fontSize: AppTypography.fontSizeXs,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  int _fakeIndex(double ms) => (ms / _fakeStepMs).round();
+
+  static const _shotLength = 3;
+
+  static double _pseudoRandom(int seed) {
+    var x = seed;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    return (x & 0xFFFFFF) / 0xFFFFFF;
+  }
+
+  Widget _fakeTileContent(int index, {bool large = false}) {
+    final shot = index ~/ _shotLength;
+    const wiggle = 0.08;
+    final bounceX = ((_pseudoRandom(shot * 2 + 1) * 2 - 1) +
+            math.sin(index * 2.7) * wiggle)
+        .clamp(-1.0, 1.0);
+    final bounceY = ((_pseudoRandom(shot * 2 + 2) * 2 - 1) +
+            math.sin(index * 3.3 + 1.5) * wiggle)
+        .clamp(-1.0, 1.0);
+    return Container(
+      color: Colors.black,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          LayoutBuilder(
+            builder: (context, constraints) {
+              final logoSize =
+                  math.min(constraints.maxWidth, constraints.maxHeight) *
+                  (large ? 0.6 : 0.7);
+              return Align(
+                alignment: Alignment(bounceX, bounceY),
+                child: SizedBox(
+                  width: logoSize,
+                  height: logoSize,
+                  child: SvgPicture.asset(
+                    'assets/icons/moonfin_logo.svg',
+                    fit: BoxFit.contain,
+                  ),
+                ),
+              );
+            },
+          ),
+          Positioned(
+            right: 3,
+            bottom: 2,
+            child: Text(
+              '$index',
+              style: TextStyle(
+                color: Colors.white70,
+                fontWeight: FontWeight.bold,
+                fontSize: large
+                    ? AppTypography.fontSizeMd
+                    : AppTypography.fontSizeXs,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -1114,6 +1114,10 @@ class Media3VideoView(
             ) {
                 cancelPendingSubtitleCue(clearView = true)
                 scheduleAudioRekickAfterSeek()
+                // Otherwise Dart only learns the seek landed from the next
+                // 250ms ticker tick, which can still report the pre-seek
+                // position if it fires just before ExoPlayer applies this.
+                emitState()
             }
         }
 

--- a/test/data/models/trickplay_info_test.dart
+++ b/test/data/models/trickplay_info_test.dart
@@ -1,0 +1,54 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/trickplay_info.dart';
+
+void main() {
+  const info = TrickplayInfo(
+    width: 100,
+    height: 60,
+    tileWidth: 5,
+    tileHeight: 4,
+    interval: 10000,
+  );
+
+  group('TrickplayInfo.resolveTile', () {
+    test('position 0 resolves to the first tile of the first sheet', () {
+      final tile = info.resolveTile(Duration.zero);
+      expect(tile.imageIndex, 0);
+      expect(tile.sourceRect, const Rect.fromLTWH(0, 0, 100, 60));
+    });
+
+    test('mid-interval position stays on the same tile as its floor', () {
+      final tile = info.resolveTile(const Duration(milliseconds: 9999));
+      expect(tile.imageIndex, 0);
+      expect(tile.sourceRect, const Rect.fromLTWH(0, 0, 100, 60));
+    });
+
+    test('tile-grid col/row math for a mid-sheet tile', () {
+      final tile = info.resolveTile(const Duration(milliseconds: 70000));
+      expect(tile.imageIndex, 0);
+      expect(tile.sourceRect, const Rect.fromLTWH(200, 60, 100, 60));
+    });
+
+    test('last tile of the first sheet is the bottom-right cell', () {
+      final tile = info.resolveTile(const Duration(milliseconds: 199999));
+      expect(tile.imageIndex, 0);
+      expect(tile.sourceRect, const Rect.fromLTWH(400, 180, 100, 60));
+    });
+
+    test('sheet-boundary rollover resets to tile (0,0) on the next sheet', () {
+      final tile = info.resolveTile(const Duration(milliseconds: 200000));
+      expect(tile.imageIndex, 1);
+      expect(tile.sourceRect, const Rect.fromLTWH(0, 0, 100, 60));
+    });
+
+    test('carries thumb/tile dimensions through unchanged', () {
+      final tile = info.resolveTile(const Duration(milliseconds: 70000));
+      expect(tile.thumbWidth, 100);
+      expect(tile.thumbHeight, 60);
+      expect(tile.tileWidth, 5);
+      expect(tile.tileHeight, 4);
+    });
+  });
+}

--- a/test/data/models/trickplay_prefetch_planner_test.dart
+++ b/test/data/models/trickplay_prefetch_planner_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/trickplay_info.dart';
+import 'package:moonfin/data/models/trickplay_prefetch_planner.dart';
+
+void main() {
+  const info = TrickplayInfo(
+    width: 100,
+    height: 60,
+    tileWidth: 5,
+    tileHeight: 4,
+    interval: 10000,
+  );
+  const totalDuration = Duration(minutes: 20);
+
+  group('TrickplayPrefetchPlanner.planImageIndexes (directional, D-pad)', () {
+    test('forward returns only sheets ahead of the current one', () {
+      final indexes = TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: const Duration(seconds: 220), // sheet 1
+        totalDuration: totalDuration,
+        directionForward: true,
+        sheetsAhead: 2,
+      );
+      expect(indexes, [2, 3]);
+    });
+
+    test('backward returns only sheets behind the current one', () {
+      final indexes = TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: const Duration(seconds: 420), // sheet 2
+        totalDuration: totalDuration,
+        directionForward: false,
+        sheetsAhead: 2,
+      );
+      expect(indexes, [1, 0]);
+    });
+
+    test('backward near the start clamps at sheet 0, no negatives', () {
+      final indexes = TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: Duration.zero, // sheet 0
+        totalDuration: totalDuration,
+        directionForward: false,
+        sheetsAhead: 2,
+      );
+      expect(indexes, isEmpty);
+    });
+
+    test('forward near the end clamps at the last sheet', () {
+      final indexes = TrickplayPrefetchPlanner.planImageIndexes(
+        info: info,
+        position: totalDuration - const Duration(seconds: 1), // last sheet
+        totalDuration: totalDuration,
+        directionForward: true,
+        sheetsAhead: 2,
+      );
+      expect(indexes, isEmpty);
+    });
+  });
+
+  group('TrickplayPrefetchPlanner.planAllImageIndexes (touch/mouse)', () {
+    test('covers every sheet, ordered nearest-to-position outward', () {
+      final indexes = TrickplayPrefetchPlanner.planAllImageIndexes(
+        info: info,
+        position: const Duration(seconds: 420), // sheet 2
+        totalDuration: totalDuration,
+      );
+      expect(indexes.toSet(), {0, 1, 2, 3, 4, 5});
+      expect(indexes.first, 2);
+      final distances = indexes.map((i) => (i - 2).abs()).toList();
+      for (var i = 1; i < distances.length; i++) {
+        expect(distances[i], greaterThanOrEqualTo(distances[i - 1]));
+      }
+    });
+
+    test('maxSheets caps the result for very long content', () {
+      final indexes = TrickplayPrefetchPlanner.planAllImageIndexes(
+        info: info,
+        position: Duration.zero,
+        totalDuration: const Duration(hours: 10), // 180 sheets, > 128 cap
+        maxSheets: 128,
+      );
+      expect(indexes.length, 128);
+      expect(indexes.every((i) => i < 128), isTrue);
+    });
+  });
+}

--- a/test/data/models/trickplay_preview_layout_test.dart
+++ b/test/data/models/trickplay_preview_layout_test.dart
@@ -418,4 +418,82 @@ void main() {
       expect(atCeiling.width, closeTo(atMax.width, 0.001));
     });
   });
+
+  group('TrickplayPreviewLayout.plan', () {
+    const seek = Duration(minutes: 30);
+    const total = Duration(hours: 1);
+
+    TrickplayPreviewPlan planAt({required bool isStrip}) =>
+        TrickplayPreviewLayout.plan(
+          trackWidth: 1000,
+          scalePercent: 30,
+          aspect: 9 / 16,
+          maxHeightBudget: 400,
+          positionMs: 1800000,
+          durationMs: 3600000,
+          followScrub: true,
+          verticalPositionPercent: 50,
+          isStrip: isStrip,
+          spacing: 4,
+          overflowMargin: 16,
+          seekPosition: seek,
+          totalDuration: total,
+          stepMs: 30000,
+        );
+
+    test('agrees with the pieces it is built from', () {
+      final plan = planAt(isStrip: true);
+      final tile = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 30,
+        aspect: 9 / 16,
+        maxHeightBudget: 400,
+      );
+      expect(plan.tileWidth, tile.width);
+      expect(plan.tileHeight, tile.height);
+      final mainLeft = TrickplayPreviewLayout.resolveSingleLeft(
+        positionMs: 1800000,
+        durationMs: 3600000,
+        trackWidth: 1000,
+        tileWidth: tile.width,
+        followScrub: true,
+      );
+      expect(plan.leftOffset, mainLeft - plan.leftCount * (tile.width + 4));
+      expect(
+        plan.verticalTravel,
+        TrickplayPreviewLayout.resolveVerticalTravel(
+          50,
+          maxTravel: TrickplayPreviewLayout.resolveVerticalTravelMax(
+            rawMaxTravel: 400 - tile.height,
+            trackWidth: 1000,
+          ),
+        ),
+      );
+    });
+
+    test(
+      'the highlighted slot is the seek position and the wings step out',
+      () {
+        final plan = planAt(isStrip: true);
+        expect(plan.slotsByIndex[0]!.targetPosition, seek);
+        expect(
+          plan.slotsByIndex[1]!.targetPosition,
+          seek + const Duration(seconds: 30),
+        );
+        expect(
+          plan.slotsByIndex[-1]!.targetPosition,
+          seek - const Duration(seconds: 30),
+        );
+        expect(plan.slotsByIndex.length, plan.leftCount + 1 + plan.rightCount);
+        expect(plan.leftCount, greaterThan(0));
+      },
+    );
+
+    test('single mode has one slot and no wings', () {
+      final plan = planAt(isStrip: false);
+      expect(plan.leftCount, 0);
+      expect(plan.rightCount, 0);
+      expect(plan.slotsByIndex.keys, [0]);
+    });
+  });
 }

--- a/test/data/models/trickplay_preview_layout_test.dart
+++ b/test/data/models/trickplay_preview_layout_test.dart
@@ -1,0 +1,421 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/trickplay_preview_layout.dart';
+
+void main() {
+  group('TrickplayPreviewLayout.trackXForPosition', () {
+    test('position 0 sits at the thumb radius inset', () {
+      final x = TrickplayPreviewLayout.trackXForPosition(
+        positionMs: 0,
+        durationMs: 100000,
+        trackWidth: 1000,
+      );
+      expect(x, TrickplayPreviewLayout.seekThumbRadius);
+    });
+
+    test('position at duration sits at the far inset', () {
+      final x = TrickplayPreviewLayout.trackXForPosition(
+        positionMs: 100000,
+        durationMs: 100000,
+        trackWidth: 1000,
+      );
+      expect(x, 1000 - TrickplayPreviewLayout.seekThumbRadius);
+    });
+
+    test('zero duration does not divide by zero', () {
+      final x = TrickplayPreviewLayout.trackXForPosition(
+        positionMs: 500,
+        durationMs: 0,
+        trackWidth: 1000,
+      );
+      expect(x, TrickplayPreviewLayout.seekThumbRadius);
+    });
+  });
+
+  group('TrickplayPreviewLayout.resolveSingleLeft', () {
+    test('centered on the track when not following scrub', () {
+      final left = TrickplayPreviewLayout.resolveSingleLeft(
+        positionMs: 10000,
+        durationMs: 100000,
+        trackWidth: 1000,
+        tileWidth: 200,
+        followScrub: false,
+      );
+      expect(left, (1000 - 200) / 2);
+    });
+
+    test('tracks the thumb when following scrub', () {
+      final left = TrickplayPreviewLayout.resolveSingleLeft(
+        positionMs: 50000,
+        durationMs: 100000,
+        trackWidth: 1000,
+        tileWidth: 200,
+        followScrub: true,
+      );
+      final thumbX = TrickplayPreviewLayout.trackXForPosition(
+        positionMs: 50000,
+        durationMs: 100000,
+        trackWidth: 1000,
+      );
+      expect(left, thumbX - 100);
+    });
+
+    test('stays fully on-screen near the left edge while following', () {
+      final left = TrickplayPreviewLayout.resolveSingleLeft(
+        positionMs: 0,
+        durationMs: 100000,
+        trackWidth: 1000,
+        tileWidth: 200,
+        followScrub: true,
+      );
+      expect(left, greaterThanOrEqualTo(0.0));
+    });
+
+    test('stays fully on-screen near the right edge while following', () {
+      final left = TrickplayPreviewLayout.resolveSingleLeft(
+        positionMs: 100000,
+        durationMs: 100000,
+        trackWidth: 1000,
+        tileWidth: 200,
+        followScrub: true,
+      );
+      expect(left, lessThanOrEqualTo(1000 - 200));
+    });
+  });
+
+  group('TrickplayPreviewLayout.resolveStrip', () {
+    test('fills evenly on both sides when the main tile is centered', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 450,
+        trackWidth: 1000,
+        tileWidth: 100,
+        spacing: 0,
+      );
+      expect(layout.leftCount, layout.rightCount);
+      expect(layout.slotCount, layout.leftCount * 2 + 1);
+    });
+
+    test('spawns fewer slots on the left when main tile is near the left edge', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 10,
+        trackWidth: 1000,
+        tileWidth: 100,
+        spacing: 0,
+      );
+      expect(layout.leftCount, lessThan(layout.rightCount));
+    });
+
+    test('spawns fewer slots on the right when main tile is near the right edge', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 890,
+        trackWidth: 1000,
+        tileWidth: 100,
+        spacing: 0,
+      );
+      expect(layout.rightCount, lessThan(layout.leftCount));
+    });
+
+    test('leftOffset places the highlighted slot exactly at mainTileLeft', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 273,
+        trackWidth: 1000,
+        tileWidth: 80,
+        spacing: 8,
+      );
+      final highlightSlotLeft =
+          layout.leftOffset + layout.leftCount * (80 + 8);
+      expect(highlightSlotLeft, closeTo(273, 0.001));
+    });
+
+    test(
+      'always spawns exactly one full-size slot beyond the last one that '
+      'fully fits, genuinely overflowing the track rather than being '
+      'shrunk to fit',
+      () {
+        final layout = TrickplayPreviewLayout.resolveStrip(
+          mainTileLeft: 895,
+          trackWidth: 1000,
+          tileWidth: 100,
+          spacing: 10,
+        );
+        expect(layout.rightCount, 1);
+      },
+    );
+
+    test(
+      'still spawns the overflow slot on the left even at a true edge',
+      () {
+        final layout = TrickplayPreviewLayout.resolveStrip(
+          mainTileLeft: 5,
+          trackWidth: 1000,
+          tileWidth: 100,
+          spacing: 10,
+        );
+        expect(layout.leftCount, 1);
+      },
+    );
+
+    test(
+      'does not run away spawning full slots indefinitely when there is '
+      'plenty of room',
+      () {
+        final layout = TrickplayPreviewLayout.resolveStrip(
+          mainTileLeft: 10,
+          trackWidth: 1000,
+          tileWidth: 50,
+          spacing: 0,
+        );
+        expect(layout.rightCount, 19);
+      },
+    );
+
+    test(
+      'overflowMargin lets the overflow slot reach further before it '
+      'stops counting as fitting, without moving leftOffset',
+      () {
+        const mainTileLeft = 95.6;
+        const trackWidth = 340.0;
+        const tileWidth = 51.0;
+        const spacing = 4.0;
+
+        final withoutMargin = TrickplayPreviewLayout.resolveStrip(
+          mainTileLeft: mainTileLeft,
+          trackWidth: trackWidth,
+          tileWidth: tileWidth,
+          spacing: spacing,
+        );
+        final withMargin = TrickplayPreviewLayout.resolveStrip(
+          mainTileLeft: mainTileLeft,
+          trackWidth: trackWidth,
+          tileWidth: tileWidth,
+          spacing: spacing,
+          overflowMargin: 8,
+        );
+
+        expect(withMargin.leftCount, 2);
+        expect(withMargin.rightCount, 4);
+        expect(withMargin.leftOffset, closeTo(-14.4, 0.001));
+        expect(withMargin.leftOffset, withoutMargin.leftOffset);
+      },
+    );
+
+    test('overflowMargin of 0 behaves exactly like omitting it', () {
+      final withZero = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 273,
+        trackWidth: 1000,
+        tileWidth: 80,
+        spacing: 8,
+        overflowMargin: 0,
+      );
+      final omitted = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 273,
+        trackWidth: 1000,
+        tileWidth: 80,
+        spacing: 8,
+      );
+      expect(withZero.leftCount, omitted.leftCount);
+      expect(withZero.rightCount, omitted.rightCount);
+      expect(withZero.leftOffset, omitted.leftOffset);
+    });
+
+    test('maxSlotsPerSide guards against a degenerate near-zero tile size', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 500,
+        trackWidth: 1000,
+        tileWidth: 0.001,
+        spacing: 0,
+        maxSlotsPerSide: 50,
+      );
+      expect(layout.leftCount, lessThanOrEqualTo(50));
+      expect(layout.rightCount, lessThanOrEqualTo(50));
+    });
+
+    test('a literal-zero step returns no wing tiles instead of throwing', () {
+      final layout = TrickplayPreviewLayout.resolveStrip(
+        mainTileLeft: 50,
+        trackWidth: 1000,
+        tileWidth: 0,
+        spacing: 0,
+      );
+      expect(layout.leftCount, 0);
+      expect(layout.rightCount, 0);
+      expect(layout.leftOffset, 50);
+    });
+  });
+
+  group('TrickplayPreviewLayout.resolveVerticalTravel', () {
+    test('0% stays at the resting position (no travel)', () {
+      final travel = TrickplayPreviewLayout.resolveVerticalTravel(
+        0,
+        maxTravel: 100,
+      );
+      expect(travel, 0);
+    });
+
+    test('100% travels the full distance to the ceiling', () {
+      final travel = TrickplayPreviewLayout.resolveVerticalTravel(
+        100,
+        maxTravel: 100,
+      );
+      expect(travel, 100);
+    });
+
+    test('50% travels halfway to the ceiling', () {
+      final travel = TrickplayPreviewLayout.resolveVerticalTravel(
+        50,
+        maxTravel: 100,
+      );
+      expect(travel, 50);
+    });
+
+    test('out-of-range percentages are clamped into 0-100', () {
+      expect(
+        TrickplayPreviewLayout.resolveVerticalTravel(-20, maxTravel: 100),
+        0,
+      );
+      expect(
+        TrickplayPreviewLayout.resolveVerticalTravel(150, maxTravel: 100),
+        100,
+      );
+    });
+
+    test('never exceeds a caller-supplied small maxTravel', () {
+      final travel = TrickplayPreviewLayout.resolveVerticalTravel(
+        100,
+        maxTravel: 12,
+      );
+      expect(travel, lessThanOrEqualTo(12));
+    });
+  });
+
+  group('TrickplayPreviewLayout.resolveVerticalTravelMax', () {
+    test('a wide (landscape) track rarely binds - the raw ceiling distance wins', () {
+      final maxTravel = TrickplayPreviewLayout.resolveVerticalTravelMax(
+        rawMaxTravel: 300,
+        trackWidth: 1200,
+      );
+      expect(maxTravel, 300);
+    });
+
+    test('a narrow (portrait) track caps travel to trackWidth, not the raw ceiling distance', () {
+      final maxTravel = TrickplayPreviewLayout.resolveVerticalTravelMax(
+        rawMaxTravel: 900,
+        trackWidth: 250,
+      );
+      expect(maxTravel, 250);
+    });
+
+    test('never goes negative even with a negative raw distance', () {
+      final maxTravel = TrickplayPreviewLayout.resolveVerticalTravelMax(
+        rawMaxTravel: -40,
+        trackWidth: 250,
+      );
+      expect(maxTravel, 0);
+    });
+  });
+
+  group('TrickplayPreviewLayout.resolveTileSize', () {
+    test('100% fills the whole maxHeightBudget when the track is wide enough', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 100,
+        aspect: 9 / 16,
+        maxHeightBudget: 500,
+      );
+      expect(size.height, closeTo(500, 0.001));
+      expect(size.width, closeTo(500 / (9 / 16), 0.001));
+    });
+
+    test('the multiplier-1.0x slider value is half of maxHeightBudget', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 40,
+        aspect: 9 / 16,
+        maxHeightBudget: 500,
+      );
+      expect(size.height, closeTo(250, 0.001));
+    });
+
+    test('never shrinks below the 24px height floor', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 10,
+        aspect: 9 / 16,
+        maxHeightBudget: 0,
+      );
+      expect(size.height, greaterThanOrEqualTo(24.0));
+    });
+
+    test('height never exceeds maxHeightBudget regardless of trackWidth', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 3800,
+        scalePercent: 100,
+        aspect: 9 / 16,
+        maxHeightBudget: 100,
+      );
+      expect(size.height, lessThanOrEqualTo(100.0 + 0.001));
+    });
+
+    test('width never exceeds a narrow (portrait) trackWidth, even with a generous height budget', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 100,
+        scalePercent: 100,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      expect(size.width, closeTo(100, 0.001));
+    });
+
+    test('trackWidth narrower than the 24px height floor still wins - width never exceeds it', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 30,
+        scalePercent: 100,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      expect(size.width, closeTo(30, 0.001));
+      expect(size.height, lessThan(24.0));
+    });
+
+    test('respects the tile aspect ratio in both dimensions', () {
+      final size = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 40,
+        aspect: 3 / 4,
+        maxHeightBudget: 1000,
+      );
+      expect(size.height / size.width, closeTo(3 / 4, 0.001));
+    });
+
+    test('clamps a scalePercent below 10 to the 0.5x floor', () {
+      final atFloor = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 0,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      final atMin = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 10,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      expect(atFloor.width, closeTo(atMin.width, 0.001));
+    });
+
+    test('clamps a scalePercent above 100 to the 2.0x ceiling', () {
+      final atCeiling = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 150,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      final atMax = TrickplayPreviewLayout.resolveTileSize(
+        trackWidth: 1000,
+        scalePercent: 100,
+        aspect: 9 / 16,
+        maxHeightBudget: 1000,
+      );
+      expect(atCeiling.width, closeTo(atMax.width, 0.001));
+    });
+  });
+}

--- a/test/data/models/trickplay_strip_resolution_test.dart
+++ b/test/data/models/trickplay_strip_resolution_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/trickplay_info.dart';
+import 'package:moonfin/data/models/trickplay_strip_resolution.dart';
+
+void main() {
+  const totalDuration = Duration(minutes: 10);
+  const stepMs = 30000;
+
+  group('TrickplayStripResolver.resolve', () {
+    test('returns 5 slots indexed -2..2 with slot 0 centered', () {
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: const Duration(minutes: 5),
+        totalDuration: totalDuration,
+        stepMs: stepMs,
+      );
+      expect(slots.map((s) => s.slotIndex), [-2, -1, 0, 1, 2]);
+      expect(slots[2].targetPosition, const Duration(minutes: 5));
+      expect(slots[2].inRange, isTrue);
+    });
+
+    test('edge slots near the start of media go out of range', () {
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: const Duration(seconds: 15),
+        totalDuration: totalDuration,
+        stepMs: stepMs,
+      );
+      expect(slots[0].inRange, isFalse);
+      expect(slots[0].targetPosition, isNull);
+      expect(slots[1].inRange, isFalse);
+      expect(slots[2].inRange, isTrue);
+      expect(slots[3].inRange, isTrue);
+      expect(slots[4].inRange, isTrue);
+    });
+
+    test('edge slots near the end of media go out of range', () {
+      final nearEnd = totalDuration - const Duration(seconds: 15);
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: nearEnd,
+        totalDuration: totalDuration,
+        stepMs: stepMs,
+      );
+      expect(slots[0].inRange, isTrue);
+      expect(slots[1].inRange, isTrue);
+      expect(slots[2].inRange, isTrue);
+      expect(slots[3].inRange, isFalse);
+      expect(slots[3].targetPosition, isNull);
+      expect(slots[4].inRange, isFalse);
+    });
+
+    test('adjacent slots can span two different sprite sheets', () {
+      const info = TrickplayInfo(
+        width: 100,
+        height: 60,
+        tileWidth: 5,
+        tileHeight: 4,
+        interval: 10000,
+      );
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: const Duration(seconds: 220),
+        totalDuration: const Duration(seconds: 600),
+        stepMs: 150000,
+        slotCount: 3,
+      );
+      final left = info.resolveTile(slots[0].targetPosition!);
+      final center = info.resolveTile(slots[1].targetPosition!);
+      expect(left.imageIndex, 0);
+      expect(center.imageIndex, 1);
+    });
+
+    test('asymmetric highlightIndex spawns more slots on one side', () {
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: const Duration(minutes: 5),
+        totalDuration: totalDuration,
+        stepMs: stepMs,
+        slotCount: 6,
+        highlightIndex: 1,
+      );
+      expect(slots.map((s) => s.slotIndex), [-1, 0, 1, 2, 3, 4]);
+      expect(slots[1].targetPosition, const Duration(minutes: 5));
+    });
+
+    test('highlightIndex is clamped into range rather than throwing', () {
+      final slots = TrickplayStripResolver.resolve(
+        fakeTimelinePosition: const Duration(minutes: 5),
+        totalDuration: totalDuration,
+        stepMs: stepMs,
+        slotCount: 5,
+        highlightIndex: 99,
+      );
+      expect(slots.map((s) => s.slotIndex), [-4, -3, -2, -1, 0]);
+      expect(slots[4].targetPosition, const Duration(minutes: 5));
+    });
+
+    test(
+      'slotIndex (the widget key) stays stable across a continuous drag '
+      'while targetPosition does not - two resolves a few ms apart, same '
+      'slotCount/highlightIndex, should be keyable without churn',
+      () {
+        final before = TrickplayStripResolver.resolve(
+          fakeTimelinePosition: const Duration(minutes: 5),
+          totalDuration: totalDuration,
+          stepMs: stepMs,
+        );
+        final after = TrickplayStripResolver.resolve(
+          fakeTimelinePosition: const Duration(
+            milliseconds: 5 * 60 * 1000 + 16,
+          ),
+          totalDuration: totalDuration,
+          stepMs: stepMs,
+        );
+        expect(
+          after.map((s) => s.slotIndex),
+          before.map((s) => s.slotIndex),
+        );
+        for (var i = 0; i < before.length; i++) {
+          expect(
+            after[i].targetPosition!.inMilliseconds,
+            isNot(before[i].targetPosition!.inMilliseconds),
+          );
+        }
+      },
+    );
+  });
+}

--- a/test/preference/trickplay_migration_test.dart
+++ b/test/preference/trickplay_migration_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/di/injection.dart'
+    show migrateTrickplayPreferenceConsolidation;
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const legacyEnabledKey = 'trick_play_enabled';
+  const legacyDisplayStyleKey = 'trickplay_display_style';
+  const legacyReplaceVideoKey = 'trickplay_replace_video_while_scrubbing';
+  const legacyVerticalOffsetPxKey = 'trickplay_vertical_offset_px';
+  const migrationKey = 'pref_trickplay_consolidation_v1';
+
+  Future<PreferenceStore> storeWith(Map<String, Object> values) async {
+    SharedPreferences.setMockInitialValues(values);
+    final store = PreferenceStore();
+    await store.init();
+    return store;
+  }
+
+  group('trickplay preference consolidation migration', () {
+    test('explicit legacy off becomes disabled', () async {
+      final store = await storeWith({legacyEnabledKey: false});
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.disabled.name,
+      );
+      expect(store.getBool(migrationKey), isTrue);
+    });
+
+    test('untouched legacy toggle stays on the new single default', () async {
+      final store = await storeWith({});
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.single.name,
+      );
+    });
+
+    test('legacy strip style wins over replace-video', () async {
+      final store = await storeWith({
+        legacyEnabledKey: true,
+        legacyReplaceVideoKey: true,
+        legacyDisplayStyleKey: 'strip',
+      });
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.strip.name,
+      );
+    });
+
+    test('legacy replace-video maps to full mode on its own', () async {
+      final store = await storeWith({
+        legacyEnabledKey: true,
+        legacyReplaceVideoKey: true,
+      });
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.full.name,
+      );
+    });
+
+    test('legacy strip style maps to strip mode', () async {
+      final store = await storeWith({
+        legacyEnabledKey: true,
+        legacyDisplayStyleKey: 'strip',
+      });
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.strip.name,
+      );
+    });
+
+    test('existing new-key value is never overwritten', () async {
+      final store = await storeWith({
+        UserPreferences.trickPlayMode.key: TrickplayMode.full.name,
+        legacyEnabledKey: false,
+      });
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getString(UserPreferences.trickPlayMode.key),
+        TrickplayMode.full.name,
+      );
+    });
+
+    test('positive legacy px offset converts to a percent', () async {
+      final store = await storeWith({legacyVerticalOffsetPxKey: 40});
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getInt(UserPreferences.trickPlayVerticalPositionPercent.key),
+        50,
+      );
+    });
+
+    test('negative legacy px offset clamps to the 0% floor', () async {
+      final store = await storeWith({legacyVerticalOffsetPxKey: -40});
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.getInt(UserPreferences.trickPlayVerticalPositionPercent.key),
+        isNull,
+      );
+    });
+
+    test('runs only once', () async {
+      final store = await storeWith({migrationKey: true, legacyEnabledKey: false});
+
+      await migrateTrickplayPreferenceConsolidation(store);
+
+      expect(
+        store.containsKey(UserPreferences.trickPlayMode.key),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/preference/trickplay_migration_test.dart
+++ b/test/preference/trickplay_migration_test.dart
@@ -10,9 +10,6 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const legacyEnabledKey = 'trick_play_enabled';
-  const legacyDisplayStyleKey = 'trickplay_display_style';
-  const legacyReplaceVideoKey = 'trickplay_replace_video_while_scrubbing';
-  const legacyVerticalOffsetPxKey = 'trickplay_vertical_offset_px';
   const migrationKey = 'pref_trickplay_consolidation_v1';
 
   Future<PreferenceStore> storeWith(Map<String, Object> values) async {
@@ -22,7 +19,7 @@ void main() {
     return store;
   }
 
-  group('trickplay preference consolidation migration', () {
+  group('trickplay preference migration', () {
     test('explicit legacy off becomes disabled', () async {
       final store = await storeWith({legacyEnabledKey: false});
 
@@ -35,61 +32,24 @@ void main() {
       expect(store.getBool(migrationKey), isTrue);
     });
 
-    test('untouched legacy toggle stays on the new single default', () async {
-      final store = await storeWith({});
+    test(
+      'legacy on and an untouched toggle both leave the default alone',
+      () async {
+        for (final values in [
+          <String, Object>{},
+          {legacyEnabledKey: true},
+        ]) {
+          final store = await storeWith(values);
 
-      await migrateTrickplayPreferenceConsolidation(store);
+          await migrateTrickplayPreferenceConsolidation(store);
 
-      expect(
-        store.getString(UserPreferences.trickPlayMode.key),
-        TrickplayMode.single.name,
-      );
-    });
+          expect(store.containsKey(UserPreferences.trickPlayMode.key), isFalse);
+          expect(store.getBool(migrationKey), isTrue);
+        }
+      },
+    );
 
-    test('legacy strip style wins over replace-video', () async {
-      final store = await storeWith({
-        legacyEnabledKey: true,
-        legacyReplaceVideoKey: true,
-        legacyDisplayStyleKey: 'strip',
-      });
-
-      await migrateTrickplayPreferenceConsolidation(store);
-
-      expect(
-        store.getString(UserPreferences.trickPlayMode.key),
-        TrickplayMode.strip.name,
-      );
-    });
-
-    test('legacy replace-video maps to full mode on its own', () async {
-      final store = await storeWith({
-        legacyEnabledKey: true,
-        legacyReplaceVideoKey: true,
-      });
-
-      await migrateTrickplayPreferenceConsolidation(store);
-
-      expect(
-        store.getString(UserPreferences.trickPlayMode.key),
-        TrickplayMode.full.name,
-      );
-    });
-
-    test('legacy strip style maps to strip mode', () async {
-      final store = await storeWith({
-        legacyEnabledKey: true,
-        legacyDisplayStyleKey: 'strip',
-      });
-
-      await migrateTrickplayPreferenceConsolidation(store);
-
-      expect(
-        store.getString(UserPreferences.trickPlayMode.key),
-        TrickplayMode.strip.name,
-      );
-    });
-
-    test('existing new-key value is never overwritten', () async {
+    test('an existing new value is never overwritten', () async {
       final store = await storeWith({
         UserPreferences.trickPlayMode.key: TrickplayMode.full.name,
         legacyEnabledKey: false,
@@ -103,37 +63,15 @@ void main() {
       );
     });
 
-    test('positive legacy px offset converts to a percent', () async {
-      final store = await storeWith({legacyVerticalOffsetPxKey: 40});
-
-      await migrateTrickplayPreferenceConsolidation(store);
-
-      expect(
-        store.getInt(UserPreferences.trickPlayVerticalPositionPercent.key),
-        50,
-      );
-    });
-
-    test('negative legacy px offset clamps to the 0% floor', () async {
-      final store = await storeWith({legacyVerticalOffsetPxKey: -40});
-
-      await migrateTrickplayPreferenceConsolidation(store);
-
-      expect(
-        store.getInt(UserPreferences.trickPlayVerticalPositionPercent.key),
-        isNull,
-      );
-    });
-
     test('runs only once', () async {
-      final store = await storeWith({migrationKey: true, legacyEnabledKey: false});
+      final store = await storeWith({
+        migrationKey: true,
+        legacyEnabledKey: false,
+      });
 
       await migrateTrickplayPreferenceConsolidation(store);
 
-      expect(
-        store.containsKey(UserPreferences.trickPlayMode.key),
-        isFalse,
-      );
+      expect(store.containsKey(UserPreferences.trickPlayMode.key), isFalse);
     });
   });
 }

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -81,6 +81,11 @@ final class AppleTvPlayerViewController: UIViewController {
 
     private var trickplay: TrickplayData?
     private var trickplaySheets: [Int: UIImage] = [:]
+    private var trickplaySheetsLoading: Set<Int> = []
+    private var trickplayMode: TrickplayMode = .single
+    private var trickplayScalePercent = 30
+    private var trickplayVerticalPercent = 0
+    private var trickplayFollowScrub = true
 
     // The Next Up card, skip button, and Still Watching prompt are pure
     // renderers. The Dart side owns every decision (when to show, the
@@ -125,7 +130,15 @@ final class AppleTvPlayerViewController: UIViewController {
     private var streamStats: [(label: String, value: String)] = []
 
     private var scrubTargetMs: Int?
-    private var scrubCommitTimer: Timer?
+    // Shown on the scrubber from the commit until the player has landed, so
+    // the timeline never jumps back to the old position for a frame.
+    private var scrubFrozenMs: Int?
+    // Bumped whenever a new gesture or an outside seek starts, so an older
+    // commit still waiting to land can't resume playback under the new one.
+    private var scrubCommitId = 0
+    private var scrubConvergeTimer: Timer?
+    private var scrubConvergeDeadline: TimeInterval = 0
+    private var wasPlayingBeforeScrub = false
     private var scrubHoldTimer: Timer?
     private var scrubHoldForward = false
     private var scrubHoldStart: TimeInterval = 0
@@ -144,6 +157,8 @@ final class AppleTvPlayerViewController: UIViewController {
         let rows: Int
         let intervalMs: Int
     }
+
+    private enum TrickplayMode: String { case disabled, single, strip, full }
 
     private enum Zone { case scrubber, buttons }
     private enum ControlId {
@@ -171,9 +186,9 @@ final class AppleTvPlayerViewController: UIViewController {
 
     private let trickplayContainer = UIView()
     private let trickplayImageView = UIImageView()
-    private let trickplayWidth: CGFloat = 480
-    private var trickplayCenterX: NSLayoutConstraint?
-    private var trickplayHeight: NSLayoutConstraint?
+    private let trickplayStrip = UIView()
+    private var trickplayStripTiles: [UIImageView] = []
+    private let trickplayCover = UIImageView()
 
     private let topContainer = UIView()
     private let topGradientLayer = CAGradientLayer()
@@ -693,39 +708,22 @@ final class AppleTvPlayerViewController: UIViewController {
     }
 
     private func setupTrickplay() {
-        trickplayContainer.translatesAutoresizingMaskIntoConstraints = false
         trickplayContainer.backgroundColor = .black
-        trickplayContainer.layer.cornerRadius = 6
+        trickplayContainer.layer.cornerRadius = 8
         trickplayContainer.layer.borderWidth = 2
-        trickplayContainer.layer.borderColor = UIColor.white.cgColor
         trickplayContainer.clipsToBounds = true
         trickplayContainer.isHidden = true
         osdContainer.addSubview(trickplayContainer)
 
-        trickplayImageView.translatesAutoresizingMaskIntoConstraints = false
         trickplayImageView.contentMode = .scaleAspectFill
         trickplayContainer.addSubview(trickplayImageView)
 
-        let center = trickplayContainer.centerXAnchor.constraint(
-            equalTo: scrubber.leadingAnchor)
-        let height = trickplayContainer.heightAnchor.constraint(
-            equalToConstant: trickplayWidth * 9 / 16)
-        trickplayCenterX = center
-        trickplayHeight = height
-        NSLayoutConstraint.activate([
-            center,
-            height,
-            trickplayContainer.widthAnchor.constraint(equalToConstant: trickplayWidth),
-            trickplayContainer.bottomAnchor.constraint(
-                equalTo: scrubber.topAnchor, constant: -14),
-            trickplayImageView.leadingAnchor.constraint(
-                equalTo: trickplayContainer.leadingAnchor),
-            trickplayImageView.trailingAnchor.constraint(
-                equalTo: trickplayContainer.trailingAnchor),
-            trickplayImageView.topAnchor.constraint(equalTo: trickplayContainer.topAnchor),
-            trickplayImageView.bottomAnchor.constraint(
-                equalTo: trickplayContainer.bottomAnchor),
-        ])
+        trickplayStrip.isHidden = true
+        osdContainer.addSubview(trickplayStrip)
+
+        trickplayCover.backgroundColor = .black
+        trickplayCover.isHidden = true
+        view.insertSubview(trickplayCover, belowSubview: topContainer)
     }
 
     // Mirrors the Flutter NextUpOverlay layout at TV scale: a thumbnail on
@@ -1193,7 +1191,6 @@ final class AppleTvPlayerViewController: UIViewController {
     }
 
     private func parseTrickplay(_ raw: Any?) {
-        trickplaySheets.removeAll()
         guard let dict = raw as? [String: Any],
             let urls = dict["urls"] as? [String],
             let width = (dict["width"] as? NSNumber)?.intValue,
@@ -1204,13 +1201,27 @@ final class AppleTvPlayerViewController: UIViewController {
             width > 0, height > 0, cols > 0, rows > 0, intervalMs > 0
         else {
             trickplay = nil
+            trickplaySheets.removeAll()
+            trickplaySheetsLoading.removeAll()
+            hideTrickplay()
             return
+        }
+        // A settings change resends the same sheets, which are worth keeping.
+        if trickplay?.urls != urls {
+            trickplaySheets.removeAll()
+            trickplaySheetsLoading.removeAll()
         }
         let headers = (dict["headers"] as? [String: String]) ?? [:]
         trickplay = TrickplayData(
             urls: urls, headers: headers, width: width, height: height,
             cols: cols, rows: rows, intervalMs: intervalMs)
-        trickplayHeight?.constant = trickplayWidth * CGFloat(height) / CGFloat(width)
+        trickplayMode = TrickplayMode(rawValue: (dict["mode"] as? String) ?? "") ?? .single
+        trickplayScalePercent = (dict["scalePercent"] as? NSNumber)?.intValue ?? 30
+        trickplayVerticalPercent = (dict["verticalPositionPercent"] as? NSNumber)?.intValue ?? 0
+        trickplayFollowScrub = (dict["followScrub"] as? Bool) ?? true
+        if scrubTargetMs != nil || scrubFrozenMs != nil {
+            updateTrickplay()
+        }
     }
 
     private func parsePauseMeta(_ raw: Any?) {
@@ -1377,8 +1388,8 @@ final class AppleTvPlayerViewController: UIViewController {
         super.viewDidDisappear(animated)
         updateTimer?.invalidate()
         updateTimer = nil
-        scrubCommitTimer?.invalidate()
-        scrubCommitTimer = nil
+        scrubConvergeTimer?.invalidate()
+        scrubConvergeTimer = nil
         scrubHoldTimer?.invalidate()
         scrubHoldTimer = nil
         player.stop()
@@ -1432,7 +1443,7 @@ final class AppleTvPlayerViewController: UIViewController {
             return
         }
         if scrubTargetMs != nil {
-            cancelScrub()
+            abandonScrubSession()
             showOsd()
             return
         }
@@ -1522,7 +1533,7 @@ final class AppleTvPlayerViewController: UIViewController {
             if commit {
                 commitScrub()
             } else {
-                cancelScrub()
+                abandonScrubSession()
             }
             focusedZone = zoneBeforePanScrub ?? .buttons
             updateFocusHighlight()
@@ -1676,17 +1687,16 @@ final class AppleTvPlayerViewController: UIViewController {
         guard scrubHoldTimer != nil else { return }
         scrubHoldTimer?.invalidate()
         scrubHoldTimer = nil
-        if scrubTargetMs != nil { commitScrub() }
+        // With a preview up the session outlives the key: the preview stays on
+        // the paused frame and play is what commits. With nothing to look at,
+        // letting go is the commit.
+        if scrubTargetMs != nil && !hasTrickplayPreview { commitScrub() }
     }
 
     private func handleSelect() {
         switch focusedZone {
         case .scrubber:
-            if scrubTargetMs != nil {
-                commitScrub()
-            } else {
-                togglePlayPause()
-            }
+            togglePlayPause()
         case .buttons:
             guard controls.indices.contains(focusedControlIndex) else { return }
             activate(controls[focusedControlIndex])
@@ -1726,11 +1736,11 @@ final class AppleTvPlayerViewController: UIViewController {
         case .prev:
             onPrevious?()
         case .skipBack:
-            adjustScrub(byMs: -skipBackMs)
+            seekDirect(toMs: Int(player.currentTime * 1000) - skipBackMs)
         case .playPause:
             togglePlayPause()
         case .skipForward:
-            adjustScrub(byMs: skipForwardMs)
+            seekDirect(toMs: Int(player.currentTime * 1000) + skipForwardMs)
         case .next:
             onNext?()
         case .speed:
@@ -1888,6 +1898,13 @@ final class AppleTvPlayerViewController: UIViewController {
     }
 
     private func togglePlayPause() {
+        // During a paused scrub session play means go to the scrubbed spot
+        // and carry on from there, not resume where the video was paused.
+        if scrubTargetMs != nil {
+            wasPlayingBeforeScrub = true
+            commitScrub()
+            return
+        }
         switch player.state {
         case .playing, .buffering, .opening:
             player.pause()
@@ -1900,90 +1917,297 @@ final class AppleTvPlayerViewController: UIViewController {
         player.state == .paused
     }
 
+    private var hasTrickplayPreview: Bool {
+        trickplayMode != .disabled && trickplay != nil
+    }
+
+    // Pauses once per session so the preview has a still frame to sit on.
+    // Without a preview scrubbing leaves playback alone.
+    private func beginScrub() {
+        scrubCommitId += 1
+        scrubConvergeTimer?.invalidate()
+        scrubConvergeTimer = nil
+        scrubFrozenMs = nil
+        guard hasTrickplayPreview else { return }
+        if !wasPlayingBeforeScrub {
+            wasPlayingBeforeScrub = !isPaused()
+            if wasPlayingBeforeScrub { player.pause() }
+        }
+    }
+
+    // Moves the frozen target only. The one real seek happens in commitScrub.
     private func adjustScrub(byMs deltaMs: Int) {
         guard !isLive else { return }
         let durationMs = Int(player.duration * 1000)
         guard durationMs > 0 else { return }
-        let base = scrubTargetMs ?? Int(player.currentTime * 1000)
+        // A quick press after a release lands while the last commit is still
+        // converging, when the player still reads the old position.
+        let base = scrubTargetMs ?? scrubFrozenMs ?? Int(player.currentTime * 1000)
+        if scrubTargetMs == nil { beginScrub() }
         scrubTargetMs = min(durationMs, max(0, base + deltaMs))
+        prefetchTrickplay(aroundMs: base, forward: deltaMs > 0, sheetsAhead: 2)
         renderProgress()
         updateTrickplay()
-        scrubCommitTimer?.invalidate()
-        scrubCommitTimer = Timer.scheduledTimer(
-            withTimeInterval: 0.6, repeats: false
-        ) { [weak self] _ in
-            Task { @MainActor in self?.commitScrub() }
-        }
     }
 
     private func commitScrub() {
-        scrubCommitTimer?.invalidate()
-        scrubCommitTimer = nil
         guard let target = scrubTargetMs else { return }
         scrubTargetMs = nil
-        trickplayContainer.isHidden = true
+        scrubFrozenMs = target
+        scrubCommitId += 1
+        let commitId = scrubCommitId
         player.seek(to: Double(target) / 1000.0)
         onUserSeek?()
+        renderProgress()
+        updateTrickplay()
+        scrubConvergeDeadline = ProcessInfo.processInfo.systemUptime + 2.0
+        scrubConvergeTimer?.invalidate()
+        scrubConvergeTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) {
+            [weak self] _ in
+            Task { @MainActor in self?.checkScrubConverged(commitId: commitId, targetMs: target) }
+        }
     }
 
-    private func cancelScrub() {
+    // The frozen timeline lets go once the player reads close to the target,
+    // or after two seconds so a seek that never lands can't hold it forever.
+    private func checkScrubConverged(commitId: Int, targetMs: Int) {
+        guard commitId == scrubCommitId else {
+            scrubConvergeTimer?.invalidate()
+            scrubConvergeTimer = nil
+            return
+        }
+        let landed = abs(Int(player.currentTime * 1000) - targetMs) <= 800
+        let timedOut = ProcessInfo.processInfo.systemUptime >= scrubConvergeDeadline
+        guard landed || timedOut else { return }
+        scrubConvergeTimer?.invalidate()
+        scrubConvergeTimer = nil
+        scrubFrozenMs = nil
+        if wasPlayingBeforeScrub {
+            wasPlayingBeforeScrub = false
+            player.resume()
+        }
+        renderProgress()
+        updateTrickplay()
+    }
+
+    // A skip, a chapter jump or a seek sent from the app lands somewhere the
+    // session knows nothing about, so the session is dropped rather than left
+    // to commit its stale target the next time play is pressed.
+    private func abandonScrubSession() {
+        guard scrubTargetMs != nil || scrubFrozenMs != nil || wasPlayingBeforeScrub else {
+            return
+        }
+        scrubCommitId += 1
         scrubHoldTimer?.invalidate()
         scrubHoldTimer = nil
-        scrubCommitTimer?.invalidate()
-        scrubCommitTimer = nil
+        scrubConvergeTimer?.invalidate()
+        scrubConvergeTimer = nil
         scrubTargetMs = nil
-        trickplayContainer.isHidden = true
+        scrubFrozenMs = nil
+        hideTrickplay()
+        if wasPlayingBeforeScrub {
+            wasPlayingBeforeScrub = false
+            player.resume()
+        }
         renderProgress()
     }
 
+    private func seekDirect(toMs ms: Int) {
+        abandonScrubSession()
+        let durationMs = Int(player.duration * 1000)
+        let clamped = durationMs > 0 ? min(durationMs, max(0, ms)) : max(0, ms)
+        player.seek(to: Double(clamped) / 1000.0)
+        onUserSeek?()
+    }
+
+    func seekFromHost(toSeconds seconds: TimeInterval) {
+        abandonScrubSession()
+        player.seek(to: seconds)
+    }
+
+    private func hideTrickplay() {
+        trickplayContainer.isHidden = true
+        trickplayStrip.isHidden = true
+        trickplayCover.isHidden = true
+    }
+
+    // The same sizing rule as the Flutter player: the slider maps 10 to 100
+    // percent onto half to double the space between the overlays, and a tile
+    // never grows past that space or the track width.
+    private func resolveTileSize(trackWidth: CGFloat, aspect: CGFloat, budget: CGFloat) -> CGSize {
+        let percent = CGFloat(min(100, max(10, trickplayScalePercent)))
+        let scale = 0.5 + (percent - 10) / 90 * 1.5
+        let safeBudget = max(budget, 32)
+        let safeTrack = max(trackWidth, 24)
+        let desired = min(max(safeBudget * (scale / 2), 24), safeBudget)
+        let height = min(desired, safeTrack * aspect)
+        return CGSize(width: height / aspect, height: height)
+    }
+
     private func updateTrickplay() {
-        guard let tp = trickplay, let target = scrubTargetMs, player.duration > 0 else {
-            trickplayContainer.isHidden = true
+        guard hasTrickplayPreview, let tp = trickplay,
+            let target = scrubTargetMs ?? scrubFrozenMs, player.duration > 0
+        else {
+            hideTrickplay()
             return
         }
-        let tilesPerImage = tp.cols * tp.rows
-        guard tilesPerImage > 0 else { return }
-        let tileIndex = target / tp.intervalMs
-        let imageIndex = tileIndex / tilesPerImage
-        let tileOffset = tileIndex % tilesPerImage
-        let col = tileOffset % tp.cols
-        let row = tileOffset / tp.cols
-
-        let width = scrubber.bounds.width
-        if width > 0 {
-            let fraction = CGFloat(min(1, max(0, Double(target) / (player.duration * 1000))))
-            let half: CGFloat = 120
-            let x = min(width - half, max(half, fraction * width))
-            trickplayCenterX?.constant = x
+        let durationMs = Int(player.duration * 1000)
+        if trickplayMode == .full {
+            trickplayContainer.isHidden = true
+            trickplayStrip.isHidden = true
+            renderTrickplayCover(tp, targetMs: target)
+            return
         }
+        trickplayCover.isHidden = true
 
-        if let sheet = trickplaySheets[imageIndex] {
-            cropTrickplay(sheet, col: col, row: row, data: tp)
+        let scrubFrame = scrubber.convert(scrubber.bounds, to: osdContainer)
+        let trackWidth = scrubFrame.width
+        guard trackWidth > 0 else {
+            hideTrickplay()
+            return
+        }
+        let aspect = CGFloat(tp.height) / CGFloat(tp.width)
+        let previewBottom = scrubFrame.minY - 14
+        let budget = previewBottom - topContainer.bounds.height
+        let tile = resolveTileSize(trackWidth: trackWidth, aspect: aspect, budget: budget)
+        let maxTravel = max(min(budget - tile.height, trackWidth), 0)
+        let travel = CGFloat(min(100, max(0, trickplayVerticalPercent))) / 100 * maxTravel
+        let fraction = CGFloat(min(1, max(0, Double(target) / Double(durationMs))))
+        let thumbX = 7 + fraction * max(trackWidth - 14, 0)
+        let mainLeft: CGFloat =
+            trickplayFollowScrub
+            ? min(max(thumbX - tile.width / 2, 0), max(trackWidth - tile.width, 0))
+            : (trackWidth - tile.width) / 2
+        let y = previewBottom - travel - tile.height
+
+        if trickplayMode == .strip {
+            trickplayContainer.isHidden = true
+            renderTrickplayStrip(
+                tp, targetMs: target, durationMs: durationMs, mainLeft: mainLeft,
+                originX: scrubFrame.minX, y: y, tile: tile, trackWidth: trackWidth)
+            return
+        }
+        trickplayStrip.isHidden = true
+        trickplayContainer.layer.borderColor = themeAccent.cgColor
+        trickplayContainer.frame = CGRect(
+            x: scrubFrame.minX + mainLeft, y: y, width: tile.width, height: tile.height)
+        trickplayImageView.frame = trickplayContainer.bounds
+        if let image = trickplayTile(tp, atMs: target) {
+            trickplayImageView.image = image
             trickplayContainer.isHidden = false
         } else {
             trickplayContainer.isHidden = true
-            loadTrickplaySheet(imageIndex)
         }
     }
 
-    private func cropTrickplay(_ sheet: UIImage, col: Int, row: Int, data: TrickplayData) {
-        guard let cg = sheet.cgImage else { return }
+    private func renderTrickplayStrip(
+        _ tp: TrickplayData, targetMs: Int, durationMs: Int, mainLeft: CGFloat,
+        originX: CGFloat, y: CGFloat, tile: CGSize, trackWidth: CGFloat
+    ) {
+        let spacing: CGFloat = 4
+        let overflow: CGFloat = 24
+        let step = tile.width + spacing
+        guard step > 0 else {
+            trickplayStrip.isHidden = true
+            return
+        }
+        let leftCount = min(500, max(0, Int(((mainLeft + overflow) / step).rounded(.down)) + 1))
+        let rightCount = min(
+            500, max(0, Int(((trackWidth + overflow - mainLeft - tile.width) / step).rounded(.down)) + 1))
+        let count = leftCount + 1 + rightCount
+        while trickplayStripTiles.count < count {
+            let tileView = UIImageView()
+            tileView.contentMode = .scaleAspectFill
+            tileView.clipsToBounds = true
+            tileView.backgroundColor = .black
+            tileView.layer.cornerRadius = 8
+            trickplayStrip.addSubview(tileView)
+            trickplayStripTiles.append(tileView)
+        }
+        for (index, tileView) in trickplayStripTiles.enumerated() {
+            tileView.isHidden = index >= count
+        }
+        let leftOffset = mainLeft - CGFloat(leftCount) * step
+        trickplayStrip.frame = CGRect(
+            x: originX + leftOffset, y: y, width: CGFloat(count) * step - spacing,
+            height: tile.height)
+        let stepMs = max(skipForwardMs, 1)
+        for index in 0..<count {
+            let slot = index - leftCount
+            let tileView = trickplayStripTiles[index]
+            tileView.frame = CGRect(
+                x: CGFloat(index) * step, y: 0, width: tile.width, height: tile.height)
+            tileView.layer.borderWidth = slot == 0 ? 2 : 1
+            tileView.layer.borderColor =
+                slot == 0 ? themeAccent.cgColor : UIColor(white: 1, alpha: 0.25).cgColor
+            let ms = targetMs + slot * stepMs
+            let image = ms < 0 || ms > durationMs ? nil : trickplayTile(tp, atMs: ms)
+            tileView.image = image
+            tileView.alpha = image == nil ? 0 : 1
+        }
+        trickplayStrip.isHidden = false
+    }
+
+    private func renderTrickplayCover(_ tp: TrickplayData, targetMs: Int) {
+        trickplayCover.frame = view.bounds
+        switch player.zoomMode {
+        case .fit: trickplayCover.contentMode = .scaleAspectFit
+        case .autoCrop: trickplayCover.contentMode = .scaleAspectFill
+        case .stretch: trickplayCover.contentMode = .scaleToFill
+        }
+        if let image = trickplayTile(tp, atMs: targetMs) {
+            trickplayCover.image = image
+            trickplayCover.isHidden = false
+        } else {
+            trickplayCover.isHidden = true
+        }
+    }
+
+    // The cropped thumbnail for a position, or nil while its sheet is still
+    // on its way. Asking for it is what starts the download.
+    private func trickplayTile(_ tp: TrickplayData, atMs ms: Int) -> UIImage? {
+        let tilesPerImage = tp.cols * tp.rows
+        guard tilesPerImage > 0 else { return nil }
+        let lastMs = max(0, Int(player.duration * 1000) - 1)
+        let tileIndex = min(max(0, ms), lastMs) / tp.intervalMs
+        let imageIndex = tileIndex / tilesPerImage
+        let offset = tileIndex % tilesPerImage
+        guard let sheet = trickplaySheets[imageIndex] else {
+            loadTrickplaySheet(imageIndex)
+            return nil
+        }
+        guard let cg = sheet.cgImage else { return nil }
         let rect = CGRect(
-            x: col * data.width, y: row * data.height,
-            width: data.width, height: data.height)
-        if let cropped = cg.cropping(to: rect) {
-            trickplayImageView.image = UIImage(cgImage: cropped)
+            x: (offset % tp.cols) * tp.width, y: (offset / tp.cols) * tp.height,
+            width: tp.width, height: tp.height)
+        return cg.cropping(to: rect).map { UIImage(cgImage: $0) }
+    }
+
+    private func prefetchTrickplay(aroundMs ms: Int, forward: Bool, sheetsAhead: Int) {
+        guard hasTrickplayPreview, let tp = trickplay, player.duration > 0, sheetsAhead > 0
+        else { return }
+        let tilesPerImage = tp.cols * tp.rows
+        guard tilesPerImage > 0 else { return }
+        let lastIndex = max(0, (Int(player.duration * 1000) - 1) / tp.intervalMs / tilesPerImage)
+        let current = max(0, ms) / tp.intervalMs / tilesPerImage
+        for ahead in 1...sheetsAhead {
+            let index = forward ? current + ahead : current - ahead
+            if index < 0 || index > lastIndex { break }
+            loadTrickplaySheet(index)
         }
     }
 
     private func loadTrickplaySheet(_ index: Int) {
         guard let tp = trickplay, index >= 0, index < tp.urls.count,
-            trickplaySheets[index] == nil
+            trickplaySheets[index] == nil, !trickplaySheetsLoading.contains(index)
         else { return }
+        trickplaySheetsLoading.insert(index)
         loadImage(tp.urls[index], headers: tp.headers) { [weak self] image in
-            guard let self, let image else { return }
+            guard let self else { return }
+            self.trickplaySheetsLoading.remove(index)
+            guard let image else { return }
             self.trickplaySheets[index] = image
-            if self.scrubTargetMs != nil {
+            if self.scrubTargetMs != nil || self.scrubFrozenMs != nil {
                 self.updateTrickplay()
             }
         }
@@ -2153,8 +2377,7 @@ final class AppleTvPlayerViewController: UIViewController {
             sheet.addAction(
                 UIAlertAction(title: "\(chapter.title) · \(stamp)", style: .default) {
                     [weak self] _ in
-                    self?.player.seek(to: Double(chapter.startMs) / 1000.0)
-                    self?.onUserSeek?()
+                    self?.seekDirect(toMs: chapter.startMs)
                     self?.showOsd()
                 })
         }
@@ -2458,7 +2681,8 @@ final class AppleTvPlayerViewController: UIViewController {
             return
         }
         let duration = player.duration
-        let current = scrubTargetMs.map { Double($0) / 1000.0 } ?? player.currentTime
+        let current =
+            (scrubTargetMs ?? scrubFrozenMs).map { Double($0) / 1000.0 } ?? player.currentTime
         scrubber.progress = duration > 0 ? Float(min(1, max(0, current / duration))) : 0
         currentTimeLabel.text = formatTime(current)
         durationLabel.text = formatTime(duration)
@@ -2497,6 +2721,9 @@ final class AppleTvPlayerViewController: UIViewController {
 
     private func updateOsd() {
         renderProgress()
+        if scrubTargetMs == nil && scrubFrozenMs == nil {
+            prefetchTrickplay(aroundMs: Int(player.currentTime * 1000), forward: true, sheetsAhead: 1)
+        }
         controlIcons[.playPause]?.image = UIImage(
             systemName: isPaused() ? "play.fill" : "pause.fill",
             withConfiguration: UIImage.SymbolConfiguration(pointSize: 27, weight: .medium))
@@ -2508,7 +2735,7 @@ final class AppleTvPlayerViewController: UIViewController {
 
         let shouldShow =
             !osdDismissed && !nextUpVisible
-            && (isPaused() || scrubTargetMs != nil
+            && (isPaused() || scrubTargetMs != nil || scrubFrozenMs != nil
                 || (CACurrentMediaTime() - lastShowAt < 4.0))
         let visible = osdContainer.alpha > 0.5
         if shouldShow && !visible {

--- a/tvos/Runner/Playback/AppleTvVideoChannel.swift
+++ b/tvos/Runner/Playback/AppleTvVideoChannel.swift
@@ -120,7 +120,13 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
         case "stop":
             player?.stop()
         case "seek":
-            player?.seek(to: ms(args["positionMs"]))
+            // Through the player screen when it is up, so a seek the app sends
+            // (a remote skip, a segment skip) drops any scrub in progress.
+            if let vc = playerVC {
+                vc.seekFromHost(toSeconds: ms(args["positionMs"]))
+            } else {
+                player?.seek(to: ms(args["positionMs"]))
+            }
         case "setSpeed":
             player?.setRate((args["speed"] as? NSNumber)?.floatValue ?? 1.0)
         case "setAudioTrack":


### PR DESCRIPTION
# Pull Request

## Summary
Reworks trickplay into selectable display modes with a configurable preview. Adds Off / Single / Filmstrip / Full Screen modes — Filmstrip shows a Netflix-style strip of thumbnails around the scrub position, and Full Screen covers the video with the trickplay image while scrubbing.

The preview is user-configurable — size, distance from the seekbar, and whether it follows the scrub handle. Sizing is driven by the live ceiling-to-floor space between the overlays, so a given size reads consistently regardless of window or video shape. The settings screen shows a live preview that runs the player's own layout code, so it always matches actual playback.

Scrubbing is reworked around the previews. When a trickplay preview is showing, a D-pad scrub becomes a session: playback pauses, the preview stays on screen after the keys are released, and play commits the selected position and continues — the preview never vanishes out from under you and the video never races ahead while browsing. Pointer drags commit and continue on release, and without a preview scrubbing leaves playback untouched. In every case the seek used to commit on a ~250ms debounce timeout that could fire mid-hold and visibly jump the timeline back after release; now input only moves a frozen target visually, the one real seek fires on the actual release or play signal, and the timeline stays frozen until the player's position has converged on the target.

## Related Issues
- Closes #143
- Fixes #1025
- Related to #682

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Add a Trick Play display mode setting: Off, Single, Filmstrip, Full Screen
- Add Preview Size, Distance From Seekbar, and a follow-scrub-handle toggle
- Add a live settings preview that reuses the player's own layout code
- Size the preview by the available height between the overlays instead of a fraction of the seekbar width
- Move the per-tile time label onto the tile's bottom edge
- Prefetch trickplay sheets based on input method (touch/mouse vs D-pad)
- Add desktop hover-to-peek over the seek track
- Migrate the old trickplay prefs into the single trickPlayMode enum
- Rework scrubbing into a single-seek session: commit on release or play instead of a debounce timeout, keeping the timeline frozen until the position converges
- Pause playback while scrubbing with a trickplay preview and keep the preview up after release; play commits and continues
- Emit a native state push on seek discontinuity so the seek-landed signal is immediate instead of waiting on the 250ms ticker

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Settings → Video Playback → set Trick Play to each mode (Single, Filmstrip, Full Screen).
2. On a TV, hold a D-pad scrub on the seekbar: playback pauses and the preview follows the frozen target; release and the preview stays; press play and playback continues from the selected position with no jump-back.
3. Hold one direction, release, and immediately press the other: the target continues from where you were, not the old position.
4. With Trick Play off (or an item without trickplay images), scrub with the D-pad: playback keeps running and release commits directly, as before.
5. Drag the seekbar with a mouse or finger: the preview follows, and release commits and continues.
6. Change Preview Size (e.g. 100% then 90%) and Distance From Seekbar; confirm the live settings preview matches the real player.
7. Toggle follow scrub handle and confirm the preview tracks the handle instead of staying centered.
8. On desktop, hover the seek track and confirm hover-to-peek shows the same preview a scrub would.

## Screenshots (if applicable)
https://github.com/user-attachments/assets/2f63291b-5986-40a5-bb43-7c5ca250af6d

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced