### PR TITLE
feat: optimize visual and settings performance on TV

### DIFF
--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/painting.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../data/models/aggregated_item.dart';
+import '../../preference/user_preferences.dart';
 import 'connectivity_service.dart';
 import 'media_server_client_factory.dart';
 
@@ -44,7 +45,12 @@ class BackgroundService {
   Stream<String?> get backgroundStream => _backgroundController.stream;
   Stream<BlurContext> get blurContextStream => _blurContextController.stream;
 
+  bool get _backdropsAllowed =>
+      !GetIt.instance.isRegistered<UserPreferences>() ||
+      GetIt.instance<UserPreferences>().shouldShowBackdrops;
+
   void setBackground(AggregatedItem? item, {BlurContext context = BlurContext.details}) {
+    if (!_backdropsAllowed) return clearBackgrounds();
     if (item == null) return clearBackgrounds();
 
     _blurContext = context;
@@ -130,6 +136,7 @@ class BackgroundService {
   }
 
   void setBackgroundUrl(String url, {BlurContext context = BlurContext.browsing}) {
+    if (!_backdropsAllowed) return clearBackgrounds();
     _blurContext = context;
     _blurContextController.add(context);
     _loadBackgrounds([url]);

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3269,6 +3269,34 @@
   "@showBackdropImages": {
     "description": "Description for background backdrops"
   },
+  "deviceBackdrops": "Backdrops on This Device",
+  "@deviceBackdrops": {
+    "description": "Device-wide master setting for backdrop artwork"
+  },
+  "deviceBackdropsSubtitle": "Overrides every profile. Turn off to stop loading and displaying background artwork on this device.",
+  "@deviceBackdropsSubtitle": {
+    "description": "Description for the device-wide backdrop override"
+  },
+  "backdropRendering": "Backdrop Rendering",
+  "@backdropRendering": {
+    "description": "Setting for the backdrop rendering budget"
+  },
+  "backdropRenderingSubtitle": "Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.",
+  "@backdropRenderingSubtitle": {
+    "description": "Description for the backdrop rendering budget"
+  },
+  "backdropRenderingAutomatic": "Automatic",
+  "@backdropRenderingAutomatic": {
+    "description": "Backdrop rendering option: choose for this device"
+  },
+  "backdropRenderingQuality": "Quality",
+  "@backdropRenderingQuality": {
+    "description": "Backdrop rendering option: full artwork and transitions"
+  },
+  "backdropRenderingPerformance": "Performance",
+  "@backdropRenderingPerformance": {
+    "description": "Backdrop rendering option: reduced work"
+  },
   "seriesThumbnails": "Display Series Thumbnails",
   "@seriesThumbnails": {
     "description": "Setting for series thumbnails"
@@ -5045,6 +5073,14 @@
   "enableBuiltInScreensaver": "Enable the built-in screensaver",
   "@enableBuiltInScreensaver": {
     "description": "Description for in-app screensaver"
+  },
+  "deviceScreensaver": "Moonfin Screensaver on This Device",
+  "@deviceScreensaver": {
+    "description": "Device-wide master setting for Moonfin's screensaver"
+  },
+  "deviceScreensaverSubtitle": "Overrides every profile. Turn off to let the system screensaver start instead.",
+  "@deviceScreensaverSubtitle": {
+    "description": "Description for the device-wide screensaver override"
   },
   "mode": "Mode",
   "@mode": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4198,6 +4198,48 @@ abstract class AppLocalizations {
   /// **'Show backdrop images behind content'**
   String get showBackdropImages;
 
+  /// Device-wide master setting for backdrop artwork
+  ///
+  /// In en, this message translates to:
+  /// **'Backdrops on This Device'**
+  String get deviceBackdrops;
+
+  /// Description for the device-wide backdrop override
+  ///
+  /// In en, this message translates to:
+  /// **'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.'**
+  String get deviceBackdropsSubtitle;
+
+  /// Setting for the backdrop rendering budget
+  ///
+  /// In en, this message translates to:
+  /// **'Backdrop Rendering'**
+  String get backdropRendering;
+
+  /// Description for the backdrop rendering budget
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.'**
+  String get backdropRenderingSubtitle;
+
+  /// Backdrop rendering option: choose for this device
+  ///
+  /// In en, this message translates to:
+  /// **'Automatic'**
+  String get backdropRenderingAutomatic;
+
+  /// Backdrop rendering option: full artwork and transitions
+  ///
+  /// In en, this message translates to:
+  /// **'Quality'**
+  String get backdropRenderingQuality;
+
+  /// Backdrop rendering option: reduced work
+  ///
+  /// In en, this message translates to:
+  /// **'Performance'**
+  String get backdropRenderingPerformance;
+
   /// Setting for series thumbnails
   ///
   /// In en, this message translates to:
@@ -6759,6 +6801,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Enable the built-in screensaver'**
   String get enableBuiltInScreensaver;
+
+  /// Device-wide master setting for Moonfin's screensaver
+  ///
+  /// In en, this message translates to:
+  /// **'Moonfin Screensaver on This Device'**
+  String get deviceScreensaver;
+
+  /// Description for the device-wide screensaver override
+  ///
+  /// In en, this message translates to:
+  /// **'Overrides every profile. Turn off to let the system screensaver start instead.'**
+  String get deviceScreensaverSubtitle;
 
   /// Setting for mode
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -2328,6 +2328,29 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showBackdropImages => 'Wys agtergrondprente agter inhoud';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Reeks-kleinkiekies';
 
   @override
@@ -3729,6 +3752,13 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Aktiveer die ingeboude skermbewaarder';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modus';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -2338,6 +2338,29 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showBackdropImages => 'إظهار الصور الخلفية خلف المحتوى';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'الصور المصغرة للسلسلة';
 
   @override
@@ -3732,6 +3755,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'تمكين شاشة التوقف المدمجة';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'الوضع';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -2336,6 +2336,29 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showBackdropImages => 'Паказваць выявы фону за змесцівам';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Эскізы серыі';
 
   @override
@@ -3744,6 +3767,13 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Уключыць убудаваную застаўку';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Рэжым';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -2332,6 +2332,29 @@ class AppLocalizationsBg extends AppLocalizations {
       'Показване на фонови изображения зад съдържанието';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Сериални миниатюри';
 
   @override
@@ -3743,6 +3766,13 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Активирайте вградения скрийнсейвър';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -2316,6 +2316,29 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showBackdropImages => 'বিষয়বস্তুর পিছনে ব্যাকড্রপ ছবি দেখান';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'সিরিজ থাম্বনেল';
 
   @override
@@ -3717,6 +3740,13 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'অন্তর্নির্মিত স্ক্রিনসেভার সক্রিয় করুন';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'মোড';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -2353,6 +2353,29 @@ class AppLocalizationsCa extends AppLocalizations {
       'Mostra imatges de fons darrere del contingut';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniatures de la sèrie';
 
   @override
@@ -3772,6 +3795,13 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Activa l\'estalvi de pantalla integrat';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mode';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -2337,6 +2337,29 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showBackdropImages => 'Zobrazit obrázky pozadí za obsahem';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniatury seriálu';
 
   @override
@@ -3734,6 +3757,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Povolit vestavěný spořič obrazovky';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Režim';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -2348,6 +2348,29 @@ class AppLocalizationsCy extends AppLocalizations {
       'Dangos delweddau cefndir y tu ôl i\'r cynnwys';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Mân-luniau Cyfres';
 
   @override
@@ -3749,6 +3772,13 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Galluogi\'r arbedwr sgrin adeiledig';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modd';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -2323,6 +2323,29 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showBackdropImages => 'Vis baggrundsbilleder bag indhold';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serie miniaturebilleder';
 
   @override
@@ -3724,6 +3747,13 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Aktiver den indbyggede pauseskærm';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Tilstand';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2406,6 +2406,29 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showBackdropImages => 'Hintergrundbilder hinter Inhalten anzeigen';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serien-Miniaturbilder';
 
   @override
@@ -3817,6 +3840,13 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Integrierten Bildschirmschoner aktivieren';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modus';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -2349,6 +2349,29 @@ class AppLocalizationsEl extends AppLocalizations {
       'Εμφάνιση εικόνων φόντου πίσω από το περιεχόμενο';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Μικρογραφίες σειράς';
 
   @override
@@ -3765,6 +3788,13 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Ενεργοποιήστε την ενσωματωμένη προφύλαξη οθόνης';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Λειτουργία';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2312,6 +2312,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showBackdropImages => 'Show backdrop images behind content';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Display Series Thumbnails';
 
   @override
@@ -3705,6 +3728,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Enable the built-in screensaver';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mode';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -2322,6 +2322,29 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showBackdropImages => 'Montru fonbildojn malantaŭ enhavo';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Seriobildetoj';
 
   @override
@@ -3722,6 +3745,13 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Ebligu la enkonstruitan ekranŝirmilon';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Reĝimo';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2337,6 +2337,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showBackdropImages => 'Mostrar imágenes de fondo';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniaturas de series';
 
   @override
@@ -3749,6 +3772,13 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Habilitar el salvapantallas integrado';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modo';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -2330,6 +2330,29 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showBackdropImages => 'Kuva sisu taga taustapildid';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sarja pisipildid';
 
   @override
@@ -3727,6 +3750,13 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Lubage sisseehitatud ekraanisäästja';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Režiim';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -2311,6 +2311,29 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showBackdropImages => 'نمایش تصاویر پس زمینه پشت محتوا';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'ریز عکسهای سری';
 
   @override
@@ -3702,6 +3725,13 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'محافظ صفحه نمایش داخلی را فعال کنید';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'حالت';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -2331,6 +2331,29 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showBackdropImages => 'Näytä taustakuvat sisällön takana';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sarjan pikkukuvat';
 
   @override
@@ -3740,6 +3763,13 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Ota sisäänrakennettu näytönsäästäjä käyttöön';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Tila';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2350,6 +2350,29 @@ class AppLocalizationsFr extends AppLocalizations {
       'Afficher des images d’arrière-plan derrière le contenu';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Afficher le visuel de la série';
 
   @override
@@ -3773,6 +3796,13 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Activer l’économiseur d’écran intégré';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mode';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -2349,6 +2349,29 @@ class AppLocalizationsGl extends AppLocalizations {
   String get showBackdropImages => 'Mostra imaxes de fondo detrás do contido';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniaturas da serie';
 
   @override
@@ -3764,6 +3787,13 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Activa o protector de pantalla integrado';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modo';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2308,6 +2308,29 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showBackdropImages => 'הצג תמונות רקע מאחורי תוכן';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'תמונות ממוזערות של סדרה';
 
   @override
@@ -3691,6 +3714,13 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'הפעל את שומר המסך המובנה';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'מצב';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2318,6 +2318,29 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showBackdropImages => 'सामग्री के पीछे पृष्ठभूमि छवियाँ दिखाएँ';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'श्रृंखला थंबनेल';
 
   @override
@@ -3716,6 +3739,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'अंतर्निर्मित स्क्रीनसेवर सक्षम करें';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'मोड';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -2439,6 +2439,29 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showBackdropImages => 'Prikaži slike pozadine iza sadržaja';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sličice serije';
 
   @override
@@ -3846,6 +3869,13 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Omogućite ugrađeni čuvar zaslona';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Način';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -2336,6 +2336,29 @@ class AppLocalizationsHu extends AppLocalizations {
       'Háttérképek megjelenítése a tartalom mögött';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sorozatminiatűrök';
 
   @override
@@ -3748,6 +3771,13 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Engedélyezd a beépített képernyővédőt';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mód';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2325,6 +2325,29 @@ class AppLocalizationsId extends AppLocalizations {
       'Tampilkan gambar backdrop di belakang konten';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Tampilkan Thumbnail Serial';
 
   @override
@@ -3725,6 +3748,13 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Aktifkan screen saver bawaan';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mode';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2333,6 +2333,29 @@ class AppLocalizationsIt extends AppLocalizations {
       'Mostra immagini di sfondo dietro i contenuti';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniature Serie';
 
   @override
@@ -3747,6 +3770,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Abilita lo screensaver integrato';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modalità';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2281,6 +2281,29 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showBackdropImages => 'コンテンツの後ろに背景画像を表示する';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'シリーズのサムネイル';
 
   @override
@@ -3643,6 +3666,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => '内蔵スクリーンセーバーを有効にする';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'モード';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -2329,6 +2329,29 @@ class AppLocalizationsKk extends AppLocalizations {
   String get showBackdropImages => 'Мазмұнның артындағы фон суреттерін көрсету';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Нобайлар сериясы';
 
   @override
@@ -3738,6 +3761,13 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Кірістірілген экран сақтағышын қосыңыз';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -2333,6 +2333,29 @@ class AppLocalizationsKn extends AppLocalizations {
       'ವಿಷಯದ ಹಿಂದೆ ಬ್ಯಾಕ್‌ಡ್ರಾಪ್ ಚಿತ್ರಗಳನ್ನು ತೋರಿಸಿ';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'ಸರಣಿ ಥಂಬ್‌ನೇಲ್‌ಗಳು';
 
   @override
@@ -3743,6 +3766,13 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'ಅಂತರ್ನಿರ್ಮಿತ ಸ್ಕ್ರೀನ್ ಸೇವರ್ ಅನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಿ';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'ಮೋಡ್';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2278,6 +2278,29 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showBackdropImages => '콘텐츠 뒤에 배경 이미지 표시';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => '시리즈 썸네일';
 
   @override
@@ -3626,6 +3649,13 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => '내장 화면 보호기 활성화';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => '모드';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -2333,6 +2333,29 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showBackdropImages => 'Rodyti fono vaizdus už turinio';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serijos miniatiūros';
 
   @override
@@ -3742,6 +3765,13 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Įjunkite įmontuotą ekrano užsklandą';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Režimas';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -2338,6 +2338,29 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showBackdropImages => 'Rādīt fona kolāžas attēlus aiz satura';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sērijas sīktēli';
 
   @override
@@ -3741,6 +3764,13 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Iespējojiet iebūvēto ekrānsaudzētāju';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Režīms';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -2336,6 +2336,29 @@ class AppLocalizationsMk extends AppLocalizations {
   String get showBackdropImages => 'Прикажи слики од позадина зад содржината';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Сликички од серии';
 
   @override
@@ -3745,6 +3768,13 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Овозможете го вградениот заштитник на екранот';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2335,6 +2335,29 @@ class AppLocalizationsMl extends AppLocalizations {
       'ഉള്ളടക്കത്തിന് പിന്നിലെ ബാക്ക്‌ഡ്രോപ്പ് ചിത്രങ്ങൾ കാണിക്കുക';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'സീരീസ് ലഘുചിത്രങ്ങൾ';
 
   @override
@@ -3747,6 +3770,13 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'അന്തർനിർമ്മിത സ്ക്രീൻസേവർ പ്രവർത്തനക്ഷമമാക്കുക';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'മോഡ്';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -2323,6 +2323,29 @@ class AppLocalizationsMn extends AppLocalizations {
       'Агуулгын ард байгаа дэвсгэр зургийг харуулах';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Цуврал өнгөц зураг';
 
   @override
@@ -3731,6 +3754,13 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Суулгасан дэлгэц амраагчийг идэвхжүүлнэ үү';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Горим';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2321,6 +2321,29 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showBackdropImages => 'Vis bakteppebilder bak innhold';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serieminiatyrbilder';
 
   @override
@@ -3719,6 +3742,13 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Aktiver den innebygde skjermspareren';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modus';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -2335,6 +2335,29 @@ class AppLocalizationsNl extends AppLocalizations {
       'Toon achtergrondafbeeldingen achter de inhoud';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serieminiaturen';
 
   @override
@@ -3743,6 +3766,13 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Schakel de ingebouwde screensaver in';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modus';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -2321,6 +2321,29 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showBackdropImages => 'ਸਮੱਗਰੀ ਦੇ ਪਿੱਛੇ ਬੈਕਡ੍ਰੌਪ ਚਿੱਤਰ ਦਿਖਾਓ';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'ਲੜੀ ਥੰਬਨੇਲ';
 
   @override
@@ -3715,6 +3738,13 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'ਬਿਲਟ-ਇਨ ਸਕ੍ਰੀਨਸੇਵਰ ਨੂੰ ਸਮਰੱਥ ਬਣਾਓ';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'ਮੋਡ';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -2463,6 +2463,29 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showBackdropImages => 'Pokazuj grafiki tła za treścią';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Wyświetlaj miniatury seriali';
 
   @override
@@ -3874,6 +3897,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Włącz wbudowany wygaszacz ekranu';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Tryb';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2332,6 +2332,29 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showBackdropImages => 'Mostrar imagens de fundo atrás do conteúdo';
 
   @override
+  String get deviceBackdrops => 'Imagens de Fundo Neste Dispositivo';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Substitui todos os perfis. Desative para não carregar nem exibir imagens de fundo neste dispositivo.';
+
+  @override
+  String get backdropRendering => 'Renderização das Imagens de Fundo';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automático otimiza TVs. Qualidade mantém a arte completa e transições; Desempenho usa imagens menores e trocas instantâneas para reduzir travamentos.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automático';
+
+  @override
+  String get backdropRenderingQuality => 'Qualidade';
+
+  @override
+  String get backdropRenderingPerformance => 'Desempenho';
+
+  @override
   String get seriesThumbnails => 'Miniaturas de Séries';
 
   @override
@@ -3742,6 +3765,14 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Habilitar a proteção de tela integrada';
+
+  @override
+  String get deviceScreensaver =>
+      'Proteção de Tela do Moonfin Neste Dispositivo';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Substitui todos os perfis. Desative para permitir que a proteção de tela do sistema seja iniciada.';
 
   @override
   String get mode => 'Modo';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -2338,6 +2338,29 @@ class AppLocalizationsRo extends AppLocalizations {
       'Afișați imagini de fundal în spatele conținutului';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniaturi ale seriei';
 
   @override
@@ -3752,6 +3775,13 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Activați screensaverul încorporat';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mod';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2345,6 +2345,29 @@ class AppLocalizationsRu extends AppLocalizations {
       'Показывать фоновые изображения позади контента';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Миниатюры серий';
 
   @override
@@ -3754,6 +3777,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Включите встроенную заставку';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -2320,6 +2320,29 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showBackdropImages => 'අන්තර්ගතය පිටුපස පසුබිම් රූප පෙන්වන්න';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'මාලාවේ සිඟිති රූ';
 
   @override
@@ -3722,6 +3745,13 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'බිල්ට් තිර සුරැකුම සබල කරන්න';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'ප්‍රකාරය';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -2343,6 +2343,29 @@ class AppLocalizationsSk extends AppLocalizations {
   String get showBackdropImages => 'Zobraziť obrázky pozadia za obsahom';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniatúry série';
 
   @override
@@ -3747,6 +3770,13 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Povoliť vstavaný šetrič obrazovky';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Režim';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -2345,6 +2345,29 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showBackdropImages => 'Pokaži slike ozadja za vsebino';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Sličice serije';
 
   @override
@@ -3751,6 +3774,13 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Omogoči vgrajeni ohranjevalnik zaslona';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Način';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -2339,6 +2339,29 @@ class AppLocalizationsSq extends AppLocalizations {
   String get showBackdropImages => 'Shfaq imazhet e sfondit pas përmbajtjes';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Miniaturat e serive';
 
   @override
@@ -3753,6 +3776,13 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Aktivizo mbrojtësin e integruar të ekranit';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modaliteti';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -2440,6 +2440,29 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showBackdropImages => 'Прикажите слике позадине иза садржаја';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Сличице серије';
 
   @override
@@ -3845,6 +3868,13 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Омогућите уграђени чувар екрана';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -2330,6 +2330,29 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showBackdropImages => 'Visa bakgrundsbilder bakom innehåll';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Serieminiatyrer';
 
   @override
@@ -3729,6 +3752,13 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Aktivera den inbyggda skärmsläckaren';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Läge';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -2337,6 +2337,29 @@ class AppLocalizationsSw extends AppLocalizations {
   String get showBackdropImages => 'Onyesha picha za mandhari nyuma ya maudhui';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Vijipicha vya mfululizo';
 
   @override
@@ -3749,6 +3772,13 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Washa kihifadhi skrini kilichojengewa ndani';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Modi';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -2338,6 +2338,29 @@ class AppLocalizationsTa extends AppLocalizations {
       'உள்ளடக்கத்திற்குப் பின்னால் பின்னணிப் படங்களைக் காட்டு';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'தொடர் சிறுபடங்கள்';
 
   @override
@@ -3749,6 +3772,13 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'உள்ளமைக்கப்பட்ட ஸ்கிரீன்சேவரை இயக்கவும்';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'பயன்முறை';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2334,6 +2334,29 @@ class AppLocalizationsTe extends AppLocalizations {
       'కంటెంట్ వెనుక బ్యాక్‌డ్రాప్ చిత్రాలను చూపండి';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'సిరీస్ సూక్ష్మచిత్రాలు';
 
   @override
@@ -3743,6 +3766,13 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'అంతర్నిర్మిత స్క్రీన్‌సేవర్‌ని ప్రారంభించండి';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'మోడ్';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -2308,6 +2308,29 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showBackdropImages => 'แสดงภาพฉากหลังเบื้องหลังเนื้อหา';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'ภาพขนาดย่อของซีรีส์';
 
   @override
@@ -3699,6 +3722,13 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'เปิดใช้งานสกรีนเซฟเวอร์ในตัว';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'โหมด';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -2340,6 +2340,29 @@ class AppLocalizationsTl extends AppLocalizations {
       'Ipakita ang mga larawan sa backdrop sa likod ng nilalaman';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Mga Thumbnail ng Serye';
 
   @override
@@ -3755,6 +3778,13 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Paganahin ang built-in na screensaver';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mode';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -2319,6 +2319,29 @@ class AppLocalizationsTr extends AppLocalizations {
       'İçeriğin arkasındaki arka plan resimlerini göster';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Dizi Küçük Resimlerini Göster';
 
   @override
@@ -3730,6 +3753,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Yerleşik ekran koruyucuyu etkinleştirin';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Mod';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -2326,6 +2326,29 @@ class AppLocalizationsUg extends AppLocalizations {
       'ئارقا كۆرۈنۈشتىكى رەسىملەرنى مەزمۇننىڭ ئارقىسىدا كۆرسىتىڭ';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Series Thumbnails';
 
   @override
@@ -3730,6 +3753,13 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'قاچىلانغان ئېكراننى قوزغىتىڭ';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'ھالەت';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2343,6 +2343,29 @@ class AppLocalizationsUk extends AppLocalizations {
   String get showBackdropImages => 'Показувати зображення фону за вмістом';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Мініатюри серії';
 
   @override
@@ -3748,6 +3771,13 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => 'Увімкніть вбудовану заставку';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Режим';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2327,6 +2327,29 @@ class AppLocalizationsVi extends AppLocalizations {
       'Hiển thị hình ảnh phông nền phía sau nội dung';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => 'Hình thu nhỏ của loạt phim';
 
   @override
@@ -3729,6 +3752,13 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get enableBuiltInScreensaver =>
       'Kích hoạt trình bảo vệ màn hình tích hợp';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => 'Chế độ';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2269,6 +2269,29 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showBackdropImages => '顯示內容後面的背景影像';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => '系列縮圖';
 
   @override
@@ -3611,6 +3634,13 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => '啟用內建螢幕保護程式';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => '模式';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2265,6 +2265,29 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showBackdropImages => '在内容后方显示背景图';
 
   @override
+  String get deviceBackdrops => 'Backdrops on This Device';
+
+  @override
+  String get deviceBackdropsSubtitle =>
+      'Overrides every profile. Turn off to stop loading and displaying background artwork on this device.';
+
+  @override
+  String get backdropRendering => 'Backdrop Rendering';
+
+  @override
+  String get backdropRenderingSubtitle =>
+      'Automatic optimizes TVs. Quality keeps full artwork and crossfades; Performance uses smaller artwork and instant changes to reduce lag.';
+
+  @override
+  String get backdropRenderingAutomatic => 'Automatic';
+
+  @override
+  String get backdropRenderingQuality => 'Quality';
+
+  @override
+  String get backdropRenderingPerformance => 'Performance';
+
+  @override
   String get seriesThumbnails => '显示剧集缩略图';
 
   @override
@@ -3589,6 +3612,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get enableBuiltInScreensaver => '启用内置屏幕保护程序';
+
+  @override
+  String get deviceScreensaver => 'Moonfin Screensaver on This Device';
+
+  @override
+  String get deviceScreensaverSubtitle =>
+      'Overrides every profile. Turn off to let the system screensaver start instead.';
 
   @override
   String get mode => '模式';

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -2692,6 +2692,34 @@
     "@showBackdropImages": {
         "description": "Description for background backdrops"
     },
+    "deviceBackdrops": "Imagens de Fundo Neste Dispositivo",
+    "@deviceBackdrops": {
+        "description": "Device-wide master setting for backdrop artwork"
+    },
+    "deviceBackdropsSubtitle": "Substitui todos os perfis. Desative para não carregar nem exibir imagens de fundo neste dispositivo.",
+    "@deviceBackdropsSubtitle": {
+        "description": "Description for the device-wide backdrop override"
+    },
+    "backdropRendering": "Renderização das Imagens de Fundo",
+    "@backdropRendering": {
+        "description": "Setting for the backdrop rendering budget"
+    },
+    "backdropRenderingSubtitle": "Automático otimiza TVs. Qualidade mantém a arte completa e transições; Desempenho usa imagens menores e trocas instantâneas para reduzir travamentos.",
+    "@backdropRenderingSubtitle": {
+        "description": "Description for the backdrop rendering budget"
+    },
+    "backdropRenderingAutomatic": "Automático",
+    "@backdropRenderingAutomatic": {
+        "description": "Backdrop rendering option: choose for this device"
+    },
+    "backdropRenderingQuality": "Qualidade",
+    "@backdropRenderingQuality": {
+        "description": "Backdrop rendering option: full artwork and transitions"
+    },
+    "backdropRenderingPerformance": "Desempenho",
+    "@backdropRenderingPerformance": {
+        "description": "Backdrop rendering option: reduced work"
+    },
     "seriesThumbnails": "Miniaturas de Séries",
     "@seriesThumbnails": {
         "description": "Setting for series thumbnails"
@@ -3738,6 +3766,14 @@
     "enableBuiltInScreensaver": "Habilitar a proteção de tela integrada",
     "@enableBuiltInScreensaver": {
         "description": "Description for in-app screensaver"
+    },
+    "deviceScreensaver": "Proteção de Tela do Moonfin Neste Dispositivo",
+    "@deviceScreensaver": {
+        "description": "Device-wide master setting for Moonfin's screensaver"
+    },
+    "deviceScreensaverSubtitle": "Substitui todos os perfis. Desative para permitir que a proteção de tela do sistema seja iniciada.",
+    "@deviceScreensaverSubtitle": {
+        "description": "Description for the device-wide screensaver override"
     },
     "mode": "Modo",
     "@mode": {

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -202,6 +202,13 @@ enum DesktopScrollWheelAction {
 /// `reduced` forces the zero-blur sheen everywhere.
 enum GlassQualityMode { auto, full, reduced }
 
+/// Rendering budget for full-screen browsing backdrops.
+///
+/// [automatic] keeps the quality path on phones and desktops, while TVs use
+/// the lower-cost path. [quality] preserves the full decode and crossfade;
+/// [performance] uses a smaller decode and swaps a single layer immediately.
+enum BackdropRenderMode { automatic, quality, performance }
+
 /// Persisted settled quality of the adaptive glass renderer, mirroring the
 /// package's GlassQuality tiers. `unset` means no benchmark has settled yet,
 /// so the adaptive scope runs its warm-up pass on next launch. Kept as a

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -919,6 +919,26 @@ class UserPreferences extends ChangeNotifier {
     defaultValue: true,
   );
 
+  /// Device-wide master switch for backdrop artwork. This intentionally stays
+  /// unscoped so a low-power TV can disable background artwork once without
+  /// repeating the choice for every Jellyfin profile. The profile preference
+  /// above is preserved and takes effect again if this override is re-enabled.
+  static final deviceBackdropsEnabled = Preference(
+    key: 'pref_device_backdrops_enabled',
+    defaultValue: true,
+  );
+
+  bool get shouldShowBackdrops =>
+      get(deviceBackdropsEnabled) && get(backdropEnabled);
+
+  /// Device-local because the appropriate artwork budget depends on the GPU,
+  /// not the signed-in server profile or the user's other Moonfin clients.
+  static final backdropRenderMode = EnumPreference(
+    key: 'pref_backdrop_render_mode',
+    defaultValue: BackdropRenderMode.automatic,
+    values: BackdropRenderMode.values,
+  );
+
   /// Plays retro games through the native libretro backend instead of the
   /// EmulatorJS WebView, on platforms that have both. Deliberately not synced:
   /// the right backend is a per-device choice.
@@ -1513,6 +1533,17 @@ class UserPreferences extends ChangeNotifier {
     key: 'pref_screensaver_enabled',
     defaultValue: true,
   );
+
+  /// Device-wide master switch for Moonfin's in-app screensaver. When false,
+  /// profile settings remain intact but the controller stays disarmed and
+  /// releases its wake lock so the operating system screensaver can run.
+  static final deviceScreensaverEnabled = Preference(
+    key: 'pref_device_screensaver_enabled',
+    defaultValue: true,
+  );
+
+  bool get shouldUseInAppScreensaver =>
+      get(deviceScreensaverEnabled) && get(screensaverEnabled);
 
   static final screensaverMode = EnumPreference(
     key: 'pref_screensaver_mode',

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1260,7 +1260,7 @@ class _DetailContentState extends State<_DetailContent> {
     final blurAmount = widget.prefs
         .get(UserPreferences.detailsBackgroundBlurAmount)
         .toDouble();
-    final backdropEnabled = widget.prefs.get(UserPreferences.backdropEnabled);
+    final backdropEnabled = widget.prefs.shouldShowBackdrops;
     final useSplitLayout =
         item.type == 'Person' && _useDesktopDetailLayout(context);
     final isAlbumOrPlaylist =

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4487,14 +4487,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return '${m}m';
   }
 
-  /// Full-bleed cinematic backdrop owned by the Modern screen (deliberately
-  /// ignores the global backdrop-hide / blur prefs; no blur). In landscape the
+  /// Full-bleed cinematic backdrop owned by the Modern screen. The device-wide
+  /// backdrop override still wins so low-power TVs can suppress every artwork
+  /// path without changing the profile's own preference. In landscape the
   /// image is right-aligned and embedded into the page with layered scrims: a
   /// strong left-to-right gradient keeping the left content readable, a
   /// bottom-to-top gradient blending the lower UI into the background, and a
   /// subtle edge vignette. In portrait it fades from the top into the content.
   Widget _buildBackdrop(bool landscape, String? backdropUrl) {
     final base = AppColorScheme.background;
+    if (!widget.prefs.shouldShowBackdrops) {
+      return ColoredBox(color: base);
+    }
     final item = _vm.item;
     final url = backdropUrl ?? (item?.type == 'Person' ? (_randomBackdropUrl ?? _imageUrl(item!)) : null);
     final blurAmount = widget.prefs

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -68,6 +68,7 @@ import '../../widgets/settings/settings_panel.dart';
 import '../../widgets/top_toolbar.dart';
 import '../../navigation/home_refresh_bus.dart';
 import '../../widgets/bounded_network_image.dart';
+import '../../widgets/backdrop_render_profile.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../navigation/route_lifecycle_observer.dart';
 import '../../util/home_row_title_localizer.dart';
@@ -268,6 +269,10 @@ class _HomeShellState extends State<_HomeShell>
 
   void _onPrefsChanged() {
     if (!mounted) return;
+    if (!_userPrefs.shouldShowBackdrops &&
+        _backgroundService.currentUrl != null) {
+      _backgroundService.clearBackgrounds();
+    }
     final currentJson = _userPrefs.get(UserPreferences.homeSectionsJson);
     final currentMultiServer = _userPrefs.get(
       UserPreferences.enableMultiServerLibraries,
@@ -454,7 +459,11 @@ class _HomeShellState extends State<_HomeShell>
 
   @override
   Widget build(BuildContext context) {
-    final backdropEnabled = _userPrefs.get(UserPreferences.backdropEnabled);
+    final backdropEnabled = _userPrefs.shouldShowBackdrops;
+    final backdropRenderProfile = BackdropRenderProfile.resolve(
+      _userPrefs.get(UserPreferences.backdropRenderMode),
+      isTv: PlatformDetection.isTV,
+    );
     final blurAmount = _userPrefs
         .get(UserPreferences.browsingBackgroundBlurAmount)
         .toDouble();
@@ -489,6 +498,7 @@ class _HomeShellState extends State<_HomeShell>
                       return _Backdrop(
                         url: url,
                         blurAmount: blurAmount,
+                        renderProfile: backdropRenderProfile,
                         useMakdBackdropFx: useMakdBackdropFx,
                       );
                     },
@@ -559,11 +569,13 @@ class _GradientScrim extends StatelessWidget {
 class _Backdrop extends StatelessWidget {
   final String? url;
   final double blurAmount;
+  final BackdropRenderProfile renderProfile;
   final bool useMakdBackdropFx;
 
   const _Backdrop({
     this.url,
     required this.blurAmount,
+    required this.renderProfile,
     this.useMakdBackdropFx = false,
   });
 
@@ -572,7 +584,8 @@ class _Backdrop extends StatelessWidget {
     return RepaintBoundary(
       child: FullscreenBackdropSwitcher(
         imageUrl: url,
-        duration: BackgroundService.transitionDuration,
+        duration: renderProfile.transitionDuration,
+        animateTransitions: renderProfile.animateTransitions,
         imageBuilder: (imageUrl) {
           final image = _blurredImage(context, imageUrl, blurAmount);
           if (!useMakdBackdropFx) {
@@ -619,9 +632,9 @@ class _Backdrop extends StatelessWidget {
                 ? viewportWidth * pixelRatio * 0.6
                 : viewportWidth * pixelRatio)
             .round();
-    final maxWidth = targetPxWidth < 480
-        ? 480
-        : (targetPxWidth > 1280 ? 1280 : targetPxWidth);
+    final maxWidth = targetPxWidth
+        .clamp(480, renderProfile.maxDecodeWidth)
+        .toInt();
     final image = BoundedNetworkImage(
       imageUrl: imageUrl,
       scale: blur > 0 ? 0.3 : 1.0,

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -312,7 +312,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final topPad = MediaQuery.of(context).padding.top;
     final prefs = GetIt.instance<UserPreferences>();
     final navbarPosition = prefs.get(UserPreferences.navbarPosition);
-    final backdropEnabled = prefs.get(UserPreferences.backdropEnabled);
+    final backdropEnabled = prefs.shouldShowBackdrops;
     final navbarHeight = navbarPosition == NavbarPosition.top
         ? (PlatformDetection.isTV ? 95.0 : PlatformDetection.useMobileUi ? 60.0 : 80.0)
         : 0.0;

--- a/lib/ui/screens/settings/panel/general_style_screen.dart
+++ b/lib/ui/screens/settings/panel/general_style_screen.dart
@@ -175,6 +175,14 @@ class _GeneralStyleScreenState extends State<_GeneralStyleScreen> {
                 ),
               adaptiveListSection(
                 children: [
+                  SwitchPreferenceTile(
+                    preference: UserPreferences.deviceBackdropsEnabled,
+                    title: l10n.deviceBackdrops,
+                    subtitle: l10n.deviceBackdropsSubtitle,
+                    icon: Icons.layers_clear_outlined,
+                    onChanged: GetIt.instance<UserPreferences>()
+                        .notifyPreferenceChanged,
+                  ),
                   EnumPreferenceTile<DesktopUiScale>(
                     preference: UserPreferences.desktopUiScale,
                     title: l10n.desktopUiScale,
@@ -205,6 +213,22 @@ class _GeneralStyleScreenState extends State<_GeneralStyleScreen> {
                     subtitle: l10n.showBackdropImages,
                     icon: Icons.photo,
                     onChanged: _pushPersonalizationSync,
+                  ),
+                  EnumPreferenceTile<BackdropRenderMode>(
+                    preference: UserPreferences.backdropRenderMode,
+                    title: l10n.backdropRendering,
+                    description: l10n.backdropRenderingSubtitle,
+                    icon: Icons.speed_outlined,
+                    onChanged: GetIt.instance<UserPreferences>()
+                        .notifyPreferenceChanged,
+                    labelOf: (v) => switch (v) {
+                      BackdropRenderMode.automatic =>
+                        l10n.backdropRenderingAutomatic,
+                      BackdropRenderMode.quality =>
+                        l10n.backdropRenderingQuality,
+                      BackdropRenderMode.performance =>
+                        l10n.backdropRenderingPerformance,
+                    },
                   ),
                   EnumPreferenceTile<OledMode>(
                     preference: UserPreferences.oledMode,

--- a/lib/ui/screens/settings/panel/settings_panel_infra.dart
+++ b/lib/ui/screens/settings/panel/settings_panel_infra.dart
@@ -189,11 +189,12 @@ void _ensureSettingsTileVisible(
 }) {
   WidgetsBinding.instance.addPostFrameCallback((_) {
     if (!context.mounted) return;
+    final motion = SettingsMotionProfile.of(context);
     Scrollable.ensureVisible(
       context,
       alignment: alignment,
       alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
-      duration: const Duration(milliseconds: 120),
+      duration: motion.focusScrollDuration,
       curve: Curves.easeOut,
     );
   });

--- a/lib/ui/screens/settings/panel/settings_panel_tiles.dart
+++ b/lib/ui/screens/settings/panel/settings_panel_tiles.dart
@@ -187,6 +187,7 @@ class _DoubleSliderTileState extends State<_DoubleSliderTile> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final motion = SettingsMotionProfile.of(context);
     return Padding(
       padding: const EdgeInsets.fromLTRB(12, 4, 12, 4),
       child: Focus(
@@ -200,9 +201,8 @@ class _DoubleSliderTileState extends State<_DoubleSliderTile> {
             setState(() => _outerFocused = focused);
           }
         },
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 90),
-          curve: Curves.easeOut,
+        child: buildSettingsFocusSurface(
+          context,
           decoration: BoxDecoration(
             color: _outerFocused
                 ? AppColorScheme.onSurface
@@ -214,7 +214,7 @@ class _DoubleSliderTileState extends State<_DoubleSliderTile> {
                       : ThemeRegistry.active.borders.cardBorder)
                   .copyWith(width: 1),
             ),
-            boxShadow: _outerFocused
+            boxShadow: _outerFocused && motion.showFocusGlow
                 ? ThemeRegistry.active.borders.focusGlow
                 : null,
           ),

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -585,10 +585,22 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       keywords: ['mouse', 'wheel', 'speed', 'scrolling'],
     ),
     style.leaf(
+      'pref_device_backdrops_enabled',
+      l10n.deviceBackdrops,
+      subtitle: l10n.deviceBackdropsSubtitle,
+      keywords: ['all profiles', 'device override', 'background images'],
+    ),
+    style.leaf(
       'pref_show_backdrop',
       l10n.backgroundBackdrops,
       subtitle: l10n.showBackdropImages,
       keywords: ['background images'],
+    ),
+    style.leaf(
+      'pref_backdrop_render_mode',
+      l10n.backdropRendering,
+      subtitle: l10n.backdropRenderingSubtitle,
+      keywords: ['background images', 'performance', 'lag', 'tv'],
     ),
     style.leaf(
       'pref_oled_mode',
@@ -729,6 +741,12 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
 
     if (PlatformDetection.isTV) ...[
       screensaver.screen(keywords: ['idle', 'dim', 'burn in']),
+      screensaver.leaf(
+        'pref_device_screensaver_enabled',
+        l10n.deviceScreensaver,
+        subtitle: l10n.deviceScreensaverSubtitle,
+        keywords: ['system screensaver', 'android tv', 'all profiles'],
+      ),
       screensaver.leaf(
         'pref_screensaver_enabled',
         l10n.inAppScreensaver,

--- a/lib/ui/screens/settings/screensaver_settings_screen.dart
+++ b/lib/ui/screens/settings/screensaver_settings_screen.dart
@@ -57,10 +57,20 @@ class _ScreensaverSettingsScreenState extends State<ScreensaverSettingsScreen> {
               adaptiveListSection(
                 children: [
                   SwitchPreferenceTile(
+                    preference: UserPreferences.deviceScreensaverEnabled,
+                    title: l10n.deviceScreensaver,
+                    subtitle: l10n.deviceScreensaverSubtitle,
+                    icon: Icons.tv_off_outlined,
+                    onChanged: GetIt.instance<UserPreferences>()
+                        .notifyPreferenceChanged,
+                  ),
+                  SwitchPreferenceTile(
                     preference: UserPreferences.screensaverEnabled,
                     title: l10n.inAppScreensaver,
                     subtitle: l10n.enableBuiltInScreensaver,
                     icon: Icons.wallpaper,
+                    onChanged: GetIt.instance<UserPreferences>()
+                        .notifyPreferenceChanged,
                   ),
                   EnumPreferenceTile<ScreensaverMode>(
                     preference: UserPreferences.screensaverMode,
@@ -75,6 +85,8 @@ class _ScreensaverSettingsScreenState extends State<ScreensaverSettingsScreen> {
                     preference: UserPreferences.screensaverTimeout,
                     title: l10n.timeout,
                     icon: Icons.timer,
+                    onChanged: GetIt.instance<UserPreferences>()
+                        .notifyPreferenceChanged,
                     labelOf: (value) => l10n.minutesShort(value.minutes),
                   ),
                   SliderPreferenceTile(

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -61,6 +61,7 @@ import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/button_layout_list.dart';
 import '../../widgets/settings/preference_tiles.dart';
 import '../../widgets/settings/settings_panel.dart';
+import '../../widgets/settings/settings_motion_profile.dart';
 import '../../widgets/settings/settings_section_header.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/support_dialog.dart';

--- a/lib/ui/screensaver/screensaver_controller.dart
+++ b/lib/ui/screensaver/screensaver_controller.dart
@@ -12,7 +12,7 @@ import '../../util/platform_detection.dart';
 class ScreensaverController {
   ScreensaverController(this._prefs, PlaybackManager playbackManager) {
     if (PlatformDetection.isTV) {
-      _enabledCache = _prefs.get(UserPreferences.screensaverEnabled);
+      _enabledCache = _prefs.shouldUseInAppScreensaver;
       _timeoutCache = _prefs.get(UserPreferences.screensaverTimeout);
       _playingSub = playbackManager.state.playingStream.listen(
         _onPlayingChanged,
@@ -115,7 +115,7 @@ class ScreensaverController {
   }
 
   void _onPrefsChanged() {
-    final enabled = _prefs.get(UserPreferences.screensaverEnabled);
+    final enabled = _prefs.shouldUseInAppScreensaver;
     final timeout = _prefs.get(UserPreferences.screensaverTimeout);
     if (enabled == _enabledCache && timeout == _timeoutCache) return;
     _enabledCache = enabled;

--- a/lib/ui/widgets/backdrop_render_profile.dart
+++ b/lib/ui/widgets/backdrop_render_profile.dart
@@ -1,0 +1,39 @@
+import '../../preference/preference_constants.dart';
+
+/// Concrete rendering limits resolved from the user's backdrop preference.
+///
+/// Keeping this policy outside the widget makes the automatic TV behavior
+/// deterministic and testable without pretending that every TV GPU has the
+/// same capabilities as a phone or desktop GPU.
+class BackdropRenderProfile {
+  final int maxDecodeWidth;
+  final Duration transitionDuration;
+  final bool animateTransitions;
+
+  const BackdropRenderProfile({
+    required this.maxDecodeWidth,
+    required this.transitionDuration,
+    required this.animateTransitions,
+  });
+
+  static const quality = BackdropRenderProfile(
+    maxDecodeWidth: 1280,
+    transitionDuration: Duration(milliseconds: 800),
+    animateTransitions: true,
+  );
+
+  static const performance = BackdropRenderProfile(
+    maxDecodeWidth: 720,
+    transitionDuration: Duration.zero,
+    animateTransitions: false,
+  );
+
+  static BackdropRenderProfile resolve(
+    BackdropRenderMode mode, {
+    required bool isTv,
+  }) => switch (mode) {
+    BackdropRenderMode.automatic => isTv ? performance : quality,
+    BackdropRenderMode.quality => quality,
+    BackdropRenderMode.performance => performance,
+  };
+}

--- a/lib/ui/widgets/fullscreen_backdrop_switcher.dart
+++ b/lib/ui/widgets/fullscreen_backdrop_switcher.dart
@@ -6,6 +6,7 @@ class FullscreenBackdropSwitcher extends StatefulWidget {
   final Duration duration;
   final Alignment alignment;
   final Duration fadeInDuration;
+  final bool animateTransitions;
   final Widget Function(String imageUrl)? imageBuilder;
 
   const FullscreenBackdropSwitcher({
@@ -14,6 +15,7 @@ class FullscreenBackdropSwitcher extends StatefulWidget {
     required this.duration,
     this.alignment = Alignment.topCenter,
     this.fadeInDuration = const Duration(milliseconds: 300),
+    this.animateTransitions = true,
     this.imageBuilder,
   });
 
@@ -68,6 +70,22 @@ class _FullscreenBackdropSwitcherState extends State<FullscreenBackdropSwitcher>
     }
 
     final next = widget.imageUrl;
+
+    if (!widget.animateTransitions) {
+      _controller.stop();
+      if (_currentUrl == next &&
+          _incomingUrl == null &&
+          _pendingUrl == null) {
+        return;
+      }
+      setState(() {
+        _currentUrl = next;
+        _incomingUrl = null;
+        _pendingUrl = null;
+      });
+      return;
+    }
+
     final shown = _incomingUrl ?? _currentUrl;
 
     if (next == shown) {

--- a/lib/ui/widgets/media_bar.dart
+++ b/lib/ui/widgets/media_bar.dart
@@ -41,6 +41,7 @@ import '../../playback/appletv_preview_player.dart';
 import '../../playback/html_video_backend_profile.dart';
 import '../../playback/inline_preview_engine.dart';
 import '../../playback/media3_player_backend.dart';
+import 'backdrop_render_profile.dart';
 import 'bounded_network_image.dart';
 import 'fullscreen_backdrop_switcher.dart';
 import 'navigation_layout.dart';
@@ -104,6 +105,12 @@ class _MediaBarState extends State<MediaBar>
   final _playbackManager = GetIt.instance<PlaybackManager>();
   final _audioArbiter = GetIt.instance<PlaybackArbiter>();
   final _screensaverController = GetIt.instance<ScreensaverController>();
+  bool get _showBackdrops => widget.prefs.shouldShowBackdrops;
+  BackdropRenderProfile get _backdropRenderProfile =>
+      BackdropRenderProfile.resolve(
+        widget.prefs.get(UserPreferences.backdropRenderMode),
+        isTv: PlatformDetection.isTV,
+      );
   // The playback module only registers a Media3 backend on some platforms, so
   // ask the container instead of repeating its platform list here.
   final Media3PlayerBackend? _media3TrailerBackend =
@@ -530,6 +537,14 @@ class _MediaBarState extends State<MediaBar>
   void _syncMakdBackdropWithCurrentSlide() {
     if (!_isHomeRouteActive) return;
 
+    if (!_showBackdrops) {
+      _lastSyncedMakdBackdropUrl = null;
+      if (_backgroundService.currentUrl != null) {
+        _backgroundService.clearBackgrounds();
+      }
+      return;
+    }
+
     final mode = UserPreferences.normalizeMediaBarMode(
       widget.prefs.get(UserPreferences.mediaBarMode),
     );
@@ -586,7 +601,10 @@ class _MediaBarState extends State<MediaBar>
     final activeBookHeight = contentHeight * 0.84;
     final activeBookWidth = activeBookHeight * 0.72;
     final posterCacheW = (activeBookWidth * 0.88 * dpr).round().clamp(150, 400);
-    final backdropCacheW = (screenWidth * dpr).round().clamp(640, 1280);
+    final backdropCacheW = (screenWidth * dpr).round().clamp(
+      640,
+      _backdropRenderProfile.maxDecodeWidth,
+    );
 
     final warmIndices = <int>{
       centerIndex,
@@ -627,7 +645,7 @@ class _MediaBarState extends State<MediaBar>
               );
             }
           } else {
-            if (item.backdropUrl != null) {
+            if (_showBackdrops && item.backdropUrl != null) {
               await precacheImage(
                 ResizeImage(
                   offlineAwareImageProvider(item.backdropUrl!),
@@ -825,7 +843,10 @@ class _MediaBarState extends State<MediaBar>
     final activeBookHeight = contentHeight * 0.84;
     final activeBookWidth = activeBookHeight * 0.72;
     final posterCacheW = (activeBookWidth * 0.88 * dpr).round().clamp(150, 400);
-    final backdropCacheW = (screenWidth * dpr).round().clamp(640, 1280);
+    final backdropCacheW = (screenWidth * dpr).round().clamp(
+      640,
+      _backdropRenderProfile.maxDecodeWidth,
+    );
 
     final isBookshelf = _isBookshelfMode();
 
@@ -851,7 +872,7 @@ class _MediaBarState extends State<MediaBar>
             );
           }
         } else {
-          if (item.backdropUrl != null) {
+          if (_showBackdrops && item.backdropUrl != null) {
             precacheImage(
               ResizeImage(
                 offlineAwareImageProvider(item.backdropUrl!),
@@ -2031,6 +2052,8 @@ class _MediaBarState extends State<MediaBar>
                     child: _BackdropLayer(
                       items: items,
                       currentIndex: _currentIndex,
+                      enabled: _showBackdrops,
+                      renderProfile: _backdropRenderProfile,
                     ),
                   ),
                   ..._buildVideoOverlays(allowPersistentMedia3: true),
@@ -2229,11 +2252,15 @@ class _MediaBarState extends State<MediaBar>
                       child: _BackdropLayer(
                         items: items,
                         currentIndex: _currentIndex,
-                        zoomDuration: Duration(
-                          milliseconds: widget.prefs.get(
-                            UserPreferences.mediaBarIntervalMs,
-                          ),
-                        ),
+                        enabled: _showBackdrops,
+                        renderProfile: _backdropRenderProfile,
+                        zoomDuration: _backdropRenderProfile.animateTransitions
+                            ? Duration(
+                                milliseconds: widget.prefs.get(
+                                  UserPreferences.mediaBarIntervalMs,
+                                ),
+                              )
+                            : null,
                       ),
                     ),
                   if (!isMobile)
@@ -2696,6 +2723,10 @@ class _MediaBarState extends State<MediaBar>
             return;
           }
 
+          if (!_showBackdrops) {
+            return;
+          }
+
           final backdropUrl = items[clampedIndex].backdropUrl;
 
           if (backdropUrl == null || backdropUrl.isEmpty) {
@@ -2734,6 +2765,9 @@ class _MediaBarState extends State<MediaBar>
                 ? null
                 : Stack(fit: StackFit.expand, children: trailerOverlays),
             onAmbientArtworkChanged: (artworkUrl) {
+              if (!_showBackdrops) {
+                return;
+              }
               if (artworkUrl == null || artworkUrl.isEmpty) {
                 return;
               }
@@ -2775,7 +2809,7 @@ class _MediaBarState extends State<MediaBar>
   }
 
   void _prefetchGalleryWindow(List<MediaBarSlideItem> items, int centerIndex) {
-    if (!mounted || items.isEmpty) return;
+    if (!mounted || items.isEmpty || !_showBackdrops) return;
     final pageSize = GalleryLayout.pageSize;
     final start = (centerIndex ~/ pageSize) * pageSize;
     final end = (start + pageSize * 2).clamp(0, items.length);
@@ -3065,6 +3099,8 @@ class _MediaBarState extends State<MediaBar>
 class _BackdropLayer extends StatelessWidget {
   final List<MediaBarSlideItem> items;
   final int currentIndex;
+  final bool enabled;
+  final BackdropRenderProfile renderProfile;
 
   /// When set, the backdrop slowly zooms (Ken Burns) over this duration
   final Duration? zoomDuration;
@@ -3072,23 +3108,26 @@ class _BackdropLayer extends StatelessWidget {
   const _BackdropLayer({
     required this.items,
     required this.currentIndex,
+    required this.enabled,
+    required this.renderProfile,
     this.zoomDuration,
   });
 
   @override
   Widget build(BuildContext context) {
-    final url = (currentIndex >= 0 && currentIndex < items.length)
+    final url = enabled && currentIndex >= 0 && currentIndex < items.length
         ? items[currentIndex].backdropUrl
         : null;
     return RepaintBoundary(
       child: FullscreenBackdropSwitcher(
         imageUrl: url,
-        duration: const Duration(milliseconds: 600),
+        duration: renderProfile.transitionDuration,
+        animateTransitions: renderProfile.animateTransitions,
         imageBuilder: (imageUrl) {
           final Widget image = BoundedNetworkImage(
             imageUrl: imageUrl,
             minWidth: 640,
-            maxWidth: 1280,
+            maxWidth: renderProfile.maxDecodeWidth,
             errorBuilder: (_, _, _) =>
                 ColoredBox(color: AppColorScheme.background),
           );

--- a/lib/ui/widgets/mediabar/banner_media_bar.dart
+++ b/lib/ui/widgets/mediabar/banner_media_bar.dart
@@ -13,6 +13,7 @@ import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../util/platform_detection.dart';
 import '../bounded_network_image.dart';
+import '../backdrop_render_profile.dart';
 import '../rating_display.dart';
 import 'media_bar_status_focus.dart';
 
@@ -329,14 +330,21 @@ class _BannerMediaBarState extends State<BannerMediaBar> {
   }
 
   Widget _backdrop(MediaBarSlideItem item) {
+    if (!widget.prefs.shouldShowBackdrops) {
+      return ColoredBox(color: AppColorScheme.surface);
+    }
     final url = item.backdropUrl;
     if (url == null) {
       return ColoredBox(color: AppColorScheme.surface);
     }
+    final renderProfile = BackdropRenderProfile.resolve(
+      widget.prefs.get(UserPreferences.backdropRenderMode),
+      isTv: PlatformDetection.isTV,
+    );
     return BoundedNetworkImage(
       imageUrl: url,
       minWidth: 640,
-      maxWidth: 1280,
+      maxWidth: renderProfile.maxDecodeWidth,
       errorBuilder: (_, _, _) => ColoredBox(color: AppColorScheme.surface),
     );
   }

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -13,6 +13,7 @@ import '../adaptive/adaptive_icons.dart';
 import '../adaptive/sf_symbol.dart';
 import '../overlay_sheet.dart';
 import 'preference_binding.dart';
+import 'settings_motion_profile.dart';
 
 Widget withBackClose(BuildContext dialogContext, Widget child) {
   final closeDialog = createDialogBackCloseHandler(dialogContext);
@@ -163,6 +164,7 @@ BoxDecoration _settingsTileDecoration(
   BuildContext context, {
   required bool focused,
 }) {
+  final motion = SettingsMotionProfile.of(context);
   if (AppUiIdiomResolver.isApple) {
     if (!focused) return const BoxDecoration();
     return BoxDecoration(
@@ -203,7 +205,7 @@ BoxDecoration _settingsTileDecoration(
         width: 1.0,
       ),
     ),
-    boxShadow: focused
+    boxShadow: focused && motion.showFocusGlow
         ? (borderTokens.focusGlow.isNotEmpty
               ? borderTokens.focusGlow
               : [
@@ -265,14 +267,32 @@ Widget buildSettingsSelectionBubble(
 void _ensureFocusVisible(BuildContext context, {double alignment = 0.9}) {
   WidgetsBinding.instance.addPostFrameCallback((_) {
     if (!context.mounted) return;
+    final motion = SettingsMotionProfile.of(context);
     Scrollable.ensureVisible(
       context,
       alignment: alignment,
       alignmentPolicy: ScrollPositionAlignmentPolicy.explicit,
-      duration: const Duration(milliseconds: 120),
+      duration: motion.focusScrollDuration,
       curve: Curves.easeOut,
     );
   });
+}
+
+Widget buildSettingsFocusSurface(
+  BuildContext context, {
+  required BoxDecoration decoration,
+  required Widget child,
+}) {
+  final motion = SettingsMotionProfile.of(context);
+  if (motion.tileFocusDuration == Duration.zero) {
+    return DecoratedBox(decoration: decoration, child: child);
+  }
+  return AnimatedContainer(
+    duration: motion.tileFocusDuration,
+    curve: Curves.easeOut,
+    decoration: decoration,
+    child: child,
+  );
 }
 
 class SettingsListTypography extends StatelessWidget {
@@ -745,9 +765,8 @@ class _SliderPreferenceTileState extends State<SliderPreferenceTile> {
       },
       child: Padding(
         padding: _settingsTileOuterPadding(context),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 90),
-          curve: Curves.easeOut,
+        child: buildSettingsFocusSurface(
+          context,
           decoration: _settingsTileDecoration(context, focused: _outerFocused),
           child: ListTileTheme.merge(
             textColor: invert
@@ -1162,6 +1181,22 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
     // Gate the tile highlight to keyboard/D-pad
     final focusVisible = InputModeTracker.showFocusVisuals(context, _focused);
     final highlighted = focusVisible && settingsTileInvertsOnFocus;
+    final tile = ListTileTheme.merge(
+      textColor: highlighted
+          ? AppColors.black.withValues(alpha: 0.87)
+          : settingsHeadlineColor(),
+      iconColor: highlighted
+          ? AppColors.black.withValues(alpha: 0.54)
+          : AppColorScheme.onSurface.withValues(alpha: 0.7),
+      titleTextStyle: _kSettingsTitleTextStyle,
+      subtitleTextStyle: _kSettingsSubtitleTextStyle,
+      child: Material(
+        type: MaterialType.transparency,
+        child: Builder(
+          builder: (ctx) => widget.builder(ctx, focusVisible),
+        ),
+      ),
+    );
     return Focus(
       focusNode: _effectiveFocusNode,
       canRequestFocus: false,
@@ -1172,26 +1207,10 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
         padding: widget.outerPadding ?? _settingsTileOuterPadding(context),
         child: Opacity(
           opacity: widget.enabled ? 1.0 : 0.45,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 90),
-            curve: Curves.easeOut,
+          child: buildSettingsFocusSurface(
+            context,
             decoration: _settingsTileDecoration(context, focused: focusVisible),
-            child: ListTileTheme.merge(
-              textColor: highlighted
-                  ? AppColors.black.withValues(alpha: 0.87)
-                  : settingsHeadlineColor(),
-              iconColor: highlighted
-                  ? AppColors.black.withValues(alpha: 0.54)
-                  : AppColorScheme.onSurface.withValues(alpha: 0.7),
-              titleTextStyle: _kSettingsTitleTextStyle,
-              subtitleTextStyle: _kSettingsSubtitleTextStyle,
-              child: Material(
-                type: MaterialType.transparency,
-                child: Builder(
-                  builder: (ctx) => widget.builder(ctx, focusVisible),
-                ),
-              ),
-            ),
+            child: tile,
           ),
         ),
       ),

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -432,7 +432,10 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
             subtitle: widget.subtitle != null
                 ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
                 : null,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 4,
+            ),
             value: widget.inverted ? !value : value,
             onChanged: widget.enabled
                 ? (v) {
@@ -542,7 +545,10 @@ class _EnumPreferenceTileState<T extends Enum>
                 : null,
             isThreeLine: widget.description != null,
             titleAlignment: ListTileTitleAlignment.center,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 4,
+            ),
             onTap: () => _showPicker(context, current),
           );
         },
@@ -605,8 +611,8 @@ class _EnumPreferenceTileState<T extends Enum>
                           color: invert
                               ? AppColors.black.withValues(alpha: 0.54)
                               : (AppUiIdiomResolver.isApple
-                                  ? AppColorScheme.accent
-                                  : null),
+                                    ? AppColorScheme.accent
+                                    : null),
                         )
                       : null,
                   onTap: () {
@@ -1192,9 +1198,7 @@ class _TvFocusHighlightState extends State<TvFocusHighlight> {
       subtitleTextStyle: _kSettingsSubtitleTextStyle,
       child: Material(
         type: MaterialType.transparency,
-        child: Builder(
-          builder: (ctx) => widget.builder(ctx, focusVisible),
-        ),
+        child: Builder(builder: (ctx) => widget.builder(ctx, focusVisible)),
       ),
     );
     return Focus(

--- a/lib/ui/widgets/settings/settings_motion_profile.dart
+++ b/lib/ui/widgets/settings/settings_motion_profile.dart
@@ -58,7 +58,6 @@ class SettingsMotionProfile {
 
   static SettingsMotionProfile of(BuildContext context) => resolve(
     isTv: PlatformDetection.isTV,
-    disableAnimations:
-        MediaQuery.maybeOf(context)?.disableAnimations ?? false,
+    disableAnimations: MediaQuery.maybeOf(context)?.disableAnimations ?? false,
   );
 }

--- a/lib/ui/widgets/settings/settings_motion_profile.dart
+++ b/lib/ui/widgets/settings/settings_motion_profile.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../util/platform_detection.dart';
+
+/// Rendering policy for settings surfaces.
+///
+/// TV clients trade decorative motion for immediate D-pad feedback. This is
+/// especially important on older Android TV renderers, where sliding and
+/// fading a clipped full-height panel can queue seconds of main/render-thread
+/// work after a single key press.
+class SettingsMotionProfile {
+  final Duration panelTransitionDuration;
+  final Duration nestedTransitionDuration;
+  final Duration nestedReverseTransitionDuration;
+  final Duration tileFocusDuration;
+  final Duration focusScrollDuration;
+  final bool animateTransitions;
+  final bool showFocusGlow;
+  final bool useHardEdgeClip;
+
+  const SettingsMotionProfile({
+    required this.panelTransitionDuration,
+    required this.nestedTransitionDuration,
+    required this.nestedReverseTransitionDuration,
+    required this.tileFocusDuration,
+    required this.focusScrollDuration,
+    required this.animateTransitions,
+    required this.showFocusGlow,
+    required this.useHardEdgeClip,
+  });
+
+  static const quality = SettingsMotionProfile(
+    panelTransitionDuration: Duration(milliseconds: 220),
+    nestedTransitionDuration: Duration(milliseconds: 160),
+    nestedReverseTransitionDuration: Duration(milliseconds: 130),
+    tileFocusDuration: Duration(milliseconds: 90),
+    focusScrollDuration: Duration(milliseconds: 120),
+    animateTransitions: true,
+    showFocusGlow: true,
+    useHardEdgeClip: false,
+  );
+
+  static const performance = SettingsMotionProfile(
+    panelTransitionDuration: Duration.zero,
+    nestedTransitionDuration: Duration.zero,
+    nestedReverseTransitionDuration: Duration.zero,
+    tileFocusDuration: Duration.zero,
+    focusScrollDuration: Duration.zero,
+    animateTransitions: false,
+    showFocusGlow: false,
+    useHardEdgeClip: true,
+  );
+
+  static SettingsMotionProfile resolve({
+    required bool isTv,
+    bool disableAnimations = false,
+  }) => isTv || disableAnimations ? performance : quality;
+
+  static SettingsMotionProfile of(BuildContext context) => resolve(
+    isTv: PlatformDetection.isTV,
+    disableAnimations:
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false,
+  );
+}

--- a/lib/ui/widgets/settings/settings_panel.dart
+++ b/lib/ui/widgets/settings/settings_panel.dart
@@ -115,11 +115,7 @@ class SettingsPanel extends StatelessWidget {
       if (navBorder != null) {
         content = DecoratedBox(
           position: DecorationPosition.foreground,
-          decoration: BoxDecoration(
-            border: Border(
-              left: navBorder,
-            ),
-          ),
+          decoration: BoxDecoration(border: Border(left: navBorder)),
           child: body,
         );
       } else {

--- a/lib/ui/widgets/settings/settings_panel.dart
+++ b/lib/ui/widgets/settings/settings_panel.dart
@@ -11,6 +11,7 @@ import '../../../util/platform_detection.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../overlay_sheet.dart';
 import 'preference_tiles.dart';
+import 'settings_motion_profile.dart';
 
 class SettingsPanel extends StatelessWidget {
   final Widget child;
@@ -31,6 +32,7 @@ class SettingsPanel extends StatelessWidget {
   static Future<void> open(BuildContext context, Widget content) {
     FocusManager.instance.primaryFocus?.unfocus();
     final l10n = AppLocalizations.of(context);
+    final motion = SettingsMotionProfile.of(context);
     isOpenNotifier.value = true;
     final navigatorKey = GlobalKey();
     final future = showGeneralDialog<void>(
@@ -38,10 +40,11 @@ class SettingsPanel extends StatelessWidget {
       barrierDismissible: true,
       barrierLabel: l10n.settings,
       barrierColor: AppColorScheme.scrim.withValues(alpha: 0.54),
-      transitionDuration: const Duration(milliseconds: 220),
+      transitionDuration: motion.panelTransitionDuration,
       pageBuilder: (_, anim, _) =>
           SettingsPanel(navigatorKey: navigatorKey, child: content),
       transitionBuilder: (context, anim, secondAnim, child) {
+        if (!motion.animateTransitions) return child;
         final slide = Tween<Offset>(
           begin: const Offset(1.0, 0.0),
           end: Offset.zero,
@@ -59,6 +62,7 @@ class SettingsPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final motion = SettingsMotionProfile.of(context);
     final screenWidth = MediaQuery.sizeOf(context).width;
     final appleTv = AppUiIdiomResolver.appleTvStyle;
     final isMobile = PlatformDetection.useMobileUi;
@@ -129,7 +133,7 @@ class SettingsPanel extends StatelessWidget {
         borderRadius: BorderRadius.horizontal(
           left: Radius.circular(panelCorner),
         ),
-        clipBehavior: Clip.antiAlias,
+        clipBehavior: motion.useHardEdgeClip ? Clip.hardEdge : Clip.antiAlias,
         child: content,
       ),
     );
@@ -212,13 +216,15 @@ class _SettingsNavigatorState extends State<_SettingsNavigator> {
 extension SettingsPush on BuildContext {
   Future<void> pushSettingsScreen(Widget screen, {FocusNode? returnFocus}) {
     final focusToRestore = returnFocus ?? FocusManager.instance.primaryFocus;
+    final motion = SettingsMotionProfile.of(this);
     return Navigator.of(this)
         .push(
           PageRouteBuilder(
             pageBuilder: (_, _, _) => _AutoFocusWrapper(child: screen),
-            transitionDuration: const Duration(milliseconds: 160),
-            reverseTransitionDuration: const Duration(milliseconds: 130),
+            transitionDuration: motion.nestedTransitionDuration,
+            reverseTransitionDuration: motion.nestedReverseTransitionDuration,
             transitionsBuilder: (context, anim, _, child) {
+              if (!motion.animateTransitions) return child;
               final slide =
                   Tween<Offset>(
                     begin: const Offset(1.0, 0.0),

--- a/test/preference/device_visual_overrides_test.dart
+++ b/test/preference/device_visual_overrides_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/data/services/background_service.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+Future<UserPreferences> _prefs([
+  Map<String, Object> initialValues = const {},
+]) async {
+  SharedPreferences.setMockInitialValues(initialValues);
+  final store = PreferenceStore();
+  await store.init();
+  return UserPreferences(store);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  test('device backdrop override wins without changing profile preference', () async {
+    final prefs = await _prefs();
+
+    expect(prefs.get(UserPreferences.backdropEnabled), isTrue);
+    expect(prefs.shouldShowBackdrops, isTrue);
+
+    await prefs.set(UserPreferences.deviceBackdropsEnabled, false);
+
+    expect(prefs.shouldShowBackdrops, isFalse);
+    expect(prefs.get(UserPreferences.backdropEnabled), isTrue);
+
+    await prefs.set(UserPreferences.deviceBackdropsEnabled, true);
+    expect(prefs.shouldShowBackdrops, isTrue);
+  });
+
+  test('device screensaver override wins without changing profile preference', () async {
+    final prefs = await _prefs();
+
+    expect(prefs.get(UserPreferences.screensaverEnabled), isTrue);
+    expect(prefs.shouldUseInAppScreensaver, isTrue);
+
+    await prefs.set(UserPreferences.deviceScreensaverEnabled, false);
+
+    expect(prefs.shouldUseInAppScreensaver, isFalse);
+    expect(prefs.get(UserPreferences.screensaverEnabled), isTrue);
+
+    await prefs.set(UserPreferences.deviceScreensaverEnabled, true);
+    expect(prefs.shouldUseInAppScreensaver, isTrue);
+  });
+
+  test('device overrides remain active when the signed-in profile changes', () async {
+    final prefs = await _prefs(const {
+      'pref_last_server_id': 'server',
+      'pref_last_user_id': 'user-one',
+      'pref_show_backdrop_server_user-one': true,
+      'pref_screensaver_enabled_server_user-one': true,
+      'pref_show_backdrop_server_user-two': true,
+      'pref_screensaver_enabled_server_user-two': true,
+    });
+
+    await prefs.set(UserPreferences.deviceBackdropsEnabled, false);
+    await prefs.set(UserPreferences.deviceScreensaverEnabled, false);
+    expect(prefs.shouldShowBackdrops, isFalse);
+    expect(prefs.shouldUseInAppScreensaver, isFalse);
+
+    await prefs.set(UserPreferences.lastUserId, 'user-two');
+    expect(prefs.shouldShowBackdrops, isFalse);
+    expect(prefs.shouldUseInAppScreensaver, isFalse);
+    expect(
+      prefs.getEffectivePreference(UserPreferences.deviceBackdropsEnabled).key,
+      UserPreferences.deviceBackdropsEnabled.key,
+    );
+    expect(
+      prefs
+          .getEffectivePreference(UserPreferences.deviceScreensaverEnabled)
+          .key,
+      UserPreferences.deviceScreensaverEnabled.key,
+    );
+  });
+
+  test('background service does not retain URLs while override is off', () async {
+    final prefs = await _prefs();
+    await prefs.set(UserPreferences.deviceBackdropsEnabled, false);
+    GetIt.instance.registerSingleton<UserPreferences>(prefs);
+    final service = BackgroundService();
+
+    service.setBackgroundUrl('https://example.invalid/backdrop.jpg');
+
+    expect(service.currentUrl, isNull);
+    service.dispose();
+  });
+}

--- a/test/ui/widgets/backdrop_render_profile_test.dart
+++ b/test/ui/widgets/backdrop_render_profile_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/ui/widgets/backdrop_render_profile.dart';
+
+void main() {
+  test('automatic uses the performance profile on TV', () {
+    final profile = BackdropRenderProfile.resolve(
+      BackdropRenderMode.automatic,
+      isTv: true,
+    );
+
+    expect(profile.maxDecodeWidth, 720);
+    expect(profile.animateTransitions, isFalse);
+  });
+
+  test('automatic preserves the quality profile off TV', () {
+    final profile = BackdropRenderProfile.resolve(
+      BackdropRenderMode.automatic,
+      isTv: false,
+    );
+
+    expect(profile.maxDecodeWidth, 1280);
+    expect(profile.animateTransitions, isTrue);
+    expect(profile.transitionDuration, const Duration(milliseconds: 800));
+  });
+
+  test('explicit modes override the device default', () {
+    expect(
+      BackdropRenderProfile.resolve(
+        BackdropRenderMode.quality,
+        isTv: true,
+      ),
+      same(BackdropRenderProfile.quality),
+    );
+    expect(
+      BackdropRenderProfile.resolve(
+        BackdropRenderMode.performance,
+        isTv: false,
+      ),
+      same(BackdropRenderProfile.performance),
+    );
+  });
+}

--- a/test/ui/widgets/fullscreen_backdrop_switcher_test.dart
+++ b/test/ui/widgets/fullscreen_backdrop_switcher_test.dart
@@ -3,11 +3,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:moonfin/ui/widgets/fullscreen_backdrop_switcher.dart';
 
 void main() {
-  Widget app(String? imageUrl) {
+  Widget app(String? imageUrl, {bool animateTransitions = true}) {
     return MaterialApp(
       home: FullscreenBackdropSwitcher(
         imageUrl: imageUrl,
         duration: const Duration(milliseconds: 800),
+        animateTransitions: animateTransitions,
         imageBuilder: (url) => Text(url),
       ),
     );
@@ -80,5 +81,31 @@ void main() {
 
     expect(find.text('b'), findsOneWidget);
     expect(find.text('a'), findsNothing);
+  });
+
+  testWidgets('replaces a backdrop immediately when transitions are disabled', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app('a', animateTransitions: false));
+
+    await tester.pumpWidget(app('b', animateTransitions: false));
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsOneWidget);
+    expect(find.byType(FadeTransition), findsNothing);
+  });
+
+  testWidgets('disabling transitions settles an in-flight backdrop', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app('a'));
+    await tester.pumpWidget(app('b'));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    await tester.pumpWidget(app('b', animateTransitions: false));
+
+    expect(find.text('a'), findsNothing);
+    expect(find.text('b'), findsOneWidget);
+    expect(find.byType(FadeTransition), findsNothing);
   });
 }

--- a/test/ui/widgets/settings/settings_motion_profile_test.dart
+++ b/test/ui/widgets/settings/settings_motion_profile_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/settings/settings_motion_profile.dart';
+
+void main() {
+  test('TV settings use immediate low-cost motion', () {
+    final profile = SettingsMotionProfile.resolve(isTv: true);
+
+    expect(profile.panelTransitionDuration, Duration.zero);
+    expect(profile.nestedTransitionDuration, Duration.zero);
+    expect(profile.tileFocusDuration, Duration.zero);
+    expect(profile.focusScrollDuration, Duration.zero);
+    expect(profile.animateTransitions, isFalse);
+    expect(profile.showFocusGlow, isFalse);
+    expect(profile.useHardEdgeClip, isTrue);
+  });
+
+  test('non-TV settings preserve the existing presentation', () {
+    final profile = SettingsMotionProfile.resolve(isTv: false);
+
+    expect(
+      profile.panelTransitionDuration,
+      const Duration(milliseconds: 220),
+    );
+    expect(
+      profile.nestedTransitionDuration,
+      const Duration(milliseconds: 160),
+    );
+    expect(profile.tileFocusDuration, const Duration(milliseconds: 90));
+    expect(profile.focusScrollDuration, const Duration(milliseconds: 120));
+    expect(profile.animateTransitions, isTrue);
+    expect(profile.showFocusGlow, isTrue);
+    expect(profile.useHardEdgeClip, isFalse);
+  });
+
+  test('reduced-motion accessibility uses the performance profile', () {
+    expect(
+      SettingsMotionProfile.resolve(
+        isTv: false,
+        disableAnimations: true,
+      ),
+      same(SettingsMotionProfile.performance),
+    );
+  });
+}

--- a/test/ui/widgets/settings/settings_motion_profile_test.dart
+++ b/test/ui/widgets/settings/settings_motion_profile_test.dart
@@ -17,14 +17,8 @@ void main() {
   test('non-TV settings preserve the existing presentation', () {
     final profile = SettingsMotionProfile.resolve(isTv: false);
 
-    expect(
-      profile.panelTransitionDuration,
-      const Duration(milliseconds: 220),
-    );
-    expect(
-      profile.nestedTransitionDuration,
-      const Duration(milliseconds: 160),
-    );
+    expect(profile.panelTransitionDuration, const Duration(milliseconds: 220));
+    expect(profile.nestedTransitionDuration, const Duration(milliseconds: 160));
     expect(profile.tileFocusDuration, const Duration(milliseconds: 90));
     expect(profile.focusScrollDuration, const Duration(milliseconds: 120));
     expect(profile.animateTransitions, isTrue);
@@ -34,10 +28,7 @@ void main() {
 
   test('reduced-motion accessibility uses the performance profile', () {
     expect(
-      SettingsMotionProfile.resolve(
-        isTv: false,
-        disableAnimations: true,
-      ),
+      SettingsMotionProfile.resolve(isTv: false, disableAnimations: true),
       same(SettingsMotionProfile.performance),
     );
   });


### PR DESCRIPTION
# Pull Request

## Summary

Add device-wide visual controls and a reduced-motion settings path for
low-power TV clients: a master backdrop switch, a TV-aware backdrop render
profile, a master switch that lets the operating-system screensaver take over,
and immediate settings-panel navigation on TV.

## Related Issues

None.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Add unscoped device-wide backdrop and in-app screensaver master switches
  while preserving per-profile settings.
- Route home, classic/modern detail, Seerr, media-bar variants, prefetch, and
  background synchronization through the effective backdrop setting.
- Add Automatic, Quality, and Performance rendering modes; Automatic uses a
  720 px decode budget with no crossfade or Ken Burns motion on TV, while
  retaining the existing quality path elsewhere.
- Release the screensaver wake lock when the device master switch is disabled
  so the Android system dream can run.
- Add a shared settings motion profile. Android TV and accessibility
  reduced-motion clients open the settings panel and nested pages immediately,
  use hard-edge panel clipping, skip animated focus scrolling, and avoid the
  blurred focus glow. Non-TV clients retain the existing transitions and glow.
- Add English and Portuguese settings copy, generated localizations, settings
  search entries, and focused regression tests.

## Platform

- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Ran focused preference, backdrop-render-profile, and settings-motion tests,
   app analysis, and debug/release Android TV builds in CI.
2. Installed the signed beta side by side on a 32-bit ARM Android 9 TV with
   2 GiB RAM; verified home, media bar, modern detail, settings, and nested
   settings pages with device backdrops disabled.
3. Verified the app held no wake lock or keep-screen-on window with the device
   screensaver switch disabled, then confirmed the configured Android photo
   dream took over during idle.
4. Captured two warmed single-DPAD-right home-row samples. The current stable
   control peaked at 127% CPU; the changed build repeated at 17.1% and 3.1%.
5. Measured the sidebar Settings panel separately. A warm pre-change open used
   467 app CPU ticks over 6.930 s (67.4% overall, 236.9% peak) and grew PSS by
   7,330 KiB. The normalized changed-build repeat used 60 ticks over 8.452 s
   (7.1% overall, 166.2% peak) and grew PSS by 1,615 KiB: about 87% fewer ticks,
   89% lower overall CPU, 30% lower sampled peak, and 78% less PSS growth.
6. Verified that a single focus move remained within measurement noise (it was
   already cheap), and that the nested Personalization page opens and navigates
   back correctly.

CI build and validation runs:

- https://github.com/sabino/Moonfin-Core/actions/runs/32994157088
- https://github.com/sabino/Moonfin-Core/actions/runs/33027182766

The measurements are device-level directional evidence, not general
benchmarks.

## Screenshots (if applicable)

Manual 1920x1080 captures were reviewed locally. They contain a private media
library and profiles, so they are intentionally not attached.

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
