### PR TITLE
feat(seerr): better posters grid and download progress bar

### DIFF
--- a/lib/data/services/seerr/seerr_download_progress.dart
+++ b/lib/data/services/seerr/seerr_download_progress.dart
@@ -11,12 +11,22 @@ class SeerrDownloadSummary {
   /// the UI can label the full bar instead of showing a stuck 100%.
   final bool isImporting;
 
+  /// Total bytes and how many have arrived. The UI shows these next to the
+  /// percentage. Zero when the server reports no usable sizes.
+  final int totalBytes;
+  final int downloadedBytes;
+
   const SeerrDownloadSummary({
     required this.fraction,
     required this.isImporting,
+    this.totalBytes = 0,
+    this.downloadedBytes = 0,
   });
 
   int get percent => (fraction * 100).round();
+
+  /// Whether the byte counts are worth showing.
+  bool get hasSize => totalBytes > 0;
 
   static const _statusProcessing = 3;
   static const _statusPartiallyAvailable = 4;
@@ -63,6 +73,8 @@ class SeerrDownloadSummary {
     return SeerrDownloadSummary(
       fraction: ((total - left) / total).clamp(0.0, 1.0),
       isImporting: left <= 0,
+      totalBytes: total,
+      downloadedBytes: total - left,
     );
   }
 }

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -94,9 +94,27 @@ class SeerrHttpClient {
       throw DioException(
         requestOptions: response.requestOptions,
         response: response,
-        message: '$context: HTTP ${response.statusCode}',
+        message: '$context: HTTP ${response.statusCode}${_errorDetail(response)}',
       );
     }
