### PR TITLE
apply theme accent color instead of hardcoding cyan

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13850,7 +13850,9 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                     ThemeRegistry.active.borders.focusBorder.copyWith(
                                       color: isNeon
                                           ? const Color(0xFF00FFFF)
-                                          : AppColorScheme.accent,
+                                          : AppColorScheme.accent.withValues(
+                                              alpha: 0.7,
+                                            ),
                                       width: 1.5,
                                     ),
                                   ),

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13850,7 +13850,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                     ThemeRegistry.active.borders.focusBorder.copyWith(
                                       color: isNeon
                                           ? const Color(0xFF00FFFF)
-                                          : Colors.cyan.withValues(alpha: 0.7),
+                                          : AppColorScheme.accent,
                                       width: 1.5,
                                     ),
                                   ),

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -156,7 +156,9 @@ class SeasonCard extends StatelessWidget {
                               ThemeRegistry.active.borders.focusBorder.copyWith(
                                 color: isNeon
                                     ? const Color(0xFF00FFFF)
-                                    : Colors.cyan.withValues(alpha: 0.7),
+                                    : AppColorScheme.accent.withValues(
+                                        alpha: 0.7,
+                                      ),
                                 width: 1.5,
                               ),
                             )


### PR DESCRIPTION
# Pull Request

## Summary
The border color around episodes should use app accent color, but it was hardcoded to cryan (moonfin theme's accent color). 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1266 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- replace "cyan" with "theme accentColor" for episode border color on details screen
- 
- 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Tried different themes, it follows the accent color now
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="2370" height="1726" alt="image" src="https://github.com/user-attachments/assets/67ddd3eb-5b74-4c6c-ae74-9e47b4558baf" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
