### PR TITLE
remove long press delay for home row reordering on desktop

### DIFF
--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1835,7 +1835,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
           SliverToBoxAdapter(child: _buildHeader(l10n)),
         ReorderableAnimatedListImpl<HomeSectionConfig>(
           items: items,
-          dragStartDelay: PlatformDetection.useMobileUi ? Duration(milliseconds: 500) : Duration.zero,
+          dragStartDelay: PlatformDetection.useMobileUi
+              ? const Duration(milliseconds: 500)
+              : Duration.zero,
           scrollDirection: Axis.vertical,
           buildDefaultDragHandles: true,
           // Comparing the enabled state and turning off swap detection makes a

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1835,6 +1835,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
           SliverToBoxAdapter(child: _buildHeader(l10n)),
         ReorderableAnimatedListImpl<HomeSectionConfig>(
           items: items,
+          dragStartDelay: PlatformDetection.useMobileUi ? Duration(milliseconds: 500) : Duration.zero,
           scrollDirection: Axis.vertical,
           buildDefaultDragHandles: true,
           // Comparing the enabled state and turning off swap detection makes a


### PR DESCRIPTION
# Pull Request

## Summary
Because the home sections list uses a ReorderableAnimatedListImpl inside a CustomScrollView, the drag handles on the items are basically ignored, and the scrolling listener takes over. Only a long press allows the items to be reordered. This made some desktop users think they straight up couldn't reorder the home sections on desktop. 

I tried fixing the drag handle so it worked as intended, but there was just no way to force it to take priority (that I could find in the 2 hours I spent trying). It always prioritized the scroll handler first. 

So I added 1 line to remove the long press delay and prioritize reorder over scroll. On mobile, it keeps a 500ms delay to ensure a user can still scroll, and needs to long press to move items. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add dragStartDelay parameter to home sections ReorderableAnimatedList
- if using mobile (touchscreen), set the delay to 500ms to keep the existing "long press" functionality
- on desktop standalone/web, set the delay to 0 since the scroll wheel handles scrolling, not click/drag
- tv uses a different builder for this component and thus is unaffected 

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. On desktop, just click/drag to reorder rows
2. On mobile, click/drag scrolls through the page
3. On mobile, long press then drag will reorder the rows

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