+  }
+
+  /// Seerr and the Moonbase proxy send the reason in a JSON body. Include it
+  /// so the screen shows more than a status code.
+  String _errorDetail(Response response) {
+    final data = response.data;
+    if (data == null) return '';
+    String? detail;
+    if (data is Map) {
+      final message = data['message'] ?? data['error'] ?? data['code'];
+      detail = message?.toString();
+    } else if (data is String && data.trim().isNotEmpty) {
+      detail = data.trim();
+    }
+    if (detail == null || detail.isEmpty) return '';
+    // A proxy in front of the server may answer with an HTML error page.
+    if (detail.length > 200) detail = '${detail.substring(0, 200)}...';
+    return ' - $detail';
   }
 
   Future<Map<String, dynamic>> getCurrentUser() async {

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -100,20 +100,18 @@ class SeerrHttpClient {
   }
 
   /// Seerr and the Moonbase proxy send the reason in a JSON body. Include it
-  /// so the screen shows more than a status code.
+  /// so the screen shows more than a status code, and take nothing else. The
+  /// message ends up in the diagnostic report, and a raw body from a proxy in
+  /// front of the server is an error page that can carry paths or tokens the
+  /// report's redaction wasn't written for.
   String _errorDetail(Response response) {
     final data = response.data;
-    if (data == null) return '';
-    String? detail;
-    if (data is Map) {
-      final message = data['message'] ?? data['error'] ?? data['code'];
-      detail = message?.toString();
-    } else if (data is String && data.trim().isNotEmpty) {
-      detail = data.trim();
-    }
+    if (data is! Map) return '';
+    final detail = (data['message'] ?? data['error'] ?? data['code'])
+        ?.toString()
+        .trim();
     if (detail == null || detail.isEmpty) return '';
-    // A proxy in front of the server may answer with an HTML error page.
-    if (detail.length > 200) detail = '${detail.substring(0, 200)}...';
+    if (detail.length > 200) return ' - ${detail.substring(0, 200)}...';
     return ' - $detail';
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5631,6 +5631,43 @@
   "@seerrRequestedStatus": {
     "description": "Seerr media status when item has been requested"
   },
+  "seerrDownloading": "Downloading",
+  "@seerrDownloading": {
+    "description": "Seerr download bar label when the server reports no usable file sizes"
+  },
+  "seerrDownloadingSize": "Downloading · {done} / {total}",
+  "@seerrDownloadingSize": {
+    "description": "Label above the Seerr download progress bar when byte counts are known",
+    "placeholders": {
+      "done": {
+        "type": "String"
+      },
+      "total": {
+        "type": "String"
+      }
+    }
+  },
+  "seerrDownloadedOfTotal": "{done} / {total}",
+  "@seerrDownloadedOfTotal": {
+    "description": "Short form of the Seerr download label, used when the card is too narrow for the verb",
+    "placeholders": {
+      "done": {
+        "type": "String"
+      },
+      "total": {
+        "type": "String"
+      }
+    }
+  },
+  "seerrPercentValue": "{percent}%",
+  "@seerrPercentValue": {
+    "description": "Standalone percentage shown at the end of the Seerr download bar label",
+    "placeholders": {
+      "percent": {
+        "type": "int"
+      }
+    }
+  },
   "seerrDownloadingPercent": "Downloading · {percent}%",
   "@seerrDownloadingPercent": {
     "description": "Label above the Seerr download progress bar",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7552,6 +7552,30 @@ abstract class AppLocalizations {
   /// **'Requested'**
   String get seerrRequestedStatus;
 
+  /// Seerr download bar label when the server reports no usable file sizes
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading'**
+  String get seerrDownloading;
+
+  /// Label above the Seerr download progress bar when byte counts are known
+  ///
+  /// In en, this message translates to:
+  /// **'Downloading · {done} / {total}'**
+  String seerrDownloadingSize(String done, String total);
+
+  /// Short form of the Seerr download label, used when the card is too narrow for the verb
+  ///
+  /// In en, this message translates to:
+  /// **'{done} / {total}'**
+  String seerrDownloadedOfTotal(String done, String total);
+
+  /// Standalone percentage shown at the end of the Seerr download bar label
+  ///
+  /// In en, this message translates to:
+  /// **'{percent}%'**
+  String seerrPercentValue(int percent);
+
   /// Label above the Seerr download progress bar
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -4171,6 +4171,24 @@ class AppLocalizationsAf extends AppLocalizations {
   String get seerrRequestedStatus => 'Versoek';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Laai af · $percent%';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -4169,6 +4169,24 @@ class AppLocalizationsAr extends AppLocalizations {
   String get seerrRequestedStatus => 'مطلوب';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'جارٍ التحميل · $percent%';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -4187,6 +4187,24 @@ class AppLocalizationsBe extends AppLocalizations {
   String get seerrRequestedStatus => 'Запытаны';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Спампоўванне · $percent%';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4190,6 +4190,24 @@ class AppLocalizationsBg extends AppLocalizations {
   String get seerrRequestedStatus => 'Поискано';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Изтегляне · $percent%';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -4158,6 +4158,24 @@ class AppLocalizationsBn extends AppLocalizations {
   String get seerrRequestedStatus => 'অনুরোধ করেছেন';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'ডাউনলোড হচ্ছে · $percent%';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -4225,6 +4225,24 @@ class AppLocalizationsCa extends AppLocalizations {
   String get seerrRequestedStatus => 'Sol·licitat';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Descarregant · $percent%';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4178,6 +4178,24 @@ class AppLocalizationsCs extends AppLocalizations {
   String get seerrRequestedStatus => 'Vyžádáno';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Stahování · $percent %';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -4193,6 +4193,24 @@ class AppLocalizationsCy extends AppLocalizations {
   String get seerrRequestedStatus => 'Gofynwyd';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Wrthi\'n lawrlwytho · $percent%';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4165,6 +4165,24 @@ class AppLocalizationsDa extends AppLocalizations {
   String get seerrRequestedStatus => 'Anmodet';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Downloader · $percent%';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4270,6 +4270,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get seerrRequestedStatus => 'Angefragt';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Wird heruntergeladen · $percent%';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4215,6 +4215,24 @@ class AppLocalizationsEl extends AppLocalizations {
   String get seerrRequestedStatus => 'Ζητήθηκε';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Λήψη · $percent%';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4146,6 +4146,24 @@ class AppLocalizationsEn extends AppLocalizations {
   String get seerrRequestedStatus => 'Requested';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Downloading · $percent%';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -4164,6 +4164,24 @@ class AppLocalizationsEo extends AppLocalizations {
   String get seerrRequestedStatus => 'Petita';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Elŝutante · $percent%';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4200,6 +4200,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seerrRequestedStatus => 'Solicitado';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Descargando · $percent%';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4171,6 +4171,24 @@ class AppLocalizationsEt extends AppLocalizations {
   String get seerrRequestedStatus => 'Soovitud';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Allalaadimine · $percent%';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -4146,6 +4146,24 @@ class AppLocalizationsFa extends AppLocalizations {
   String get seerrRequestedStatus => 'درخواست شده است';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'در حال دانلود · $percent%';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4186,6 +4186,24 @@ class AppLocalizationsFi extends AppLocalizations {
   String get seerrRequestedStatus => 'Pyydetty';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Ladataan · $percent %';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4221,6 +4221,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seerrRequestedStatus => 'Demandé';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Téléchargement · $percent%';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -4214,6 +4214,24 @@ class AppLocalizationsGl extends AppLocalizations {
   String get seerrRequestedStatus => 'Solicitado';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Descargando · $percent%';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -4123,6 +4123,24 @@ class AppLocalizationsHe extends AppLocalizations {
   String get seerrRequestedStatus => 'התבקש';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'מוריד · $percent%';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -4157,6 +4157,24 @@ class AppLocalizationsHi extends AppLocalizations {
   String get seerrRequestedStatus => 'अनुरोध किया';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'डाउनलोड हो रहा है · $percent%';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4288,6 +4288,24 @@ class AppLocalizationsHr extends AppLocalizations {
   String get seerrRequestedStatus => 'Zatraženo';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Preuzimanje · $percent%';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4199,6 +4199,24 @@ class AppLocalizationsHu extends AppLocalizations {
   String get seerrRequestedStatus => 'Kért';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Letöltés · $percent%';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -4170,6 +4170,24 @@ class AppLocalizationsId extends AppLocalizations {
   String get seerrRequestedStatus => 'Diminta';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Mengunduh · $percent%';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4194,6 +4194,24 @@ class AppLocalizationsIt extends AppLocalizations {
   String get seerrRequestedStatus => 'Richiesto';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Scaricamento · $percent%';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -4067,6 +4067,24 @@ class AppLocalizationsJa extends AppLocalizations {
   String get seerrRequestedStatus => 'リクエスト済み';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'ダウンロード中 · $percent%';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -4185,6 +4185,24 @@ class AppLocalizationsKk extends AppLocalizations {
   String get seerrRequestedStatus => 'Сұралған';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Жүктелуде · $percent%';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -4191,6 +4191,24 @@ class AppLocalizationsKn extends AppLocalizations {
   String get seerrRequestedStatus => 'ಕೋರಲಾಗಿದೆ';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ · $percent%';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -4049,6 +4049,24 @@ class AppLocalizationsKo extends AppLocalizations {
   String get seerrRequestedStatus => '요청됨';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return '다운로드 중 · $percent%';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4190,6 +4190,24 @@ class AppLocalizationsLt extends AppLocalizations {
   String get seerrRequestedStatus => 'Paprašyta';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Atsisiunčiama · $percent%';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4188,6 +4188,24 @@ class AppLocalizationsLv extends AppLocalizations {
   String get seerrRequestedStatus => 'Pieprasīts';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Lejupielādē · $percent%';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -4188,6 +4188,24 @@ class AppLocalizationsMk extends AppLocalizations {
   String get seerrRequestedStatus => 'Побарана';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Се презема · $percent%';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -4196,6 +4196,24 @@ class AppLocalizationsMl extends AppLocalizations {
   String get seerrRequestedStatus => 'അഭ്യർത്ഥിച്ചു';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'ഡൗൺലോഡ് ചെയ്യുന്നു · $percent%';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -4178,6 +4178,24 @@ class AppLocalizationsMn extends AppLocalizations {
   String get seerrRequestedStatus => 'Хүссэн';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Татаж байна · $percent%';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4161,6 +4161,24 @@ class AppLocalizationsNb extends AppLocalizations {
   String get seerrRequestedStatus => 'Forespurt';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Laster ned · $percent %';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4192,6 +4192,24 @@ class AppLocalizationsNl extends AppLocalizations {
   String get seerrRequestedStatus => 'Gevraagd';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Downloaden · $percent%';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -4154,6 +4154,24 @@ class AppLocalizationsPa extends AppLocalizations {
   String get seerrRequestedStatus => 'ਬੇਨਤੀ ਕੀਤੀ';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ · $percent%';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4319,6 +4319,24 @@ class AppLocalizationsPl extends AppLocalizations {
   String get seerrRequestedStatus => 'Prośba wysłana';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Pobieranie · $percent%';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4192,6 +4192,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get seerrRequestedStatus => 'Solicitado';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Baixando · $percent%';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4201,6 +4201,24 @@ class AppLocalizationsRo extends AppLocalizations {
   String get seerrRequestedStatus => 'Solicitat';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Se descarcă · $percent%';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -4200,6 +4200,24 @@ class AppLocalizationsRu extends AppLocalizations {
   String get seerrRequestedStatus => 'Запрошено';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Скачивание · $percent%';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -4166,6 +4166,24 @@ class AppLocalizationsSi extends AppLocalizations {
   String get seerrRequestedStatus => 'ඉල්ලා ඇත';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'බාගත වෙමින් · $percent%';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4191,6 +4191,24 @@ class AppLocalizationsSk extends AppLocalizations {
   String get seerrRequestedStatus => 'Požadované';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Sťahuje sa · $percent %';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4194,6 +4194,24 @@ class AppLocalizationsSl extends AppLocalizations {
   String get seerrRequestedStatus => 'Zahtevano';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Prenašanje · $percent %';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -4201,6 +4201,24 @@ class AppLocalizationsSq extends AppLocalizations {
   String get seerrRequestedStatus => 'Kërkuar';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Po shkarkohet · $percent%';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4289,6 +4289,24 @@ class AppLocalizationsSr extends AppLocalizations {
   String get seerrRequestedStatus => 'Захтевано';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Преузимање · $percent%';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4169,6 +4169,24 @@ class AppLocalizationsSv extends AppLocalizations {
   String get seerrRequestedStatus => 'Begärde';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Laddar ner · $percent%';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -4197,6 +4197,24 @@ class AppLocalizationsSw extends AppLocalizations {
   String get seerrRequestedStatus => 'Umeomba';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Inapakua · $percent%';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -4202,6 +4202,24 @@ class AppLocalizationsTa extends AppLocalizations {
   String get seerrRequestedStatus => 'கோரப்பட்டது';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'பதிவிறக்குகிறது · $percent%';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -4191,6 +4191,24 @@ class AppLocalizationsTe extends AppLocalizations {
   String get seerrRequestedStatus => 'అభ్యర్థించారు';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'డౌన్‌లోడ్ అవుతోంది · $percent%';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -4135,6 +4135,24 @@ class AppLocalizationsTh extends AppLocalizations {
   String get seerrRequestedStatus => 'ร้องขอ';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'กำลังดาวน์โหลด · $percent%';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -4208,6 +4208,24 @@ class AppLocalizationsTl extends AppLocalizations {
   String get seerrRequestedStatus => 'Hiniling';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Nagda-download · $percent%';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -4179,6 +4179,24 @@ class AppLocalizationsTr extends AppLocalizations {
   String get seerrRequestedStatus => 'İstendi';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'İndiriliyor · %$percent';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -4175,6 +4175,24 @@ class AppLocalizationsUg extends AppLocalizations {
   String get seerrRequestedStatus => 'تەلەپ قىلىندى';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'چۈشۈرۈلۈۋاتىدۇ · $percent%';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -4194,6 +4194,24 @@ class AppLocalizationsUk extends AppLocalizations {
   String get seerrRequestedStatus => 'Просив';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Завантаження · $percent%';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -4170,6 +4170,24 @@ class AppLocalizationsVi extends AppLocalizations {
   String get seerrRequestedStatus => 'Đã yêu cầu';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return 'Đang tải xuống · $percent%';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -4033,6 +4033,24 @@ class AppLocalizationsYue extends AppLocalizations {
   String get seerrRequestedStatus => '已請求';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return '下載緊 · $percent%';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4010,6 +4010,24 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seerrRequestedStatus => '已请求';
 
   @override
+  String get seerrDownloading => 'Downloading';
+
+  @override
+  String seerrDownloadingSize(String done, String total) {
+    return 'Downloading · $done / $total';
+  }
+
+  @override
+  String seerrDownloadedOfTotal(String done, String total) {
+    return '$done / $total';
+  }
+
+  @override
+  String seerrPercentValue(int percent) {
+    return '$percent%';
+  }
+
+  @override
   String seerrDownloadingPercent(int percent) {
     return '下载中 · $percent%';
   }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7150,9 +7150,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final withDownloads = downloads == null
         ? rowContent
         : Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
               rowContent,
+              // Space it off the buttons, or it reads as an underline.
+              SizedBox(height: buttonRunSpacing),
               SeerrItemDownloadBars(state: downloads),
             ],
           );

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -66,8 +66,8 @@ import '../../../widgets/seerr/seerr_collection_banner.dart';
 import '../../../widgets/seerr/seerr_item_chips.dart';
 import '../../../widgets/seerr/seerr_request_dialog.dart';
 import '../../../widgets/seerr/seerr_item_status.dart';
-import '../../../widgets/seerr/seerr_stats_card.dart';
 import '../../../widgets/seerr/seerr_status_pill.dart';
+import '../../../widgets/seerr/seerr_stats_card.dart';
 
 double _desktopUiScale({UserPreferences? prefs}) {
   final effectivePrefs = prefs ?? GetIt.instance<UserPreferences>();
@@ -4211,8 +4211,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (item.genres.isNotEmpty) {
       addText(item.genres.take(3).join(' · '));
     }
-    // A badge rather than another word in the line, so it sits outside the dot
-    // separators.
+    // A badge rather than another word in the line, so it sits outside the
+    // dot separators.
     final seerrStatus = seerrItemStatus(_vm);
     final seerrPills = seerrStatus == null
         ? null

--- a/lib/ui/screens/seerr/seerr_requests_screen.dart
+++ b/lib/ui/screens/seerr/seerr_requests_screen.dart
@@ -1,7 +1,10 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
+import 'package:intl/intl.dart';
 import 'package:go_router/go_router.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
@@ -22,6 +25,7 @@ import '../../widgets/adaptive/adaptive_glass.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/seerr_download_progress_bar.dart';
+import '../../widgets/seerr/seerr_media_type_badge.dart';
 import '../../widgets/seerr/seerr_text_field.dart';
 import '../../widgets/seerr/seerr_tv_controls.dart';
 import '../../widgets/track_selector_dialog.dart';
@@ -29,13 +33,44 @@ import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/focusable_wrapper.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 
-const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w200';
+// w342, like the other Seerr screens. w200 is too soft once the grid
+// enlarges it.
+const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w342';
+
+/// Row height for the request card, the issue card and the skeleton. Shared
+/// so a card does not jump when it loads. Fits the worst case: title, status
+/// or progress bar, requester, date and actions.
+const double _cardHeight = 175;
+
+/// Poster width on the stacked card. Keeps a 1.59 ratio with [_cardHeight].
+const double _cardPosterWidth = 110;
 
 double _uiScale() => PlatformDetection.useDesktopUi
     ? GetIt.instance<UserPreferences>()
           .get(UserPreferences.desktopUiScale)
           .scaleFactor
     : 1.0;
+
+/// Timestamps arrive as ISO strings. Parse them so intl can format for the
+/// locale.
+String _formatRequestDate(BuildContext context, String? iso) {
+  if (iso == null || iso.isEmpty) return '';
+  final parsed = DateTime.tryParse(iso);
+  if (parsed == null) return '';
+  final locale = Localizations.localeOf(context).toString();
+  return DateFormat.yMMMd(locale).format(parsed.toLocal());
+}
+
+/// Badge text in a light tint of the badge colour, like Seerr does. Keeps the
+/// badge one hue instead of dropping flat white or black into it.
+Color _badgeForeground(Color background) =>
+    Color.lerp(background, Colors.white, 0.82) ?? Colors.white;
+
+/// Poster grid on desktop and TV, stacked card on phone and tablet.
+///
+/// On TV both `useMobileUi` and `useDesktopUi` are false, so "not mobile" is
+/// the check that covers desktop and TV together.
+bool get _usesTileGrid => !PlatformDetection.useMobileUi;
 
 /// Foreground that stays readable on a filled status-colored button.
 Color _onStatusColor(Color background) =>
@@ -206,7 +241,14 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
-          padding: EdgeInsets.fromLTRB(tabsLeft, topInset + 16, 16, 0),
+          // The TV navbar reservation already clears the toolbar, so it
+          // needs less room above the tabs.
+          padding: EdgeInsets.fromLTRB(
+            tabsLeft,
+            topInset + (PlatformDetection.isTV ? 4 : 16),
+            16,
+            0,
+          ),
           child: Row(
             children: [
               _HubTab(
@@ -271,32 +313,64 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
 
     return Padding(
       padding: EdgeInsets.fromLTRB(_leftInset, 4, 16, 8),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            for (final f in SeerrRequestFilter.values) ...[
-              _HubChip(
-                label: filterLabel(f),
-                count: f == SeerrRequestFilter.pending ? pendingCount : null,
-                selected: s.filter == f,
-                onTap: () => vm.setFilter(f),
-              ),
+      // Its own group, so the chips are one target reached by pressing up
+      // from the grid.
+      child: FocusTraversalGroup(
+        policy: ReadingOrderTraversalPolicy(),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (final f in SeerrRequestFilter.values) ...[
+                _HubChip(
+                  label: filterLabel(f),
+                  count: f == SeerrRequestFilter.pending ? pendingCount : null,
+                  selected: s.filter == f,
+                  onTap: () => vm.setFilter(f),
+                ),
+                const SizedBox(width: 8),
+              ],
               const SizedBox(width: 8),
+              _HubChip(
+                label: s.sort == 'added'
+                    ? '${l10n.sortBy}: ${l10n.sortNewest}'
+                    : '${l10n.sortBy}: ${l10n.sortLastModified}',
+                selected: false,
+                onTap: () =>
+                    vm.setSort(s.sort == 'added' ? 'modified' : 'added'),
+              ),
             ],
-            const SizedBox(width: 8),
-            _HubChip(
-              label: s.sort == 'added'
-                  ? '${l10n.sortBy}: ${l10n.sortNewest}'
-                  : '${l10n.sortBy}: ${l10n.sortLastModified}',
-              selected: false,
-              onTap: () =>
-                  vm.setSort(s.sort == 'added' ? 'modified' : 'added'),
-            ),
-          ],
+          ),
         ),
       ),
     );
+  }
+
+  /// Geometry from the last tile-grid layout, so a focus move can snap to a
+  /// whole row instead of stopping wherever ensureVisible left it.
+  ({int perLine, double lineExtent, double lineSpacing, double leadingPad})?
+  _tileGeometry;
+
+  /// Slide the grid so the focused tile's row starts at the top. Runs after
+  /// the frame so it settles after the focus system has scrolled.
+  void _snapToTileRow(int index) {
+    if (!_usesTileGrid) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final g = _tileGeometry;
+      if (g == null || !mounted || !_requestsScroll.hasClients) return;
+      final line = index ~/ g.perLine;
+      final target =
+          (g.leadingPad + line * (g.lineExtent + g.lineSpacing)).clamp(
+            0.0,
+            _requestsScroll.position.maxScrollExtent,
+          );
+      if ((_requestsScroll.position.pixels - target).abs() < 1) return;
+      _requestsScroll.animateTo(
+        target,
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOut,
+      );
+    });
   }
 
   Widget _buildRequestsList(
@@ -324,6 +398,58 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
     }
 
     final disableAnimations = MediaQuery.of(context).disableAnimations;
+    final scale = _uiScale();
+
+    Widget entry(int index) {
+      final req = s.requests[index];
+      final animate =
+          !disableAnimations && !_animatedRequestIds.contains(req.id);
+      if (animate) _animatedRequestIds.add(req.id);
+      return _Entrance(
+        key: ValueKey('req-${req.id}'),
+        animate: animate,
+        slot: index.clamp(0, 8),
+        child: _RequestCard(
+          request: req,
+          summary: s.summaryFor(req),
+          canManage: s.canManageRequests,
+          isActioning: s.actioningRequestId == req.id,
+          onTap: () => _onRequestTap(req),
+          onApprove: () => vm.approveRequest(req.id),
+          onDecline: () => vm.declineRequest(req.id),
+          onRetry: () => vm.retryRequest(req.id),
+          onFocusGained: () => _snapToTileRow(index),
+        ),
+      );
+    }
+
+    if (_usesTileGrid) {
+      return RefreshIndicator(
+        onRefresh: vm.refresh,
+        // Its own traversal group, so an arrow press finds the next poster
+        // before it leaves for the filter chips.
+        child: FocusTraversalGroup(
+          policy: ReadingOrderTraversalPolicy(),
+          child: LayoutBuilder(
+            builder: (context, constraints) => GridView.builder(
+              controller: _requestsScroll,
+              // Top inset leaves room for the focus scale on the first row.
+              padding: EdgeInsets.fromLTRB(_leftInset, 12, 16, 80),
+              gridDelegate: _tileGrid(
+                scale,
+                constraints.maxWidth - _leftInset - 16,
+                12,
+              ),
+              itemCount: s.requests.length + (s.hasMore ? 1 : 0),
+              itemBuilder: (context, index) => index >= s.requests.length
+                  ? const _LoaderRow()
+                  : entry(index),
+            ),
+          ),
+        ),
+      );
+    }
+
     return RefreshIndicator(
       onRefresh: vm.refresh,
       child: ListView.builder(
@@ -470,7 +596,58 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
     );
   }
 
+  /// Shared by the grid and its skeleton, so the loading state has the same
+  /// shape as what replaces it.
+  /// Height a tile needs beyond its poster: caption inset, title, status or
+  /// progress, requester and date (106), plus 24 of slack for the focus scale.
+  /// A constant because the grid needs it before layout.
+  static const double _captionHeight = 130;
+
+  /// Grid sized so a tile holds a whole 2:3 poster plus the caption. Records
+  /// the geometry it works out so the row snap uses the same numbers.
+  ///
+  /// The ratio comes from the real tile width: the poster scales with width
+  /// but the caption is a fixed height, so no single ratio works everywhere.
+  SliverGridDelegate _tileGrid(double scale, double available, double topPad) {
+    final extent = (PlatformDetection.isTV ? 150.0 : 220.0) * scale;
+    final spacing = 16 * scale;
+    final rowSpacing = 24 * scale;
+    final columns = math.max(
+      1,
+      ((available + spacing) / (extent + spacing)).ceil(),
+    );
+    final tileWidth = (available - spacing * (columns - 1)) / columns;
+    final tileHeight = tileWidth * 1.5 + _captionHeight * scale;
+    _tileGeometry = (
+      perLine: columns,
+      lineExtent: tileHeight,
+      lineSpacing: rowSpacing,
+      leadingPad: topPad,
+    );
+    return SliverGridDelegateWithFixedCrossAxisCount(
+      crossAxisCount: columns,
+      childAspectRatio: tileWidth / tileHeight,
+      crossAxisSpacing: spacing,
+      mainAxisSpacing: rowSpacing,
+    );
+  }
+
   Widget _buildSkeletonList() {
+    if (_usesTileGrid) {
+      return LayoutBuilder(
+        builder: (context, constraints) => GridView.builder(
+          physics: const NeverScrollableScrollPhysics(),
+          padding: EdgeInsets.fromLTRB(_leftInset, 12, 16, 80),
+          gridDelegate: _tileGrid(
+            _uiScale(),
+            constraints.maxWidth - _leftInset - 16,
+            12,
+          ),
+          itemCount: 12,
+          itemBuilder: (_, _) => const _SkeletonCard(tile: true),
+        ),
+      );
+    }
     return ListView(
       physics: const NeverScrollableScrollPhysics(),
       padding: EdgeInsets.fromLTRB(_leftInset, 8, 16, 80),
@@ -616,7 +793,10 @@ class _LoaderRow extends StatelessWidget {
 
 /// Pulsing placeholder card shown while a tab loads.
 class _SkeletonCard extends StatefulWidget {
-  const _SkeletonCard();
+  /// Poster-shaped, matching the desktop grid, rather than the stacked row.
+  final bool tile;
+
+  const _SkeletonCard({this.tile = false});
 
   @override
   State<_SkeletonCard> createState() => _SkeletonCardState();
@@ -652,8 +832,51 @@ class _SkeletonCardState extends State<_SkeletonCard>
             borderRadius: AppRadius.circular(4),
           ),
         );
+        if (widget.tile) {
+          // Same slack as the real tile, so the poster is the same size.
+          return Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AspectRatio(
+                  aspectRatio: 2 / 3,
+                  child: Container(
+                    width: double.infinity,
+                    decoration: BoxDecoration(
+                      color: fill,
+                      borderRadius: radius,
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    10 * scale,
+                    8 * scale,
+                    10 * scale,
+                    10 * scale,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      bar(120, 13),
+                      SizedBox(height: 4 * scale),
+                      bar(70, 18),
+                      SizedBox(height: 4 * scale),
+                      bar(100, 11),
+                      SizedBox(height: 4 * scale),
+                      bar(80, 11),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          );
+        }
+
         return Container(
-          height: 140 * scale,
+          height: _cardHeight * scale,
           margin: EdgeInsets.only(bottom: 12 * scale),
           decoration: BoxDecoration(
             color: AppColorScheme.onSurface.withValues(alpha: 0.04),
@@ -662,7 +885,7 @@ class _SkeletonCardState extends State<_SkeletonCard>
           child: Row(
             children: [
               Container(
-                width: 93 * scale,
+                width: _cardPosterWidth * scale,
                 decoration: BoxDecoration(
                   color: fill,
                   borderRadius: BorderRadius.only(
@@ -840,9 +1063,12 @@ class _HubChipState extends State<_HubChip> with FocusStateMixin {
             scale: showFocusBorder ? 1.05 : 1.0,
             duration: const Duration(milliseconds: 120),
             child: Container(
+              // The border grows 1 -> 2 on focus and adds to the container
+              // size, so take that pixel back out of the padding to keep the
+              // box steady.
               padding: EdgeInsets.symmetric(
-                horizontal: 12 * scale,
-                vertical: 6 * scale,
+                horizontal: 12 * scale - (showFocusBorder ? 1 : 0),
+                vertical: 6 * scale - (showFocusBorder ? 1 : 0),
               ),
               decoration: BoxDecoration(
                 color: widget.selected
@@ -1003,12 +1229,18 @@ class _HubCardShell extends StatelessWidget {
   final bool highlighted;
   final Color highlightColor;
   final bool expandOnFocus;
+
+  /// Gap under the card, for the stacked list. The grid uses mainAxisSpacing
+  /// instead, where this margin would eat into every cell.
+  final bool spacedBelow;
+
   final Widget child;
 
   const _HubCardShell({
     required this.highlighted,
     required this.highlightColor,
     required this.expandOnFocus,
+    this.spacedBelow = true,
     required this.child,
   });
 
@@ -1022,7 +1254,9 @@ class _HubCardShell extends StatelessWidget {
       duration: const Duration(milliseconds: 120),
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 120),
-        margin: EdgeInsets.only(bottom: 12 * scale),
+        margin: spacedBelow
+            ? EdgeInsets.only(bottom: 12 * scale)
+            : EdgeInsets.zero,
         decoration: BoxDecoration(
           borderRadius: radius,
           border: Border.fromBorderSide(
@@ -1049,28 +1283,33 @@ class _HubCardShell extends StatelessWidget {
   }
 }
 
-class _TypeBadge extends StatelessWidget {
+/// One badge shape for the request card, so the type badge and the status
+/// pill match in height.
+class _Badge extends StatelessWidget {
   final String label;
   final Color color;
 
-  const _TypeBadge({required this.label, required this.color});
+  const _Badge({required this.label, required this.color});
 
   @override
   Widget build(BuildContext context) {
     final scale = _uiScale();
     return Container(
-      padding: EdgeInsets.symmetric(horizontal: 6 * scale, vertical: 2 * scale),
+      padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 3 * scale),
       decoration: BoxDecoration(
-        color: color,
+        // Seerr's badge treatment: fill at 80%, a full border of the same
+        // hue, light text of that hue. Reads better on dark than solid with
+        // white text.
+        color: color.withValues(alpha: 0.8),
+        border: Border.all(color: color),
         borderRadius: AppRadius.circular(4),
       ),
       child: Text(
         label,
         style: TextStyle(
-          color: AppColorScheme.onBadge,
-          fontSize: 9.5 * scale,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0.4,
+          color: _badgeForeground(color),
+          fontSize: 11 * scale,
+          fontWeight: FontWeight.w600,
         ),
       ),
     );
@@ -1087,6 +1326,10 @@ class _RequestCard extends StatefulWidget {
   final VoidCallback? onDecline;
   final VoidCallback? onRetry;
 
+  /// Fired when this card takes focus, so the grid can slide its row to a
+  /// whole-row offset instead of leaving the next one half cut.
+  final VoidCallback? onFocusGained;
+
   const _RequestCard({
     required this.request,
     this.summary,
@@ -1096,6 +1339,7 @@ class _RequestCard extends StatefulWidget {
     this.onApprove,
     this.onDecline,
     this.onRetry,
+    this.onFocusGained,
   });
 
   @override
@@ -1127,7 +1371,7 @@ class _RequestCardState extends State<_RequestCard> with FocusStateMixin {
     final title =
         media?.title ?? media?.name ?? widget.summary?.title ?? l10n.unknown;
     final requester = request.requestedBy?.bestName ?? l10n.unknown;
-    final date = request.createdAt?.split('T').first ?? '';
+    final date = _formatRequestDate(context, request.createdAt);
 
     return _CardActionFocus(
       cardFocus: _cardFocus,
@@ -1135,11 +1379,19 @@ class _RequestCardState extends State<_RequestCard> with FocusStateMixin {
       child: MouseRegion(
         onEnter: (_) => setHovered(true),
         onExit: (_) => setHovered(false),
-        child: _HubCardShell(
-          highlighted: showFocusBorder,
-          highlightColor: focusColor,
-          expandOnFocus: cardFocusExpansion,
-          child: _buildCard(l10n, posterPath, title, requester, date),
+        // Room inside the cell for the focus scale. The scale is a transform
+        // so it never widens the layout box, and ensureVisible parks a focused
+        // cell flush against the viewport edge. A 344px tile at 1.02 needs
+        // 3.4px a side; 12 also covers the border, a theme glow and rounding.
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: _usesTileGrid ? 12 : 0),
+          child: _HubCardShell(
+            highlighted: showFocusBorder,
+            highlightColor: focusColor,
+            expandOnFocus: cardFocusExpansion,
+            spacedBelow: !_usesTileGrid,
+            child: _buildCard(l10n, posterPath, title, requester, date),
+          ),
         ),
       ),
     );
@@ -1152,150 +1404,375 @@ class _RequestCardState extends State<_RequestCard> with FocusStateMixin {
     String requester,
     String date,
   ) {
-    final scale = _uiScale();
-    final onSurface = AppColorScheme.onSurface;
-    final isTv = request.type == 'tv';
-    final typeLabel = (isTv ? l10n.series : l10n.movie).toUpperCase();
-    final modifier = request.modifiedBy?.bestName;
-    final downloadSummary = SeerrDownloadSummary.forRequest(request);
-
     return InkWell(
       onTap: widget.onTap,
       focusNode: _cardFocus,
-      onFocusChange: setFocused,
-      child: SizedBox(
-        height: 140 * scale,
-        child: Row(
-          children: [
-            SizedBox(
-              width: 93 * scale,
-              child: posterPath != null
-                  ? CachedNetworkImage(
-                      imageUrl: '$_tmdbPosterBase$posterPath',
-                      fit: BoxFit.cover,
-                      height: double.infinity,
-                      placeholder: (_, _) =>
-                          ColoredBox(color: AppColorScheme.surfaceVariant),
-                    )
-                  : Container(
-                      color: AppColorScheme.surfaceVariant,
-                      child: Icon(
-                        Icons.movie,
-                        color: onSurface.withValues(alpha: 0.24),
-                        size: 40 * scale,
-                      ),
+      onFocusChange: (value) {
+        setFocused(value);
+        if (value) widget.onFocusGained?.call();
+      },
+      child: _usesTileGrid
+          ? _posterTile(l10n, posterPath, title, requester, date)
+          : _compactRow(l10n, posterPath, title, requester, date),
+    );
+  }
+
+  /// Poster tile for the desktop and TV grid. The poster is what you scan and
+  /// the stripe under it carries the status. Phone and tablet keep the card.
+  Widget _posterTile(
+    AppLocalizations l10n,
+    String? posterPath,
+    String title,
+    String requester,
+    String date,
+  ) {
+    final scale = _uiScale();
+    final onSurface = AppColorScheme.onSurface;
+    final downloadSummary = SeerrDownloadSummary.forRequest(request);
+    final (statusLabel, statusColor) = _StatusChip.infoFor(request, l10n);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // A true 2:3. As Expanded it took whatever the caption left over and
+        // BoxFit.cover cropped it.
+        AspectRatio(
+          aspectRatio: 2 / 3,
+          child: ClipRRect(
+            borderRadius: AppRadius.circular(8),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (posterPath != null)
+                  CachedNetworkImage(
+                    imageUrl: '$_tmdbPosterBase$posterPath',
+                    fit: BoxFit.cover,
+                    placeholder: (_, _) =>
+                        ColoredBox(color: AppColorScheme.surfaceVariant),
+                  )
+                else
+                  Container(
+                    color: AppColorScheme.surfaceVariant,
+                    child: Icon(
+                      Icons.movie,
+                      color: onSurface.withValues(alpha: 0.24),
+                      size: 40 * scale,
                     ),
-            ),
-            Expanded(
-              child: Padding(
-                padding: EdgeInsets.all(12 * scale),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: TextStyle(
-                        color: onSurface,
-                        fontSize: 15 * scale,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    SizedBox(height: 6 * scale),
-                    Row(
-                      children: [
-                        _TypeBadge(
-                          label: request.is4k ? '$typeLabel · 4K' : typeLabel,
-                          color: isTv
-                              ? AppColorScheme.mediaTypeBadgeShow
-                              : AppColorScheme.mediaTypeBadgeMovie,
-                        ),
-                      ],
-                    ),
-                    const Spacer(),
-                    Row(
-                      children: [
-                        _StatusChip(request: request),
-                        const Spacer(),
-                        if (date.isNotEmpty)
-                          Text(
-                            date,
-                            style: TextStyle(
-                              color: onSurface.withValues(alpha: 0.38),
-                              fontSize: 11 * scale,
-                            ),
-                          ),
-                      ],
-                    ),
-                    if (downloadSummary != null) ...[
-                      SizedBox(height: 4 * scale),
-                      SeerrDownloadProgressBar(
-                        summary: downloadSummary,
-                        scale: scale,
-                      ),
-                    ],
-                    SizedBox(height: 4 * scale),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            modifier != null
-                                ? '${l10n.requestedByName(requester)} · ${l10n.modifiedByName(modifier)}'
-                                : l10n.requestedByName(requester),
-                            style: TextStyle(
-                              color: onSurface.withValues(alpha: 0.54),
-                              fontSize: 12 * scale,
-                            ),
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                        if (widget.isActioning)
-                          SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: onSurface,
-                            ),
-                          )
-                        else if (widget.canManage &&
-                            request.status == SeerrRequest.statusPending) ...[
-                          _CardActionButton(
-                            label: l10n.approve,
-                            icon: Icons.check_circle_outline,
-                            color: AppColorScheme.statusAvailable,
-                            focusNode: _approveFocus,
-                            onPressed: widget.onApprove,
-                          ),
-                          const SizedBox(width: 6),
-                          _CardActionButton(
-                            label: l10n.declineAction,
-                            icon: Icons.cancel_outlined,
-                            color: AppColorScheme.statusError,
-                            focusNode: _declineFocus,
-                            onPressed: widget.onDecline,
-                          ),
-                        ] else if (widget.canManage &&
-                            request.status == SeerrRequest.statusFailed)
-                          _CardActionButton(
-                            label: l10n.retry,
-                            icon: Icons.refresh,
-                            color: AppColorScheme.statusPending,
-                            focusNode: _retryFocus,
-                            onPressed: widget.onRetry,
-                          ),
-                      ],
-                    ),
-                  ],
+                  ),
+                Positioned(
+                  top: 8 * scale,
+                  left: 8 * scale,
+                  child: SeerrMediaTypeBadge(
+                    mediaType: request.type,
+                    suffix: request.is4k ? '4K' : null,
+                    scale: scale,
+                  ),
                 ),
+                // Status colour only. Progress is the bar under the title.
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: _StatusStripe(color: statusColor, scale: scale),
+                ),
+              ],
+            ),
+          ),
+        ),
+        // Inset so the caption does not touch the card edges.
+        Padding(
+          padding: EdgeInsets.fromLTRB(
+            10 * scale,
+            8 * scale,
+            10 * scale,
+            10 * scale,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                title,
+                style: TextStyle(
+                  color: onSurface,
+                  fontSize: 14 * scale,
+                  fontWeight: FontWeight.w600,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              SizedBox(height: 4 * scale),
+              // Fixed height. The bar is taller than a status word and the
+              // poster takes what the caption leaves, so reserve one height to
+              // keep posters level across a row.
+              SizedBox(
+                height: 26 * scale,
+                width: double.infinity,
+                child: downloadSummary != null
+                    ? Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: SeerrDownloadProgressBar(
+                          summary: downloadSummary,
+                          // The tile's own scale, so the bar stays in
+                          // proportion with the caption around it.
+                          scale: scale,
+                        ),
+                      )
+                    : Align(
+                        alignment: AlignmentDirectional.centerStart,
+                        child: _StatusPill(
+                          label: statusLabel,
+                          color: statusColor,
+                        ),
+                      ),
+              ),
+              SizedBox(height: 4 * scale),
+              Text(
+                l10n.requestedByName(requester),
+                style: TextStyle(
+                  color: onSurface.withValues(alpha: 0.54),
+                  fontSize: 12 * scale,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (date.isNotEmpty)
+                Text(
+                  date,
+                  style: TextStyle(
+                    color: onSurface.withValues(alpha: 0.38),
+                    fontSize: 12 * scale,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              if (_actions(l10n, onSurface).isNotEmpty) ...[
+                SizedBox(height: 6 * scale),
+                Row(children: _actions(l10n, onSurface)),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _compactRow(
+    AppLocalizations l10n,
+    String? posterPath,
+    String title,
+    String requester,
+    String date,
+  ) {
+    final scale = _uiScale();
+    final onSurface = AppColorScheme.onSurface;
+    final downloadSummary = SeerrDownloadSummary.forRequest(request);
+    return SizedBox(
+      // Fixed on purpose. The list gives children an unbounded height, so
+      // sizing to content here (stretch, IntrinsicHeight) throws.
+      height: _cardHeight * scale,
+      child: Row(
+        children: [
+          SizedBox(
+            width: _cardPosterWidth * scale,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                if (posterPath != null)
+                  CachedNetworkImage(
+                    imageUrl: '$_tmdbPosterBase$posterPath',
+                    fit: BoxFit.cover,
+                    height: double.infinity,
+                    placeholder: (_, _) =>
+                        ColoredBox(color: AppColorScheme.surfaceVariant),
+                  )
+                else
+                  Container(
+                    color: AppColorScheme.surfaceVariant,
+                    child: Icon(
+                      Icons.movie,
+                      color: onSurface.withValues(alpha: 0.24),
+                      size: 40 * scale,
+                    ),
+                  ),
+                // On the artwork like the poster tiles, so the title keeps
+                // the full line.
+                Positioned(
+                  top: 6 * scale,
+                  left: 6 * scale,
+                  child: SeerrMediaTypeBadge(
+                    mediaType: request.type,
+                    suffix: request.is4k ? '4K' : null,
+                    scale: scale,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.all(12 * scale),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // The type badge is on the poster, so the title has the
+                  // full width.
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: onSurface,
+                      fontSize: 15 * scale,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  SizedBox(height: 6 * scale),
+                  // One state line, like the grid. The bar says more than the
+                  // chip, and the two together contradict each other.
+                  if (downloadSummary != null)
+                    SeerrDownloadProgressBar(summary: downloadSummary)
+                  else
+                    _StatusChip(request: request),
+                  // Pins the provenance to the foot so it lines up across the
+                  // list. The card height is fixed, so the slack is real.
+                  const Spacer(),
+                  Row(
+                    children: [
+                      Expanded(
+                        // Who asked, then when. The editor is usually the
+                        // requester, so it is not shown.
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              l10n.requestedByName(requester),
+                              style: TextStyle(
+                                color: onSurface.withValues(alpha: 0.54),
+                                fontSize: 12 * scale,
+                              ),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            if (date.isNotEmpty)
+                              Text(
+                                date,
+                                style: TextStyle(
+                                  color: onSurface.withValues(alpha: 0.38),
+                                  fontSize: 12 * scale,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                          ],
+                        ),
+                      ),
+                      if (widget.isActioning)
+                        SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: onSurface,
+                          ),
+                        )
+                      else if (widget.canManage &&
+                          request.status == SeerrRequest.statusPending) ...[
+                        _CardActionButton(
+                          label: l10n.approve,
+                          icon: Icons.check_circle_outline,
+                          color: AppColorScheme.statusAvailable,
+                          focusNode: _approveFocus,
+                          onPressed: widget.onApprove,
+                        ),
+                        const SizedBox(width: 6),
+                        _CardActionButton(
+                          label: l10n.declineAction,
+                          icon: Icons.cancel_outlined,
+                          color: AppColorScheme.statusError,
+                          focusNode: _declineFocus,
+                          onPressed: widget.onDecline,
+                        ),
+                      ] else if (widget.canManage &&
+                          request.status == SeerrRequest.statusFailed)
+                        _CardActionButton(
+                          label: l10n.retry,
+                          icon: Icons.refresh,
+                          color: AppColorScheme.statusPending,
+                          focusNode: _retryFocus,
+                          onPressed: widget.onRetry,
+                        ),
+                    ],
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
+
+  /// Approve/decline, retry, or the spinner. Shared so the tile and the card
+  /// offer the same actions.
+  List<Widget> _actions(AppLocalizations l10n, Color onSurface) {
+    if (widget.isActioning) {
+      return [
+        SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2, color: onSurface),
+        ),
+      ];
+    }
+    if (widget.canManage && request.status == SeerrRequest.statusPending) {
+      return [
+        _CardActionButton(
+          label: l10n.approve,
+          icon: Icons.check_circle_outline,
+          color: AppColorScheme.statusAvailable,
+          focusNode: _approveFocus,
+          onPressed: widget.onApprove,
+        ),
+        const SizedBox(width: 8),
+        _CardActionButton(
+          label: l10n.declineAction,
+          icon: Icons.cancel_outlined,
+          color: AppColorScheme.statusError,
+          focusNode: _declineFocus,
+          onPressed: widget.onDecline,
+        ),
+      ];
+    }
+    if (widget.canManage && request.status == SeerrRequest.statusFailed) {
+      return [
+        _CardActionButton(
+          label: l10n.retry,
+          icon: Icons.refresh,
+          color: AppColorScheme.statusPending,
+          focusNode: _retryFocus,
+          onPressed: widget.onRetry,
+        ),
+      ];
+    }
+    return const [];
+  }
+}
+
+/// The band at the foot of a poster tile. Status colour only, so a wall of
+/// tiles is easy to scan. Not a progress bar: the app already has one.
+class _StatusStripe extends StatelessWidget {
+  final Color color;
+  final double scale;
+
+  const _StatusStripe({required this.color, required this.scale});
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+    height: 5 * scale,
+    child: ColoredBox(color: color),
+  );
 }
 
 class _StatusPill extends StatelessWidget {
@@ -1305,29 +1782,7 @@ class _StatusPill extends StatelessWidget {
   const _StatusPill({required this.label, required this.color});
 
   @override
-  Widget build(BuildContext context) {
-    final scale = _uiScale();
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 3 * scale),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.2),
-        borderRadius: AppRadius.circular(4),
-        border: Border.fromBorderSide(
-          ThemeRegistry.active.borders.chipBorder.copyWith(
-            color: color.withValues(alpha: 0.4),
-          ),
-        ),
-      ),
-      child: Text(
-        label,
-        style: TextStyle(
-          color: color,
-          fontSize: 11 * scale,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => _Badge(label: label, color: color);
 }
 
 class _StatusChip extends StatelessWidget {
@@ -1342,6 +1797,10 @@ class _StatusChip extends StatelessWidget {
     return _StatusPill(label: label, color: color);
   }
 
+  /// Label and colour for a request, shared by the pill and the tile stripe.
+  static (String, Color) infoFor(SeerrRequest request, AppLocalizations l10n) =>
+      _StatusChip(request: request)._statusInfo(l10n);
+
   /// Mirrors the seerr web UI: the request's own status wins only for
   /// declined and failed, everything else reflects the media status.
   (String, Color) _statusInfo(AppLocalizations l10n) {
@@ -1351,21 +1810,46 @@ class _StatusChip extends StatelessWidget {
     if (request.status == SeerrRequest.statusFailed) {
       return (l10n.failedStatus, AppColorScheme.statusError);
     }
-    if (request.status == SeerrRequest.statusCompleted) {
-      return (l10n.seerrAvailableStatus, AppColorScheme.statusAvailable);
-    }
-    final mediaStatus =
-        request.is4k ? request.media?.status4k : request.media?.status;
+    // Media status wins, not the request status. A completed request whose
+    // media was later deleted is media status 7. Seerr's own RequestCard reads
+    // media.status too.
+    final mediaStatus = request.is4k
+        ? request.media?.status4k
+        : request.media?.status;
+    // Seerr shows one media status as two words. Its StatusBadge reads
+    // "Processing" when downloadStatus is not empty and "Requested" when it is
+    // empty. Waiting on Radarr and downloading are the same code but not the
+    // same state, so mirror that.
+    final queue = request.is4k
+        ? request.media?.downloadStatus4k
+        : request.media?.downloadStatus;
+    final inProgress = queue != null && queue.isNotEmpty;
     return switch (mediaStatus) {
       2 => (l10n.pendingStatus, AppColorScheme.statusPending),
-      3 => (l10n.seerrRequestedStatus, AppColorScheme.statusRequested),
-      4 => (l10n.partiallyAvailable, AppColorScheme.statusAvailable),
+      3 =>
+        inProgress
+            ? (l10n.processingStatus, AppColorScheme.statusRequested)
+            : (l10n.seerrRequestedStatus, AppColorScheme.statusRequested),
+      4 =>
+        inProgress
+            ? (l10n.processingStatus, AppColorScheme.statusRequested)
+            : (l10n.partiallyAvailable, AppColorScheme.statusAvailable),
       5 => (l10n.seerrAvailableStatus, AppColorScheme.statusAvailable),
       6 => (l10n.blocklistedStatus, AppColorScheme.statusError),
       7 => (l10n.deletedStatus, AppColorScheme.statusError),
-      _ => request.status == SeerrRequest.statusPending
-          ? (l10n.pendingStatus, AppColorScheme.statusPending)
-          : (l10n.approvedStatus, AppColorScheme.accent),
+      // Only when the media status is unknown does the request status
+      // decide.
+      _ => switch (request.status) {
+        SeerrRequest.statusPending => (
+          l10n.pendingStatus,
+          AppColorScheme.statusPending,
+        ),
+        SeerrRequest.statusCompleted => (
+          l10n.seerrAvailableStatus,
+          AppColorScheme.statusAvailable,
+        ),
+        _ => (l10n.approvedStatus, AppColorScheme.accent),
+      },
     };
   }
 }
@@ -1412,7 +1896,7 @@ class _IssueCardState extends State<_IssueCard> with FocusStateMixin {
     final title =
         media?.title ?? media?.name ?? widget.summary?.title ?? l10n.unknown;
     final reporter = issue.createdBy?.bestName ?? l10n.unknown;
-    final date = issue.createdAt?.split('T').first ?? '';
+    final date = _formatRequestDate(context, issue.createdAt);
     final scope = _issueScopeLabel(l10n, issue);
     final typeLine = scope.isEmpty
         ? _issueTypeLabel(l10n, issue.issueType).toUpperCase()
@@ -1460,11 +1944,11 @@ class _IssueCardState extends State<_IssueCard> with FocusStateMixin {
       focusNode: _cardFocus,
       onFocusChange: setFocused,
       child: SizedBox(
-        height: 140 * scale,
+        height: _cardHeight * scale,
         child: Row(
           children: [
             SizedBox(
-              width: 93 * scale,
+              width: _cardPosterWidth * scale,
               child: posterPath != null
                   ? CachedNetworkImage(
                       imageUrl: '$_tmdbPosterBase$posterPath',

--- a/lib/ui/screens/seerr/seerr_requests_screen.dart
+++ b/lib/ui/screens/seerr/seerr_requests_screen.dart
@@ -1406,6 +1406,7 @@ class _RequestCardState extends State<_RequestCard> with FocusStateMixin {
   ) {
     return InkWell(
       onTap: widget.onTap,
+      mouseCursor: SystemMouseCursors.click,
       focusNode: _cardFocus,
       onFocusChange: (value) {
         setFocused(value);
@@ -1941,6 +1942,7 @@ class _IssueCardState extends State<_IssueCard> with FocusStateMixin {
 
     return InkWell(
       onTap: widget.onTap,
+      mouseCursor: SystemMouseCursors.click,
       focusNode: _cardFocus,
       onFocusChange: setFocused,
       child: SizedBox(

--- a/lib/ui/screens/seerr/seerr_requests_screen.dart
+++ b/lib/ui/screens/seerr/seerr_requests_screen.dart
@@ -26,6 +26,7 @@ import '../../widgets/navigation_layout.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/seerr_download_progress_bar.dart';
 import '../../widgets/seerr/seerr_media_type_badge.dart';
+import '../../widgets/seerr/seerr_request_tile_caption.dart';
 import '../../widgets/seerr/seerr_text_field.dart';
 import '../../widgets/seerr/seerr_tv_controls.dart';
 import '../../widgets/track_selector_dialog.dart';
@@ -596,15 +597,10 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
     );
   }
 
-  /// Shared by the grid and its skeleton, so the loading state has the same
-  /// shape as what replaces it.
-  /// Height a tile needs beyond its poster: caption inset, title, status or
-  /// progress, requester and date (106), plus 24 of slack for the focus scale.
-  /// A constant because the grid needs it before layout.
-  static const double _captionHeight = 130;
-
   /// Grid sized so a tile holds a whole 2:3 poster plus the caption. Records
-  /// the geometry it works out so the row snap uses the same numbers.
+  /// the geometry it works out so the row snap uses the same numbers. Shared
+  /// by the grid and its skeleton, so the loading state has the same shape as
+  /// what replaces it.
   ///
   /// The ratio comes from the real tile width: the poster scales with width
   /// but the caption is a fixed height, so no single ratio works everywhere.
@@ -617,7 +613,10 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
       ((available + spacing) / (extent + spacing)).ceil(),
     );
     final tileWidth = (available - spacing * (columns - 1)) / columns;
-    final tileHeight = tileWidth * 1.5 + _captionHeight * scale;
+    final tileHeight =
+        tileWidth * 1.5 + SeerrRequestTileCaption.reservedHeight * scale;
+    // Written during build on purpose. It is a plain field the row snap reads
+    // after the frame, not state the widget rebuilds from.
     _tileGeometry = (
       perLine: columns,
       lineExtent: tileHeight,
@@ -1480,79 +1479,20 @@ class _RequestCardState extends State<_RequestCard> with FocusStateMixin {
             ),
           ),
         ),
-        // Inset so the caption does not touch the card edges.
-        Padding(
-          padding: EdgeInsets.fromLTRB(
-            10 * scale,
-            8 * scale,
-            10 * scale,
-            10 * scale,
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                title,
-                style: TextStyle(
-                  color: onSurface,
-                  fontSize: 14 * scale,
-                  fontWeight: FontWeight.w600,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              SizedBox(height: 4 * scale),
-              // Fixed height. The bar is taller than a status word and the
-              // poster takes what the caption leaves, so reserve one height to
-              // keep posters level across a row.
-              SizedBox(
-                height: 26 * scale,
-                width: double.infinity,
-                child: downloadSummary != null
-                    ? Align(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: SeerrDownloadProgressBar(
-                          summary: downloadSummary,
-                          // The tile's own scale, so the bar stays in
-                          // proportion with the caption around it.
-                          scale: scale,
-                        ),
-                      )
-                    : Align(
-                        alignment: AlignmentDirectional.centerStart,
-                        child: _StatusPill(
-                          label: statusLabel,
-                          color: statusColor,
-                        ),
-                      ),
-              ),
-              SizedBox(height: 4 * scale),
-              Text(
-                l10n.requestedByName(requester),
-                style: TextStyle(
-                  color: onSurface.withValues(alpha: 0.54),
-                  fontSize: 12 * scale,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              if (date.isNotEmpty)
-                Text(
-                  date,
-                  style: TextStyle(
-                    color: onSurface.withValues(alpha: 0.38),
-                    fontSize: 12 * scale,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              if (_actions(l10n, onSurface).isNotEmpty) ...[
-                SizedBox(height: 6 * scale),
-                Row(children: _actions(l10n, onSurface)),
-              ],
-            ],
-          ),
+        SeerrRequestTileCaption(
+          title: title,
+          requestedBy: l10n.requestedByName(requester),
+          date: date,
+          scale: scale,
+          status: downloadSummary != null
+              ? SeerrDownloadProgressBar(
+                  summary: downloadSummary,
+                  // The tile's own scale, so the bar stays in proportion
+                  // with the caption around it.
+                  scale: scale,
+                )
+              : _StatusPill(label: statusLabel, color: statusColor),
+          actions: _actions(l10n, onSurface),
         ),
       ],
     );

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -4,6 +4,7 @@ import 'package:flutter_tvos/flutter_tvos.dart'
     show TvRemoteController, TvRemoteTouchEvent, TvRemoteTouchPhase;
 import 'package:moonfin_design/moonfin_design.dart';
 
+import 'seerr/seerr_media_type_badge.dart';
 import '../../preference/preference_constants.dart';
 import '../../util/platform_detection.dart';
 import '../../util/focus/dpad_keys.dart';
@@ -769,7 +770,7 @@ class _CardImage extends StatelessWidget {
                   Positioned(
                     top: 6,
                     left: 6,
-                    child: _buildSeerrMediaTypeBadge(),
+                    child: SeerrMediaTypeBadge(mediaType: seerrMediaType),
                   ),
                 if (_showSeerrStatusIndicator)
                   Positioned(
@@ -849,32 +850,6 @@ class _CardImage extends StatelessWidget {
   }
 
   bool get _showSeerrStatusIndicator => SeerrMediaStatus.hasDot(seerrStatus);
-
-  Widget _buildSeerrMediaTypeBadge() {
-    final type = seerrMediaType?.toLowerCase();
-    final isMovie = type == 'movie';
-    final badgeColor = isMovie
-        ? AppColorScheme.mediaTypeBadgeMovie
-        : AppColorScheme.mediaTypeBadgeShow;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: badgeColor.withValues(alpha: 0.85),
-        borderRadius: AppRadius.circular(4),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-        child: Text(
-          isMovie ? 'MOVIE' : 'SERIES',
-          style: TextStyle(
-            color: AppColorScheme.onBadge,
-            fontSize: 10,
-            fontWeight: FontWeight.w600,
-            letterSpacing: 0.8,
-          ),
-        ),
-      ),
-    );
-  }
 
   Widget _buildWatchedIndicator() {
     if (isPlayed) {

--- a/lib/ui/widgets/seerr/seerr_media_type_badge.dart
+++ b/lib/ui/widgets/seerr/seerr_media_type_badge.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../../l10n/app_localizations.dart';
+
+/// The MOVIE / SERIES badge that sits on the corner of Seerr artwork.
+///
+/// Shared so the discover rows and the requests grid cannot drift apart on
+/// wording or size.
+class SeerrMediaTypeBadge extends StatelessWidget {
+  /// Seerr's own media type string, `movie` or `tv`. Anything else reads as a
+  /// series, matching what the API sends for shows.
+  final String? mediaType;
+
+  /// Appended after a separator, for the requests grid's `FILM · 4K`.
+  final String? suffix;
+
+  /// Multiplier for platforms that scale their chrome, 1.0 everywhere else.
+  final double scale;
+
+  const SeerrMediaTypeBadge({
+    super.key,
+    required this.mediaType,
+    this.suffix,
+    this.scale = 1.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final isMovie = mediaType?.toLowerCase() == 'movie';
+    final color = isMovie
+        ? AppColorScheme.mediaTypeBadgeMovie
+        : AppColorScheme.mediaTypeBadgeShow;
+    final label = (isMovie ? l10n.movie : l10n.series).toUpperCase();
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.85),
+        borderRadius: AppRadius.circular(4),
+      ),
+      child: Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: 6 * scale,
+          vertical: 2 * scale,
+        ),
+        child: Text(
+          suffix != null ? '$label · $suffix' : label,
+          style: TextStyle(
+            color: AppColorScheme.onBadge,
+            fontSize: 10 * scale,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.8,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/seerr/seerr_request_tile_caption.dart
+++ b/lib/ui/widgets/seerr/seerr_request_tile_caption.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+/// The caption under a poster in the requests grid.
+///
+/// The grid sizes its tiles before layout, so the caption has a fixed
+/// reservation rather than a measured height. Keeping the caption here, next
+/// to that number, is what lets a test catch the two drifting apart.
+class SeerrRequestTileCaption extends StatelessWidget {
+  final String title;
+  final String requestedBy;
+  final String date;
+  final double scale;
+
+  /// Fills the fixed status slot: the download bar or the status pill.
+  final Widget status;
+
+  final List<Widget> actions;
+
+  const SeerrRequestTileCaption({
+    super.key,
+    required this.title,
+    required this.requestedBy,
+    required this.date,
+    required this.scale,
+    required this.status,
+    this.actions = const [],
+  });
+
+  /// Height a tile reserves beyond its poster at scale 1.
+  ///
+  /// Sized for the fullest caption, which is a pending request a manager can
+  /// approve or decline: inset, title, status slot, requester, date and the
+  /// action row, with a few pixels over for font line heights.
+  static const double reservedHeight = 150;
+
+  @override
+  Widget build(BuildContext context) {
+    final onSurface = AppColorScheme.onSurface;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        10 * scale,
+        8 * scale,
+        10 * scale,
+        10 * scale,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: TextStyle(
+              color: onSurface,
+              fontSize: 14 * scale,
+              fontWeight: FontWeight.w600,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          SizedBox(height: 4 * scale),
+          // Fixed height. The bar is taller than a status word and the poster
+          // takes what the caption leaves, so reserve one height to keep
+          // posters level across a row.
+          SizedBox(
+            height: 26 * scale,
+            width: double.infinity,
+            child: Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: status,
+            ),
+          ),
+          SizedBox(height: 4 * scale),
+          Text(
+            requestedBy,
+            style: TextStyle(
+              color: onSurface.withValues(alpha: 0.54),
+              fontSize: 12 * scale,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          if (date.isNotEmpty)
+            Text(
+              date,
+              style: TextStyle(
+                color: onSurface.withValues(alpha: 0.38),
+                fontSize: 12 * scale,
+              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          if (actions.isNotEmpty) ...[
+            SizedBox(height: 6 * scale),
+            Row(children: actions),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/seerr/seerr_status_pill.dart
+++ b/lib/ui/widgets/seerr/seerr_status_pill.dart
@@ -131,19 +131,20 @@ class SeerrStatusPill extends StatelessWidget {
     }
 
     final color = seerrStatusColor(_effectiveStatus);
+    // Seerr's badge treatment: fill at 80%, a full border of the same hue,
+    // light text of that hue. This pill sits over cover art, where a 20% tint
+    // is unreadable.
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
       decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.2),
-        border: Border.fromBorderSide(
-          ThemeRegistry.active.borders.chipBorder.copyWith(color: color),
-        ),
-        borderRadius: AppRadius.circular(6),
+        color: color.withValues(alpha: 0.8),
+        border: Border.all(color: color),
+        borderRadius: AppRadius.circular(8),
       ),
       child: Text(
         text,
         style: TextStyle(
-          color: color,
+          color: Color.lerp(color, Colors.white, 0.82),
           fontWeight: FontWeight.w600,
           fontSize: 13,
         ),

--- a/lib/ui/widgets/seerr_download_progress_bar.dart
+++ b/lib/ui/widgets/seerr_download_progress_bar.dart
@@ -1,55 +1,183 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../data/services/seerr/seerr_download_progress.dart';
 import '../../l10n/app_localizations.dart';
+import '../../preference/user_preferences.dart';
+import '../../util/download_utils.dart';
+import '../../util/platform_detection.dart';
 
-/// Thin decorative progress bar for an active Seerr download. Not focusable,
-/// so d-pad traversal is unaffected wherever it is placed.
+/// Progress bar for an active Seerr download. Not focusable, so d-pad
+/// traversal is unaffected.
+///
+/// Capped rather than stretched: across a full desktop pane a thin bar reads
+/// as a divider, not as progress.
 class SeerrDownloadProgressBar extends StatelessWidget {
   final SeerrDownloadSummary summary;
   final String? prefixLabel;
-  final double scale;
+
+  /// Overrides the platform scale. A poster tile passes its own caption scale,
+  /// since the TV bump below is sized for the detail screen.
+  final double? scale;
 
   const SeerrDownloadProgressBar({
     super.key,
     required this.summary,
     this.prefixLabel,
-    this.scale = 1.0,
+    this.scale,
   });
+
+  /// Past this the track is mostly empty and stops reading as a bar. Also
+  /// about the width of the detail screen's action row, so the two line up.
+  static const double _maxWidth = 320;
+
+  /// Width the full "Downloading · 1.4 GB / 15.2 GB" form needs.
+  static const double _fullLabelWidth = 260;
+
+  /// Low enough for a TV tile, which leaves about 111px. The sizes are
+  /// Flexible and ellipsize while the percentage stays, so a narrow tile
+  /// truncates them rather than dropping them. Below this the percentage
+  /// stands alone.
+  static const double _sizeLabelWidth = 90;
+
+  /// Posters shrink on TV because they are large artwork. The bar and its
+  /// label sit at the legibility floor instead, so they scale up.
+  static double _barScale() {
+    // Readable at three metres without outweighing the metadata line above.
+    if (PlatformDetection.isTV) return 1.1;
+    if (!PlatformDetection.useDesktopUi) return 1.0;
+    if (!GetIt.instance.isRegistered<UserPreferences>()) return 1.0;
+    return GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
     final onSurface = AppColorScheme.onSurface;
-    final label = summary.isImporting
-        ? l10n.seerrImportingStatus
-        : l10n.seerrDownloadingPercent(summary.percent);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
+    final scale = this.scale ?? _barScale();
+
+    final role = theme.textTheme.labelMedium ?? const TextStyle();
+    final labelStyle = role.copyWith(
+      color: onSurface.withValues(alpha: 0.7),
+      fontSize: (role.fontSize ?? 12) * scale,
+      fontWeight: FontWeight.w500,
+    );
+
+    // Mobile fills the width to match the full-width action button above it.
+    //
+    // Not scaled: the height and label scale for distance but the buttons do
+    // not. Fixed rather than measured off the row, since the row grows when a
+    // button expands on focus.
+    final cap = PlatformDetection.useMobileUi ? double.infinity : _maxWidth;
+
+    // Align first: a ConstrainedBox alone cannot shrink under a tight width
+    // from the parent, and callers do place this inside sized boxes.
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: cap),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LayoutBuilder(
+              builder: (context, constraints) =>
+                  _label(l10n, labelStyle, constraints.maxWidth),
+            ),
+            SizedBox(height: 4 * scale),
+            ClipRRect(
+              borderRadius: AppRadius.circular(4),
+              child: TweenAnimationBuilder<double>(
+                // The poll is every 15s. Without a tween the bar looks
+                // frozen between ticks.
+                tween: Tween<double>(end: summary.fraction),
+                duration: const Duration(milliseconds: 600),
+                curve: Curves.easeOut,
+                builder: (context, value, _) => LinearProgressIndicator(
+                  value: value,
+                  backgroundColor: onSurface.withValues(alpha: 0.12),
+                  color: AppColorScheme.accent,
+                  minHeight: 6 * scale,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Label row: what is happening on the left, how far along on the right.
+  /// The left side drops detail as the space shrinks so the percentage on the
+  /// right always survives.
+  Widget _label(AppLocalizations l10n, TextStyle style, double width) {
+    if (summary.isImporting) {
+      return Text(
+        _withPrefix(l10n.seerrImportingStatus),
+        style: style,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      );
+    }
+
+    final leading = _leadingLabel(l10n, width);
+    final trailing = Text(
+      l10n.seerrPercentValue(summary.percent),
+      style: style,
+      maxLines: 1,
+    );
+
+    if (leading == null) {
+      return Align(alignment: AlignmentDirectional.centerEnd, child: trailing);
+    }
+
+    return Row(
       children: [
-        Text(
-          prefixLabel != null ? '$prefixLabel · $label' : label,
-          style: TextStyle(
-            color: onSurface.withValues(alpha: 0.7),
-            fontSize: 11 * scale,
-            fontWeight: FontWeight.w500,
-          ),
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        ),
-        SizedBox(height: 3 * scale),
-        ClipRRect(
-          borderRadius: AppRadius.circular(2),
-          child: LinearProgressIndicator(
-            value: summary.fraction,
-            backgroundColor: onSurface.withValues(alpha: 0.12),
-            color: AppColorScheme.accent,
-            minHeight: 3 * scale,
+        Flexible(
+          child: Text(
+            leading,
+            style: style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
           ),
         ),
+        Text(' \u00b7 ', style: style),
+        trailing,
       ],
     );
   }
+
+  /// Null when the bar is too narrow to say anything but the percentage.
+  String? _leadingLabel(AppLocalizations l10n, double width) {
+    if (!summary.hasSize) {
+      return width >= _sizeLabelWidth
+          ? _withPrefix(l10n.seerrDownloading)
+          : null;
+    }
+    final done = _sameUnitAs(summary.downloadedBytes, summary.totalBytes);
+    final total = _sameUnitAs(summary.totalBytes, summary.totalBytes);
+    if (width >= _fullLabelWidth) {
+      return _withPrefix(l10n.seerrDownloadingSize(done, total));
+    }
+    if (width >= _sizeLabelWidth) {
+      return _withPrefix(l10n.seerrDownloadedOfTotal(done, total));
+    }
+    return null;
+  }
+
+  /// Both halves in the total's unit, so it reads "1.6 GB / 4.4 GB" and not
+  /// "330.9 MB / 12.4 GB". Local to this label because formatBytes is shared
+  /// with other screens.
+  static String _sameUnitAs(int bytes, int reference) {
+    const gb = 1024 * 1024 * 1024;
+    if (reference < gb) return formatBytes(bytes);
+    return '${(bytes / gb).toStringAsFixed(1)} GB';
+  }
+
+  String _withPrefix(String label) =>
+      prefixLabel != null ? '$prefixLabel \u00b7 $label' : label;
 }

--- a/test/seerr_download_progress_bar_test.dart
+++ b/test/seerr_download_progress_bar_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_download_progress.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/ui/widgets/seerr_download_progress_bar.dart';
+
+const _gb = 1024 * 1024 * 1024;
+
+/// 1.4 GB of 15.2 GB, about 9%.
+const _summary = SeerrDownloadSummary(
+  fraction: 0.09,
+  isImporting: false,
+  totalBytes: 15 * _gb,
+  downloadedBytes: 1 * _gb,
+);
+
+Widget _host({required double width, SeerrDownloadSummary summary = _summary}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: width,
+          child: SeerrDownloadProgressBar(summary: summary),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('wide: shows the verb and both sizes', (tester) async {
+    await tester.pumpWidget(_host(width: 320));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Downloading'), findsOneWidget);
+    expect(find.textContaining('/'), findsOneWidget);
+    expect(find.text('9%'), findsOneWidget);
+  });
+
+  testWidgets('medium: drops the verb, keeps the sizes', (tester) async {
+    await tester.pumpWidget(_host(width: 200));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Downloading'), findsNothing);
+    expect(find.textContaining('/'), findsOneWidget);
+    expect(find.text('9%'), findsOneWidget);
+  });
+
+  testWidgets('poster tile width still shows the sizes', (tester) async {
+    // A desktop grid tile leaves roughly this much for the caption.
+    await tester.pumpWidget(_host(width: 166));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('/'), findsOneWidget);
+    expect(find.text('9%'), findsOneWidget);
+  });
+
+  testWidgets('TV tile truncates the sizes but keeps the percentage', (
+    tester,
+  ) async {
+    // A TV grid tile leaves roughly this much for the caption: too little for
+    // the sizes and the percentage both, so the sizes ellipsize.
+    await tester.pumpWidget(_host(width: 111));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('/'), findsOneWidget);
+    expect(find.text('9%'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('narrow: percentage survives alone', (tester) async {
+    await tester.pumpWidget(_host(width: 70));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('/'), findsNothing);
+    expect(find.text('9%'), findsOneWidget);
+  });
+
+  testWidgets('fills the width on mobile, so it lines up with the button', (
+    tester,
+  ) async {
+    // flutter test reports defaultTargetPlatform as android, so this exercises
+    // the mobile branch: no cap, matching the full-width action button above
+    // it on the detail screen. The desktop and TV cap cannot be exercised here
+    // without a seam over PlatformDetection.
+    await tester.pumpWidget(_host(width: 600));
+    await tester.pumpAndSettle();
+
+    final bar = tester.getSize(find.byType(LinearProgressIndicator));
+    expect(bar.width, 600);
+    expect(bar.height, greaterThanOrEqualTo(6));
+  });
+
+  testWidgets('importing says so instead of showing a stuck 100%', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        width: 320,
+        summary: const SeerrDownloadSummary(
+          fraction: 1,
+          isImporting: true,
+          totalBytes: 15 * _gb,
+          downloadedBytes: 15 * _gb,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Importing'), findsOneWidget);
+    expect(find.text('100%'), findsNothing);
+  });
+
+  testWidgets('no server sizes: falls back to the verb and the percentage', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _host(
+        width: 320,
+        summary: const SeerrDownloadSummary(fraction: 0.09, isImporting: false),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('/'), findsNothing);
+    expect(find.textContaining('Downloading'), findsOneWidget);
+    expect(find.text('9%'), findsOneWidget);
+  });
+
+  // The bar lives inside a fixed 140px card row that a ListView hands an
+  // unbounded height. A stretch/IntrinsicHeight parent throws there, and
+  // content taller than 140 overflows, so pin both.
+  testWidgets('card column fits the 175px row at phone width', (tester) async {
+    tester.view.physicalSize = const Size(360, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ListView(
+            children: [
+              SizedBox(
+                height: 175,
+                child: Row(
+                  children: [
+                    const SizedBox(width: 110),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.all(12),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                const Flexible(child: Text('Toy Story 5')),
+                                const SizedBox(width: 8),
+                                Container(width: 40, height: 17),
+                                const SizedBox(width: 8),
+                                Container(width: 70, height: 22),
+                              ],
+                            ),
+                            const SizedBox(height: 8),
+                            const SeerrDownloadProgressBar(summary: _summary),
+                            const SizedBox(height: 8),
+                            const Row(
+                              children: [
+                                Expanded(
+                                  child: Text(
+                                    'Requested by Axel · Modified by Axel · '
+                                    '26 August 2026',
+                                    maxLines: 2,
+                                  ),
+                                ),
+                                SizedBox(width: 32, height: 32),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/seerr_download_progress_bar_test.dart
+++ b/test/seerr_download_progress_bar_test.dart
@@ -159,9 +159,9 @@ void main() {
                               children: [
                                 const Flexible(child: Text('Toy Story 5')),
                                 const SizedBox(width: 8),
-                                Container(width: 40, height: 17),
+                                const SizedBox(width: 40, height: 17),
                                 const SizedBox(width: 8),
-                                Container(width: 70, height: 22),
+                                const SizedBox(width: 70, height: 22),
                               ],
                             ),
                             const SizedBox(height: 8),

--- a/test/ui/widgets/seerr/seerr_request_tile_caption_test.dart
+++ b/test/ui/widgets/seerr/seerr_request_tile_caption_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/seerr/seerr_request_tile_caption.dart';
+
+void main() {
+  // The grid reserves a fixed height for the caption before layout. Adding a
+  // line to the caption without raising the reservation clips the poster on
+  // every tile, and nothing else would notice.
+  testWidgets('the fullest caption fits the height the grid reserves', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 220,
+              child: SeerrRequestTileCaption(
+                title: 'Toy Story 5',
+                requestedBy: 'Requested by Axel',
+                date: '26 August 2026',
+                scale: 1,
+                status: const SizedBox.shrink(),
+                // The approve and decline buttons set a minimum height
+                // of 32, and the caption gives the status its own slot.
+                actions: const [SizedBox(width: 32, height: 32)],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final height = tester.getSize(find.byType(SeerrRequestTileCaption)).height;
+    expect(height, lessThanOrEqualTo(SeerrRequestTileCaption.reservedHeight));
+    // And not far under it, or the reservation has drifted above what the
+    // caption draws and every tile carries dead space.
+    expect(height, greaterThan(SeerrRequestTileCaption.reservedHeight - 16));
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
The Requests page was a stacked list of wide rows on every platform, which left a desktop window three quarters empty and only fitted two cards on a TV. Desktop and TV now show a grid of poster tiles, phone and tablet keep the row cards, reworked to fit a narrow screen.

The download bar had no width of its own, so on a detail screen it stretched to 1500px and read as a divider under the buttons. It is capped now, and it says `1.6 GB / 4.4 GB · 9%` instead of a bare percentage, using byte counts the client already gives.

Two status bugs came out of the same work. A completed request whose media was later deleted showed as "Available" while the detail screen correctly showed "Deleted", and the type badge read "MOVIE" in every language on one screen (seerr main page) and "FILM" on another (seerr request page).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Desktop and TV render a grid of poster tiles. `_usesTileGrid` is `!useMobileUi`, since on TV both `useMobileUi` and `useDesktopUi` are false.
- The grid ratio is computed from the real tile width. The poster scales with width but the caption is a fixed height, so no single `childAspectRatio` gives a whole 2:3 poster at every width.
- The grid records the geometry it drew, and a focused tile snaps its row to the top. Without it a row parked wherever `ensureVisible` stopped and the row below was always half cut.
- The skeleton uses the same grid delegate and tile shape, so the loading state does not change shape when the data lands.
- `_HubCardShell`'s bottom margin is off in grid mode. The grid separates rows with `mainAxisSpacing`, and the margin was taking 12px out of every cell.
- Phone and tablet card: bigger poster (93 -> 110, card 148 -> 175), type badge on the poster corner, status pill under the title, provenance pinned to the foot, and no more "Modified by".
- Poster art comes from `w342` like the other Seerr screens, not `w200`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator / simulator (android TV & android)
- [x] Tested on physical device (macOS)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open the Requests page on desktop. Posters in a grid, the column count following the window.
2. Same page on a TV. Walk the posters with the D-pad.
3. Request something and watch a card while it downloads. The status pill gives way to the bar, which reads `1.6 GB / 4.4 GB · 9%` and advances smoothly.
4. Same item on the detail screen. The bar sits under the buttons at about their width, full width on a phone, with better readability.
5. Phone: the card shows the badge on the poster, the pill under the title, and the requester and date at the foot.

## Screenshots (if applicable)
### Desktops (macOS here)
#### Request page
Before
<img width="1840" height="1115" alt="Screenshot 2026-08-27 at 17 56 41" src="https://github.com/user-attachments/assets/bb3503a9-4f9a-42de-a280-be5e9bdb4cf6" />
After
<img width="1840" height="1115" alt="Screenshot 2026-08-27 at 18 00 22" src="https://github.com/user-attachments/assets/af83f8f8-e15d-4e51-b072-a4fea37dfd92" />

#### Details page
Before
<img width="1840" height="1115" alt="Screenshot 2026-08-27 at 17 56 31" src="https://github.com/user-attachments/assets/693ec7fe-1a46-4ce6-8633-c5d4c2b5d412" />
After
<img width="1840" height="1115" alt="Screenshot 2026-08-27 at 18 00 10" src="https://github.com/user-attachments/assets/be36ecc9-2dc1-403e-a873-16ed82599572" />

### TV (android TV here)
#### Request page
Before
<img width="1046" height="628" alt="Screenshot 2026-08-27 at 17 57 18" src="https://github.com/user-attachments/assets/c2d54d2f-4ef3-43d5-8f39-de42385ac1d7" />
After
<img width="1046" height="628" alt="Screenshot 2026-08-27 at 17 59 44" src="https://github.com/user-attachments/assets/99fef2b2-cd40-49e2-8432-5c24304a3fc9" />

#### Details page
Before
<img width="1046" height="628" alt="Screenshot 2026-08-27 at 17 56 57" src="https://github.com/user-attachments/assets/30855076-1b0f-4f12-891e-e50cfb8122ee" />
After
<img width="1046" height="628" alt="Screenshot 2026-08-27 at 18 09 10" src="https://github.com/user-attachments/assets/8f193da3-884b-4c2d-a4c3-6c96e30e4256" />

### Mobile (android here)
#### Request page
Before
<img width="519" height="1034" alt="Screenshot 2026-08-27 at 17 56 08" src="https://github.com/user-attachments/assets/2a022e07-3823-4186-852c-4bf8927adec6" />
After
<img width="519" height="1034" alt="Screenshot 2026-08-27 at 18 01 32" src="https://github.com/user-attachments/assets/a9326d67-c688-4757-924d-5ac31f2691e2" />

#### Details page
Before
<img width="519" height="1034" alt="Screenshot 2026-08-27 at 17 55 55" src="https://github.com/user-attachments/assets/14b9d5b7-3752-48b9-b8e4-6ed3d833840c" />
After
<img width="519" height="1034" alt="Screenshot 2026-08-27 at 18 01 15" src="https://github.com/user-attachments/assets/a36194a8-7bc6-40d3-8f62-9d351e2bcd0f" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
