### PR TITLE
Add trickplay thumbnail support for Emby

### DIFF
--- a/lib/data/models/trickplay_info.dart
+++ b/lib/data/models/trickplay_info.dart
@@ -31,6 +31,7 @@ class TrickplayInfo {
                 imageTag: thumbnail.imageTag,
               ),
             )
+            .where((frame) => frame.isValid)
             .toList()
           ..sort((a, b) => a.positionTicks.compareTo(b.positionTicks));
 
@@ -65,7 +66,9 @@ class TrickplayInfo {
 
   bool get isValid {
     if (width <= 0 || height <= 0) return false;
-    if (usesIndividualFrames) return frames.every((frame) => frame.isValid);
+    // The frames were filtered as the list was built, and this runs on every
+    // scrub, so it can't afford to walk them again.
+    if (usesIndividualFrames) return true;
     return tileWidth > 0 && tileHeight > 0 && interval > 0;
   }
 

--- a/lib/data/models/trickplay_info.dart
+++ b/lib/data/models/trickplay_info.dart
@@ -1,11 +1,14 @@
 import 'dart:ui' show Rect;
 
+import 'package:server_core/server_core.dart';
+
 class TrickplayInfo {
   final int width;
   final int height;
   final int tileWidth;
   final int tileHeight;
   final int interval;
+  final List<TrickplayFrameInfo> frames;
 
   const TrickplayInfo({
     required this.width,
@@ -13,18 +16,88 @@ class TrickplayInfo {
     required this.tileWidth,
     required this.tileHeight,
     required this.interval,
+    this.frames = const [],
   });
 
-  bool get isValid =>
-      width > 0 &&
-      height > 0 &&
-      tileWidth > 0 &&
-      tileHeight > 0 &&
-      interval > 0;
+  factory TrickplayInfo.fromThumbnailSet(
+    TrickplayThumbnailSet thumbnailSet, {
+    required int width,
+  }) {
+    final sorted =
+        thumbnailSet.thumbnails
+            .map(
+              (thumbnail) => TrickplayFrameInfo(
+                positionTicks: thumbnail.positionTicks,
+                imageTag: thumbnail.imageTag,
+              ),
+            )
+            .toList()
+          ..sort((a, b) => a.positionTicks.compareTo(b.positionTicks));
+
+    final frames = <TrickplayFrameInfo>[];
+    for (final frame in sorted) {
+      if (frames.isNotEmpty &&
+          frames.last.positionTicks == frame.positionTicks) {
+        frames[frames.length - 1] = frame;
+      } else {
+        frames.add(frame);
+      }
+    }
+
+    final height = (width / thumbnailSet.aspectRatio).round();
+    final interval = frames.length > 1
+        ? ((frames[1].positionTicks - frames[0].positionTicks) ~/ 10000).clamp(
+            1,
+            1 << 31,
+          )
+        : 10000;
+    return TrickplayInfo(
+      width: width,
+      height: height,
+      tileWidth: 1,
+      tileHeight: 1,
+      interval: interval,
+      frames: List.unmodifiable(frames),
+    );
+  }
+
+  bool get usesIndividualFrames => frames.isNotEmpty;
+
+  bool get isValid {
+    if (width <= 0 || height <= 0) return false;
+    if (usesIndividualFrames) return frames.every((frame) => frame.isValid);
+    return tileWidth > 0 && tileHeight > 0 && interval > 0;
+  }
 
   int get tilesPerImage => tileWidth * tileHeight;
 
   TrickplayTileResolution resolveTile(Duration position) {
+    if (usesIndividualFrames) {
+      final positionTicks = position.inMicroseconds * 10;
+      var low = 0;
+      var high = frames.length - 1;
+      while (low <= high) {
+        final middle = low + ((high - low) >> 1);
+        if (frames[middle].positionTicks <= positionTicks) {
+          low = middle + 1;
+        } else {
+          high = middle - 1;
+        }
+      }
+      final imageIndex = high.clamp(0, frames.length - 1);
+      final frame = frames[imageIndex];
+      return TrickplayTileResolution(
+        imageIndex: imageIndex,
+        sourceRect: Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+        thumbWidth: width.toDouble(),
+        thumbHeight: height.toDouble(),
+        tileWidth: 1,
+        tileHeight: 1,
+        positionTicks: frame.positionTicks,
+        imageTag: frame.imageTag,
+      );
+    }
+
     final positionMs = position.inMilliseconds;
     final tileIndex = positionMs ~/ interval;
     final perImage = tilesPerImage;
@@ -88,6 +161,8 @@ class TrickplayTileResolution {
   final double thumbHeight;
   final int tileWidth;
   final int tileHeight;
+  final int? positionTicks;
+  final String? imageTag;
 
   const TrickplayTileResolution({
     required this.imageIndex,
@@ -96,7 +171,21 @@ class TrickplayTileResolution {
     required this.thumbHeight,
     required this.tileWidth,
     required this.tileHeight,
+    this.positionTicks,
+    this.imageTag,
   });
+}
+
+class TrickplayFrameInfo {
+  final int positionTicks;
+  final String imageTag;
+
+  const TrickplayFrameInfo({
+    required this.positionTicks,
+    required this.imageTag,
+  });
+
+  bool get isValid => positionTicks >= 0 && imageTag.isNotEmpty;
 }
 
 class TrickplayTile {

--- a/lib/data/offline/connectivity_aware_media_server_client.dart
+++ b/lib/data/offline/connectivity_aware_media_server_client.dart
@@ -68,6 +68,10 @@ class ConnectivityAwareMediaServerClient implements MediaServerClient {
   ImageApi get imageApi => _useOffline() ? _offlineImages : _online.imageApi;
 
   @override
+  TrickplayApi? get trickplayApi =>
+      _useOffline() ? null : _online.trickplayApi;
+
+  @override
   UserViewsApi get userViewsApi =>
       _useOffline() ? _offlineViews : _online.userViewsApi;
 

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -55,6 +55,10 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
   StreamSubscription<Duration>? _positionSub;
   UserPreferences? _prefsListened;
   String _lastTrickplayPrefs = '';
+  TrickplayInfo? _trickplayInfo;
+  String? _trickplayKey;
+  int _trickplayLoadGeneration = 0;
+  static const int _trickplayFrameWidth = 320;
   SyncPlayManager? _syncPlay;
   AppThemeController? _themeController;
   ScreensaverController? _screensaverController;
@@ -605,34 +609,57 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     if (prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
       return null;
     }
-    final raw = _rawDataForQueueItem(item);
     final itemId = _itemIdForQueueItem(item);
     final client = _clientForQueueItem(item);
-    if (raw == null || itemId == null || itemId.isEmpty || client == null) {
+    if (itemId == null || itemId.isEmpty || client == null) {
       return null;
     }
     final mediaSourceId = manager.currentResolution?.mediaSourceId;
-    final info = TrickplayInfo.fromItemData(raw, mediaSourceId: mediaSourceId);
+    final key = '$itemId|${mediaSourceId ?? ''}';
+    final info = key == _trickplayKey ? _trickplayInfo : null;
     if (info == null || !info.isValid) return null;
 
-    final runtimeTicks = raw['RunTimeTicks'] as int?;
-    final durationMs = runtimeTicks != null ? runtimeTicks ~/ 10000 : 0;
-    final msPerImage = info.interval * info.tilesPerImage;
-    var imageCount = durationMs > 0 ? (durationMs / msPerImage).ceil() + 1 : 16;
-    imageCount = imageCount.clamp(1, 128);
-
-    final urls = List<String>.generate(
-      imageCount,
-      (i) => client.imageApi.getTrickplayTileImageUrl(
-        itemId,
-        width: info.width,
-        index: i,
-        mediaSourceId: mediaSourceId,
-      ),
-    );
+    final List<String> urls;
+    final List<int> timestampsMs;
+    if (info.usesIndividualFrames) {
+      urls = info.frames
+          .map(
+            (frame) => client.trickplayApi!.getFrameImageUrl(
+              itemId,
+              width: info.width,
+              positionTicks: frame.positionTicks,
+              imageTag: frame.imageTag,
+              mediaSourceId: mediaSourceId,
+            ),
+          )
+          .toList(growable: false);
+      timestampsMs = info.frames
+          .map((frame) => frame.positionTicks ~/ 10000)
+          .toList(growable: false);
+    } else {
+      final raw = _rawDataForQueueItem(item);
+      final runtimeTicks = raw?['RunTimeTicks'] as int?;
+      final durationMs = runtimeTicks != null ? runtimeTicks ~/ 10000 : 0;
+      final msPerImage = info.interval * info.tilesPerImage;
+      var imageCount = durationMs > 0
+          ? (durationMs / msPerImage).ceil() + 1
+          : 16;
+      imageCount = imageCount.clamp(1, 128);
+      urls = List<String>.generate(
+        imageCount,
+        (i) => client.imageApi.getTrickplayTileImageUrl(
+          itemId,
+          width: info.width,
+          index: i,
+          mediaSourceId: mediaSourceId,
+        ),
+      );
+      timestampsMs = const [];
+    }
     final token = client.accessToken;
     return {
       'urls': urls,
+      if (timestampsMs.isNotEmpty) 'timestampsMs': timestampsMs,
       'headers': {
         if (token != null && token.isNotEmpty)
           'Authorization': 'MediaBrowser Token="$token"',
@@ -975,6 +1002,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
     final manager = _manager;
     if (manager == null) return;
     final item = manager.queueService.currentItem;
+    unawaited(_loadTrickplayForCurrentItem(item, manager));
     final id = _itemIdForQueueItem(item);
     if (id == null || id.isEmpty || id == _segmentsLoadedForItemId) return;
     final client = _clientForQueueItem(item);
@@ -999,6 +1027,55 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
         }),
       );
     } catch (_) {}
+  }
+
+  Future<void> _loadTrickplayForCurrentItem(
+    dynamic item,
+    PlaybackManager manager,
+  ) async {
+    final itemId = _itemIdForQueueItem(item);
+    final mediaSourceId = manager.currentResolution?.mediaSourceId;
+    final key = itemId == null ? null : '$itemId|${mediaSourceId ?? ''}';
+    if (key == _trickplayKey) return;
+
+    final generation = ++_trickplayLoadGeneration;
+    _trickplayKey = key;
+    _trickplayInfo = null;
+    if (itemId == null || itemId.isEmpty) {
+      _pushMetadata();
+      return;
+    }
+
+    final raw = _rawDataForQueueItem(item);
+    var info = raw == null
+        ? null
+        : TrickplayInfo.fromItemData(raw, mediaSourceId: mediaSourceId);
+    final client = _clientForQueueItem(item);
+    if (info == null && client?.trickplayApi != null) {
+      try {
+        final thumbnailSet = await client!.trickplayApi!.getThumbnailSet(
+          itemId,
+          width: _trickplayFrameWidth,
+          mediaSourceId: mediaSourceId,
+        );
+        if (thumbnailSet != null && thumbnailSet.isValid) {
+          info = TrickplayInfo.fromThumbnailSet(
+            thumbnailSet,
+            width: _trickplayFrameWidth,
+          );
+        }
+      } catch (_) {
+        // Emby BIF previews are optional. Playback remains usable when the
+        // server has not generated them or the request fails.
+      }
+    }
+
+    if (!mounted || generation != _trickplayLoadGeneration) return;
+    final currentItemId = _itemIdForQueueItem(manager.queueService.currentItem);
+    final currentSourceId = manager.currentResolution?.mediaSourceId;
+    if (currentItemId != itemId || currentSourceId != mediaSourceId) return;
+    _trickplayInfo = info?.isValid == true ? info : null;
+    _pushMetadata();
   }
 
   AppleTvQueueSnapshot _queueSnapshot() {
@@ -1427,6 +1504,7 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
 
   @override
   void dispose() {
+    _trickplayLoadGeneration++;
     _exitSub?.cancel();
     _queueSub?.cancel();
     _sessionEndedSub?.cancel();

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -232,6 +232,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   TrickplayInfo? _trickplayInfo;
   String? _trickplayMediaSourceId;
+  int _trickplayLoadGeneration = 0;
+  static const int _trickplayFrameWidth = 320;
 
   final _overlayFocus = FocusNode();
   final _tvSeekbarFocus = FocusNode(debugLabel: 'video_player_tv_seekbar');
@@ -982,6 +984,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   @override
   void dispose() {
+    _trickplayLoadGeneration++;
     if (_isInPiP && GetIt.instance.isRegistered<PlaybackArbiter>()) {
       GetIt.instance<PlaybackArbiter>().pipActive = false;
     }
@@ -1520,11 +1523,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   Future<void> _loadSegmentsForCurrentItem() async {
     final item = _queue.currentItem;
+    final trickplayLoad = _loadTrickplayInfo(item);
     if (item is AggregatedItem) {
       _segmentService = _createSegmentService(item);
       await _segmentService.loadSegments(item.id);
     }
-    _loadTrickplayInfo(item);
+    await trickplayLoad;
     await _pushMedia3UiMetadata();
   }
 
@@ -2118,31 +2122,55 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
   }
 
-  void _loadTrickplayInfo(dynamic item) {
+  Future<void> _loadTrickplayInfo(dynamic item) async {
+    final generation = ++_trickplayLoadGeneration;
     final rawData = _rawDataForQueueItem(item);
-    if (rawData == null) {
-      if (mounted) {
-        setState(() {
-          _trickplayInfo = null;
-          _trickplayMediaSourceId = null;
-        });
-      }
-      return;
-    }
-
+    final itemId = _itemIdForQueueItem(item);
     final mediaSourceId = _manager.currentResolution?.mediaSourceId;
-    final info = TrickplayInfo.fromItemData(
-      rawData,
-      mediaSourceId: mediaSourceId,
-    );
     _prefetchedTrickplayIndexes.clear();
     _touchTrickplayPrefetchStarted = false;
     if (mounted) {
       setState(() {
-        _trickplayInfo = info;
+        _trickplayInfo = null;
         _trickplayMediaSourceId = mediaSourceId;
       });
     }
+
+    var info = rawData == null
+        ? null
+        : TrickplayInfo.fromItemData(rawData, mediaSourceId: mediaSourceId);
+    if (info == null && itemId != null && itemId.isNotEmpty) {
+      final client = _clientForQueueItem(item);
+      final trickplayApi = client.trickplayApi;
+      if (trickplayApi != null) {
+        try {
+          final thumbnailSet = await trickplayApi.getThumbnailSet(
+            itemId,
+            width: _trickplayFrameWidth,
+            mediaSourceId: mediaSourceId,
+          );
+          if (thumbnailSet != null && thumbnailSet.isValid) {
+            info = TrickplayInfo.fromThumbnailSet(
+              thumbnailSet,
+              width: _trickplayFrameWidth,
+            );
+          }
+        } catch (_) {
+          // Missing, unavailable, or malformed BIF data is an optional
+          // playback enhancement and must never interrupt playback.
+        }
+      }
+    }
+
+    if (!mounted || generation != _trickplayLoadGeneration) return;
+    if (_itemIdForQueueItem(_queue.currentItem) != itemId ||
+        _manager.currentResolution?.mediaSourceId != mediaSourceId) {
+      return;
+    }
+    setState(() {
+      _trickplayInfo = info?.isValid == true ? info : null;
+      _trickplayMediaSourceId = mediaSourceId;
+    });
   }
 
   void _refreshTrickplayIfNeeded() {
@@ -2151,7 +2179,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final resolvedSourceId = _manager.currentResolution?.mediaSourceId;
     if (resolvedSourceId != null &&
         resolvedSourceId != _trickplayMediaSourceId) {
-      _loadTrickplayInfo(item);
+      unawaited(_loadTrickplayInfo(item));
     }
   }
 
@@ -2161,6 +2189,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
     final info = _trickplayInfo;
     if (info == null || !info.isValid) return;
+    if (info.usesIndividualFrames) return;
     final duration = _state.duration;
     if (duration <= Duration.zero) return;
 
@@ -2192,6 +2221,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         info: info,
         position: position,
         totalDuration: duration,
+        maxSheets: info.usesIndividualFrames ? 7 : 128,
       ),
     );
   }
@@ -2234,12 +2264,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     for (final index in indexes) {
       if (!_prefetchedTrickplayIndexes.add(index)) continue;
       if (!mounted) return;
-      final url = client.imageApi.getTrickplayTileImageUrl(
-        itemId,
-        width: info.width,
-        index: index,
-        mediaSourceId: _trickplayMediaSourceId,
+      final url = _trickplayImageUrl(
+        info: info,
+        imageIndex: index,
+        itemId: itemId,
+        client: client,
       );
+      if (url == null) continue;
       unawaited(
         precacheImage(
           CachedNetworkImageProvider(
@@ -5086,12 +5117,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         : position;
     final resolution = info.resolveTile(resolvePosition);
     final trickplayClient = _clientForQueueItem(item);
-    final url = trickplayClient.imageApi.getTrickplayTileImageUrl(
-      itemId,
-      width: info.width,
-      index: resolution.imageIndex,
-      mediaSourceId: _trickplayMediaSourceId,
+    final url = _trickplayImageUrl(
+      info: info,
+      imageIndex: resolution.imageIndex,
+      itemId: itemId,
+      client: trickplayClient,
+      resolution: resolution,
     );
+    if (url == null) return null;
     final token = trickplayClient.accessToken;
     final headers = <String, String>{
       ...serverImageHeaders,
@@ -5100,6 +5133,33 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     };
 
     return TrickplayTile(url: url, headers: headers, resolution: resolution);
+  }
+
+  String? _trickplayImageUrl({
+    required TrickplayInfo info,
+    required int imageIndex,
+    required String itemId,
+    required MediaServerClient client,
+    TrickplayTileResolution? resolution,
+  }) {
+    if (!info.usesIndividualFrames) {
+      return client.imageApi.getTrickplayTileImageUrl(
+        itemId,
+        width: info.width,
+        index: imageIndex,
+        mediaSourceId: _trickplayMediaSourceId,
+      );
+    }
+
+    if (imageIndex < 0 || imageIndex >= info.frames.length) return null;
+    final frame = info.frames[imageIndex];
+    return client.trickplayApi?.getFrameImageUrl(
+      itemId,
+      width: info.width,
+      positionTicks: resolution?.positionTicks ?? frame.positionTicks,
+      imageTag: resolution?.imageTag ?? frame.imageTag,
+      mediaSourceId: _trickplayMediaSourceId,
+    );
   }
 
   Widget _buildTvTransportRow() {

--- a/packages/server_core/lib/server_core.dart
+++ b/packages/server_core/lib/server_core.dart
@@ -20,6 +20,7 @@ export 'src/api/syncplay_api.dart';
 export 'src/api/items_api.dart';
 export 'src/api/playback_api.dart';
 export 'src/api/image_api.dart';
+export 'src/api/trickplay_api.dart';
 export 'src/api/session_api.dart';
 export 'src/api/system_api.dart';
 export 'src/api/user_library_api.dart';

--- a/packages/server_core/lib/src/api/trickplay_api.dart
+++ b/packages/server_core/lib/src/api/trickplay_api.dart
@@ -1,0 +1,74 @@
+class TrickplayThumbnail {
+  final int positionTicks;
+  final String imageTag;
+
+  const TrickplayThumbnail({
+    required this.positionTicks,
+    required this.imageTag,
+  });
+
+  static TrickplayThumbnail? fromJson(Map<String, dynamic> json) {
+    final positionTicks = (json['PositionTicks'] as num?)?.toInt();
+    final imageTag = json['ImageTag']?.toString().trim();
+    if (positionTicks == null ||
+        positionTicks < 0 ||
+        imageTag == null ||
+        imageTag.isEmpty) {
+      return null;
+    }
+    return TrickplayThumbnail(positionTicks: positionTicks, imageTag: imageTag);
+  }
+}
+
+class TrickplayThumbnailSet {
+  final double aspectRatio;
+  final List<TrickplayThumbnail> thumbnails;
+
+  const TrickplayThumbnailSet({
+    required this.aspectRatio,
+    required this.thumbnails,
+  });
+
+  bool get isValid => aspectRatio > 0 && thumbnails.isNotEmpty;
+
+  static TrickplayThumbnailSet? fromJson(Map<String, dynamic> json) {
+    final aspectRatio = (json['AspectRatio'] as num?)?.toDouble();
+    final rawThumbnails = json['Thumbnails'];
+    if (aspectRatio == null ||
+        !aspectRatio.isFinite ||
+        aspectRatio <= 0 ||
+        rawThumbnails is! List) {
+      return null;
+    }
+
+    final thumbnails = rawThumbnails
+        .whereType<Map>()
+        .map(
+          (entry) => TrickplayThumbnail.fromJson(entry.cast<String, dynamic>()),
+        )
+        .whereType<TrickplayThumbnail>()
+        .toList(growable: false);
+    if (thumbnails.isEmpty) return null;
+
+    return TrickplayThumbnailSet(
+      aspectRatio: aspectRatio,
+      thumbnails: thumbnails,
+    );
+  }
+}
+
+abstract class TrickplayApi {
+  Future<TrickplayThumbnailSet?> getThumbnailSet(
+    String itemId, {
+    required int width,
+    String? mediaSourceId,
+  });
+
+  String getFrameImageUrl(
+    String itemId, {
+    required int width,
+    required int positionTicks,
+    required String imageTag,
+    String? mediaSourceId,
+  });
+}

--- a/packages/server_core/lib/src/media_server_client.dart
+++ b/packages/server_core/lib/src/media_server_client.dart
@@ -26,6 +26,7 @@ import 'api/admin_items_api.dart';
 import 'api/client_log_api.dart';
 import 'api/syncplay_api.dart';
 import 'api/games_api.dart';
+import 'api/trickplay_api.dart';
 
 abstract class MediaServerClient {
   ServerType get serverType;
@@ -44,6 +45,7 @@ abstract class MediaServerClient {
   ItemsApi get itemsApi;
   PlaybackApi get playbackApi;
   ImageApi get imageApi;
+  TrickplayApi? get trickplayApi => null;
   SessionApi get sessionApi;
   SystemApi get systemApi;
   UserLibraryApi get userLibraryApi;

--- a/packages/server_emby/lib/server_emby.dart
+++ b/packages/server_emby/lib/server_emby.dart
@@ -6,6 +6,7 @@ export 'src/api/emby_auth_api.dart';
 export 'src/api/emby_items_api.dart';
 export 'src/api/emby_playback_api.dart';
 export 'src/api/emby_image_api.dart';
+export 'src/api/emby_trickplay_api.dart';
 export 'src/api/emby_session_api.dart';
 export 'src/api/emby_system_api.dart';
 export 'src/api/emby_user_library_api.dart';

--- a/packages/server_emby/lib/src/api/emby_trickplay_api.dart
+++ b/packages/server_emby/lib/src/api/emby_trickplay_api.dart
@@ -51,7 +51,8 @@ class EmbyTrickplayApi implements TrickplayApi {
       'maxWidth': width.toString(),
       'tag': imageTag,
       'PositionTicks': positionTicks.toString(),
-      'MediaSourceId': ?mediaSourceId,
+      if (mediaSourceId != null && mediaSourceId.isNotEmpty)
+        'MediaSourceId': mediaSourceId,
       'quality': '90',
     });
     return '${_getBaseUrl()}/Items/$itemId/Images/Thumbnail$query';

--- a/packages/server_emby/lib/src/api/emby_trickplay_api.dart
+++ b/packages/server_emby/lib/src/api/emby_trickplay_api.dart
@@ -1,0 +1,59 @@
+import 'package:dio/dio.dart';
+import 'package:server_core/server_core.dart';
+
+class EmbyTrickplayApi implements TrickplayApi {
+  final Dio _dio;
+  final String Function() _getBaseUrl;
+  final String? Function() _getApiKey;
+
+  EmbyTrickplayApi(this._dio, this._getBaseUrl, this._getApiKey);
+
+  String _buildQuery(Map<String, String> params) {
+    final apiKey = _getApiKey();
+    if (apiKey != null) params['api_key'] = apiKey;
+    return params.isEmpty
+        ? ''
+        : '?${params.entries.map((entry) => '${Uri.encodeComponent(entry.key)}=${Uri.encodeComponent(entry.value)}').join('&')}';
+  }
+
+  @override
+  Future<TrickplayThumbnailSet?> getThumbnailSet(
+    String itemId, {
+    required int width,
+    String? mediaSourceId,
+  }) async {
+    try {
+      final response = await _dio.get<Map<String, dynamic>>(
+        '/Items/$itemId/ThumbnailSet',
+        queryParameters: {
+          'Width': width,
+          if (mediaSourceId != null && mediaSourceId.isNotEmpty)
+            'MediaSourceId': mediaSourceId,
+        },
+      );
+      final data = response.data;
+      return data == null ? null : TrickplayThumbnailSet.fromJson(data);
+    } on DioException catch (error) {
+      if (error.response?.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  @override
+  String getFrameImageUrl(
+    String itemId, {
+    required int width,
+    required int positionTicks,
+    required String imageTag,
+    String? mediaSourceId,
+  }) {
+    final query = _buildQuery({
+      'maxWidth': width.toString(),
+      'tag': imageTag,
+      'PositionTicks': positionTicks.toString(),
+      'MediaSourceId': ?mediaSourceId,
+      'quality': '90',
+    });
+    return '${_getBaseUrl()}/Items/$itemId/Images/Thumbnail$query';
+  }
+}

--- a/packages/server_emby/lib/src/emby_media_server_client.dart
+++ b/packages/server_emby/lib/src/emby_media_server_client.dart
@@ -13,6 +13,7 @@ import 'api/emby_live_tv_api.dart';
 import 'api/emby_instant_mix_api.dart';
 import 'api/emby_display_preferences_api.dart';
 import 'api/emby_users_api.dart';
+import 'api/emby_trickplay_api.dart';
 
 class EmbyMediaServerClient extends MediaServerClient {
   final Dio _dio;
@@ -100,6 +101,10 @@ class EmbyMediaServerClient extends MediaServerClient {
   @override
   late final ImageApi imageApi =
       EmbyImageApi(() => _baseUrl, () => _accessToken);
+
+  @override
+  late final TrickplayApi trickplayApi =
+      EmbyTrickplayApi(_dio, () => _baseUrl, () => _accessToken);
 
   @override
   late final SessionApi sessionApi = EmbySessionApi(_dio);

--- a/packages/server_emby/test/emby_trickplay_api_test.dart
+++ b/packages/server_emby/test/emby_trickplay_api_test.dart
@@ -97,6 +97,30 @@ void main() {
     expect(result, isNull);
   });
 
+  test('returns null when the server has generated no previews', () async {
+    final dio = Dio()
+      ..interceptors.add(
+        _FakeServer((options, handler) {
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              // A library with no generated previews sends no AspectRatio
+              // at all, not an empty one.
+              data: const <String, dynamic>{'Thumbnails': <dynamic>[]},
+            ),
+          );
+        }),
+      );
+
+    final result = await EmbyTrickplayApi(
+      dio,
+      () => 'https://emby.example',
+      () => null,
+    ).getThumbnailSet('no-previews', width: 320);
+
+    expect(result, isNull);
+  });
+
   test('builds an individually addressable Emby BIF frame URL', () {
     final api = EmbyTrickplayApi(
       Dio(),

--- a/packages/server_emby/test/emby_trickplay_api_test.dart
+++ b/packages/server_emby/test/emby_trickplay_api_test.dart
@@ -1,0 +1,127 @@
+import 'package:dio/dio.dart';
+import 'package:server_emby/server_emby.dart';
+import 'package:test/test.dart';
+
+class _FakeServer extends Interceptor {
+  _FakeServer(this.handle);
+
+  final void Function(RequestOptions options, RequestInterceptorHandler handler)
+  handle;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) =>
+      handle(options, handler);
+}
+
+void main() {
+  test('loads and parses an Emby thumbnail set', () async {
+    RequestOptions? request;
+    final dio = Dio()
+      ..interceptors.add(
+        _FakeServer((options, handler) {
+          request = options;
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: const <String, dynamic>{
+                'AspectRatio': 16 / 9,
+                'Thumbnails': [
+                  {'PositionTicks': 0, 'ImageTag': 'bif-tag'},
+                  {'PositionTicks': 100000000, 'ImageTag': 'bif-tag'},
+                ],
+              },
+            ),
+          );
+        }),
+      );
+
+    final result = await EmbyTrickplayApi(
+      dio,
+      () => 'https://emby.example',
+      () => null,
+    ).getThumbnailSet('item-1', width: 320, mediaSourceId: 'source-1');
+
+    expect(request?.path, '/Items/item-1/ThumbnailSet');
+    expect(request?.queryParameters, {
+      'Width': 320,
+      'MediaSourceId': 'source-1',
+    });
+    expect(result?.aspectRatio, closeTo(16 / 9, 0.0001));
+    expect(result?.thumbnails, hasLength(2));
+    expect(result?.thumbnails.last.positionTicks, 100000000);
+    expect(result?.thumbnails.last.imageTag, 'bif-tag');
+  });
+
+  test('returns null for a missing BIF', () async {
+    final dio = Dio()
+      ..interceptors.add(
+        _FakeServer((options, handler) {
+          handler.reject(
+            DioException(
+              requestOptions: options,
+              response: Response(requestOptions: options, statusCode: 404),
+              type: DioExceptionType.badResponse,
+            ),
+          );
+        }),
+      );
+
+    final result = await EmbyTrickplayApi(
+      dio,
+      () => 'https://emby.example',
+      () => null,
+    ).getThumbnailSet('missing', width: 320);
+
+    expect(result, isNull);
+  });
+
+  test('returns null for malformed thumbnail metadata', () async {
+    final dio = Dio()
+      ..interceptors.add(
+        _FakeServer((options, handler) {
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: const <String, dynamic>{'AspectRatio': 0, 'Thumbnails': []},
+            ),
+          );
+        }),
+      );
+
+    final result = await EmbyTrickplayApi(
+      dio,
+      () => 'https://emby.example',
+      () => null,
+    ).getThumbnailSet('bad', width: 320);
+
+    expect(result, isNull);
+  });
+
+  test('builds an individually addressable Emby BIF frame URL', () {
+    final api = EmbyTrickplayApi(
+      Dio(),
+      () => 'https://emby.example/emby',
+      () => 'secret-token',
+    );
+
+    final uri = Uri.parse(
+      api.getFrameImageUrl(
+        'item-1',
+        width: 320,
+        positionTicks: 200000000,
+        imageTag: 'bif-tag',
+        mediaSourceId: 'source-1',
+      ),
+    );
+
+    expect(uri.path, '/emby/Items/item-1/Images/Thumbnail');
+    expect(uri.queryParameters, {
+      'maxWidth': '320',
+      'tag': 'bif-tag',
+      'PositionTicks': '200000000',
+      'MediaSourceId': 'source-1',
+      'quality': '90',
+      'api_key': 'secret-token',
+    });
+  });
+}

--- a/test/data/models/trickplay_info_test.dart
+++ b/test/data/models/trickplay_info_test.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moonfin/data/models/trickplay_info.dart';
+import 'package:server_core/server_core.dart';
 
 void main() {
   const info = TrickplayInfo(
@@ -49,6 +50,58 @@ void main() {
       expect(tile.thumbHeight, 60);
       expect(tile.tileWidth, 5);
       expect(tile.tileHeight, 4);
+    });
+  });
+
+  group('timestamped Emby frames', () {
+    final frameInfo = TrickplayInfo.fromThumbnailSet(
+      const TrickplayThumbnailSet(
+        aspectRatio: 16 / 9,
+        thumbnails: [
+          TrickplayThumbnail(positionTicks: 0, imageTag: 'tag-0'),
+          TrickplayThumbnail(positionTicks: 75000000, imageTag: 'tag-1'),
+          TrickplayThumbnail(positionTicks: 210000000, imageTag: 'tag-2'),
+        ],
+      ),
+      width: 320,
+    );
+
+    test('uses the thumbnail aspect ratio for preview dimensions', () {
+      expect(frameInfo.isValid, isTrue);
+      expect(frameInfo.usesIndividualFrames, isTrue);
+      expect(frameInfo.width, 320);
+      expect(frameInfo.height, 180);
+      expect(frameInfo.tilesPerImage, 1);
+    });
+
+    test('chooses the last frame at or before the scrub position', () {
+      expect(frameInfo.resolveTile(Duration.zero).imageIndex, 0);
+      expect(
+        frameInfo.resolveTile(const Duration(milliseconds: 7499)).imageIndex,
+        0,
+      );
+      final exact = frameInfo.resolveTile(const Duration(milliseconds: 7500));
+      expect(exact.imageIndex, 1);
+      expect(exact.positionTicks, 75000000);
+      expect(exact.imageTag, 'tag-1');
+      expect(frameInfo.resolveTile(const Duration(minutes: 2)).imageIndex, 2);
+    });
+
+    test('sorts timestamps and replaces duplicate positions', () {
+      final sorted = TrickplayInfo.fromThumbnailSet(
+        const TrickplayThumbnailSet(
+          aspectRatio: 2,
+          thumbnails: [
+            TrickplayThumbnail(positionTicks: 100, imageTag: 'old'),
+            TrickplayThumbnail(positionTicks: 0, imageTag: 'first'),
+            TrickplayThumbnail(positionTicks: 100, imageTag: 'new'),
+          ],
+        ),
+        width: 200,
+      );
+
+      expect(sorted.frames.map((frame) => frame.positionTicks), [0, 100]);
+      expect(sorted.frames.last.imageTag, 'new');
     });
   });
 }

--- a/test/data/models/trickplay_info_test.dart
+++ b/test/data/models/trickplay_info_test.dart
@@ -87,6 +87,22 @@ void main() {
       expect(frameInfo.resolveTile(const Duration(minutes: 2)).imageIndex, 2);
     });
 
+    test('drops a frame it could never fetch', () {
+      final info = TrickplayInfo.fromThumbnailSet(
+        const TrickplayThumbnailSet(
+          aspectRatio: 2,
+          thumbnails: [
+            TrickplayThumbnail(positionTicks: 0, imageTag: 'first'),
+            TrickplayThumbnail(positionTicks: 100, imageTag: ''),
+          ],
+        ),
+        width: 200,
+      );
+
+      expect(info.frames.map((frame) => frame.imageTag), ['first']);
+      expect(info.isValid, isTrue);
+    });
+
     test('sorts timestamps and replaces duplicate positions', () {
       final sorted = TrickplayInfo.fromThumbnailSet(
         const TrickplayThumbnailSet(

--- a/test/data/models/trickplay_prefetch_planner_test.dart
+++ b/test/data/models/trickplay_prefetch_planner_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moonfin/data/models/trickplay_info.dart';
 import 'package:moonfin/data/models/trickplay_prefetch_planner.dart';
+import 'package:server_core/server_core.dart';
 
 void main() {
   const info = TrickplayInfo(
@@ -83,5 +84,35 @@ void main() {
       expect(indexes.length, 128);
       expect(indexes.every((i) => i < 128), isTrue);
     });
+  });
+
+  test('timestamped frames use their real indexes and respect the cap', () {
+    final timestamped = TrickplayInfo.fromThumbnailSet(
+      TrickplayThumbnailSet(
+        aspectRatio: 16 / 9,
+        thumbnails: List.generate(
+          20,
+          (index) => TrickplayThumbnail(
+            positionTicks: index * index * 10000000,
+            imageTag: 'frame-$index',
+          ),
+        ),
+      ),
+      width: 320,
+    );
+
+    final indexes = TrickplayPrefetchPlanner.planAllImageIndexes(
+      info: timestamped,
+      position: const Duration(seconds: 100),
+      totalDuration: const Duration(minutes: 10),
+      maxSheets: 7,
+    );
+
+    expect(indexes, hasLength(7));
+    expect(
+      indexes.first,
+      timestamped.resolveTile(const Duration(seconds: 100)).imageIndex,
+    );
+    expect(indexes.every((index) => index >= 0 && index < 20), isTrue);
   });
 }

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -156,6 +156,7 @@ final class AppleTvPlayerViewController: UIViewController {
         let cols: Int
         let rows: Int
         let intervalMs: Int
+        let timestampsMs: [Int]
     }
 
     private enum TrickplayMode: String { case disabled, single, strip, full }
@@ -1212,9 +1213,18 @@ final class AppleTvPlayerViewController: UIViewController {
             trickplaySheetsLoading.removeAll()
         }
         let headers = (dict["headers"] as? [String: String]) ?? [:]
+        let timestampsMs = (dict["timestampsMs"] as? [NSNumber])?.map(\.intValue) ?? []
+        if !timestampsMs.isEmpty && timestampsMs.count != urls.count {
+            trickplay = nil
+            trickplaySheets.removeAll()
+            trickplaySheetsLoading.removeAll()
+            hideTrickplay()
+            return
+        }
         trickplay = TrickplayData(
             urls: urls, headers: headers, width: width, height: height,
-            cols: cols, rows: rows, intervalMs: intervalMs)
+            cols: cols, rows: rows, intervalMs: intervalMs,
+            timestampsMs: timestampsMs)
         trickplayMode = TrickplayMode(rawValue: (dict["mode"] as? String) ?? "") ?? .single
         trickplayScalePercent = (dict["scalePercent"] as? NSNumber)?.intValue ?? 30
         trickplayVerticalPercent = (dict["verticalPositionPercent"] as? NSNumber)?.intValue ?? 0
@@ -2169,13 +2179,22 @@ final class AppleTvPlayerViewController: UIViewController {
         let tilesPerImage = tp.cols * tp.rows
         guard tilesPerImage > 0 else { return nil }
         let lastMs = max(0, Int(player.duration * 1000) - 1)
-        let tileIndex = min(max(0, ms), lastMs) / tp.intervalMs
-        let imageIndex = tileIndex / tilesPerImage
-        let offset = tileIndex % tilesPerImage
+        let boundedMs = min(max(0, ms), lastMs)
+        let imageIndex: Int
+        let offset: Int
+        if tp.timestampsMs.isEmpty {
+            let tileIndex = boundedMs / tp.intervalMs
+            imageIndex = tileIndex / tilesPerImage
+            offset = tileIndex % tilesPerImage
+        } else {
+            imageIndex = trickplayImageIndex(tp, atMs: boundedMs)
+            offset = 0
+        }
         guard let sheet = trickplaySheets[imageIndex] else {
             loadTrickplaySheet(imageIndex)
             return nil
         }
+        if !tp.timestampsMs.isEmpty { return sheet }
         guard let cg = sheet.cgImage else { return nil }
         let rect = CGRect(
             x: (offset % tp.cols) * tp.width, y: (offset / tp.cols) * tp.height,
@@ -2188,13 +2207,35 @@ final class AppleTvPlayerViewController: UIViewController {
         else { return }
         let tilesPerImage = tp.cols * tp.rows
         guard tilesPerImage > 0 else { return }
-        let lastIndex = max(0, (Int(player.duration * 1000) - 1) / tp.intervalMs / tilesPerImage)
-        let current = max(0, ms) / tp.intervalMs / tilesPerImage
+        let lastIndex: Int
+        let current: Int
+        if tp.timestampsMs.isEmpty {
+            lastIndex = max(0, (Int(player.duration * 1000) - 1) / tp.intervalMs / tilesPerImage)
+            current = max(0, ms) / tp.intervalMs / tilesPerImage
+        } else {
+            lastIndex = tp.timestampsMs.count - 1
+            current = trickplayImageIndex(tp, atMs: max(0, ms))
+        }
         for ahead in 1...sheetsAhead {
             let index = forward ? current + ahead : current - ahead
             if index < 0 || index > lastIndex { break }
             loadTrickplaySheet(index)
         }
+    }
+
+    private func trickplayImageIndex(_ tp: TrickplayData, atMs ms: Int) -> Int {
+        guard !tp.timestampsMs.isEmpty else { return 0 }
+        var low = 0
+        var high = tp.timestampsMs.count - 1
+        while low <= high {
+            let middle = low + (high - low) / 2
+            if tp.timestampsMs[middle] <= ms {
+                low = middle + 1
+            } else {
+                high = middle - 1
+            }
+        }
+        return min(max(high, 0), tp.timestampsMs.count - 1)
     }
 
     private func loadTrickplaySheet(_ index: Int) {


### PR DESCRIPTION
# Pull Request

## Summary
Add trickplay thumbnail support for Emby playback so timeline previews display server-provided images while seeking (#949).

## Related Issues

- Closes #949 
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- introduce a shared trickplay API and thumbnail data models
- fetch Emby thumbnail-set metadata and individual preview frames
- support non-uniform thumbnail timestamps during frame lookup
- integrate thumbnail loading into Flutter and tvOS playback controls
- use bounded prefetching with race protection and graceful fallbacks
- preserve connectivity-aware media server behavior
- add model, API, and playback prefetch tests

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device - Android TV (Shield 2019 PRO running Android 11)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Make sure you're connected to an Emby server and Video Preview Thumbnails are enabled and generated for your library.
2. Settings → Video Playback → set Trick Play to something other than Disabled
3. Play a movie or episode with video previews
4. The trickplay scrubbing works as expected.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/530449f9-5381-41f9-b03b-ad6e103ce76c


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
