### PR TITLE
Feat(windows): hdr output

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2292,6 +2292,14 @@
   "@playbackInformation": {
     "description": "Title for stream info sheet"
   },
+  "showMpvStats": "Show mpv Statistics (Shift+I)",
+  "@showMpvStats": {
+    "description": "Button in the stream info sheet that shows mpv's own statistics overlay; Shift+I is the keyboard shortcut"
+  },
+  "hideMpvStats": "Hide mpv Statistics (Shift+I)",
+  "@hideMpvStats": {
+    "description": "Button in the stream info sheet that hides mpv's own statistics overlay; Shift+I is the keyboard shortcut"
+  },
   "playback": "Playback",
   "@playback": {
     "description": "Section header in stream info"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2340,6 +2340,47 @@
   "@hdr": {
     "description": "Stream info label for HDR type"
   },
+  "hdrOutput": "HDR output",
+  "@hdrOutput": {
+    "description": "Stream info label for whether HDR is reaching the display untouched"
+  },
+  "hdrOutputActive": "Active — {format}",
+  "@hdrOutputActive": {
+    "description": "Stream info value when HDR passthrough is running, e.g. 'Active — HDR10 (PQ, BT.2020)'",
+    "placeholders": {
+      "format": {
+        "type": "String"
+      }
+    }
+  },
+  "hdrOutputActiveTonemapped": "Active — tone-mapped to SDR for this display",
+  "@hdrOutputActiveTonemapped": {
+    "description": "Stream info value when native output is engaged but the window sits on a display without HDR, so the renderer is tone-mapping"
+  },
+  "hdrOutputDisplayNotHdr": "Inactive — display is not in HDR mode",
+  "@hdrOutputDisplayNotHdr": {
+    "description": "Stream info value when the display has not been switched into HDR"
+  },
+  "hdrOutputContentSdr": "Inactive — content is SDR",
+  "@hdrOutputContentSdr": {
+    "description": "Stream info value when the title itself is not HDR"
+  },
+  "hdrOutputDisabled": "Inactive — turned off in settings",
+  "@hdrOutputDisabled": {
+    "description": "Stream info value when the native HDR output preference is off"
+  },
+  "hdrOutputFailed": "Inactive — could not start, using the standard path",
+  "@hdrOutputFailed": {
+    "description": "Stream info value when the native HDR window could not be created"
+  },
+  "nativeHdrOutput": "Native HDR output",
+  "@nativeHdrOutput": {
+    "description": "Settings label for sending HDR to the display untouched"
+  },
+  "nativeHdrOutputDescription": "Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.",
+  "@nativeHdrOutputDescription": {
+    "description": "Settings description for native HDR output"
+  },
   "codec": "Codec",
   "@codec": {
     "description": "Stream info label for codec"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3028,6 +3028,18 @@ abstract class AppLocalizations {
   /// **'Playback Information'**
   String get playbackInformation;
 
+  /// Button in the stream info sheet that shows mpv's own statistics overlay; Shift+I is the keyboard shortcut
+  ///
+  /// In en, this message translates to:
+  /// **'Show mpv Statistics (Shift+I)'**
+  String get showMpvStats;
+
+  /// Button in the stream info sheet that hides mpv's own statistics overlay; Shift+I is the keyboard shortcut
+  ///
+  /// In en, this message translates to:
+  /// **'Hide mpv Statistics (Shift+I)'**
+  String get hideMpvStats;
+
   /// Section header in stream info
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3100,6 +3100,60 @@ abstract class AppLocalizations {
   /// **'HDR'**
   String get hdr;
 
+  /// Stream info label for whether HDR is reaching the display untouched
+  ///
+  /// In en, this message translates to:
+  /// **'HDR output'**
+  String get hdrOutput;
+
+  /// Stream info value when HDR passthrough is running, e.g. 'Active — HDR10 (PQ, BT.2020)'
+  ///
+  /// In en, this message translates to:
+  /// **'Active — {format}'**
+  String hdrOutputActive(String format);
+
+  /// Stream info value when native output is engaged but the window sits on a display without HDR, so the renderer is tone-mapping
+  ///
+  /// In en, this message translates to:
+  /// **'Active — tone-mapped to SDR for this display'**
+  String get hdrOutputActiveTonemapped;
+
+  /// Stream info value when the display has not been switched into HDR
+  ///
+  /// In en, this message translates to:
+  /// **'Inactive — display is not in HDR mode'**
+  String get hdrOutputDisplayNotHdr;
+
+  /// Stream info value when the title itself is not HDR
+  ///
+  /// In en, this message translates to:
+  /// **'Inactive — content is SDR'**
+  String get hdrOutputContentSdr;
+
+  /// Stream info value when the native HDR output preference is off
+  ///
+  /// In en, this message translates to:
+  /// **'Inactive — turned off in settings'**
+  String get hdrOutputDisabled;
+
+  /// Stream info value when the native HDR window could not be created
+  ///
+  /// In en, this message translates to:
+  /// **'Inactive — could not start, using the standard path'**
+  String get hdrOutputFailed;
+
+  /// Settings label for sending HDR to the display untouched
+  ///
+  /// In en, this message translates to:
+  /// **'Native HDR output'**
+  String get nativeHdrOutput;
+
+  /// Settings description for native HDR output
+  ///
+  /// In en, this message translates to:
+  /// **'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.'**
+  String get nativeHdrOutputDescription;
+
   /// Stream info label for codec
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1654,6 +1654,12 @@ class AppLocalizationsAf extends AppLocalizations {
   String get playbackInformation => 'Afspeel inligting';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Afspeel';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1690,6 +1690,38 @@ class AppLocalizationsAf extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1698,6 +1698,38 @@ class AppLocalizationsAr extends AppLocalizations {
   String get hdr => 'تقرير التنمية البشرية';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'الترميز';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1662,6 +1662,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get playbackInformation => 'معلومات التشغيل';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'التشغيل';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1657,6 +1657,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get playbackInformation => 'Інфармацыя аб прайграванні';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Прайграванне';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1693,6 +1693,38 @@ class AppLocalizationsBe extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодэк';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1687,6 +1687,38 @@ class AppLocalizationsBg extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1651,6 +1651,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get playbackInformation => 'Информация за възпроизвеждане';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Възпроизвеждане';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1679,6 +1679,38 @@ class AppLocalizationsBn extends AppLocalizations {
   String get hdr => 'এইচডিআর';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'কোডেক';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1643,6 +1643,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get playbackInformation => 'প্লেব্যাক তথ্য';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'প্লেব্যাক';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1701,6 +1701,38 @@ class AppLocalizationsCa extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Còdec';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1665,6 +1665,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get playbackInformation => 'Informació de reproducció';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reproducció';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1659,6 +1659,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get playbackInformation => 'Informace o přehrávání';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Přehrávání';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1695,6 +1695,38 @@ class AppLocalizationsCs extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'kodek';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1667,6 +1667,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get playbackInformation => 'Gwybodaeth Chwarae';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Chwarae yn ôl';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1703,6 +1703,38 @@ class AppLocalizationsCy extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1646,6 +1646,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get playbackInformation => 'Afspilningsoplysninger';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Afspilning';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1682,6 +1682,38 @@ class AppLocalizationsDa extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1765,6 +1765,38 @@ class AppLocalizationsDe extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1729,6 +1729,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get playbackInformation => 'Wiedergabeinformationen';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Wiedergabe';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1701,6 +1701,38 @@ class AppLocalizationsEl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Κωδικοποιητής';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1665,6 +1665,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get playbackInformation => 'Πληροφορίες αναπαραγωγής';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Αναπαραγωγή';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1677,6 +1677,38 @@ class AppLocalizationsEn extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1641,6 +1641,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get playbackInformation => 'Playback Information';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Playback';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1683,6 +1683,38 @@ class AppLocalizationsEo extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodeko';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1647,6 +1647,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get playbackInformation => 'Informoj pri Ludado';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reproduktado';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1695,6 +1695,38 @@ class AppLocalizationsEs extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Códec';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1659,6 +1659,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get playbackInformation => 'Información de reproducción';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reproducción';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1652,6 +1652,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get playbackInformation => 'Taasesituse teave';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Taasesitus';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1688,6 +1688,38 @@ class AppLocalizationsEt extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1677,6 +1677,38 @@ class AppLocalizationsFa extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'کدک';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1641,6 +1641,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get playbackInformation => 'اطلاعات پخش';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'پخش';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1651,6 +1651,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get playbackInformation => 'Toistotiedot';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Toisto';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1687,6 +1687,38 @@ class AppLocalizationsFi extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Koodekki';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1666,6 +1666,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get playbackInformation => 'Informations de lecture';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Lecture';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1702,6 +1702,38 @@ class AppLocalizationsFr extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1700,6 +1700,38 @@ class AppLocalizationsGl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Códec';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1664,6 +1664,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get playbackInformation => 'Información de reprodución';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reprodución';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1674,6 +1674,38 @@ class AppLocalizationsHe extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'קודק';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1638,6 +1638,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get playbackInformation => 'מידע השמעה';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'השמעה';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1645,6 +1645,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get playbackInformation => 'प्लेबैक सूचना';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'प्लेबैक';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1681,6 +1681,38 @@ class AppLocalizationsHi extends AppLocalizations {
   String get hdr => 'एचडीआर';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'कोडेक';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1740,6 +1740,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get playbackInformation => 'Informacije o reprodukciji';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reprodukcija';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1776,6 +1776,38 @@ class AppLocalizationsHr extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'kodek';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1691,6 +1691,38 @@ class AppLocalizationsHu extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1655,6 +1655,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get playbackInformation => 'Lejátszási információk';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Lejátszás';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1650,6 +1650,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get playbackInformation => 'Informasi Pemutaran';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Pemutaran';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1686,6 +1686,38 @@ class AppLocalizationsId extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1689,6 +1689,38 @@ class AppLocalizationsIt extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1653,6 +1653,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get playbackInformation => 'Informazioni Riproduzione';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Riproduzione';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1613,6 +1613,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get playbackInformation => '再生情報';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => '再生';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1649,6 +1649,38 @@ class AppLocalizationsJa extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'コーデック';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1685,6 +1685,38 @@ class AppLocalizationsKk extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1649,6 +1649,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get playbackInformation => 'Ойнату туралы ақпарат';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Ойнату';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1652,6 +1652,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get playbackInformation => 'ಪ್ಲೇಬ್ಯಾಕ್ ಮಾಹಿತಿ';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'ಪ್ಲೇಬ್ಯಾಕ್';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1688,6 +1688,38 @@ class AppLocalizationsKn extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'ಕೊಡೆಕ್';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1615,6 +1615,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get playbackInformation => '재생정보';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => '재생';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1651,6 +1651,38 @@ class AppLocalizationsKo extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => '코덱';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1689,6 +1689,38 @@ class AppLocalizationsLt extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodekas';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1653,6 +1653,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get playbackInformation => 'Atkūrimo informacija';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Atkūrimas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1658,6 +1658,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get playbackInformation => 'Atskaņošanas informācija';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Atskaņošana';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1694,6 +1694,38 @@ class AppLocalizationsLv extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodeks';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1691,6 +1691,38 @@ class AppLocalizationsMk extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1655,6 +1655,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get playbackInformation => 'Информации за репродукција';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Репродукција';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1657,6 +1657,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get playbackInformation => 'പ്ലേബാക്ക് വിവരങ്ങൾ';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'പ്ലേബാക്ക്';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1693,6 +1693,38 @@ class AppLocalizationsMl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'കോഡെക്';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1682,6 +1682,38 @@ class AppLocalizationsMn extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1646,6 +1646,12 @@ class AppLocalizationsMn extends AppLocalizations {
   String get playbackInformation => 'Тоглуулах мэдээлэл';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Тоглуулах';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1683,6 +1683,38 @@ class AppLocalizationsNb extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1647,6 +1647,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get playbackInformation => 'Avspillingsinformasjon';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Avspilling';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1660,6 +1660,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get playbackInformation => 'Afspeelinformatie';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Afspelen';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1696,6 +1696,38 @@ class AppLocalizationsNl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1684,6 +1684,38 @@ class AppLocalizationsPa extends AppLocalizations {
   String get hdr => 'ਐਚ.ਡੀ.ਆਰ';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'ਕੋਡੇਕ';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1648,6 +1648,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get playbackInformation => 'ਪਲੇਬੈਕ ਜਾਣਕਾਰੀ';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'ਪਲੇਬੈਕ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1759,6 +1759,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get playbackInformation => 'Informacje o odtwarzaniu';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Odtwarzanie';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1795,6 +1795,38 @@ class AppLocalizationsPl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1653,6 +1653,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get playbackInformation => 'Informações de Reprodução';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Reprodução';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1689,6 +1689,38 @@ class AppLocalizationsPt extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1658,6 +1658,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get playbackInformation => 'Informații de redare';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Redare';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1694,6 +1694,38 @@ class AppLocalizationsRo extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1662,6 +1662,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get playbackInformation => 'Информация о воспроизведении';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Воспроизведение';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1698,6 +1698,38 @@ class AppLocalizationsRu extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1642,6 +1642,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get playbackInformation => 'පසුධාවන තොරතුරු';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'නැවත ධාවනය';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1678,6 +1678,38 @@ class AppLocalizationsSi extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'කෝඩෙක්';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1700,6 +1700,38 @@ class AppLocalizationsSk extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'kodek';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1664,6 +1664,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get playbackInformation => 'Informácie o prehrávaní';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Prehrávanie';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1664,6 +1664,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get playbackInformation => 'Informacije o predvajanju';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Predvajanje';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1700,6 +1700,38 @@ class AppLocalizationsSl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1657,6 +1657,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get playbackInformation => 'Informacioni i riprodhimit';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Riprodhimi';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1693,6 +1693,38 @@ class AppLocalizationsSq extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodiku';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1739,6 +1739,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get playbackInformation => 'Информације о репродукцији';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Репродукција';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1775,6 +1775,38 @@ class AppLocalizationsSr extends AppLocalizations {
   String get hdr => 'ХДР';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Цодец';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1649,6 +1649,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get playbackInformation => 'Uppspelningsinformation';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Uppspelning';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1685,6 +1685,38 @@ class AppLocalizationsSv extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1658,6 +1658,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get playbackInformation => 'Maelezo ya Uchezaji';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Uchezaji';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1694,6 +1694,38 @@ class AppLocalizationsSw extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodeki';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1693,6 +1693,38 @@ class AppLocalizationsTa extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'கோடெக்';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1657,6 +1657,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get playbackInformation => 'பின்னணி தகவல்';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'பின்னணி';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1652,6 +1652,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get playbackInformation => 'ప్లేబ్యాక్ సమాచారం';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'ప్లేబ్యాక్';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1688,6 +1688,38 @@ class AppLocalizationsTe extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'కోడెక్';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1674,6 +1674,38 @@ class AppLocalizationsTh extends AppLocalizations {
   String get hdr => 'เอชดีอาร์';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'ตัวแปลงสัญญาณ';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1638,6 +1638,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get playbackInformation => 'ข้อมูลการเล่น';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'การเล่น';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1695,6 +1695,38 @@ class AppLocalizationsTl extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Codec';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1659,6 +1659,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get playbackInformation => 'Impormasyon sa Pag-playback';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Pag-playback';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1684,6 +1684,38 @@ class AppLocalizationsTr extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Kodek';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1648,6 +1648,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get playbackInformation => 'Oynatma Bilgileri';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Oynatma';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1646,6 +1646,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get playbackInformation => 'قويۇش ئۇچۇرى';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'قويۇش';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1682,6 +1682,38 @@ class AppLocalizationsUg extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'كودېك';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1696,6 +1696,38 @@ class AppLocalizationsUk extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Кодек';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1660,6 +1660,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get playbackInformation => 'Інформація про відтворення';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Відтворення';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1652,6 +1652,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get playbackInformation => 'Thông tin phát lại';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => 'Phát lại';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1688,6 +1688,38 @@ class AppLocalizationsVi extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => 'Bộ giải mã';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1606,6 +1606,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get playbackInformation => '播放訊息';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => '回放';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1642,6 +1642,38 @@ class AppLocalizationsYue extends AppLocalizations {
   String get hdr => '高動態範圍';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => '編解碼器';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1603,6 +1603,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get playbackInformation => '播放信息';
 
   @override
+  String get showMpvStats => 'Show mpv Statistics (Shift+I)';
+
+  @override
+  String get hideMpvStats => 'Hide mpv Statistics (Shift+I)';
+
+  @override
   String get playback => '播放';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1639,6 +1639,38 @@ class AppLocalizationsZh extends AppLocalizations {
   String get hdr => 'HDR';
 
   @override
+  String get hdrOutput => 'HDR output';
+
+  @override
+  String hdrOutputActive(String format) {
+    return 'Active — $format';
+  }
+
+  @override
+  String get hdrOutputActiveTonemapped =>
+      'Active — tone-mapped to SDR for this display';
+
+  @override
+  String get hdrOutputDisplayNotHdr => 'Inactive — display is not in HDR mode';
+
+  @override
+  String get hdrOutputContentSdr => 'Inactive — content is SDR';
+
+  @override
+  String get hdrOutputDisabled => 'Inactive — turned off in settings';
+
+  @override
+  String get hdrOutputFailed =>
+      'Inactive — could not start, using the standard path';
+
+  @override
+  String get nativeHdrOutput => 'Native HDR output';
+
+  @override
+  String get nativeHdrOutputDescription =>
+      'Sends HDR video to the display untouched instead of converting it to SDR. Used only when the display is already in HDR mode and the title is HDR.';
+
+  @override
   String get codec => '编解码器';
 
   @override

--- a/lib/playback/hdr_composition.dart
+++ b/lib/playback/hdr_composition.dart
@@ -1,0 +1,28 @@
+import 'hdr_composition_stub.dart'
+    if (dart.library.io) 'hdr_composition_io.dart'
+    as impl;
+
+/// How the native HDR video window is composited with the Flutter UI.
+///
+/// Default (technique 2): mpv renders into a top-level window *behind* the
+/// runner window, and the runner is given per-pixel DWM transparency, so
+/// Flutter draws controls, dialogs and OSD natively over the video with no
+/// capture at all.
+///
+/// `MOONFIN_HDR_DWM=0` selects the overlay-capture fallback: mpv's window sits
+/// *above* the Flutter view and the player chrome is mirrored over it through
+/// a layered window. Menus need the video stood down and every chrome frame
+/// is a readback. `1..4` picks a specific transparency technique for the
+/// behind arrangement.
+///
+/// Parsed once here; the runner receives the mode with the video window's
+/// `create` call.
+abstract final class HdrComposition {
+  /// 1..4 = DWM transparency technique (2 is the default). 0 = the
+  /// overlay-capture fallback.
+  static final int dwmMode = impl.readDwmMode();
+
+  /// Whether the video window sits behind a transparent Flutter window, so
+  /// no capture or stand-down is needed.
+  static bool get videoBehindFlutter => dwmMode != 0;
+}

--- a/lib/playback/hdr_composition_io.dart
+++ b/lib/playback/hdr_composition_io.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+/// Reads the DWM-composition arrangement. See [hdr_composition.dart].
+///
+/// Unset - the normal case - selects technique 2, the validated default.
+/// `MOONFIN_HDR_DWM=0` falls back to the overlay-capture arrangement, and
+/// 1..4 picks a specific transparency technique.
+int readDwmMode() {
+  if (!Platform.isWindows) return 0;
+  const fallback = 2;
+  final raw = Platform.environment['MOONFIN_HDR_DWM']?.trim();
+  if (raw == null || raw.isEmpty) return fallback;
+  final mode = int.tryParse(raw);
+  if (mode == null) return fallback;
+  return mode >= 0 && mode <= 4 ? mode : fallback;
+}

--- a/lib/playback/hdr_composition_stub.dart
+++ b/lib/playback/hdr_composition_stub.dart
@@ -1,0 +1,2 @@
+/// Web stand-in: the DWM arrangement is a Windows runner question.
+int readDwmMode() => 0;

--- a/lib/playback/hdr_output_controller.dart
+++ b/lib/playback/hdr_output_controller.dart
@@ -16,6 +16,16 @@ enum HdrOutputStatus {
   failed;
 
   bool get isActive => this == active;
+
+  /// Whether the answer came from one of the two expensive checks and may
+  /// have been given too early, so a later fact is allowed to reopen it.
+  ///
+  /// Both are questions whose true answer can arrive after they were asked:
+  /// mpv reports what it decoded only once the file is loaded, and a big
+  /// remux over the network can take longer than any bounded wait; the
+  /// display is switched by the auto-HDR preference asynchronously. The
+  /// preference and a failure, by contrast, are settled for the session.
+  bool get isRevisitable => this == contentIsSdr || this == displayNotInHdrMode;
 }
 
 /// Decides whether mpv gets its own window, and owns that window's lifetime.
@@ -88,6 +98,11 @@ class HdrOutputController {
   /// Returns the HWND to hand mpv as `wid`, or null to stay on the texture
   /// path. Every cheap gate - engaged, failed, no presenter, preference off -
   /// is answered before either callback runs.
+  ///
+  /// A "no" from either expensive check is not sticky (see
+  /// [HdrOutputStatus.isRevisitable]): calling again decides afresh, which is
+  /// how the backend reopens the question once mpv reports HDR params that
+  /// were not there yet when the first decision was made.
   ///
   /// [isHdrContent] and [displayInHdrMode] are callbacks rather than values
   /// because both are expensive and neither is needed unless everything ahead

--- a/lib/playback/hdr_output_controller.dart
+++ b/lib/playback/hdr_output_controller.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/foundation.dart';
+
+import 'hdr_video_window.dart';
+
+/// Whether native HDR output is running and, if not, why - for the playback
+/// info sheet.
+enum HdrOutputStatus {
+  /// Running: HDR is reaching the display untouched.
+  active,
+  disabledByPreference,
+  displayNotInHdrMode,
+  contentIsSdr,
+
+  /// The window could not be created, or mpv would not take it. Sticky for
+  /// the session, and the texture path carries on.
+  failed;
+
+  bool get isActive => this == active;
+}
+
+/// Decides whether mpv gets its own window, and owns that window's lifetime.
+///
+/// The decision is made once per presenting screen and then sticks. `Player`
+/// and `VideoController` are built once in the `MediaKitPlayerBackend` factory
+/// and registered as a startup singleton, so there is no clean way to swap
+/// paths per item — and there is no need to. Once engaged, SDR content in the
+/// native window is not a regression: mpv renders it, and with `gpu-next`
+/// renders it better than the texture path does.
+class HdrOutputController {
+  /// [window] is injectable so the decision can be tested without a platform
+  /// channel - every path through [maybeEngage] past the display gate touches
+  /// it, and those are the paths worth pinning down.
+  HdrOutputController({HdrVideoWindow? window})
+    : window = window ?? HdrVideoWindow();
+
+  final HdrVideoWindow window;
+
+  /// What is actually going to the display while [HdrOutputStatus.active].
+  ///
+  /// Always HDR10: DXGI carries only static HDR10 metadata, so there is no
+  /// HDR10+ or Dolby Vision passthrough on Windows for a normal application.
+  /// libplacebo applies the dynamic metadata or the RPU and folds the result
+  /// into HDR10, which is the best available - not a shortcut.
+  static const String activeOutputFormat = 'HDR10 (PQ, BT.2020)';
+
+  /// The single source of truth for engagement; [isEngaged] and [hasFailed]
+  /// are views of it.
+  ///
+  /// A notifier rather than a plain field because engagement finishes
+  /// asynchronously at the tail of `play()`, long after the player screen last
+  /// built. Without a signal the swap from the texture surface to the native
+  /// window would wait for some unrelated setState to happen along, and until
+  /// it did mpv would be drawing into a window nothing had claimed - so still
+  /// hidden.
+  final ValueNotifier<HdrOutputStatus> status = ValueNotifier(
+    HdrOutputStatus.contentIsSdr,
+  );
+
+  bool get isEngaged => status.value.isActive;
+
+  /// Whether a previous attempt failed. Sticky, so a broken configuration is
+  /// not retried on every item.
+  bool get hasFailed => status.value == HdrOutputStatus.failed;
+
+  /// Whether a screen able to present the native window currently exists.
+  ///
+  /// The backend is a process-wide singleton shared with Live TV and the mini
+  /// player, which render media_kit's texture and know nothing about the
+  /// native window - engaging under them would swap mpv onto a window nothing
+  /// ever shows and leave a black picture. Only the video player screen sets
+  /// this, and engagement is refused without it.
+  bool presenterActive = false;
+
+  /// One decision at a time. The sticky flags are only written after several
+  /// awaits, so without this two overlapping `play()` calls could both pass
+  /// the gates and run the mpv handover concurrently against the same window.
+  bool _deciding = false;
+
+  /// Back to the undecided state, for when the presenting screen goes away:
+  /// the next playback decides afresh instead of inheriting a sticky
+  /// engagement nothing can present any more.
+  void reset() {
+    status.value = HdrOutputStatus.contentIsSdr;
+  }
+
+  /// Decides and, if the answer is yes, creates the window.
+  ///
+  /// Returns the HWND to hand mpv as `wid`, or null to stay on the texture
+  /// path. Every cheap gate - engaged, failed, no presenter, preference off -
+  /// is answered before either callback runs.
+  ///
+  /// [isHdrContent] and [displayInHdrMode] are callbacks rather than values
+  /// because both are expensive and neither is needed unless everything ahead
+  /// of it passed. Waiting for mpv's video-params costs up to two seconds on
+  /// an audio track, where they never arrive at all - and this backend is the
+  /// singleton for music and audiobooks too. The display query enumerates
+  /// every display path.
+  ///
+  /// [engageMpv] must return false if mpv refused the handle, so the failure
+  /// is recorded rather than leaving a black window on screen.
+  Future<int?> maybeEngage({
+    required bool preferenceEnabled,
+    required Future<bool> Function() isHdrContent,
+    required Future<bool> Function() displayInHdrMode,
+    required Future<bool> Function(int handle) engageMpv,
+  }) async {
+    if (isEngaged) {
+      return window.handle;
+    }
+    if (hasFailed || _deciding || !presenterActive) {
+      return null;
+    }
+    _deciding = true;
+    try {
+      return await _decide(
+        preferenceEnabled: preferenceEnabled,
+        isHdrContent: isHdrContent,
+        displayInHdrMode: displayInHdrMode,
+        engageMpv: engageMpv,
+      );
+    } finally {
+      _deciding = false;
+    }
+  }
+
+  Future<int?> _decide({
+    required bool preferenceEnabled,
+    required Future<bool> Function() isHdrContent,
+    required Future<bool> Function() displayInHdrMode,
+    required Future<bool> Function(int handle) engageMpv,
+  }) async {
+    if (!preferenceEnabled) {
+      status.value = HdrOutputStatus.disabledByPreference;
+      return null;
+    }
+    if (!await isHdrContent()) {
+      status.value = HdrOutputStatus.contentIsSdr;
+      return null;
+    }
+    if (!await displayInHdrMode()) {
+      // Switching the display is the auto-HDR preference's job, and it runs
+      // before this. If it is off, or the display refused, there is nothing
+      // useful to send.
+      status.value = HdrOutputStatus.displayNotInHdrMode;
+      return null;
+    }
+
+    final handle = await window.create();
+    if (handle == null) {
+      status.value = HdrOutputStatus.failed;
+      return null;
+    }
+
+    if (!await engageMpv(handle)) {
+      await window.destroy();
+      status.value = HdrOutputStatus.failed;
+      return null;
+    }
+
+    status.value = HdrOutputStatus.active;
+    return handle;
+  }
+}
+
+/// Whether what mpv decoded is HDR.
+///
+/// mpv is the better source than the server's `VideoRangeType`, which can be
+/// missing or wrong — what matters is what actually decoded. But it cannot
+/// answer for **Dolby Vision Profile 5**: that has no HDR10 base layer and
+/// frequently no VUI transfer characteristic, so the picture is IPT and only
+/// becomes BT.2020 PQ once libplacebo applies the RPU — which happens under
+/// `gpu-next`, which is the very thing being decided. mpv reports a P5 title
+/// as SDR right up until it stops being one.
+///
+/// BT.2020 primaries break that tie: IPT is carried on them, so they are
+/// present even when the transfer characteristic is not. Wide-gamut SDR also
+/// matches, and the cost of being wrong there is only that mpv tone-maps in
+/// its own window rather than the texture, on a display already in HDR mode
+/// since that is a precondition for reaching this at all.
+bool isHdrVideoParams({required String? gamma, required String? primaries}) {
+  final transfer = gamma?.toLowerCase() ?? '';
+  if (transfer == 'pq' || transfer == 'st2084' || transfer == 'hlg') {
+    return true;
+  }
+  return (primaries?.toLowerCase() ?? '').contains('2020');
+}

--- a/lib/playback/hdr_output_controller.dart
+++ b/lib/playback/hdr_output_controller.dart
@@ -72,14 +72,21 @@ class HdrOutputController {
   /// not retried on every item.
   bool get hasFailed => status.value == HdrOutputStatus.failed;
 
-  /// Whether a screen able to present the native window currently exists.
+  /// Whoever is currently presenting, or null.
   ///
   /// The backend is a process-wide singleton shared with Live TV and the mini
   /// player, which render media_kit's texture and know nothing about the
   /// native window - engaging under them would swap mpv onto a window nothing
   /// ever shows and leave a black picture. Only the video player screen sets
   /// this, and engagement is refused without it.
-  bool presenterActive = false;
+  ///
+  /// Held by identity, for the same reason [HdrVideoWindow] holds its own: the
+  /// player screen is rebuilt on route changes and the incoming state mounts
+  /// before the outgoing one disposes, so a departing screen must not stand
+  /// down a session its successor has already taken over.
+  Object? presenter;
+
+  bool get presenterActive => presenter != null;
 
   /// One decision at a time. The sticky flags are only written after several
   /// awaits, so without this two overlapping `play()` calls could both pass

--- a/lib/playback/hdr_overlay_channel.dart
+++ b/lib/playback/hdr_overlay_channel.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/services.dart';
+
+/// Dart side of `windows/runner/hdr_overlay_window.cpp`: the player chrome,
+/// composited over the HDR video window with per-pixel alpha.
+///
+/// Only used in the overlay-capture fallback (`MOONFIN_HDR_DWM=0`), where
+/// mpv's child window covers the Flutter view. `UpdateLayeredWindow` is the
+/// one Win32 call that blends the player's translucent scrims correctly over
+/// an arbitrary window.
+class HdrOverlayChannel {
+  static const MethodChannel _channel = MethodChannel('moonfin/hdr_overlay');
+
+  bool _unavailable = false;
+
+  Future<T?> _invoke<T>(String method, [Map<String, Object?>? args]) async {
+    if (_unavailable) return null;
+    try {
+      return await _channel.invokeMethod<T>(method, args);
+    } on MissingPluginException {
+      // Not a Windows build, or a runner predating the channel.
+      _unavailable = true;
+      return null;
+    } on PlatformException {
+      // Nothing to recover: the next push re-establishes the state.
+      return null;
+    }
+  }
+
+  /// Pushes the overlay's pixels. [pixels] must be premultiplied RGBA, which
+  /// is what `ImageByteFormat.rawRgba` already produces; the runner swaps the
+  /// channel order into BGRA so that work stays off the UI isolate.
+  ///
+  /// [x] and [y] are in physical pixels relative to the top-level window's
+  /// client area, and [width]/[height] must match [pixels].
+  Future<void> push({
+    required double x,
+    required double y,
+    required Uint8List pixels,
+    required int width,
+    required int height,
+  }) => _invoke<void>('push', {
+    'x': x.round(),
+    'y': y.round(),
+    'width': width,
+    'height': height,
+    'bytes': pixels,
+  });
+
+  /// Hides the overlay. The controls auto-hide during playback, so this is the
+  /// steady state and it is what keeps the readback cost at zero while a film
+  /// is simply playing.
+  Future<void> hide() => _invoke<void>('hide');
+}

--- a/lib/playback/hdr_video_window.dart
+++ b/lib/playback/hdr_video_window.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/services.dart';
+
+import 'hdr_composition.dart';
+
+/// Dart side of `windows/runner/hdr_video_window.cpp`: the window mpv renders
+/// HDR video into.
+///
+/// The runner owns nothing but the window's lifetime and geometry. mpv creates
+/// and owns the D3D11 swapchain once it is handed the HWND as `wid`, which is
+/// what gives `target-colorspace-hint` a swapchain to tag - the shared texture
+/// path has none.
+class HdrVideoWindow {
+  HdrVideoWindow() {
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'monitorChanged') {
+        onMonitorChanged?.call();
+      }
+    });
+  }
+
+  static const MethodChannel _channel = MethodChannel('moonfin/hdr_video');
+
+  /// Fired by the runner when the window crosses onto another monitor.
+  ///
+  /// mpv negotiates its swapchain colorspace once, at creation, against the
+  /// display it is created on - so a window dragged from an SDR screen to an
+  /// HDR one keeps outputting SDR until the renderer is recreated. The
+  /// backend hooks this to cycle the renderer.
+  void Function()? onMonitorChanged;
+
+  int? _handle;
+  Rect? _geometry;
+  bool _visible = false;
+  bool _unavailable = false;
+
+  /// The HWND, once created. Null until [create] succeeds.
+  int? get handle => _handle;
+
+  /// Creates the window and returns its HWND, or null if it could not be
+  /// created. Safe to call repeatedly; the second call returns the same
+  /// handle.
+  Future<int?> create() async {
+    if (_handle != null) return _handle;
+    if (_unavailable) return null;
+    try {
+      // The arrangement rides along; MOONFIN_HDR_DWM is parsed once, in
+      // hdr_composition_io.dart.
+      final handle = await _channel.invokeMethod<int>('create', {
+        'dwmMode': HdrComposition.dwmMode,
+      });
+      if (handle == null || handle == 0) return null;
+      _handle = handle;
+      return handle;
+    } on MissingPluginException {
+      // Not a Windows build, or the runner predates the channel.
+      _unavailable = true;
+      return null;
+    } on PlatformException {
+      return null;
+    }
+  }
+
+  /// Moves the window to [rect], in physical pixels relative to the top-level
+  /// window's client area.
+  Future<void> setGeometry(Rect rect) async {
+    if (_handle == null) return;
+    if (_geometry == rect) return;
+    _geometry = rect;
+    try {
+      await _channel.invokeMethod<void>('setGeometry', {
+        'x': rect.left.round(),
+        'y': rect.top.round(),
+        'width': rect.width.round(),
+        'height': rect.height.round(),
+      });
+    } on PlatformException {
+      // Geometry is pushed again on the next layout, so a dropped update
+      // corrects itself.
+    }
+  }
+
+  Future<void> setVisible(bool visible) async {
+    if (_handle == null || _visible == visible) return;
+    _visible = visible;
+    try {
+      await _channel.invokeMethod<void>('setVisible', {'visible': visible});
+    } on PlatformException {
+      _visible = !visible;
+    }
+  }
+
+  /// Whoever is currently presenting the video, so a departing presenter
+  /// cannot hide a window its successor has already claimed.
+  ///
+  /// The player screen is rebuilt on route changes, and the incoming state
+  /// mounts before the outgoing one disposes - so a plain `setVisible(false)`
+  /// in `dispose` lands last and wins, leaving mpv rendering into a window
+  /// nobody can see. Claiming by identity makes the ordering irrelevant.
+  Object? _presenter;
+
+  Future<void> claim(Object presenter, Rect rect) async {
+    _presenter = presenter;
+    await setGeometry(rect);
+    await setVisible(true);
+  }
+
+  Future<void> release(Object presenter) async {
+    if (!identical(_presenter, presenter)) return;
+    _presenter = null;
+    await setVisible(false);
+  }
+
+  Future<void> destroy() async {
+    if (_handle == null) return;
+    _handle = null;
+    _geometry = null;
+    _visible = false;
+    try {
+      await _channel.invokeMethod<void>('destroy');
+    } on PlatformException {
+      // The window goes with the runner either way.
+    }
+  }
+}

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -709,6 +709,9 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// texture, so leaving mpv on a window nothing presents would black them
   /// out for the rest of the process.
   Future<void> releaseNativeHdrPresenter() async {
+    // Same lifetime as the native path: the overlay must not follow mpv into
+    // Live TV or the mini player.
+    await _hideMpvStats();
     hdrOutput.presenterActive = false;
     _monitorSettleTimer?.cancel();
     _renegotiatePending = false;
@@ -751,6 +754,45 @@ class MediaKitPlayerBackend extends PlayerBackend {
     if (displayHdr == false) return false;
     if (displayHdr == null) return null;
     return outputtingHdr ?? true;
+  }
+
+  /// Whether this libmpv build ships the `stats` script. Verified on the
+  /// Windows DLL (LuaJIT + stats.lua); Linux distro builds and the Android
+  /// libs probably do too, but stay off until checked on a device.
+  bool get supportsMpvStats => PlatformDetection.isWindows;
+
+  /// Whether mpv's built-in statistics overlay is showing.
+  bool _mpvStatsVisible = false;
+  bool get mpvStatsVisible => _mpvStatsVisible;
+
+  /// Toggles mpv's own statistics overlay (mpv's Shift+I). It draws inside
+  /// mpv's output, so it works on the native HDR window and the texture path.
+  ///
+  /// media_kit starts mpv with `osd-level=0`, which hides the OSD the stats
+  /// script draws with, so the level is raised only while the overlay is up.
+  Future<void> toggleMpvStats() async {
+    final native = _player.platform;
+    if (native is! NativePlayer || !supportsMpvStats) return;
+    final show = !_mpvStatsVisible;
+    if (show) {
+      await _nativeSetProperty(native, 'osd-level', '1');
+    }
+    final ok = await _tryNativeCommand(native, [
+      'script-binding',
+      'stats/display-stats-toggle',
+    ]);
+    if (ok) {
+      _mpvStatsVisible = show;
+    }
+    if (!_mpvStatsVisible) {
+      await _nativeSetProperty(native, 'osd-level', '0');
+    }
+  }
+
+  Future<void> _hideMpvStats() async {
+    if (_mpvStatsVisible) {
+      await toggleMpvStats();
+    }
   }
 
   /// The two halves of "is HDR really reaching the screen": the monitor's own
@@ -804,20 +846,12 @@ class MediaKitPlayerBackend extends PlayerBackend {
       await _nativeSetProperty(native, 'wid', handle.toString());
       await _nativeSetProperty(native, 'gpu-api', 'd3d11');
       await _nativeSetProperty(native, 'vo', 'gpu-next');
-      // mpv 0.40+ defaults `target-colorspace-hint-mode` to `target`: it reads
-      // the monitor's EDID capabilities through DXGI (peak, black level,
-      // primaries) and adapts the picture to them before encoding PQ. Panels
-      // that cannot really do HDR - DisplayHDR 400, "HDR Ready" - report
-      // figures that leave the picture dim, lifted and desaturated, and then
-      // tone-map it a second time themselves. `source` is the traditional
-      // passthrough: the stream's own metadata, untouched, which is what this
-      // feature promises and what other players send. Older libmpv builds
-      // without the option ignore the write.
-      await _nativeSetProperty(
-        native,
-        'target-colorspace-hint-mode',
-        'source',
-      );
+      // mpv 0.40+ defaults this to `target` (adapts the picture to the
+      // monitor's reported EDID peak, black level and primaries), which
+      // leaves weak-HDR panels dim and double-tone-mapped. `source` is plain
+      // passthrough of the stream's own metadata. Older libmpv builds without
+      // the option ignore the write.
+      await _nativeSetProperty(native, 'target-colorspace-hint-mode', 'source');
       // The option that actually produces HDR passthrough. It tags the
       // swapchain, so it only does anything on a context that owns one -
       // which is exactly what the native window just provided.

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -733,7 +733,12 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// `play()` usually runs before the video player screen has mounted, and
   /// engagement is refused without a presenter - so the screen calls this
   /// once it exists. No-ops when already engaged, failed, or disabled.
-  Future<void> ensureNativeHdrForPresenter() => _maybeEngageNativeHdr();
+  ///
+  /// Claims by identity - see [HdrOutputController.presenter].
+  Future<void> ensureNativeHdrForPresenter(Object presenter) {
+    hdrOutput.presenter = presenter;
+    return _maybeEngageNativeHdr();
+  }
 
   /// Hands the native HDR path back when the presenting screen goes away.
   ///
@@ -743,30 +748,39 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// and the mini player share this singleton and can only render the
   /// texture, so leaving mpv on a window nothing presents would black them
   /// out for the rest of the process.
-  Future<void> releaseNativeHdrPresenter() async {
+  Future<void> releaseNativeHdrPresenter(Object presenter) async {
+    // A release from a screen that already handed over is not a release.
+    if (!identical(hdrOutput.presenter, presenter)) return;
     // Same lifetime as the native path: the overlay must not follow mpv into
     // Live TV or the mini player.
     await _hideMpvStats();
-    hdrOutput.presenterActive = false;
-    _monitorSettleTimer?.cancel();
+    hdrOutput.presenter = null;
+    _renegotiateSettleTimer?.cancel();
+    _renegotiateSettleTimer = null;
+    // A leftover deadline would make the next real trigger look covered.
+    _renegotiateDue = null;
     _renegotiatePending = false;
     // A crossing that lands after this point must not re-arm the timer.
     hdrOutput.window.onMonitorChanged = null;
-    if (!hdrOutput.isEngaged) return;
-    // Forgetting the session first flips isEngaged, which is what an
-    // in-flight monitor cycle checks between its awaits - so it aborts
-    // instead of writing vo=gpu-next straight over the restore below.
-    hdrOutput.reset();
-    // And wait the cycle out (bounded) so the property writes cannot
-    // interleave even if it was already past its last check.
-    for (var i = 0; i < 40 && _renegotiating; i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+    if (hdrOutput.isEngaged) {
+      // Forgetting the session first flips isEngaged, which is what an
+      // in-flight renegotiation checks between its awaits - so it aborts
+      // instead of writing vo=gpu-next straight over the restore below.
+      hdrOutput.reset();
+      // And wait the cycle out (bounded) so the property writes cannot
+      // interleave even if it was already past its last check.
+      for (var i = 0; i < 40 && _renegotiating; i++) {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      }
+      final native = _player.platform;
+      if (native is NativePlayer) {
+        final sid = await _tryNativeGetProperty(native, 'sid');
+        await _restoreTexturePath(native, sid: sid);
+      }
     }
-    final native = _player.platform;
-    if (native is NativePlayer) {
-      final sid = await _tryNativeGetProperty(native, 'sid');
-      await _restoreTexturePath(native, sid: sid);
-    }
+    // Unconditional, and outside the engaged branch: a failed renegotiation
+    // leaves the window up with status=failed, and skipping this would leave
+    // the runner composited transparent for the rest of the process.
     await hdrOutput.window.destroy();
   }
 
@@ -882,19 +896,17 @@ class MediaKitPlayerBackend extends PlayerBackend {
     try {
       sid = await _tryNativeGetProperty(native, 'sid');
 
+      // Before the first write: these are process-wide, and Live TV and the
+      // mini player go on using them after the native path hands back.
+      await _captureNativeRenderState(native);
+
       await _nativeSetProperty(native, 'wid', handle.toString());
       await _nativeSetProperty(native, 'gpu-api', 'd3d11');
+      // Before `vo`, not after: the swapchain colorspace is negotiated at
+      // creation. Named rather than a literal because engagement is gated on
+      // the display being in HDR mode (HdrOutputController._decide).
+      await _applyPassthroughHint(native, displayHdr: true);
       await _nativeSetProperty(native, 'vo', 'gpu-next');
-      // mpv 0.40+ defaults this to `target` (adapts the picture to the
-      // monitor's reported EDID peak, black level and primaries), which
-      // leaves weak-HDR panels dim and double-tone-mapped. `source` is plain
-      // passthrough of the stream's own metadata. Older libmpv builds without
-      // the option ignore the write.
-      await _nativeSetProperty(native, 'target-colorspace-hint-mode', 'source');
-      // The option that actually produces HDR passthrough. It tags the
-      // swapchain, so it only does anything on a context that owns one -
-      // which is exactly what the native window just provided.
-      await _nativeSetProperty(native, 'target-colorspace-hint', 'yes');
       await _applyDesktopRenderQuality(native);
       // The quality overrides above replace keys a custom mpv.conf may also
       // set, and the conf was applied before this. Re-apply it so the user's
@@ -917,11 +929,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
         // Trailing-edge debounce: a drag along the boundary between two
         // screens fires a crossing per flip, and each cycle is a full renderer
         // recreation.
-        _monitorSettleTimer?.cancel();
-        _monitorSettleTimer = Timer(
-          const Duration(milliseconds: 400),
-          () => unawaited(_renegotiateForDisplay()),
-        );
+        _scheduleDisplayRenegotiation(const Duration(milliseconds: 400));
       };
       return true;
     } catch (_) {
@@ -952,7 +960,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     }
   }
 
-  /// Whether a renderer cycle for a monitor change is already under way, so
+  /// Whether a renderer cycle is already under way, so
   /// two cannot overlap.
   bool _renegotiating = false;
 
@@ -960,12 +968,48 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// the current one, against wherever the window ended up.
   bool _renegotiatePending = false;
 
-  /// Debounces monitor-crossing renegotiation - see the assignment in
-  /// [_handOverToNativeWindow].
-  Timer? _monitorSettleTimer;
+  /// Debounces renegotiation - see [_scheduleDisplayRenegotiation].
+  Timer? _renegotiateSettleTimer;
+
+  /// When the pending [_renegotiateSettleTimer] is due, so a later reason to
+  /// renegotiate cannot shorten an earlier one's settle.
+  DateTime? _renegotiateDue;
+
+  /// Queues one pass, [delay] from now. Shared by every reason to
+  /// renegotiate, and only ever pushes the deadline out: firing on a shorter
+  /// delay reads the display before the longer reason's event landed, and a
+  /// stale read makes the pass skip itself - a lost cycle, not a late one.
+  void _scheduleDisplayRenegotiation(Duration delay) {
+    final due = DateTime.now().add(delay);
+    final pending = _renegotiateDue;
+    if (_renegotiateSettleTimer != null &&
+        pending != null &&
+        pending.isAfter(due)) {
+      return;
+    }
+    _renegotiateSettleTimer?.cancel();
+    _renegotiateDue = due;
+    _renegotiateSettleTimer = Timer(delay, () {
+      _renegotiateDue = null;
+      unawaited(_renegotiateForDisplay());
+    });
+  }
+
+  /// Re-checks the display after the auto-HDR switcher changed its mode with
+  /// no window move. Both directions: a drop to SDR strands mpv on a PQ
+  /// swapchain, a rise to HDR is the fact a revisitable "no" was missing.
+  ///
+  /// Call only when the mode actually moved - a pass costs a display sweep and
+  /// an mpv read - and the settle is long because Windows applies mode changes
+  /// slowly. A display changed behind the app's back is not covered; that
+  /// needs watching, which belongs on the runner's position heartbeat.
+  void refreshNativeHdrForDisplayState() {
+    if (!hdrOutput.isEngaged && !hdrOutput.status.value.isRevisitable) return;
+    _scheduleDisplayRenegotiation(const Duration(milliseconds: 1500));
+  }
 
   /// True while the native renderer is being torn down and recreated for a
-  /// monitor crossing. In the behind-the-window arrangement the runner is
+  /// renegotiation. In the behind-the-window arrangement the runner is
   /// transparent, so the player screen paints black instead while this is
   /// set - otherwise the desktop shows through the UI until mpv's first frame
   /// lands in the new swapchain.
@@ -975,7 +1019,14 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// the window is on now. The same vo cycle as engagement, subtitles carried
   /// across the same way.
   Future<void> _renegotiateForDisplay() async {
-    if (!hdrOutput.isEngaged) return;
+    if (!hdrOutput.isEngaged) {
+      // A revisitable "no" and a display that may have just come up to HDR.
+      // The controller re-runs its own gates and settles back if not.
+      if (hdrOutput.status.value.isRevisitable) {
+        await _maybeEngageNativeHdr();
+      }
+      return;
+    }
     if (_renegotiating) {
       _renegotiatePending = true;
       return;
@@ -1006,7 +1057,11 @@ class MediaKitPlayerBackend extends PlayerBackend {
       sid = await _tryNativeGetProperty(native, 'sid');
       nativeRendererCycling.value = true;
       await _nativeSetProperty(native, 'vo', 'null');
+      await _applyPassthroughHint(native, displayHdr: displayHdr);
       await _nativeSetProperty(native, 'vo', 'gpu-next');
+      // The hint is in the mpv.conf allowlist and was just overwritten. The
+      // handover re-applies the conf for the same reason.
+      await _applyCustomMpvConfIfEnabled(force: true);
       // The renderer can refuse to come back on the new adapter. Without this
       // check vo stays null and the session keeps claiming HDR over a black
       // picture - the same verification the original handover does.
@@ -1033,11 +1088,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
       if (_renegotiatePending) {
         _renegotiatePending = false;
         if (hdrOutput.isEngaged) {
-          _monitorSettleTimer?.cancel();
-          _monitorSettleTimer = Timer(
-            const Duration(milliseconds: 100),
-            () => unawaited(_renegotiateForDisplay()),
-          );
+          _scheduleDisplayRenegotiation(const Duration(milliseconds: 100));
         }
       }
     }
@@ -1053,11 +1104,80 @@ class MediaKitPlayerBackend extends PlayerBackend {
   Future<void> _restoreTexturePath(NativePlayer native, {String? sid}) async {
     try {
       await _nativeSetProperty(native, 'wid', '0');
+      // Survives the vo swap, so clear it rather than promise passthrough
+      // into media_kit's 8-bit texture.
+      await _applyPassthroughHint(native, displayHdr: false);
       await _nativeSetProperty(native, 'vo', 'libmpv');
+      // gpu-api and the desktop quality overrides are process-wide. Left
+      // behind, one HDR title would pin d3d11 on a context that is the
+      // OpenGL render API again, for Live TV and every later SDR title.
+      await _restoreNativeRenderState(native);
       await _restoreSubtitleState(native, sid);
     } catch (_) {
       // Nothing further to try; the diagnostics row reports the failure.
     }
+  }
+
+  /// Everything the native handover overwrites that outlives it: `gpu-api`
+  /// plus the keys [_applyDesktopRenderQuality] replaces.
+  static const List<String> _nativeRenderStateKeys = [
+    'gpu-api',
+    'dither',
+    'dither-depth',
+    'scale',
+    'dscale',
+    'cscale',
+    'sigmoid-upscaling',
+    'hdr-compute-peak',
+    'tone-mapping',
+  ];
+
+  /// What those keys held before the handover, so handing back puts them back.
+  final Map<String, String> _preNativeRenderState = {};
+
+  Future<void> _captureNativeRenderState(NativePlayer native) async {
+    _preNativeRenderState.clear();
+    for (final key in _nativeRenderStateKeys) {
+      final value = await _tryNativeGetProperty(native, key);
+      if (value != null) _preNativeRenderState[key] = value;
+    }
+  }
+
+  Future<void> _restoreNativeRenderState(NativePlayer native) async {
+    if (_preNativeRenderState.isEmpty) return;
+    final saved = Map<String, String>.from(_preNativeRenderState);
+    _preNativeRenderState.clear();
+    for (final entry in saved.entries) {
+      await _nativeSetProperty(native, entry.key, entry.value);
+    }
+  }
+
+  /// Whether the hint currently says passthrough, so a failed display query
+  /// can hold the last answer instead of guessing.
+  bool _passthroughHintOn = false;
+
+  /// The single owner of `target-colorspace-hint`, which suppresses
+  /// tone-mapping - right only where the display is in HDR mode. DXGI accepts
+  /// G2084 on an SDR swapchain on plenty of drivers, so leaving it on hands PQ
+  /// to a display that reads it as sRGB and washes out to white. A null
+  /// [displayHdr] is a failed query, not an answer, and holds the last answer.
+  ///
+  /// Written while `vo` is unset: the swapchain colorspace is negotiated once.
+  Future<void> _applyPassthroughHint(
+    NativePlayer native, {
+    required bool? displayHdr,
+  }) async {
+    final on = displayHdr ?? _passthroughHintOn;
+    _passthroughHintOn = on;
+    // mpv 0.40+ defaults the mode to `target`, which adapts to the monitor's
+    // EDID and leaves weak-HDR panels dim and double-tone-mapped. `source`
+    // passes the stream's own metadata. Older builds ignore the write.
+    await _nativeSetProperty(native, 'target-colorspace-hint-mode', 'source');
+    await _nativeSetProperty(
+      native,
+      'target-colorspace-hint',
+      on ? 'yes' : 'no',
+    );
   }
 
   /// Undoes the defaults media_kit applies to every native platform.

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -11,8 +11,10 @@ import 'package:playback_core/playback_core.dart';
 
 import '../preference/preference_constants.dart';
 import '../preference/user_preferences.dart';
+import '../util/auto_hdr_switcher.dart';
 import '../util/platform_detection.dart';
 import 'device_profile_builder.dart';
+import 'hdr_output_controller.dart';
 import 'known_defects.dart';
 import 'server_transcode_capabilities.dart';
 
@@ -177,6 +179,11 @@ class MediaKitPlayerBackend extends PlayerBackend {
   final UserPreferences _prefs;
   final Future<void> Function(int handle)? _onNativeHandleReady;
   final bool _hwDecodingEnabled;
+
+  /// Owns the decision about native HDR output and the window it needs.
+  /// Public so the playback info sheet can report what actually happened.
+  final HdrOutputController hdrOutput = HdrOutputController();
+
   bool _didNotifyNativeHandle = false;
   bool _didConfigureAppleMobileLibassFont = false;
   bool _didConfigureAndroidLibassFonts = false;
@@ -252,7 +259,11 @@ class MediaKitPlayerBackend extends PlayerBackend {
     try {
       final dynamic dyn = native;
       final value = await Future.value(dyn.getProperty(key));
-      return value.toString();
+      // media_kit stringifies an unset property as '' or the literal 'null';
+      // every caller wants that as null.
+      final text = value.toString();
+      if (text.isEmpty || text == 'null') return null;
+      return text;
     } catch (_) {
       return null;
     }
@@ -657,6 +668,318 @@ class MediaKitPlayerBackend extends PlayerBackend {
     if (!_useLibass) {
       _enableNativeSubtitleRendering();
     }
+    await _maybeEngageNativeHdr();
+  }
+
+  /// Gives mpv its own D3D11 window when the content is HDR and the display is
+  /// already in HDR mode, so the stream reaches the screen untouched instead
+  /// of being flattened into media_kit's 8-bit texture.
+  ///
+  /// Runs after `open`, because the decision needs `video-params`, which only
+  /// exist once a file is loaded.
+  Future<void> _maybeEngageNativeHdr() async {
+    if (!PlatformDetection.supportsNativeHdrWindow) return;
+    final native = _player.platform;
+    if (native is! NativePlayer) return;
+    // The controller answers every cheap gate - engaged, failed, no
+    // presenter, preference off - before it invokes either callback, so the
+    // video-params wait below is never paid on an audio track: music and
+    // audiobooks share this singleton but never mount a presenter.
+    await hdrOutput.maybeEngage(
+      preferenceEnabled: _prefs.get(UserPreferences.nativeHdrOutput),
+      isHdrContent: _isHdrContent,
+      displayInHdrMode: AutoHdrSwitcher.isDisplayHdrEnabled,
+      engageMpv: (handle) => _handOverToNativeWindow(native, handle),
+    );
+  }
+
+  /// Re-runs the engagement decision for the presenting screen.
+  ///
+  /// `play()` usually runs before the video player screen has mounted, and
+  /// engagement is refused without a presenter - so the screen calls this
+  /// once it exists. No-ops when already engaged, failed, or disabled.
+  Future<void> ensureNativeHdrForPresenter() => _maybeEngageNativeHdr();
+
+  /// Hands the native HDR path back when the presenting screen goes away.
+  ///
+  /// mpv returns to media_kit's texture output, subtitles are re-asserted
+  /// across the vo swap, the native window is destroyed (which also reverts
+  /// the DWM composition), and the controller forgets the session - Live TV
+  /// and the mini player share this singleton and can only render the
+  /// texture, so leaving mpv on a window nothing presents would black them
+  /// out for the rest of the process.
+  Future<void> releaseNativeHdrPresenter() async {
+    hdrOutput.presenterActive = false;
+    _monitorSettleTimer?.cancel();
+    _renegotiatePending = false;
+    // A crossing that lands after this point must not re-arm the timer.
+    hdrOutput.window.onMonitorChanged = null;
+    if (!hdrOutput.isEngaged) return;
+    // Forgetting the session first flips isEngaged, which is what an
+    // in-flight monitor cycle checks between its awaits - so it aborts
+    // instead of writing vo=gpu-next straight over the restore below.
+    hdrOutput.reset();
+    // And wait the cycle out (bounded) so the property writes cannot
+    // interleave even if it was already past its last check.
+    for (var i = 0; i < 40 && _renegotiating; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    final native = _player.platform;
+    if (native is NativePlayer) {
+      final sid = await _tryNativeGetProperty(native, 'sid');
+      await _restoreTexturePath(native, sid: sid);
+    }
+    await hdrOutput.window.destroy();
+  }
+
+  /// What this display is actually receiving right now, as opposed to what
+  /// the session negotiated at engage time.
+  ///
+  /// The two can differ: drag the window onto an SDR monitor mid-playback and
+  /// the screen shows SDR while the session stays engaged. The monitor's own
+  /// HDR state is the authority - whichever side does the conversion, an SDR
+  /// display is not showing HDR - and mpv's `target-params`, its account of
+  /// the output target after every conversion, refines it where available.
+  ///
+  /// Null when there is nothing to say (not engaged, no native player), so
+  /// callers can fall back to the session-level status.
+  Future<bool?> isCurrentOutputHdr() async {
+    if (!hdrOutput.isEngaged) return null;
+    final native = _player.platform;
+    if (native is! NativePlayer) return null;
+    final (displayHdr, outputtingHdr) = await _readHdrOutputState(native);
+    if (displayHdr == false) return false;
+    if (displayHdr == null) return null;
+    return outputtingHdr ?? true;
+  }
+
+  /// The two halves of "is HDR really reaching the screen": the monitor's own
+  /// state, and what mpv actually negotiated - each null when it could not be
+  /// read. Kept separate because the two consumers need different shapes: the
+  /// info row collapses them with the display as authority, while the
+  /// monitor-crossing skip compares them for equality and must skip only when
+  /// both are known. Independent reads, so they run together.
+  Future<(bool?, bool?)> _readHdrOutputState(NativePlayer native) async {
+    final (displayHdr, gamma) = await (
+      AutoHdrSwitcher.displayHdrState(),
+      _tryNativeGetProperty(native, 'target-params/gamma'),
+    ).wait;
+    final bool? outputtingHdr = gamma == null
+        ? null
+        // primaries deliberately null: wide gamut alone is not HDR output.
+        : isHdrVideoParams(gamma: gamma, primaries: null);
+    return (displayHdr, outputtingHdr);
+  }
+
+  /// What mpv actually decoded, rather than what the server claimed.
+  ///
+  /// media_kit already observes `video-params` and pushes it into
+  /// [Player.stream.videoParams], so this waits on that stream rather than
+  /// polling properties over FFI. It reacts the moment mpv reports instead of
+  /// on a 100 ms granularity, and costs nothing while it waits.
+  Future<bool> _isHdrContent() async {
+    var params = _player.state.videoParams;
+    if (params.gamma == null && params.primaries == null) {
+      params = await _player.stream.videoParams
+          .firstWhere((p) => p.gamma != null || p.primaries != null)
+          .timeout(
+            const Duration(seconds: 2),
+            onTimeout: () => const VideoParams(),
+          );
+    }
+    return isHdrVideoParams(gamma: params.gamma, primaries: params.primaries);
+  }
+
+  /// Points mpv at the native window and switches it to the libplacebo
+  /// renderer over D3D11. All of these are settable after `mpv_initialize`,
+  /// so this happens mid-session without a second Player.
+  Future<bool> _handOverToNativeWindow(NativePlayer native, int handle) async {
+    // Swapping the video output tears down mpv's subtitle renderer and drops
+    // the active track, so the selection is carried across by hand on every
+    // path - re-selecting in the menu would not bring it back.
+    String? sid;
+    try {
+      sid = await _tryNativeGetProperty(native, 'sid');
+
+      await _nativeSetProperty(native, 'wid', handle.toString());
+      await _nativeSetProperty(native, 'gpu-api', 'd3d11');
+      await _nativeSetProperty(native, 'vo', 'gpu-next');
+      // The option that actually produces HDR passthrough. It tags the
+      // swapchain, so it only does anything on a context that owns one -
+      // which is exactly what the native window just provided.
+      await _nativeSetProperty(native, 'target-colorspace-hint', 'yes');
+      await _applyDesktopRenderQuality(native);
+      // The quality overrides above replace keys a custom mpv.conf may also
+      // set, and the conf was applied before this. Re-apply it so the user's
+      // values win, which is what the allowlist promised them.
+      await _applyCustomMpvConfIfEnabled(force: true);
+
+      // If the renderer refused, `current-vo` still reads as the old one and
+      // the window would sit black over the player.
+      final vo = await _tryNativeGetProperty(native, 'current-vo');
+      if (vo != 'gpu-next') {
+        await _restoreTexturePath(native, sid: sid);
+        return false;
+      }
+
+      await _restoreSubtitleState(native, sid);
+      // From here on, a crossing between an HDR and an SDR monitor recreates
+      // the renderer: `wid`-mode mpv negotiates the swapchain colorspace only
+      // at creation, and a resize does not re-ask.
+      hdrOutput.window.onMonitorChanged = () {
+        // Trailing-edge debounce: a drag along the boundary between two
+        // screens fires a crossing per flip, and each cycle is a full renderer
+        // recreation.
+        _monitorSettleTimer?.cancel();
+        _monitorSettleTimer = Timer(
+          const Duration(milliseconds: 400),
+          () => unawaited(_renegotiateForDisplay()),
+        );
+      };
+      return true;
+    } catch (_) {
+      await _restoreTexturePath(native, sid: sid);
+      return false;
+    }
+  }
+
+  /// Rebuilds mpv's subtitle rendering after the video output was swapped.
+  ///
+  /// mpv renders subtitles itself in the native window, so they come along
+  /// inside it - but only once the renderer exists again. Re-asserting
+  /// `sub-ass` and `sub-visibility` brings it back, and [sid] restores the
+  /// track that was selected before the swap. Setting `sid` last matters: it
+  /// is what actually re-initialises the renderer for that track.
+  Future<void> _restoreSubtitleState(NativePlayer native, String? sid) async {
+    try {
+      // PlayerConfiguration(libass: false) starts mpv with sub-ass=no, and the
+      // swap resets it again.
+      await _nativeSetProperty(native, 'sub-ass', 'yes');
+      await _nativeSetProperty(native, 'sub-visibility', 'yes');
+      if (sid != null && sid != 'no') {
+        await _nativeSetProperty(native, 'sid', sid);
+      }
+    } catch (_) {
+      // Subtitles can still be re-picked from the menu; the video path is
+      // already up and must not be torn down over this.
+    }
+  }
+
+  /// Whether a renderer cycle for a monitor change is already under way, so
+  /// two cannot overlap.
+  bool _renegotiating = false;
+
+  /// A crossing landed while a cycle was running; one more cycle runs after
+  /// the current one, against wherever the window ended up.
+  bool _renegotiatePending = false;
+
+  /// Debounces monitor-crossing renegotiation - see the assignment in
+  /// [_handOverToNativeWindow].
+  Timer? _monitorSettleTimer;
+
+  /// Recreates the renderer so the swapchain negotiates against the display
+  /// the window is on now. The same vo cycle as engagement, subtitles carried
+  /// across the same way.
+  Future<void> _renegotiateForDisplay() async {
+    if (!hdrOutput.isEngaged) return;
+    if (_renegotiating) {
+      _renegotiatePending = true;
+      return;
+    }
+    final native = _player.platform;
+    if (native is! NativePlayer) return;
+    _renegotiating = true;
+    String? sid;
+    try {
+      // Only when the answer would change. A crossing between two SDR screens
+      // or two HDR screens renegotiates to the same result, and the cycle is
+      // a visible blink - skipping it makes those crossings seamless. Skip
+      // only when BOTH sides are known: a failed display query mid-topology
+      // change must not read as "SDR", and an unreadable mpv output must not
+      // read as anything. When in doubt, cycle.
+      final (displayHdr, outputtingHdr) = await _readHdrOutputState(native);
+      if (displayHdr != null &&
+          outputtingHdr != null &&
+          outputtingHdr == displayHdr) {
+        return;
+      }
+
+      // The presenting screen can go away during the reads above; its release
+      // restores the texture path, and cycling now would write vo=gpu-next
+      // straight over it.
+      if (!hdrOutput.isEngaged) return;
+
+      sid = await _tryNativeGetProperty(native, 'sid');
+      await _nativeSetProperty(native, 'vo', 'null');
+      await _nativeSetProperty(native, 'vo', 'gpu-next');
+      // The renderer can refuse to come back on the new adapter. Without this
+      // check vo stays null and the session keeps claiming HDR over a black
+      // picture - the same verification the original handover does.
+      final vo = await _tryNativeGetProperty(native, 'current-vo');
+      if (vo != 'gpu-next') {
+        await _restoreTexturePath(native, sid: sid);
+        if (hdrOutput.isEngaged) {
+          hdrOutput.status.value = HdrOutputStatus.failed;
+        }
+        return;
+      }
+      await _restoreSubtitleState(native, sid);
+    } catch (_) {
+      await _restoreTexturePath(native, sid: sid);
+      if (hdrOutput.isEngaged) {
+        hdrOutput.status.value = HdrOutputStatus.failed;
+      }
+    } finally {
+      _renegotiating = false;
+      if (_renegotiatePending) {
+        _renegotiatePending = false;
+        if (hdrOutput.isEngaged) {
+          _monitorSettleTimer?.cancel();
+          _monitorSettleTimer = Timer(
+            const Duration(milliseconds: 100),
+            () => unawaited(_renegotiateForDisplay()),
+          );
+        }
+      }
+    }
+  }
+
+  /// Puts mpv back on media_kit's render-API output after leaving the native
+  /// window - a failed handover, a failed renegotiation, or the presenting
+  /// screen going away.
+  ///
+  /// Must run on every exit path: `vo` has already left `libmpv` and `wid`
+  /// points at a window about to be destroyed. The vo swap also drops mpv's
+  /// subtitle renderer, so [sid] carries the active track across.
+  Future<void> _restoreTexturePath(NativePlayer native, {String? sid}) async {
+    try {
+      await _nativeSetProperty(native, 'wid', '0');
+      await _nativeSetProperty(native, 'vo', 'libmpv');
+      await _restoreSubtitleState(native, sid);
+    } catch (_) {
+      // Nothing further to try; the diagnostics row reports the failure.
+    }
+  }
+
+  /// Undoes the defaults media_kit applies to every native platform.
+  ///
+  /// It sets `dither=no`, `scale=bilinear`, `dscale=bilinear`,
+  /// `hdr-compute-peak=no` and `sigmoid-upscaling=no` regardless of platform.
+  /// Those are phone performance choices; on a desktop GPU driving an HDR
+  /// display they are all wrong, and `dither=no` alone visibly bands dark
+  /// gradients. The caller re-applies any custom mpv.conf afterwards, so a
+  /// user who set these keys themselves still wins.
+  Future<void> _applyDesktopRenderQuality(NativePlayer native) async {
+    await _nativeSetProperty(native, 'dither', 'fruit');
+    await _nativeSetProperty(native, 'dither-depth', 'auto');
+    await _nativeSetProperty(native, 'scale', 'spline36');
+    await _nativeSetProperty(native, 'dscale', 'mitchell');
+    await _nativeSetProperty(native, 'cscale', 'spline36');
+    await _nativeSetProperty(native, 'sigmoid-upscaling', 'yes');
+    // Dynamic peak detection, which is what makes HDR10+ and Dolby Vision
+    // dynamic metadata worth anything when tone-mapping down.
+    await _nativeSetProperty(native, 'hdr-compute-peak', 'yes');
+    await _nativeSetProperty(native, 'tone-mapping', 'bt.2390');
   }
 
   Future<void> _applyLinuxHwdecFallbackIfNeeded(
@@ -823,7 +1146,11 @@ class MediaKitPlayerBackend extends PlayerBackend {
     }
   }
 
-  Future<void> _applyCustomMpvConfIfEnabled() async {
+  /// [force] re-applies even when the same file was applied already. Handing
+  /// mpv the native HDR window resets a batch of render options, so the user's
+  /// conf has to be laid back over the top; the path/mtime cache would
+  /// otherwise skip it and their values would be gone for the session.
+  Future<void> _applyCustomMpvConfIfEnabled({bool force = false}) async {
     if (!PlatformDetection.isDesktop && !PlatformDetection.isAndroid) {
       return;
     }
@@ -850,7 +1177,8 @@ class MediaKitPlayerBackend extends PlayerBackend {
       }
 
       final stat = await file.stat();
-      if (_appliedCustomMpvConfPath == path &&
+      if (!force &&
+          _appliedCustomMpvConfPath == path &&
           _appliedCustomMpvConfMtime == stat.modified) {
         return;
       }

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -232,6 +232,14 @@ class MediaKitPlayerBackend extends PlayerBackend {
   StreamSubscription<dynamic>? _ccTracksSub;
   final _tracksChangedController = StreamController<void>.broadcast();
 
+  /// What mpv reported decoding for the file `play()` last opened, or null
+  /// until it has. Kept here rather than read from `Player.state.videoParams`
+  /// because media_kit never clears that on `open` - it only pushes an empty
+  /// event down the stream - so straight after opening the next title the
+  /// state still describes the previous one.
+  VideoParams? _decodedVideoParams;
+  StreamSubscription<VideoParams>? _videoParamsSub;
+
   late final Stream<bool> _playingStream = _mergeWithStale<bool>(
     _player.stream.playing,
     () => _isStale ? false : _player.state.playing,
@@ -415,6 +423,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     _ccTracksSub = _player.stream.tracks.listen(
       (_) => unawaited(_refreshEmbeddedCaptionTracks()),
     );
+    _videoParamsSub = _player.stream.videoParams.listen(_onVideoParams);
   }
 
   factory MediaKitPlayerBackend(
@@ -662,6 +671,9 @@ class MediaKitPlayerBackend extends PlayerBackend {
 
     final media = Media(url);
     final openPaused = !autoPlay || startPosition > Duration.zero;
+    // Whatever mpv reported for the previous title must not answer for this
+    // one; the listener repopulates it once this file is loaded.
+    _decodedVideoParams = null;
     await _player.open(media, play: !openPaused);
     _updateStaleState();
     await _applyLinuxHwdecFallbackIfNeeded(media, openPaused: openPaused);
@@ -691,6 +703,29 @@ class MediaKitPlayerBackend extends PlayerBackend {
       displayInHdrMode: AutoHdrSwitcher.isDisplayHdrEnabled,
       engageMpv: (handle) => _handOverToNativeWindow(native, handle),
     );
+  }
+
+  /// Tracks what mpv decoded, and reopens the HDR decision when the facts it
+  /// depends on arrive after it was made.
+  ///
+  /// The decision runs at two fixed moments - the tail of `play()` and the
+  /// presenting screen's mount - and waits a bounded time for mpv's
+  /// `video-params`. A 4K remux over the network regularly takes longer than
+  /// that to demux and decode its first frame, and when it does the wait
+  /// times out, the title is filed as SDR, and nothing would ever ask again.
+  /// mpv reporting PQ or HLG for the current file is the moment the question
+  /// can actually be answered, so that is when it is asked again. Cheap when
+  /// nothing changed: the controller refuses without a presenter, and an
+  /// engaged, failed or disabled session is not revisited.
+  void _onVideoParams(VideoParams params) {
+    final loaded = params.gamma != null || params.primaries != null;
+    _decodedVideoParams = loaded ? params : null;
+    if (!loaded || !PlatformDetection.supportsNativeHdrWindow) return;
+    if (!hdrOutput.status.value.isRevisitable) return;
+    if (!isHdrVideoParams(gamma: params.gamma, primaries: params.primaries)) {
+      return;
+    }
+    unawaited(_maybeEngageNativeHdr());
   }
 
   /// Re-runs the engagement decision for the presenting screen.
@@ -819,16 +854,20 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// [Player.stream.videoParams], so this waits on that stream rather than
   /// polling properties over FFI. It reacts the moment mpv reports instead of
   /// on a 100 ms granularity, and costs nothing while it waits.
+  ///
+  /// Only params reported for the current file count - see
+  /// [_decodedVideoParams]. The wait is bounded because this is also reached
+  /// for audio, where params never come; when a video simply takes longer,
+  /// [_onVideoParams] reopens the decision on arrival, so a timeout here is
+  /// a deferral rather than a verdict.
   Future<bool> _isHdrContent() async {
-    var params = _player.state.videoParams;
-    if (params.gamma == null && params.primaries == null) {
-      params = await _player.stream.videoParams
-          .firstWhere((p) => p.gamma != null || p.primaries != null)
-          .timeout(
-            const Duration(seconds: 2),
-            onTimeout: () => const VideoParams(),
-          );
-    }
+    var params = _decodedVideoParams;
+    params ??= await _player.stream.videoParams
+        .firstWhere((p) => p.gamma != null || p.primaries != null)
+        .timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => const VideoParams(),
+        );
     return isHdrVideoParams(gamma: params.gamma, primaries: params.primaries);
   }
 
@@ -2250,6 +2289,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     _isDisposed = true;
     _prefs.removeListener(_onPreferencesChanged);
     _ccTracksSub?.cancel();
+    _videoParamsSub?.cancel();
     _tracksChangedController.close();
     _player.dispose();
   }

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -877,6 +877,13 @@ class MediaKitPlayerBackend extends PlayerBackend {
   /// [_handOverToNativeWindow].
   Timer? _monitorSettleTimer;
 
+  /// True while the native renderer is being torn down and recreated for a
+  /// monitor crossing. In the behind-the-window arrangement the runner is
+  /// transparent, so the player screen paints black instead while this is
+  /// set - otherwise the desktop shows through the UI until mpv's first frame
+  /// lands in the new swapchain.
+  final ValueNotifier<bool> nativeRendererCycling = ValueNotifier(false);
+
   /// Recreates the renderer so the swapchain negotiates against the display
   /// the window is on now. The same vo cycle as engagement, subtitles carried
   /// across the same way.
@@ -910,6 +917,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
       if (!hdrOutput.isEngaged) return;
 
       sid = await _tryNativeGetProperty(native, 'sid');
+      nativeRendererCycling.value = true;
       await _nativeSetProperty(native, 'vo', 'null');
       await _nativeSetProperty(native, 'vo', 'gpu-next');
       // The renderer can refuse to come back on the new adapter. Without this
@@ -924,12 +932,16 @@ class MediaKitPlayerBackend extends PlayerBackend {
         return;
       }
       await _restoreSubtitleState(native, sid);
+      // current-vo flips as soon as the renderer exists, a little before its
+      // first frame is presented; hold the black over that too.
+      await Future<void>.delayed(const Duration(milliseconds: 250));
     } catch (_) {
       await _restoreTexturePath(native, sid: sid);
       if (hdrOutput.isEngaged) {
         hdrOutput.status.value = HdrOutputStatus.failed;
       }
     } finally {
+      nativeRendererCycling.value = false;
       _renegotiating = false;
       if (_renegotiatePending) {
         _renegotiatePending = false;

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -1062,7 +1062,25 @@ class MediaKitPlayerBackend extends PlayerBackend {
     'video-sync',
     'tone-mapping',
     'tone-mapping-param',
+    'tone-mapping-mode',
+    'gamut-mapping-mode',
     'target-trc',
+    'target-prim',
+    'target-peak',
+    'target-contrast',
+    // Tags the swapchain's colorspace, which is what HDR passthrough rides on.
+    // Only the contexts that own their swapchain (d3d11, winvk, wayland) act on
+    // it, so it is inert on the Flutter texture path and harmless to allow.
+    'target-colorspace-hint',
+    'hdr-compute-peak',
+    // gpu-api and gpu-context deliberately stay OUT of this list: they belong
+    // to the unsafe-advanced tier, and listing them here would bypass that
+    // gate on every platform - a wrong gpu-context blacks out all playback.
+    'target-inverse-tone-mapping',
+    // media_kit initializes every native platform with dither=no, which bands
+    // dark gradients on desktop. Let a conf turn it back on.
+    'dither',
+    'dither-depth',
     'brightness',
     'contrast',
     'saturation',
@@ -1091,6 +1109,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
 
   static const Set<String> _advancedMpvKeys = {
     'vo',
+    'gpu-api',
     'gpu-context',
     'hwdec',
     'audio-exclusive',

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -804,6 +804,20 @@ class MediaKitPlayerBackend extends PlayerBackend {
       await _nativeSetProperty(native, 'wid', handle.toString());
       await _nativeSetProperty(native, 'gpu-api', 'd3d11');
       await _nativeSetProperty(native, 'vo', 'gpu-next');
+      // mpv 0.40+ defaults `target-colorspace-hint-mode` to `target`: it reads
+      // the monitor's EDID capabilities through DXGI (peak, black level,
+      // primaries) and adapts the picture to them before encoding PQ. Panels
+      // that cannot really do HDR - DisplayHDR 400, "HDR Ready" - report
+      // figures that leave the picture dim, lifted and desaturated, and then
+      // tone-map it a second time themselves. `source` is the traditional
+      // passthrough: the stream's own metadata, untouched, which is what this
+      // feature promises and what other players send. Older libmpv builds
+      // without the option ignore the write.
+      await _nativeSetProperty(
+        native,
+        'target-colorspace-hint-mode',
+        'source',
+      );
       // The option that actually produces HDR passthrough. It tags the
       // swapchain, so it only does anything on a context that owns one -
       // which is exactly what the native window just provided.
@@ -1412,6 +1426,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
     // Only the contexts that own their swapchain (d3d11, winvk, wayland) act on
     // it, so it is inert on the Flutter texture path and harmless to allow.
     'target-colorspace-hint',
+    'target-colorspace-hint-mode',
     'hdr-compute-peak',
     // gpu-api and gpu-context deliberately stay OUT of this list: they belong
     // to the unsafe-advanced tier, and listing them here would bypass that

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1595,6 +1595,14 @@ class UserPreferences extends ChangeNotifier {
     values: AutoHdrSwitchingBehavior.values,
   );
 
+  /// Sends HDR video to the display untouched, by giving mpv its own D3D11
+  /// window instead of the shared 8-bit texture. Windows only, and only
+  /// engaged when the display is already in HDR mode and the content is HDR.
+  static final nativeHdrOutput = Preference(
+    key: 'native_hdr_output',
+    defaultValue: true,
+  );
+
   static final preferExoPlayerFfmpeg = Preference(
     key: 'exoplayer_prefer_ffmpeg',
     defaultValue: !(PlatformDetection.isAndroid && PlatformDetection.isTV),

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1600,7 +1600,7 @@ class UserPreferences extends ChangeNotifier {
   /// engaged when the display is already in HDR mode and the content is HDR.
   static final nativeHdrOutput = Preference(
     key: 'native_hdr_output',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   static final preferExoPlayerFfmpeg = Preference(

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -174,7 +174,11 @@ CustomTransitionPage<T> _opaqueFullScreenPage<T>({
     // go_router only auto-names builder-based routes, not pageBuilder ones.
     name: state.name ?? state.uri.path,
     opaque: true,
-    barrierColor: Colors.black,
+    // No barrier on Windows. The route is opaque with a zero-length
+    // transition, so the barrier is never visible - but it paints an opaque
+    // black ModalBarrier under the page, which would paint out the video
+    // behind the transparent player screen native HDR output relies on.
+    barrierColor: PlatformDetection.isWindows ? null : Colors.black,
     transitionDuration: Duration.zero,
     reverseTransitionDuration: Duration.zero,
     transitionsBuilder: (context, animation, secondaryAnimation, child) =>

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -125,7 +125,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
       if (_state.isPlaying) _saveResume();
     });
 
-    if (PlatformDetection.useNativeVideoSurface) {
+    if (PlatformDetection.playerVolumeIsSystemManaged) {
       unawaited(_manager.backend?.setVolume(100.0));
     }
 

--- a/lib/ui/screens/playback/hdr_overlay_capture.dart
+++ b/lib/ui/screens/playback/hdr_overlay_capture.dart
@@ -4,7 +4,9 @@ import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
+import '../../../playback/hdr_composition.dart';
 import '../../../playback/hdr_overlay_channel.dart';
+import '../../../util/platform_detection.dart';
 
 /// Mirrors part of the player chrome into a layered window above the HDR
 /// video window.
@@ -33,6 +35,16 @@ class HdrOverlayCapture extends StatefulWidget {
 
   final HdrOverlayChannel channel;
   final Widget child;
+
+  /// Whether this build can ever mirror the chrome into the layered window.
+  ///
+  /// False off Windows, and false on Windows in the default arrangement where
+  /// the compositor draws Flutter over the video. Both settle at startup, so
+  /// the widget hands its child straight back rather than wrapping every
+  /// player on every platform in a boundary only this path reads.
+  static bool get canCapture =>
+      PlatformDetection.supportsNativeHdrWindow &&
+      !HdrComposition.videoBehindFlutter;
 
   @override
   State<HdrOverlayCapture> createState() => _HdrOverlayCaptureState();
@@ -172,8 +184,9 @@ class _HdrOverlayCaptureState extends State<HdrOverlayCapture>
 
   @override
   Widget build(BuildContext context) {
-    // The boundary is always present, so toggling [enabled] never forces a
-    // relayout of the chrome underneath it.
+    if (!HdrOverlayCapture.canCapture) return widget.child;
+    // Where it does run, the boundary stays up whatever [enabled] says, so
+    // toggling it never relayouts the chrome underneath.
     return RepaintBoundary(key: _boundaryKey, child: widget.child);
   }
 }

--- a/lib/ui/screens/playback/hdr_overlay_capture.dart
+++ b/lib/ui/screens/playback/hdr_overlay_capture.dart
@@ -1,0 +1,271 @@
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../../../playback/hdr_overlay_channel.dart';
+
+/// Mirrors part of the player chrome into a layered window above the HDR
+/// video window.
+///
+/// While native HDR output is running, mpv draws into its own window, which
+/// covers the Flutter view. The widget tree underneath is left exactly as it
+/// is - still laid out, still hit-tested, still holding focus - because the
+/// video window and the overlays are both `WS_EX_TRANSPARENT`, so clicks fall
+/// straight through to it. Only the *pixels* have to be re-sent, which is what
+/// this does.
+///
+/// Wrapping a subtree in this changes nothing when [enabled] is false, so the
+/// texture path is untouched.
+class HdrOverlayCapture extends StatefulWidget {
+  const HdrOverlayCapture({
+    super.key,
+    required this.enabled,
+    required this.channel,
+    required this.child,
+  });
+
+  /// Capture only while mpv owns its own window. False leaves the subtree
+  /// untouched, so the call site can wrap unconditionally and keep one element
+  /// identity - and the player's focus node - across engage/disengage.
+  final bool enabled;
+
+  final HdrOverlayChannel channel;
+  final Widget child;
+
+  @override
+  State<HdrOverlayCapture> createState() => _HdrOverlayCaptureState();
+}
+
+class _HdrOverlayCaptureState extends State<HdrOverlayCapture>
+    with WidgetsBindingObserver {
+  final _boundaryKey = GlobalKey();
+
+  /// One capture in flight at a time. `toByteData` is a GPU-to-CPU readback,
+  /// so overlapping calls would queue up behind each other and the overlay
+  /// would drift further behind the widget tree with every frame.
+  bool _capturing = false;
+
+  /// Set by the frame watch whenever Flutter actually produced a frame,
+  /// cleared when a capture starts. The timer does nothing while it is clear,
+  /// so once the chrome has faded out and nothing animates, readbacks stop
+  /// entirely - the zero-cost steady state a film spends most of its runtime
+  /// in.
+  bool _frameDirty = false;
+
+  /// Ceiling on the capture rate while the chrome is animating.
+  static const _minInterval = Duration(milliseconds: 66);
+
+  /// Drives the captures. A plain timer, not a Ticker: a ticker requests a
+  /// frame every tick, forcing build and raster at display rate while mpv owns
+  /// the pixels and Flutter should be idle. The chrome changes only through
+  /// setState and animations, which schedule their own frames; the frame
+  /// watch just records that one happened.
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    if (widget.enabled) _start();
+  }
+
+  /// A monitor crossing changes the device pixel ratio and window metrics
+  /// without necessarily rebuilding anything, so a capture taken
+  /// mid-transition can land at the wrong offset with no further frame to
+  /// correct it. Re-dirty so the next tick re-reads geometry and ratio.
+  @override
+  void didChangeMetrics() {
+    _frameDirty = true;
+  }
+
+  @override
+  void didUpdateWidget(HdrOverlayCapture oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.enabled && !oldWidget.enabled) {
+      _start();
+    } else if (!widget.enabled && oldWidget.enabled) {
+      _stop();
+      widget.channel.hide();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _stop();
+    if (widget.enabled) widget.channel.hide();
+    super.dispose();
+  }
+
+  void _start() {
+    // Capture the current state right away, then only on real frames.
+    _frameDirty = true;
+    _armFrameWatch();
+    _timer ??= Timer.periodic(_minInterval, (_) => unawaited(_capture()));
+  }
+
+  void _stop() {
+    _timer?.cancel();
+    _timer = null;
+  }
+
+  /// Marks [_frameDirty] whenever the engine produces a frame.
+  /// `addPostFrameCallback` runs after frames Flutter was going to draw
+  /// anyway and never schedules one itself, so this costs nothing while the
+  /// tree is idle.
+  void _armFrameWatch() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _frameDirty = true;
+      if (widget.enabled) _armFrameWatch();
+    });
+  }
+
+  Future<void> _capture() async {
+    if (!mounted || !widget.enabled || _capturing || !_frameDirty) return;
+    final context = _boundaryKey.currentContext;
+    final boundary = context?.findRenderObject() as RenderRepaintBoundary?;
+    if (boundary == null || !boundary.hasSize) {
+      return;
+    }
+
+    _capturing = true;
+    // Before the awaits, so a frame produced mid-capture marks it again and
+    // the next tick picks it up.
+    _frameDirty = false;
+    // Declared outside the try so the finally can dispose it even when
+    // toByteData throws; the native backing is ~33 MB at 4K.
+    ui.Image? image;
+    try {
+      // Physical pixels: the layered window is sized in them, and rendering
+      // at the logical size would upscale the chrome on a high-DPI display.
+      final ratio = MediaQuery.devicePixelRatioOf(context!);
+      image = await boundary.toImage(pixelRatio: ratio);
+      // rawRgba is premultiplied, which is what AC_SRC_ALPHA wants. The
+      // runner swaps RGBA to BGRA so that loop stays off this isolate.
+      final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      final width = image.width;
+      final height = image.height;
+
+      // `data == null` is a documented outcome of toByteData; fall through
+      // rather than return so the capture still reschedules.
+      if (data != null && mounted && widget.enabled) {
+        final origin = boundary.localToGlobal(Offset.zero) * ratio;
+        await widget.channel.push(
+          x: origin.dx,
+          y: origin.dy,
+          pixels: data.buffer.asUint8List(),
+          width: width,
+          height: height,
+        );
+      }
+    } catch (_) {
+      // A capture can fail while the tree is being torn down. The next frame
+      // either retries or the widget is gone.
+    } finally {
+      image?.dispose();
+      _capturing = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // The boundary is always present, so toggling [enabled] never forces a
+    // relayout of the chrome underneath it.
+    return RepaintBoundary(key: _boundaryKey, child: widget.child);
+  }
+}
+
+/// Reports where the video should be, so the native window can be moved there.
+///
+/// Takes the place of the `Video` widget while native HDR output is running:
+/// mpv is drawing into its own window, so there is nothing for Flutter to
+/// paint here, but the rect still has to be measured from the same layout the
+/// texture path would have used.
+class HdrVideoGeometry extends StatefulWidget {
+  const HdrVideoGeometry({
+    super.key,
+    required this.onGeometry,
+    required this.onDetached,
+    this.showVideo = true,
+  });
+
+  /// Whether the native window should be on screen at all.
+  ///
+  /// False while a route sits above the player - a track picker, the info
+  /// sheet, any dialog. Those live in the Navigator's overlay, outside this
+  /// screen's subtree, so they are not mirrored into the layered window and
+  /// the video would simply cover them: the menu opens, takes the keyboard,
+  /// and cannot be seen. Standing the video window down for the few seconds a
+  /// menu is open hands the screen back to Flutter, which can draw it. Audio
+  /// is untouched.
+  final bool showVideo;
+
+  /// Called with the video rect in physical pixels, relative to the top-level
+  /// window's client area, whenever it changes.
+  final void Function(Rect rect) onGeometry;
+
+  /// Called when this widget goes away, so the window can be released by
+  /// whoever still owns it.
+  final VoidCallback onDetached;
+
+  @override
+  State<HdrVideoGeometry> createState() => _HdrVideoGeometryState();
+}
+
+class _HdrVideoGeometryState extends State<HdrVideoGeometry> {
+  Rect? _last;
+
+  bool? _lastShown;
+
+  void _report() {
+    if (!widget.showVideo) {
+      if (_lastShown != false) {
+        _lastShown = false;
+        widget.onDetached();
+      }
+      return;
+    }
+
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return;
+    final ratio = MediaQuery.devicePixelRatioOf(context);
+    final origin = box.localToGlobal(Offset.zero) * ratio;
+    final rect = Rect.fromLTWH(
+      origin.dx,
+      origin.dy,
+      box.size.width * ratio,
+      box.size.height * ratio,
+    );
+    // Re-report the rect when coming back from hidden, since the claim that
+    // shows the window again rides on it.
+    if (rect == _last && _lastShown == true) return;
+    _last = rect;
+    _lastShown = true;
+    widget.onGeometry(rect);
+  }
+
+  @override
+  void dispose() {
+    widget.onDetached();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // A LayoutBuilder so a pure resize (maximise, fullscreen, edge drag)
+    // re-reports: those relayout without rebuilding. Once per layout, not per
+    // frame - HdrVideoWindow.claim/release owning the window by identity is
+    // what handles the dispose/build race between two player-screen states.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) _report();
+        });
+        return const SizedBox.expand();
+      },
+    );
+  }
+}

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -142,10 +142,18 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   final HdrOverlayChannel _hdrOverlayChannel = HdrOverlayChannel();
 
   ValueNotifier<HdrOutputStatus>? _hdrStatus;
+  ValueNotifier<bool>? _hdrRendererCycling;
 
   void _onHdrStatusChanged() {
     if (mounted) setState(() {});
   }
+
+  /// Whether the video area must be left transparent for the native window
+  /// to show through. False while the renderer is being recreated for a
+  /// monitor crossing: the runner is see-through then and mpv has no frame
+  /// to put behind it, so the screen paints black rather than the desktop.
+  bool get _videoShowsThrough =>
+      _nativeHdrEngaged && !(_hdrRendererCycling?.value ?? false);
 
   /// The HDR-output line for the playback info sheet, or null on platforms
   /// where there is nothing to say. Reports the outcome and, when it did not
@@ -737,6 +745,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       // not wait for an unrelated rebuild.
       _hdrStatus = hdrBackend.hdrOutput.status
         ..addListener(_onHdrStatusChanged);
+      _hdrRendererCycling = hdrBackend.nativeRendererCycling
+        ..addListener(_onHdrStatusChanged);
       // Only this screen can present the native window; Live TV and the mini
       // player share the backend but can only render the texture.
       hdrBackend.hdrOutput.presenterActive = true;
@@ -927,6 +937,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   void dispose() {
     _trickplayLoadGeneration++;
     _hdrStatus?.removeListener(_onHdrStatusChanged);
+    _hdrRendererCycling?.removeListener(_onHdrStatusChanged);
     final hdrBackend = _hdrBackend;
     if (hdrBackend != null) {
       // Hands the whole native path back: mpv returns to the texture output,
@@ -3768,11 +3779,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       },
       child: Scaffold(
         // Overlay mode: black - the capture sits inside the body, so the
-        // background is not part of it. DWM mode: transparent while engaged -
-        // the video window sits behind a see-through runner window, so any
-        // opaque pixel here would cover it.
+        // background is not part of it. DWM mode: transparent while the video
+        // shows through - the video window sits behind a see-through runner
+        // window, so any opaque pixel here would cover it.
         backgroundColor:
-            HdrComposition.videoBehindFlutter && _nativeHdrEngaged
+            HdrComposition.videoBehindFlutter && _videoShowsThrough
             ? Colors.transparent
             : Colors.black,
         body: Focus(
@@ -3837,7 +3848,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                       // paint it out.
                       Positioned.fill(
                         child: ColoredBox(
-                          color: _nativeHdrEngaged
+                          color: _videoShowsThrough
                               ? Colors.transparent
                               : Colors.black,
                         ),

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -54,6 +54,10 @@ import '../../../util/audio_labels.dart';
 import '../../../util/subtitle_track_logic.dart';
 import '../../../util/auto_hdr_switcher.dart';
 import '../../../util/episode_playability.dart';
+import '../../../playback/hdr_composition.dart';
+import '../../../playback/hdr_output_controller.dart';
+import '../../../playback/hdr_overlay_channel.dart';
+import 'hdr_overlay_capture.dart';
 import '../../../util/focus/dpad_keys.dart';
 import '../../../util/play_method_label.dart';
 import '../../../util/platform_detection.dart';
@@ -134,6 +138,53 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final backend = _activeBackend;
     return backend is Media3PlayerBackend ? backend : null;
   }
+
+  final HdrOverlayChannel _hdrOverlayChannel = HdrOverlayChannel();
+
+  ValueNotifier<HdrOutputStatus>? _hdrStatus;
+
+  void _onHdrStatusChanged() {
+    if (mounted) setState(() {});
+  }
+
+  /// The HDR-output line for the playback info sheet, or null on platforms
+  /// where there is nothing to say. Reports the outcome and, when it did not
+  /// engage, why.
+  String? _hdrOutputRow(AppLocalizations l10n, {bool hdrTonemapped = false}) {
+    final backend = _hdrBackend;
+    if (backend == null) return null;
+    final status = backend.hdrOutput.status.value;
+    // Engaged, but this display is not receiving HDR - the window sits on a
+    // monitor without it.
+    if (status.isActive && hdrTonemapped) {
+      return l10n.hdrOutputActiveTonemapped;
+    }
+    return switch (status) {
+      HdrOutputStatus.active => l10n.hdrOutputActive(
+        HdrOutputController.activeOutputFormat,
+      ),
+      HdrOutputStatus.displayNotInHdrMode => l10n.hdrOutputDisplayNotHdr,
+      HdrOutputStatus.contentIsSdr => l10n.hdrOutputContentSdr,
+      HdrOutputStatus.disabledByPreference => l10n.hdrOutputDisabled,
+      HdrOutputStatus.failed => l10n.hdrOutputFailed,
+    };
+  }
+
+  /// The backend whose HDR output this screen presents, or null on platforms
+  /// without the native window.
+  MediaKitPlayerBackend? get _hdrBackend =>
+      PlatformDetection.supportsNativeHdrWindow
+      ? (_activeMediaKitBackend ?? _backend)
+      : null;
+
+  /// Whether mpv currently renders into its own native window.
+  bool get _nativeHdrEngaged => _hdrBackend?.hdrOutput.isEngaged ?? false;
+
+  /// Whether a route sits above the player - a track picker, the info sheet,
+  /// any dialog. In overlay mode this stops the capture *and* stands the
+  /// video window down, since routes live outside the captured subtree and
+  /// the video would cover them; in DWM mode it does neither.
+  bool get _routeCovered => !(ModalRoute.of(context)?.isCurrent ?? true);
 
   HtmlVideoBackend? get _activeHtmlVideoBackend {
     final backend = _activeBackend;
@@ -679,6 +730,20 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       releaseImageMemoryForPlayback();
       detachTextInputForPlayback();
     }
+    final hdrBackend = _hdrBackend;
+    if (hdrBackend != null) {
+      // Engagement finishes at the tail of play(), after the last build, and
+      // swaps which video surface this screen shows - listen so the swap does
+      // not wait for an unrelated rebuild.
+      _hdrStatus = hdrBackend.hdrOutput.status
+        ..addListener(_onHdrStatusChanged);
+      // Only this screen can present the native window; Live TV and the mini
+      // player share the backend but can only render the texture.
+      hdrBackend.hdrOutput.presenterActive = true;
+      // play() may have run before this screen mounted and been refused for
+      // lack of a presenter; decide again now that one exists.
+      unawaited(hdrBackend.ensureNativeHdrForPresenter());
+    }
     _screensaverController.setPlaybackActive(true);
     _screensaverPlayingSub = _state.playingStream.listen(
       _screensaverController.setPlaybackActive,
@@ -861,6 +926,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   @override
   void dispose() {
     _trickplayLoadGeneration++;
+    _hdrStatus?.removeListener(_onHdrStatusChanged);
+    final hdrBackend = _hdrBackend;
+    if (hdrBackend != null) {
+      // Hands the whole native path back: mpv returns to the texture output,
+      // the window is destroyed, and the next playback decides afresh. mpv is
+      // a process-lifetime singleton shared with Live TV and the mini player,
+      // which can only render the texture.
+      unawaited(hdrBackend.releaseNativeHdrPresenter());
+      unawaited(_hdrOverlayChannel.hide());
+    }
     if (_isInPiP && GetIt.instance.isRegistered<PlaybackArbiter>()) {
       GetIt.instance<PlaybackArbiter>().pipActive = false;
     }
@@ -1174,6 +1249,22 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _ensureDesktopOverlayFocus();
   }
 
+  // Fullscreen can be entered without the player ever being asked: F11 and
+  // Alt+Enter are handled by the global shortcut in app.dart, which calls
+  // FullscreenHelper directly, and the title bar, Win+Up and the window menu
+  // bypass the app entirely. Listening to the window itself catches all of
+  // them, so _isDesktopFullscreen and the auto-HDR switch stay in step
+  // whichever route was taken.
+  @override
+  void onWindowEnterFullScreen() {
+    unawaited(_syncDesktopFullscreenState());
+  }
+
+  @override
+  void onWindowLeaveFullScreen() {
+    unawaited(_syncDesktopFullscreenState());
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState lifecycleState) {
     if (lifecycleState != AppLifecycleState.resumed) {
@@ -1408,7 +1499,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     await _pushMedia3UiMetadata();
   }
 
-  List<Map<String, dynamic>> _buildMedia3StreamInfoSections() {
+  /// [hdrTonemapped] is what the display is receiving right now, resolved at
+  /// sheet-open time; callers that never show the HDR row can leave it.
+  List<Map<String, dynamic>> _buildMedia3StreamInfoSections({
+    bool hdrTonemapped = false,
+  }) {
     final l10n = AppLocalizations.of(context);
     final resolution = _manager.currentResolution;
     final playMethod = resolution?.playMethod;
@@ -1596,6 +1691,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
           '${width ?? '?'}×${height ?? '?'}${fps != null ? ' @ ${fps.round()}fps' : ''}',
         ),
         row(l10n.hdr, _getHdrType(video)),
+        if (_hdrOutputRow(l10n, hdrTonemapped: hdrTonemapped)
+            case final hdrOutput?)
+          row(l10n.hdrOutput, hdrOutput),
         row(l10n.codec, _formatVideoCodec(video)),
         if (video['BitRate'] != null)
           row(l10n.videoBitrate, _formatBitrate(video['BitRate'] as int?)),
@@ -3669,7 +3767,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _exitPlayback();
       },
       child: Scaffold(
-        backgroundColor: Colors.black,
+        // Overlay mode: black - the capture sits inside the body, so the
+        // background is not part of it. DWM mode: transparent while engaged -
+        // the video window sits behind a see-through runner window, so any
+        // opaque pixel here would cover it.
+        backgroundColor:
+            HdrComposition.videoBehindFlutter && _nativeHdrEngaged
+            ? Colors.transparent
+            : Colors.black,
         body: Focus(
           focusNode: _overlayFocus,
           autofocus: true,
@@ -3706,13 +3811,38 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     }
                   }
                 },
-                child: Stack(
-                  fit: StackFit.expand,
-                  children: [
-                    const Positioned.fill(
-                      child: ColoredBox(color: Colors.black),
-                    ),
-                    _buildVideoSurface(),
+                // Everything this screen draws is mirrored into the layered
+                // window, not just the chrome - the OSDs, next-up,
+                // skip-segment and the locked overlay are siblings below.
+                // Routes above this screen (pickers, the info sheet) are
+                // outside this subtree and cannot be mirrored; both the
+                // capture and the video window stand down while one is open.
+                //
+                // Wrapped unconditionally so the subtree keeps one element
+                // identity; toggling a wrapper re-parents it and the player
+                // loses its focus node.
+                child: HdrOverlayCapture(
+                  enabled:
+                      // In DWM mode the compositor already draws Flutter over
+                      // the video.
+                      !HdrComposition.videoBehindFlutter &&
+                      _nativeHdrEngaged &&
+                      !_routeCovered,
+                  channel: _hdrOverlayChannel,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      // Transparent while mpv owns the video window: this
+                      // capture is drawn over the picture, so black here would
+                      // paint it out.
+                      Positioned.fill(
+                        child: ColoredBox(
+                          color: _nativeHdrEngaged
+                              ? Colors.transparent
+                              : Colors.black,
+                        ),
+                      ),
+                      _buildVideoSurface(),
                     if (PlatformDetection.isWeb)
                       const Positioned.fill(
                         child: ColoredBox(color: Colors.transparent),
@@ -3727,6 +3857,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     if (_controlsVisible &&
                         !_isOsdLocked &&
                         !hideOsdForPreroll) ...[
+                      // The chrome stays in the tree while mpv owns its own
+                      // window: both native windows are WS_EX_TRANSPARENT, so
+                      // these widgets are still what gets hit-tested - only
+                      // their pixels are re-sent by HdrOverlayCapture.
                       _buildTopOverlay(context),
                       if (!PlatformDetection.useLeanbackUi)
                         Positioned.fill(
@@ -3785,7 +3919,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                             ? _tvNextUpDismissFocus
                             : null,
                       ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -3890,6 +4025,25 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final mediaKitBackend = _activeMediaKitBackend ?? _backend;
     if (mediaKitBackend == null) {
       return const Positioned.fill(child: ColoredBox(color: Colors.black));
+    }
+
+    // Native HDR output: mpv draws into its own window, so nothing is painted
+    // here - but the rect is measured from the same layout so the window can
+    // follow it.
+    if (mediaKitBackend.hdrOutput.isEngaged) {
+      return Positioned.fill(
+        child: HdrVideoGeometry(
+          key: _videoSurfaceKey,
+          // In overlay mode the video stands down under a route (pickers,
+          // sheets) so Flutter can draw it; in DWM mode Flutter draws over
+          // the video anyway.
+          showVideo: HdrComposition.videoBehindFlutter || !_routeCovered,
+          onGeometry: (rect) =>
+              unawaited(mediaKitBackend.hdrOutput.window.claim(this, rect)),
+          onDetached: () =>
+              unawaited(mediaKitBackend.hdrOutput.window.release(this)),
+        ),
+      );
     }
     final hwDecodingEnabled = _prefs.get(UserPreferences.hardwareDecoding);
     const selectedVo = 'gpu';
@@ -7327,8 +7481,18 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _showStreamInfo() {
+    unawaited(_showStreamInfoAsync());
+  }
+
+  Future<void> _showStreamInfoAsync() async {
+    // Live display state: the session stays "active" on an SDR monitor, so
+    // the row must not claim HDR while the screen shows SDR.
+    final live = await _hdrBackend?.isCurrentOutputHdr();
+    if (!mounted) return;
     final l10n = AppLocalizations.of(context);
-    final streamInfoSections = _buildMedia3StreamInfoSections();
+    final streamInfoSections = _buildMedia3StreamInfoSections(
+      hdrTonemapped: live == false,
+    );
     unawaited(
       showStreamInfoDialog(
         context: context,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -825,9 +825,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       if (isMobilePlayback) {
         _pipService.updatePiPActions(isPlaying: playing);
         _syncAirPlayPlaybackState();
-        if (PlatformDetection.useNativeVideoSurface && playing) {
-          _syncSubtitleActive();
-        }
       }
     });
 

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -134,6 +134,15 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     return backend is MediaKitPlayerBackend ? backend : null;
   }
 
+  /// The backend whose mpv statistics overlay this screen can toggle, or null
+  /// where that libmpv build has none. Resolved like [_hdrBackend].
+  MediaKitPlayerBackend? get _mpvStatsBackend {
+    final backend = _activeMediaKitBackend ?? _backend;
+    return backend is MediaKitPlayerBackend && backend.supportsMpvStats
+        ? backend
+        : null;
+  }
+
   Media3PlayerBackend? get _activeMedia3Backend {
     final backend = _activeBackend;
     return backend is Media3PlayerBackend ? backend : null;
@@ -267,8 +276,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   MediaSegment? _skipSegment;
   Duration? _skipTo;
+
   /// True when the auto-hide setting is on for the current segment.
   bool _skipSegmentAutoHideEnabled = false;
+
   /// True while the auto-hide cooldown is still running.
   bool _skipSegmentAutoHidePending = false;
   Timer? _skipSegmentAutoHideTimer;
@@ -514,7 +525,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       results = await withProgressSnackBar(
         messenger,
         AppLocalizations.of(context).searchingSubtitles,
-        () => client.itemsApi.searchRemoteSubtitles(item.id, language: language),
+        () =>
+            client.itemsApi.searchRemoteSubtitles(item.id, language: language),
       );
     } catch (error) {
       if (!mounted) return;
@@ -2930,7 +2942,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     // While a released commit is still converging, the pending target is
     // already null but _state.position still reads pre-seek - basing a quick
     // follow-up press on it would jump back to the old position.
-    final basePosition = _pendingScrubSeekTarget ??
+    final basePosition =
+        _pendingScrubSeekTarget ??
         (_isSeeking ? _lastScrubCommitTarget : null) ??
         _state.position;
     final target = basePosition + Duration(milliseconds: ms);
@@ -3711,6 +3724,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _stepPlaybackSpeed(1);
         return KeyEventResult.handled;
       case LogicalKeyboardKey.keyI:
+        if (HardwareKeyboard.instance.isShiftPressed) {
+          // Shift+I: mpv's own statistics overlay, same key as in mpv.
+          final backend = _mpvStatsBackend;
+          if (backend == null) return KeyEventResult.ignored;
+          if (event is! KeyRepeatEvent) unawaited(backend.toggleMpvStats());
+          return KeyEventResult.handled;
+        }
         _showStreamInfo();
         _showControls();
         return KeyEventResult.handled;
@@ -3782,8 +3802,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         // background is not part of it. DWM mode: transparent while the video
         // shows through - the video window sits behind a see-through runner
         // window, so any opaque pixel here would cover it.
-        backgroundColor:
-            HdrComposition.videoBehindFlutter && _videoShowsThrough
+        backgroundColor: HdrComposition.videoBehindFlutter && _videoShowsThrough
             ? Colors.transparent
             : Colors.black,
         body: Focus(
@@ -3854,82 +3873,84 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                         ),
                       ),
                       _buildVideoSurface(),
-                    if (PlatformDetection.isWeb)
-                      const Positioned.fill(
-                        child: ColoredBox(color: Colors.transparent),
-                      ), // Workaround for a Flutter web issue where the video surface can block pointer events.
-                    _buildTrickplayVideoCover(),
-                    _buildBringupOverlay(context),
-                    if (_isRestoringPosition)
-                      const Positioned.fill(
-                        child: ColoredBox(color: Colors.black),
-                      ),
-                    _buildPausedDescriptionOverlay(),
-                    if (_controlsVisible &&
-                        !_isOsdLocked &&
-                        !hideOsdForPreroll) ...[
-                      // The chrome stays in the tree while mpv owns its own
-                      // window: both native windows are WS_EX_TRANSPARENT, so
-                      // these widgets are still what gets hit-tested - only
-                      // their pixels are re-sent by HdrOverlayCapture.
-                      _buildTopOverlay(context),
-                      if (!PlatformDetection.useLeanbackUi)
-                        Positioned.fill(
-                          child: Center(child: _buildCenterTransportControls()),
+                      if (PlatformDetection.isWeb)
+                        const Positioned.fill(
+                          child: ColoredBox(color: Colors.transparent),
+                        ), // Workaround for a Flutter web issue where the video surface can block pointer events.
+                      _buildTrickplayVideoCover(),
+                      _buildBringupOverlay(context),
+                      if (_isRestoringPosition)
+                        const Positioned.fill(
+                          child: ColoredBox(color: Colors.black),
                         ),
-                      _buildBottomOverlay(context),
-                    ],
-                    _buildBufferingIndicator(),
-                    _buildVolumeOverlay(),
-                    if (PlatformDetection.useMobileUi)
-                      _buildBrightnessOverlay(),
-                    if (PlatformDetection.useMobileUi)
-                      _buildDoubleTapSkipOverlay(),
-                    if (_isOsdLocked && !hideOsdForPreroll)
-                      _buildLockedOverlay(),
-                    if (_isSkipSegmentButtonVisible)
-                      SkipSegmentOverlay(
-                        segment: _skipSegment!,
-                        onSkip: _skipCurrentSegment,
-                        focusNode: PlatformDetection.isTV
-                            ? _tvSkipSegmentFocus
-                            : null,
-                        onDismiss: _clearSkipSegment,
-                        positionStream: _state.positionStream,
-                        initialPosition: _state.position,
-                      ),
-                    if (_showNextUp && _nextUpItem != null)
-                      NextUpOverlay(
-                        nextItem: _nextUpItem!,
-                        isMinimal:
-                            _prefs.get(UserPreferences.nextUpBehavior) ==
-                            NextUpBehavior.minimal,
-                        imageUrl:
-                            _nextUpItem!.primaryImageTag != null &&
-                                _prefs.get(UserPreferences.nextUpBehavior) !=
-                                    NextUpBehavior.minimal
-                            ? _clientForItem(
-                                _nextUpItem!,
-                              ).imageApi.getPrimaryImageUrl(
-                                _nextUpItem!.id,
-                                maxWidth: 400,
-                                tag: _nextUpItem!.primaryImageTag,
-                              )
-                            : null,
-                        timeoutMs: _prefs.get(UserPreferences.nextUpTimeout),
-                        onPlayNext: _handleNextUpPlay,
-                        onDismiss: _handleNextUpCancel,
-                        onTimeout:
-                            _prefs.get(UserPreferences.autoplayNextEpisode)
-                            ? _handleNextUpPlay
-                            : _handleNextUpCancel,
-                        focusNode: PlatformDetection.isTV
-                            ? _tvNextUpPlayFocus
-                            : null,
-                        dismissFocusNode: PlatformDetection.isTV
-                            ? _tvNextUpDismissFocus
-                            : null,
-                      ),
+                      _buildPausedDescriptionOverlay(),
+                      if (_controlsVisible &&
+                          !_isOsdLocked &&
+                          !hideOsdForPreroll) ...[
+                        // The chrome stays in the tree while mpv owns its own
+                        // window: both native windows are WS_EX_TRANSPARENT, so
+                        // these widgets are still what gets hit-tested - only
+                        // their pixels are re-sent by HdrOverlayCapture.
+                        _buildTopOverlay(context),
+                        if (!PlatformDetection.useLeanbackUi)
+                          Positioned.fill(
+                            child: Center(
+                              child: _buildCenterTransportControls(),
+                            ),
+                          ),
+                        _buildBottomOverlay(context),
+                      ],
+                      _buildBufferingIndicator(),
+                      _buildVolumeOverlay(),
+                      if (PlatformDetection.useMobileUi)
+                        _buildBrightnessOverlay(),
+                      if (PlatformDetection.useMobileUi)
+                        _buildDoubleTapSkipOverlay(),
+                      if (_isOsdLocked && !hideOsdForPreroll)
+                        _buildLockedOverlay(),
+                      if (_isSkipSegmentButtonVisible)
+                        SkipSegmentOverlay(
+                          segment: _skipSegment!,
+                          onSkip: _skipCurrentSegment,
+                          focusNode: PlatformDetection.isTV
+                              ? _tvSkipSegmentFocus
+                              : null,
+                          onDismiss: _clearSkipSegment,
+                          positionStream: _state.positionStream,
+                          initialPosition: _state.position,
+                        ),
+                      if (_showNextUp && _nextUpItem != null)
+                        NextUpOverlay(
+                          nextItem: _nextUpItem!,
+                          isMinimal:
+                              _prefs.get(UserPreferences.nextUpBehavior) ==
+                              NextUpBehavior.minimal,
+                          imageUrl:
+                              _nextUpItem!.primaryImageTag != null &&
+                                  _prefs.get(UserPreferences.nextUpBehavior) !=
+                                      NextUpBehavior.minimal
+                              ? _clientForItem(
+                                  _nextUpItem!,
+                                ).imageApi.getPrimaryImageUrl(
+                                  _nextUpItem!.id,
+                                  maxWidth: 400,
+                                  tag: _nextUpItem!.primaryImageTag,
+                                )
+                              : null,
+                          timeoutMs: _prefs.get(UserPreferences.nextUpTimeout),
+                          onPlayNext: _handleNextUpPlay,
+                          onDismiss: _handleNextUpCancel,
+                          onTimeout:
+                              _prefs.get(UserPreferences.autoplayNextEpisode)
+                              ? _handleNextUpPlay
+                              : _handleNextUpCancel,
+                          focusNode: PlatformDetection.isTV
+                              ? _tvNextUpPlayFocus
+                              : null,
+                          dismissFocusNode: PlatformDetection.isTV
+                              ? _tvNextUpDismissFocus
+                              : null,
+                        ),
                     ],
                   ),
                 ),
@@ -4009,10 +4030,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
     if (PlatformDetection.isIOS || PlatformDetection.isMacOS) {
       return Positioned.fill(
-        child: AetherVideoView(
-          key: _videoSurfaceKey,
-          zoomMode: _zoomMode.name,
-        ),
+        child: AetherVideoView(key: _videoSurfaceKey, zoomMode: _zoomMode.name),
       );
     }
 
@@ -5045,7 +5063,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     required double trackWidth,
     required bool showTimeLabel,
   }) {
-    final timeLabel = showTimeLabel ? formatPlaybackDuration(seekPosition) : null;
+    final timeLabel = showTimeLabel
+        ? formatPlaybackDuration(seekPosition)
+        : null;
     final scalePercent = _prefs.get(
       UserPreferences.trickPlayPreviewScalePercent,
     );
@@ -5054,7 +5074,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     );
 
     final resolvedBottomMargin =
-        _bottomOverlayHeight ?? TrickplayPreviewLayout.verticalTravelBottomMargin;
+        _bottomOverlayHeight ??
+        TrickplayPreviewLayout.verticalTravelBottomMargin;
     final resolvedTopMargin =
         _topOverlayHeight ?? TrickplayPreviewLayout.verticalTravelTopMargin;
 
@@ -6388,8 +6409,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                     ),
                     _controlButton(
                       seekBackIcon(_prefs.get(UserPreferences.skipBackLength)),
-                      onPressed: () =>
-                          _seekRelative(-_prefs.get(UserPreferences.skipBackLength)),
+                      onPressed: () => _seekRelative(
+                        -_prefs.get(UserPreferences.skipBackLength),
+                      ),
                       size: 46,
                       extent: 78,
                       tooltip: _tooltipMessage(
@@ -6419,9 +6441,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     _controlButton(
-                      seekForwardIcon(_prefs.get(UserPreferences.skipForwardLength)),
-                      onPressed: () =>
-                          _seekRelative(_prefs.get(UserPreferences.skipForwardLength)),
+                      seekForwardIcon(
+                        _prefs.get(UserPreferences.skipForwardLength),
+                      ),
+                      onPressed: () => _seekRelative(
+                        _prefs.get(UserPreferences.skipForwardLength),
+                      ),
                       size: 46,
                       extent: 78,
                       tooltip: _tooltipMessage(
@@ -7504,11 +7529,27 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final streamInfoSections = _buildMedia3StreamInfoSections(
       hdrTonemapped: live == false,
     );
+    // mpv's own statistics overlay, the Shift+I one, offered as a button so
+    // it can be found without knowing the key.
+    final mediaKit = _mpvStatsBackend;
     unawaited(
       showStreamInfoDialog(
         context: context,
         title: l10n.playbackInformation,
         streamInfoSections: streamInfoSections,
+        action: mediaKit == null
+            ? null
+            : (
+                label: mediaKit.mpvStatsVisible
+                    ? l10n.hideMpvStats
+                    : l10n.showMpvStats,
+                onPressed: () {
+                  // Close first: in the overlay-capture arrangement a route
+                  // above the player stands the video down.
+                  Navigator.of(context, rootNavigator: true).pop();
+                  unawaited(mediaKit.toggleMpvStats());
+                },
+              ),
       ),
     );
     _showControls();

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -732,11 +732,16 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Future<void> _syncAutoHdrSwitching() async {
     if (!PlatformDetection.isWindows) return;
     final behavior = _prefs.get(UserPreferences.autoHdrSwitchingBehavior);
-    await _autoHdrSwitcher.sync(
+    final switched = await _autoHdrSwitcher.sync(
       behavior: behavior,
       isHdrContent: _isHdrPlaybackContent(),
       isDesktopFullscreen: _isDesktopFullscreen,
     );
+    // Only on a real mode change: the window did not move, so nothing else
+    // tells the native path.
+    if (switched) {
+      _hdrBackend?.refreshNativeHdrForDisplayState();
+    }
   }
 
   @override
@@ -760,11 +765,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _hdrRendererCycling = hdrBackend.nativeRendererCycling
         ..addListener(_onHdrStatusChanged);
       // Only this screen can present the native window; Live TV and the mini
-      // player share the backend but can only render the texture.
-      hdrBackend.hdrOutput.presenterActive = true;
-      // play() may have run before this screen mounted and been refused for
-      // lack of a presenter; decide again now that one exists.
-      unawaited(hdrBackend.ensureNativeHdrForPresenter());
+      // player share the backend but can only render the texture. play() may
+      // have run before this screen mounted and been refused for lack of a
+      // presenter; decide again now that one exists.
+      unawaited(hdrBackend.ensureNativeHdrForPresenter(this));
     }
     _screensaverController.setPlaybackActive(true);
     _screensaverPlayingSub = _state.playingStream.listen(
@@ -956,7 +960,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       // the window is destroyed, and the next playback decides afresh. mpv is
       // a process-lifetime singleton shared with Live TV and the mini player,
       // which can only render the texture.
-      unawaited(hdrBackend.releaseNativeHdrPresenter());
+      unawaited(hdrBackend.releaseNativeHdrPresenter(this));
       unawaited(_hdrOverlayChannel.hide());
     }
     if (_isInPiP && GetIt.instance.isRegistered<PlaybackArbiter>()) {

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1204,6 +1204,13 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       ),
     if (PlatformDetection.isWindows)
       video.leaf('auto_hdr_switching_behavior', l10n.autoHdrSwitching),
+    if (PlatformDetection.supportsNativeHdrWindow)
+      video.leaf(
+        'native_hdr_output',
+        l10n.nativeHdrOutput,
+        subtitle: l10n.nativeHdrOutputDescription,
+        keywords: ['hdr10', 'passthrough', 'tone mapping'],
+      ),
     video.leaf(
       'pref_live_direct',
       l10n.settingsLiveTvDirect,

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -286,6 +286,13 @@ class _VideoPlaybackScreen extends StatelessWidget {
                     AutoHdrSwitchingBehavior.always => l10n.always,
                   },
                 ),
+              if (PlatformDetection.supportsNativeHdrWindow)
+                SwitchPreferenceTile(
+                  preference: UserPreferences.nativeHdrOutput,
+                  title: l10n.nativeHdrOutput,
+                  subtitle: l10n.nativeHdrOutputDescription,
+                  icon: Icons.hdr_on,
+                ),
               SwitchPreferenceTile(
                 preference: UserPreferences.liveTvDirectPlayEnabled,
                 title: l10n.settingsLiveTvDirect,

--- a/lib/ui/widgets/playback/stream_info_dialog.dart
+++ b/lib/ui/widgets/playback/stream_info_dialog.dart
@@ -12,6 +12,9 @@ Future<void> showStreamInfoDialog({
   required String title,
   required List<Map<String, dynamic>> streamInfoSections,
   double maxWidth = 560,
+
+  /// An optional button under the sections.
+  ({String label, VoidCallback onPressed})? action,
 }) async {
   final l10n = AppLocalizations.of(context);
 
@@ -26,6 +29,10 @@ Future<void> showStreamInfoDialog({
     color: Colors.white,
     fontSize: 13,
     fontWeight: FontWeight.w600,
+  );
+  final actionStyle = OutlinedButton.styleFrom(
+    foregroundColor: Colors.white,
+    side: ThemeRegistry.active.borders.chipBorder,
   );
 
   Widget infoRow(String label, String value, {bool highlight = false}) {
@@ -117,6 +124,24 @@ Future<void> showStreamInfoDialog({
                   );
                 })),
           ],
+          if (action != null)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.spaceLg,
+                AppSpacing.spaceMd,
+                AppSpacing.spaceLg,
+                0,
+              ),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: OutlinedButton.icon(
+                  onPressed: action.onPressed,
+                  icon: const Icon(Icons.query_stats_rounded),
+                  label: Text(action.label),
+                  style: actionStyle,
+                ),
+              ),
+            ),
           const SizedBox(height: AppSpacing.spaceLg),
         ],
       ),

--- a/lib/util/auto_hdr_switcher.dart
+++ b/lib/util/auto_hdr_switcher.dart
@@ -42,13 +42,16 @@ class AutoHdrSwitcher {
   bool _restoreToSdr = false;
   bool _channelUnavailable = false;
 
-  Future<void> sync({
+  /// Returns whether the display's HDR mode was actually changed. Callers run
+  /// this on every bringup phase and queue change, where it does nothing, so
+  /// react to the return value rather than to the call.
+  Future<bool> sync({
     required AutoHdrSwitchingBehavior behavior,
     required bool isHdrContent,
     required bool isDesktopFullscreen,
   }) async {
     if (!PlatformDetection.isWindows) {
-      return;
+      return false;
     }
 
     final shouldEnable = switch (behavior) {
@@ -59,24 +62,24 @@ class AutoHdrSwitcher {
     };
 
     if (shouldEnable) {
-      await _engage();
-      return;
+      return _engage();
     }
 
-    await restore();
+    return restore();
   }
 
-  Future<void> _engage() async {
-    if (_engaged || _channelUnavailable) return;
+  /// True only when it actually switched the display into HDR.
+  Future<bool> _engage() async {
+    if (_engaged || _channelUnavailable) return false;
 
     try {
       final state = await _channel.invokeMapMethod<String, dynamic>('getHdrState');
-      if (state == null) return;
+      if (state == null) return false;
 
       final supported = state['supported'] == true;
       final enabled = state['enabled'] == true;
       if (!supported) {
-        return;
+        return false;
       }
 
       _engaged = true;
@@ -87,28 +90,36 @@ class AutoHdrSwitcher {
         if (ok != true) {
           _engaged = false;
           _restoreToSdr = false;
+          return false;
         }
+        return true;
       }
     } on MissingPluginException {
       _channelUnavailable = true;
     } catch (_) {}
+    return false;
   }
 
-  Future<void> restore() async {
-    if (!_engaged) return;
+  /// True only when it actually switched the display back to SDR.
+  Future<bool> restore() async {
+    if (!_engaged) return false;
 
     final restoreToSdr = _restoreToSdr;
     _engaged = false;
     _restoreToSdr = false;
 
     if (!restoreToSdr || !PlatformDetection.isWindows || _channelUnavailable) {
-      return;
+      return false;
     }
 
     try {
-      await _channel.invokeMethod<bool>('setHdrEnabled', false);
+      // The runner reports a refusal (another process owning the output, a
+      // config call that failed) rather than throwing, same as _engage.
+      final ok = await _channel.invokeMethod<bool>('setHdrEnabled', false);
+      return ok == true;
     } on MissingPluginException {
       _channelUnavailable = true;
     } catch (_) {}
+    return false;
   }
 }

--- a/lib/util/auto_hdr_switcher.dart
+++ b/lib/util/auto_hdr_switcher.dart
@@ -6,6 +6,38 @@ import 'platform_detection.dart';
 class AutoHdrSwitcher {
   static const MethodChannel _channel = MethodChannel('moonfin/hdr_display');
 
+  /// Whether the display the window is on is currently in HDR mode.
+  ///
+  /// Native HDR output needs this before deciding to give mpv its own window:
+  /// tagging a swapchain BT.2020/PQ against an SDR display just makes mpv
+  /// tone-map twice.
+  static Future<bool> isDisplayHdrEnabled() async =>
+      await displayHdrState() ?? false;
+
+  /// Tri-state variant of [isDisplayHdrEnabled]: null when the answer could
+  /// not be determined.
+  ///
+  /// The distinction matters to the monitor-crossing renegotiation skip: the
+  /// display query can legitimately fail mid-topology-change - exactly when a
+  /// crossing fires - and a failure read as "SDR" would wrongly skip the
+  /// cycle and stick playback on the old colorspace with no retry.
+  /// Engagement keeps the collapsed bool, where unknown conservatively means
+  /// "do not engage".
+  static Future<bool?> displayHdrState() async {
+    if (!PlatformDetection.isWindows) return false;
+    try {
+      final state = await _channel.invokeMapMethod<String, dynamic>(
+        'getHdrState',
+      );
+      if (state == null) return null;
+      return state['enabled'] == true;
+    } on MissingPluginException {
+      return false;
+    } catch (_) {
+      return null;
+    }
+  }
+
   bool _engaged = false;
   bool _restoreToSdr = false;
   bool _channelUnavailable = false;

--- a/lib/util/platform_detection.dart
+++ b/lib/util/platform_detection.dart
@@ -365,6 +365,13 @@ class PlatformDetection {
 
   static bool get useNativeVideoSurface => isAndroid && isTV;
 
+  /// Volume is driven by the remote through AudioTrack, so the player's own
+  /// mixer should stay wide open rather than restoring a saved level.
+  ///
+  /// The same expression as [useNativeVideoSurface] today, but a different
+  /// question - keep them apart.
+  static bool get playerVolumeIsSystemManaged => isAndroid && isTV;
+
   /// Apple platforms use the shared AVPlayer-based preview/theme channels
   /// (`moonfin/appletv_preview`, `moonfin/appletv_theme_music`) instead of a
   /// media_kit Player for inline trailers, home-row previews and theme music.

--- a/lib/util/platform_detection.dart
+++ b/lib/util/platform_detection.dart
@@ -372,6 +372,19 @@ class PlatformDetection {
   /// question - keep them apart.
   static bool get playerVolumeIsSystemManaged => isAndroid && isTV;
 
+  /// Whether this platform can give mpv its own window for HDR output.
+  ///
+  /// Deliberately separate from [useNativeVideoSurface] rather than widening
+  /// it with an `isWindows` term: that getter is gated on [isTV], which is
+  /// user-overridable on desktop through [canOverrideInterfaceLayout], so any
+  /// Windows user picking the TV layout would activate this by accident.
+  ///
+  /// This only says the platform is capable. Whether the window is actually
+  /// used is decided per session from the content, the display's HDR state and
+  /// [UserPreferences.nativeHdrOutput] - see `HdrOutputController`. That
+  /// preference is the off switch; there is deliberately no compile-time one.
+  static bool get supportsNativeHdrWindow => isWindows;
+
   /// Apple platforms use the shared AVPlayer-based preview/theme channels
   /// (`moonfin/appletv_preview`, `moonfin/appletv_theme_music`) instead of a
   /// media_kit Player for inline trailers, home-row previews and theme music.

--- a/native/hdr_probe/CMakeLists.txt
+++ b/native/hdr_probe/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Standalone Phase 0 probe for native HDR video output on Windows.
+#
+# Deliberately NOT wired into windows/CMakeLists.txt - it is a developer tool,
+# not part of the app, and nothing add_subdirectory()s this folder.
+#
+#   cmake -S native/hdr_probe -B build/hdr_probe
+#   cmake --build build/hdr_probe --config Release
+
+cmake_minimum_required(VERSION 3.15)
+project(hdr_probe LANGUAGES CXX)
+
+add_executable(hdr_probe "hdr_probe.cpp")
+
+target_compile_features(hdr_probe PRIVATE cxx_std_17)
+target_compile_definitions(hdr_probe PRIVATE UNICODE _UNICODE NOMINMAX)
+
+# libmpv is loaded with LoadLibrary at runtime, so there is nothing to link
+# against and no headers to find. Only the Win32 window needs a library.
+if(MSVC)
+  target_compile_options(hdr_probe PRIVATE /W4)
+endif()

--- a/native/hdr_probe/README.md
+++ b/native/hdr_probe/README.md
@@ -1,0 +1,86 @@
+# HDR probe
+
+Standalone Windows tool that checks the exact `libmpv-2.dll` Moonfin ships can
+drive native HDR output: renderer options (Q1), post-init `wid` (Q2), and HDR
+actually reaching the display (Q3). Run it against a new DLL after a
+`libmpv-2.dll` upgrade, before trusting it with the native HDR path.
+
+## Build
+
+Needs Visual Studio (the same toolchain `build-windows.ps1` already requires).
+
+```powershell
+cmake -S native/hdr_probe -B build/hdr_probe
+cmake --build build/hdr_probe --config Release
+```
+
+The binary lands at `build\hdr_probe\Release\hdr_probe.exe`.
+
+## Run
+
+`libmpv-2.dll` is downloaded by the `media_kit_libs_windows_video` fork during a
+Flutter build and installed next to the app. Either path works:
+
+```
+build\windows\x64\libmpv\libmpv-2.dll
+build\windows\x64\runner\Release\libmpv-2.dll
+```
+
+Q1 and Q2 need no media and no HDR display:
+
+```powershell
+.\build\hdr_probe\Release\hdr_probe.exe --libmpv build\windows\x64\libmpv\libmpv-2.dll
+```
+
+Q3 needs a real HDR10 file **and the display already switched into HDR mode**
+(Settings → System → Display → Use HDR):
+
+```powershell
+.\build\hdr_probe\Release\hdr_probe.exe `
+  --libmpv build\windows\x64\libmpv\libmpv-2.dll `
+  --media "D:\media\some-hdr10-movie.mkv" `
+  --seconds 20
+```
+
+A window opens and plays for the requested duration. Watch the display's own
+HDR indicator while it does.
+
+## What each question decides
+
+### Q1 — renderer options
+
+Does this libmpv have `vo=gpu-next`, `gpu-api=d3d11` and
+`target-colorspace-hint`? Options are validated at parse time, so a build
+without libplacebo fails here rather than at runtime.
+
+- **All three PASS** → the shipped DLL is sufficient, no libmpv work needed.
+- **`gpu-next` FAILs** → the fork needs a newer shinchiro build in
+  `media_kit_libs_windows_video`.
+
+### Q2 — when can `wid` be set?
+
+media_kit applies every property *after* `mpv_initialize` (`real.dart:2319-2364`
+is its only pre-init block).
+
+- **Post-init property PASSes** → the Android TV pattern ports directly:
+  `vo=null` at init, then `wid` + `vo=gpu-next` once the HWND exists. No
+  media-kit change.
+- **Post-init FAILs, pre-init PASSes** → `PlayerConfiguration` needs an
+  `extraOptions` passthrough in the media-kit fork. Cheap, since
+  `media_kit_video` and `media_kit_libs_windows_video` are already forked at the
+  same ref — `media_kit` itself would need adding to `dependency_overrides`.
+
+### Q3 — does HDR reach the display?
+
+Reads the negotiated parameters and greps mpv's verbose log for the D3D11
+swapchain lines.
+
+**Passing** looks like:
+
+- `video-params/gamma` → `pq` (or `hlg`)
+- `video-params/primaries` → `bt.2020`
+- a d3d11 log line showing a 10-bit or fp16 swapchain in a BT.2020/PQ colorspace
+- the display's HDR indicator engaging
+
+**Failing** looks like `gamma` coming back as `bt.1886`, or an 8-bit swapchain —
+that means mpv tone-mapped to SDR and the DLL is not fit for the native path.

--- a/native/hdr_probe/hdr_probe.cpp
+++ b/native/hdr_probe/hdr_probe.cpp
@@ -1,0 +1,518 @@
+// Phase 0 go/no-go probe for native HDR video output on Windows.
+//
+// Answers three of the four gate questions from the HDR plan against the exact
+// libmpv-2.dll that Moonfin ships, without needing the Flutter app:
+//
+//   Q1  Does this libmpv build have vo=gpu-next, gpu-api=d3d11 and
+//       target-colorspace-hint?
+//   Q2  Is `wid` settable after mpv_initialize, or does it have to go in
+//       before init (which would mean patching the media-kit fork)?
+//   Q3  With mpv owning a real HWND and a D3D11 swapchain, does HDR actually
+//       reach the display?
+//
+// Q4 (per-pixel alpha on the Flutter window over this one) is a Flutter-side
+// question and is not covered here.
+//
+// libmpv is loaded dynamically, so no import library or headers are required.
+// The declarations below mirror libmpv/client.h; that ABI is versioned and
+// stable, and mpv_client_api_version() is checked at startup.
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+// ---------------------------------------------------------------------------
+// Minimal libmpv ABI
+// ---------------------------------------------------------------------------
+
+struct mpv_handle;
+
+enum mpv_event_id {
+  MPV_EVENT_NONE = 0,
+  MPV_EVENT_SHUTDOWN = 1,
+  MPV_EVENT_LOG_MESSAGE = 2,
+  MPV_EVENT_START_FILE = 6,
+  MPV_EVENT_END_FILE = 7,
+  MPV_EVENT_FILE_LOADED = 8,
+  MPV_EVENT_VIDEO_RECONFIG = 17,
+  MPV_EVENT_PLAYBACK_RESTART = 21,
+};
+
+struct mpv_event {
+  mpv_event_id event_id;
+  int error;
+  uint64_t reply_userdata;
+  void* data;
+};
+
+struct mpv_event_log_message {
+  const char* prefix;
+  const char* level;
+  const char* text;
+  int log_level;
+};
+
+typedef unsigned long (*fn_client_api_version)(void);
+typedef mpv_handle* (*fn_create)(void);
+typedef int (*fn_initialize)(mpv_handle*);
+typedef void (*fn_terminate_destroy)(mpv_handle*);
+typedef int (*fn_set_option_string)(mpv_handle*, const char*, const char*);
+typedef int (*fn_set_property_string)(mpv_handle*, const char*, const char*);
+typedef char* (*fn_get_property_string)(mpv_handle*, const char*);
+typedef void (*fn_free)(void*);
+typedef int (*fn_command)(mpv_handle*, const char**);
+typedef int (*fn_request_log_messages)(mpv_handle*, const char*);
+typedef mpv_event* (*fn_wait_event)(mpv_handle*, double);
+typedef const char* (*fn_error_string)(int);
+
+struct Mpv {
+  HMODULE dll = nullptr;
+  fn_client_api_version client_api_version = nullptr;
+  fn_create create = nullptr;
+  fn_initialize initialize = nullptr;
+  fn_terminate_destroy terminate_destroy = nullptr;
+  fn_set_option_string set_option_string = nullptr;
+  fn_set_property_string set_property_string = nullptr;
+  fn_get_property_string get_property_string = nullptr;
+  fn_free free = nullptr;
+  fn_command command = nullptr;
+  fn_request_log_messages request_log_messages = nullptr;
+  fn_wait_event wait_event = nullptr;
+  fn_error_string error_string = nullptr;
+};
+
+static Mpv g_mpv;
+
+template <typename T>
+static bool Resolve(T& slot, const char* name) {
+  slot = reinterpret_cast<T>(GetProcAddress(g_mpv.dll, name));
+  if (!slot) {
+    std::printf("  FAIL  missing export: %s\n", name);
+    return false;
+  }
+  return true;
+}
+
+static bool LoadMpv(const std::wstring& path) {
+  g_mpv.dll = LoadLibraryW(path.c_str());
+  if (!g_mpv.dll) {
+    std::printf("  FAIL  LoadLibrary failed (error %lu)\n", GetLastError());
+    return false;
+  }
+  bool ok = true;
+  ok &= Resolve(g_mpv.client_api_version, "mpv_client_api_version");
+  ok &= Resolve(g_mpv.create, "mpv_create");
+  ok &= Resolve(g_mpv.initialize, "mpv_initialize");
+  ok &= Resolve(g_mpv.terminate_destroy, "mpv_terminate_destroy");
+  ok &= Resolve(g_mpv.set_option_string, "mpv_set_option_string");
+  ok &= Resolve(g_mpv.set_property_string, "mpv_set_property_string");
+  ok &= Resolve(g_mpv.get_property_string, "mpv_get_property_string");
+  ok &= Resolve(g_mpv.free, "mpv_free");
+  ok &= Resolve(g_mpv.command, "mpv_command");
+  ok &= Resolve(g_mpv.request_log_messages, "mpv_request_log_messages");
+  ok &= Resolve(g_mpv.wait_event, "mpv_wait_event");
+  ok &= Resolve(g_mpv.error_string, "mpv_error_string");
+  return ok;
+}
+
+static const char* Err(int code) {
+  return code >= 0 ? "ok" : g_mpv.error_string(code);
+}
+
+// ---------------------------------------------------------------------------
+// Host window
+// ---------------------------------------------------------------------------
+
+static const wchar_t kWindowClass[] = L"MoonfinHdrProbe";
+
+static HWND CreateHostWindow() {
+  WNDCLASSW wc = {};
+  wc.lpfnWndProc = DefWindowProcW;
+  wc.hInstance = GetModuleHandleW(nullptr);
+  wc.lpszClassName = kWindowClass;
+  wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+  RegisterClassW(&wc);
+
+  HWND hwnd = CreateWindowExW(
+      0, kWindowClass, L"Moonfin HDR probe", WS_OVERLAPPEDWINDOW, CW_USEDEFAULT,
+      CW_USEDEFAULT, 1280, 720, nullptr, nullptr, wc.hInstance, nullptr);
+  if (hwnd) {
+    ShowWindow(hwnd, SW_SHOW);
+    UpdateWindow(hwnd);
+  }
+  return hwnd;
+}
+
+static void PumpWindowMessages() {
+  MSG msg;
+  while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
+    TranslateMessage(&msg);
+    DispatchMessageW(&msg);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Q1 — option availability
+// ---------------------------------------------------------------------------
+
+// Options are validated when they are parsed, so a build without libplacebo
+// rejects vo=gpu-next here rather than failing later at runtime.
+static void ProbeOptions() {
+  std::printf("\n=== Q1  Renderer options in this libmpv build ===\n\n");
+
+  struct Probe {
+    const char* key;
+    const char* value;
+    const char* why;
+  };
+  const Probe probes[] = {
+      {"vo", "gpu-next", "libplacebo renderer - REQUIRED for HDR passthrough"},
+      {"vo", "gpu", "old renderer, what the texture path uses today"},
+      {"gpu-api", "d3d11", "D3D11 context - REQUIRED, owns the swapchain"},
+      {"gpu-api", "vulkan", "alternative context that also supports the hint"},
+      {"target-colorspace-hint", "yes", "tags the swapchain - REQUIRED"},
+      {"target-colorspace-hint", "auto", "newer tri-state form of the above"},
+      {"tone-mapping", "bt.2390", "tone curve used when falling back to SDR"},
+      {"hdr-compute-peak", "yes", "dynamic peak detection"},
+      {"target-contrast", "inf", "black point handling on OLED"},
+      {"dither-depth", "auto", "banding control (media_kit ships dither=no)"},
+  };
+
+  for (const Probe& p : probes) {
+    mpv_handle* ctx = g_mpv.create();
+    if (!ctx) {
+      std::printf("  FAIL  mpv_create returned null\n");
+      return;
+    }
+    int rc = g_mpv.set_option_string(ctx, p.key, p.value);
+    std::printf("  %-5s %s=%-22s  %-52s %s\n", rc >= 0 ? "PASS" : "FAIL", p.key,
+                p.value, p.why, rc >= 0 ? "" : Err(rc));
+    g_mpv.terminate_destroy(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Q2 — when can `wid` be set?
+// ---------------------------------------------------------------------------
+
+// This decides whether the media-kit fork needs a pre-init options map.
+// media_kit applies every property AFTER mpv_initialize (real.dart:2319-2364
+// is its only pre-init block), so if `wid` is init-only, the fork has to carry
+// a PlayerConfiguration.extraOptions passthrough.
+static void ProbeWid(HWND hwnd) {
+  std::printf("\n=== Q2  Can `wid` be set after mpv_initialize? ===\n\n");
+
+  char wid_str[32];
+  std::snprintf(wid_str, sizeof(wid_str), "%lld",
+                static_cast<long long>(reinterpret_cast<intptr_t>(hwnd)));
+
+  // Control: as a pre-init option, which is how mpv documents it.
+  {
+    mpv_handle* ctx = g_mpv.create();
+    int rc = g_mpv.set_option_string(ctx, "wid", wid_str);
+    std::printf("  %-5s wid as pre-init option            %s\n",
+                rc >= 0 ? "PASS" : "FAIL", rc >= 0 ? "" : Err(rc));
+    g_mpv.terminate_destroy(ctx);
+  }
+
+  // The case that matters: after init, the way media_kit would do it.
+  {
+    mpv_handle* ctx = g_mpv.create();
+    g_mpv.set_option_string(ctx, "vo", "null");
+    g_mpv.set_option_string(ctx, "force-window", "yes");
+    int init_rc = g_mpv.initialize(ctx);
+    if (init_rc < 0) {
+      std::printf("  FAIL  mpv_initialize: %s\n", Err(init_rc));
+      g_mpv.terminate_destroy(ctx);
+      return;
+    }
+    int rc = g_mpv.set_property_string(ctx, "wid", wid_str);
+    std::printf("  %-5s wid as post-init property         %s\n",
+                rc >= 0 ? "PASS" : "FAIL", rc >= 0 ? "" : Err(rc));
+
+    int vo_rc = g_mpv.set_property_string(ctx, "vo", "gpu-next");
+    std::printf("  %-5s vo=gpu-next swap after init       %s\n",
+                vo_rc >= 0 ? "PASS" : "FAIL", vo_rc >= 0 ? "" : Err(vo_rc));
+
+    if (rc < 0) {
+      std::printf(
+          "\n  => `wid` is init-only. The media-kit fork needs a pre-init\n"
+          "     options passthrough on PlayerConfiguration.\n");
+    } else {
+      std::printf(
+          "\n  => `wid` is runtime-settable. The Android TV pattern ports\n"
+          "     directly: vo=null at init, then wid + vo once the HWND exists.\n");
+    }
+    g_mpv.terminate_destroy(ctx);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Q3 — does HDR reach the display?
+// ---------------------------------------------------------------------------
+
+static bool LineIsInteresting(const std::string& lower) {
+  static const char* kNeedles[] = {
+      "d3d11",     "swapchain", "colorspace", "colour",  "color space",
+      "hdr",       "pq",        "bt.2020",    "2084",    "st2084",
+      "feature level", "gpu-next", "placebo",  "hlg",    "peak",
+      "metadata",  "10 bit",    "r10g10b10",  "fp16",    "r16g16b16",
+  };
+  for (const char* needle : kNeedles) {
+    if (lower.find(needle) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static void PrintProperty(mpv_handle* ctx, const char* name) {
+  char* value = g_mpv.get_property_string(ctx, name);
+  if (value) {
+    std::printf("  %-28s %s\n", name, value);
+    g_mpv.free(value);
+  } else {
+    std::printf("  %-28s (unavailable)\n", name);
+  }
+}
+
+static void ProbePlayback(HWND hwnd, const std::string& media, int seconds) {
+  std::printf("\n=== Q3  Live playback into a D3D11 HDR swapchain ===\n\n");
+  std::printf("  media   : %s\n", media.c_str());
+  std::printf("  duration: %d seconds\n\n", seconds);
+  std::printf(
+      "  Put Windows into HDR mode BEFORE running this, and watch the\n"
+      "  display's own HDR indicator while it plays.\n\n");
+
+  char wid_str[32];
+  std::snprintf(wid_str, sizeof(wid_str), "%lld",
+                static_cast<long long>(reinterpret_cast<intptr_t>(hwnd)));
+
+  mpv_handle* ctx = g_mpv.create();
+  if (!ctx) {
+    std::printf("  FAIL  mpv_create returned null\n");
+    return;
+  }
+
+  struct Opt {
+    const char* key;
+    const char* value;
+  };
+  const Opt opts[] = {
+      {"wid", wid_str},
+      {"vo", "gpu-next"},
+      {"gpu-api", "d3d11"},
+      {"target-colorspace-hint", "yes"},
+      {"hwdec", "auto"},
+      {"keep-open", "yes"},
+      {"osc", "no"},
+      {"input-default-bindings", "no"},
+  };
+  for (const Opt& o : opts) {
+    int rc = g_mpv.set_option_string(ctx, o.key, o.value);
+    if (rc < 0) {
+      std::printf("  WARN  %s=%s rejected: %s\n", o.key, o.value, Err(rc));
+    }
+  }
+
+  g_mpv.request_log_messages(ctx, "v");
+
+  int init_rc = g_mpv.initialize(ctx);
+  if (init_rc < 0) {
+    std::printf("  FAIL  mpv_initialize: %s\n", Err(init_rc));
+    g_mpv.terminate_destroy(ctx);
+    return;
+  }
+
+  const char* cmd[] = {"loadfile", media.c_str(), nullptr};
+  int load_rc = g_mpv.command(ctx, cmd);
+  if (load_rc < 0) {
+    std::printf("  FAIL  loadfile: %s\n", Err(load_rc));
+    g_mpv.terminate_destroy(ctx);
+    return;
+  }
+
+  std::printf("  --- relevant mpv log lines ---\n");
+
+  const ULONGLONG deadline =
+      GetTickCount64() + static_cast<ULONGLONG>(seconds) * 1000ULL;
+  bool reported_params = false;
+
+  while (GetTickCount64() < deadline) {
+    PumpWindowMessages();
+
+    mpv_event* ev = g_mpv.wait_event(ctx, 0.05);
+    if (!ev || ev->event_id == MPV_EVENT_NONE) {
+      continue;
+    }
+    if (ev->event_id == MPV_EVENT_SHUTDOWN) {
+      break;
+    }
+    if (ev->event_id == MPV_EVENT_LOG_MESSAGE) {
+      auto* msg = static_cast<mpv_event_log_message*>(ev->data);
+      std::string text = msg->text ? msg->text : "";
+      std::string lower = text;
+      for (char& c : lower) {
+        c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+      }
+      if (LineIsInteresting(lower)) {
+        while (!text.empty() && (text.back() == '\n' || text.back() == '\r')) {
+          text.pop_back();
+        }
+        std::printf("  [%s] %s\n", msg->prefix ? msg->prefix : "?",
+                    text.c_str());
+      }
+      continue;
+    }
+    if ((ev->event_id == MPV_EVENT_VIDEO_RECONFIG ||
+         ev->event_id == MPV_EVENT_PLAYBACK_RESTART) &&
+        !reported_params) {
+      reported_params = true;
+      std::printf("\n  --- negotiated video parameters ---\n");
+      PrintProperty(ctx, "current-vo");
+      PrintProperty(ctx, "video-params/pixelformat");
+      PrintProperty(ctx, "video-params/colormatrix");
+      PrintProperty(ctx, "video-params/primaries");
+      PrintProperty(ctx, "video-params/gamma");
+      PrintProperty(ctx, "video-params/sig-peak");
+      PrintProperty(ctx, "video-params/max-luma");
+      PrintProperty(ctx, "video-params/w");
+      PrintProperty(ctx, "video-params/h");
+      PrintProperty(ctx, "hwdec-current");
+      std::printf("\n  --- continuing log capture ---\n");
+    }
+  }
+
+  std::printf("\n  --- how to read this ---\n");
+  std::printf(
+      "  HDR passthrough is working when video-params/gamma is pq (or hlg)\n"
+      "  AND video-params/primaries is bt.2020 AND the d3d11 log lines show a\n"
+      "  10-bit or fp16 swapchain in a BT.2020/PQ colorspace. If gamma comes\n"
+      "  back as bt.1886 or the swapchain is 8-bit, mpv tone-mapped to SDR and\n"
+      "  the gate has NOT been met.\n");
+
+  g_mpv.terminate_destroy(ctx);
+}
+
+// ---------------------------------------------------------------------------
+
+static std::wstring Widen(const std::string& s) {
+  if (s.empty()) {
+    return std::wstring();
+  }
+  int n = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+  std::wstring out(static_cast<size_t>(n ? n - 1 : 0), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), n);
+  return out;
+}
+
+static std::wstring DefaultLibmpvPath() {
+  wchar_t exe[MAX_PATH];
+  if (GetModuleFileNameW(nullptr, exe, MAX_PATH) == 0) {
+    return L"libmpv-2.dll";
+  }
+  std::wstring dir(exe);
+  size_t slash = dir.find_last_of(L"\\/");
+  if (slash == std::wstring::npos) {
+    return L"libmpv-2.dll";
+  }
+  return dir.substr(0, slash + 1) + L"libmpv-2.dll";
+}
+
+static void Usage() {
+  std::printf(
+      "Moonfin HDR probe - Phase 0 gate for native HDR video output\n"
+      "\n"
+      "Usage:\n"
+      "  hdr_probe.exe [--libmpv <path to libmpv-2.dll>]\n"
+      "                [--media <path to an HDR10 file>]\n"
+      "                [--seconds <n, default 15>]\n"
+      "\n"
+      "Without --media only Q1 and Q2 run. Q3 needs a real HDR file and a\n"
+      "display already switched into HDR mode.\n"
+      "\n"
+      "The shipped libmpv lands at:\n"
+      "  build\\windows\\x64\\libmpv\\libmpv-2.dll        (after a flutter build)\n"
+      "  build\\windows\\x64\\runner\\Release\\libmpv-2.dll\n");
+}
+
+int main(int argc, char** argv) {
+  std::wstring libmpv_path;
+  std::string media;
+  int seconds = 15;
+
+  for (int i = 1; i < argc; i++) {
+    std::string arg = argv[i];
+    if ((arg == "--libmpv") && i + 1 < argc) {
+      libmpv_path = Widen(argv[++i]);
+    } else if ((arg == "--media") && i + 1 < argc) {
+      media = argv[++i];
+    } else if ((arg == "--seconds") && i + 1 < argc) {
+      seconds = std::atoi(argv[++i]);
+    } else if (arg == "--help" || arg == "-h") {
+      Usage();
+      return 0;
+    } else {
+      std::printf("Unknown argument: %s\n\n", arg.c_str());
+      Usage();
+      return 2;
+    }
+  }
+
+  if (libmpv_path.empty()) {
+    libmpv_path = DefaultLibmpvPath();
+  }
+
+  std::printf("=== Moonfin HDR probe ===\n\n");
+  std::printf("  libmpv: %ls\n", libmpv_path.c_str());
+
+  if (!LoadMpv(libmpv_path)) {
+    std::printf(
+        "\nCould not load libmpv. Pass --libmpv with the path to the DLL that\n"
+        "ships with Moonfin.\n");
+    return 1;
+  }
+
+  const unsigned long api = g_mpv.client_api_version();
+  std::printf("  client API version: %lu.%lu\n", api >> 16, api & 0xFFFF);
+
+  mpv_handle* probe = g_mpv.create();
+  if (probe) {
+    char* version = g_mpv.get_property_string(probe, "mpv-version");
+    if (version) {
+      std::printf("  mpv version: %s\n", version);
+      g_mpv.free(version);
+    }
+    g_mpv.terminate_destroy(probe);
+  }
+
+  ProbeOptions();
+
+  HWND hwnd = CreateHostWindow();
+  if (!hwnd) {
+    std::printf("\n  FAIL  could not create host window (error %lu)\n",
+                GetLastError());
+    return 1;
+  }
+
+  ProbeWid(hwnd);
+
+  if (!media.empty()) {
+    ProbePlayback(hwnd, media, seconds);
+  } else {
+    std::printf(
+        "\n=== Q3  skipped ===\n\n"
+        "  Pass --media <path to an HDR10 file> to run the live playback\n"
+        "  test. Switch the display into HDR mode first.\n");
+  }
+
+  DestroyWindow(hwnd);
+  std::printf("\n=== done ===\n");
+  return 0;
+}

--- a/test/playback/hdr_output_controller_test.dart
+++ b/test/playback/hdr_output_controller_test.dart
@@ -184,6 +184,35 @@ void main() {
       expect(window.createCalls, 0);
     });
 
+    test(
+      'an SDR verdict is not sticky: the next decision starts over',
+      () async {
+        final controller = HdrOutputController(window: window);
+        // mpv had not reported video-params yet when this was asked - a 4K
+        // remux over the network can take longer than the bounded wait - so
+        // the content read as SDR.
+        await decide(controller, isHdrContent: false);
+        expect(controller.status.value.isRevisitable, isTrue);
+        asked.clear();
+
+        // Once the params arrive the backend asks again, and this time every
+        // gate must be re-run rather than the old answer returned.
+        expect(await decide(controller), 4242);
+        expect(controller.status.value, HdrOutputStatus.active);
+        expect(asked, ['content', 'display', 'engage 4242']);
+      },
+    );
+
+    test('only the expensive gates are revisitable', () {
+      expect(HdrOutputStatus.contentIsSdr.isRevisitable, isTrue);
+      expect(HdrOutputStatus.displayNotInHdrMode.isRevisitable, isTrue);
+      // The preference is the user's choice, and a failure is deliberately
+      // sticky so a broken setup is not retried on every video-params event.
+      expect(HdrOutputStatus.disabledByPreference.isRevisitable, isFalse);
+      expect(HdrOutputStatus.failed.isRevisitable, isFalse);
+      expect(HdrOutputStatus.active.isRevisitable, isFalse);
+    });
+
     test('an SDR display stops before the window is created', () async {
       final controller = HdrOutputController(window: window);
       expect(await decide(controller, displayInHdrMode: false), isNull);

--- a/test/playback/hdr_output_controller_test.dart
+++ b/test/playback/hdr_output_controller_test.dart
@@ -108,7 +108,7 @@ void main() {
     }) {
       // The tests below exercise the gates past the presenter one; without a
       // presenting screen nothing is ever decided, covered by its own test.
-      controller.presenterActive = true;
+      controller.presenter = Object();
       return controller.maybeEngage(
         preferenceEnabled: preferenceEnabled,
         isHdrContent: () async {

--- a/test/playback/hdr_output_controller_test.dart
+++ b/test/playback/hdr_output_controller_test.dart
@@ -1,0 +1,391 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/playback/hdr_output_controller.dart';
+import 'package:moonfin/playback/hdr_overlay_channel.dart';
+import 'package:moonfin/playback/hdr_video_window.dart';
+
+/// Stands in for the runner's window so the decision can be exercised without
+/// a platform channel.
+class _FakeWindow implements HdrVideoWindow {
+  _FakeWindow({this.createReturns = 4242});
+
+  final int? createReturns;
+  int createCalls = 0;
+  int destroyCalls = 0;
+  final List<String> log = [];
+
+  @override
+  int? handle;
+
+  @override
+  void Function()? onMonitorChanged;
+
+  @override
+  Future<int?> create() async {
+    createCalls++;
+    log.add('create');
+    return handle = createReturns;
+  }
+
+  @override
+  Future<void> destroy() async {
+    destroyCalls++;
+    handle = null;
+    log.add('destroy');
+  }
+
+  @override
+  Future<void> setGeometry(Rect rect) async => log.add('geometry $rect');
+
+  @override
+  Future<void> setVisible(bool visible) async => log.add('visible $visible');
+
+  @override
+  Future<void> claim(Object presenter, Rect rect) async => log.add('claim');
+
+  @override
+  Future<void> release(Object presenter) async => log.add('release');
+}
+
+void main() {
+  // The channel groups below mock the binary messenger, which needs a binding.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('isHdrVideoParams', () {
+    test('PQ and HLG transfers are HDR', () {
+      expect(isHdrVideoParams(gamma: 'pq', primaries: 'bt.2020'), isTrue);
+      expect(isHdrVideoParams(gamma: 'st2084', primaries: 'bt.2020'), isTrue);
+      expect(isHdrVideoParams(gamma: 'hlg', primaries: 'bt.2020'), isTrue);
+    });
+
+    test('plain SDR is not', () {
+      expect(isHdrVideoParams(gamma: 'bt.1886', primaries: 'bt.709'), isFalse);
+      expect(isHdrVideoParams(gamma: 'srgb', primaries: 'bt.709'), isFalse);
+      expect(isHdrVideoParams(gamma: null, primaries: null), isFalse);
+    });
+
+    test('BT.2020 primaries alone count, which is the Profile 5 case', () {
+      // A Dolby Vision Profile 5 stream has no HDR10 base layer and often no
+      // VUI transfer characteristic, so mpv reports it as SDR until libplacebo
+      // applies the RPU - which only happens once the native window is
+      // engaged, which is the decision this feeds.
+      expect(isHdrVideoParams(gamma: 'bt.1886', primaries: 'bt.2020'), isTrue);
+      expect(isHdrVideoParams(gamma: null, primaries: 'bt.2020'), isTrue);
+    });
+
+    test('case variants of the transfer are accepted', () {
+      expect(isHdrVideoParams(gamma: 'PQ', primaries: 'BT.709'), isTrue);
+      expect(isHdrVideoParams(gamma: 'HLG', primaries: 'BT.709'), isTrue);
+    });
+  });
+
+  group('HdrOutputStatus', () {
+    test('only active counts as engaged', () {
+      expect(HdrOutputStatus.active.isActive, isTrue);
+      for (final status in HdrOutputStatus.values.where(
+        (s) => s != HdrOutputStatus.active,
+      )) {
+        expect(status.isActive, isFalse);
+      }
+    });
+  });
+
+  group('HdrOutputController.maybeEngage', () {
+    late _FakeWindow window;
+    late List<String> asked;
+
+    setUp(() {
+      window = _FakeWindow();
+      asked = [];
+    });
+
+    Future<int?> decide(
+      HdrOutputController controller, {
+      bool preferenceEnabled = true,
+      bool isHdrContent = true,
+      bool displayInHdrMode = true,
+      bool mpvAccepts = true,
+    }) {
+      // The tests below exercise the gates past the presenter one; without a
+      // presenting screen nothing is ever decided, covered by its own test.
+      controller.presenterActive = true;
+      return controller.maybeEngage(
+        preferenceEnabled: preferenceEnabled,
+        isHdrContent: () async {
+          asked.add('content');
+          return isHdrContent;
+        },
+        displayInHdrMode: () async {
+          asked.add('display');
+          return displayInHdrMode;
+        },
+        engageMpv: (handle) async {
+          asked.add('engage $handle');
+          return mpvAccepts;
+        },
+      );
+    }
+
+    test('starts out reporting SDR content', () {
+      expect(
+        HdrOutputController(window: window).status.value,
+        HdrOutputStatus.contentIsSdr,
+      );
+    });
+
+    test('no presenter, no decision - Live TV must never engage', () async {
+      final controller = HdrOutputController(window: window);
+      final result = await controller.maybeEngage(
+        preferenceEnabled: true,
+        isHdrContent: () async {
+          asked.add('content');
+          return true;
+        },
+        displayInHdrMode: () async {
+          asked.add('display');
+          return true;
+        },
+        engageMpv: (_) async {
+          asked.add('engage');
+          return true;
+        },
+      );
+
+      // The backend is a shared singleton; only the video player screen can
+      // present the native window. Without it, engaging would swap mpv onto a
+      // window nothing shows and black out whoever is actually rendering.
+      expect(result, isNull);
+      expect(asked, isEmpty);
+      expect(window.createCalls, 0);
+      expect(controller.isEngaged, isFalse);
+    });
+
+    test(
+      'the preference is the first gate, and nothing else is asked',
+      () async {
+        final controller = HdrOutputController(window: window);
+        expect(await decide(controller, preferenceEnabled: false), isNull);
+
+        expect(controller.status.value, HdrOutputStatus.disabledByPreference);
+        // Both remaining checks are expensive - waiting on mpv's video-params,
+        // and enumerating every display path - so neither may run once the
+        // answer is already no.
+        expect(asked, isEmpty);
+        expect(window.createCalls, 0);
+      },
+    );
+
+    test('SDR content stops before the display is queried', () async {
+      final controller = HdrOutputController(window: window);
+      expect(await decide(controller, isHdrContent: false), isNull);
+
+      expect(controller.status.value, HdrOutputStatus.contentIsSdr);
+      expect(asked, ['content']);
+      expect(window.createCalls, 0);
+    });
+
+    test('an SDR display stops before the window is created', () async {
+      final controller = HdrOutputController(window: window);
+      expect(await decide(controller, displayInHdrMode: false), isNull);
+
+      expect(controller.status.value, HdrOutputStatus.displayNotInHdrMode);
+      expect(asked, ['content', 'display']);
+      expect(window.createCalls, 0);
+    });
+
+    test('every gate open engages and hands mpv the handle', () async {
+      final controller = HdrOutputController(window: window);
+      expect(await decide(controller), 4242);
+
+      expect(controller.status.value, HdrOutputStatus.active);
+      expect(controller.isEngaged, isTrue);
+      expect(asked, ['content', 'display', 'engage 4242']);
+      expect(window.createCalls, 1);
+      expect(window.destroyCalls, 0);
+    });
+
+    test('engagement is sticky: the second item decides nothing', () async {
+      final controller = HdrOutputController(window: window);
+      await decide(controller);
+      asked.clear();
+
+      expect(await decide(controller), 4242);
+      // Player and VideoController are built once as a startup singleton, so
+      // the path cannot be swapped per item - and re-deciding would pay for
+      // both expensive checks again on every title.
+      expect(asked, isEmpty);
+      expect(window.createCalls, 1);
+    });
+
+    test('mpv refusing the handle fails and tears the window down', () async {
+      final controller = HdrOutputController(window: window);
+      expect(await decide(controller, mpvAccepts: false), isNull);
+
+      expect(controller.status.value, HdrOutputStatus.failed);
+      expect(controller.hasFailed, isTrue);
+      expect(controller.isEngaged, isFalse);
+      // Leaving it up would float a black window over the player.
+      expect(window.destroyCalls, 1);
+    });
+
+    test('a window that cannot be created fails without asking mpv', () async {
+      final broken = _FakeWindow(createReturns: null);
+      final controller = HdrOutputController(window: broken);
+      expect(await decide(controller), isNull);
+
+      expect(controller.status.value, HdrOutputStatus.failed);
+      expect(asked, ['content', 'display']);
+    });
+
+    test('failure is sticky, so a broken setup is not retried', () async {
+      final controller = HdrOutputController(window: window);
+      await decide(controller, mpvAccepts: false);
+      asked.clear();
+
+      expect(await decide(controller), isNull);
+      expect(asked, isEmpty);
+      expect(window.createCalls, 1);
+    });
+
+    test('a status change notifies, so the player can swap surfaces', () async {
+      final controller = HdrOutputController(window: window);
+      var notified = 0;
+      controller.status.addListener(() => notified++);
+
+      await decide(controller);
+
+      // Engagement lands after the player screen's last build; without this
+      // the surface swap would wait for an unrelated setState.
+      expect(notified, greaterThanOrEqualTo(1));
+      expect(controller.status.value, HdrOutputStatus.active);
+    });
+  });
+
+  group('HdrVideoWindow over the platform channel', () {
+    const channel = MethodChannel('moonfin/hdr_video');
+    late List<MethodCall> calls;
+
+    setUp(() {
+      calls = [];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return call.method == 'create' ? 99 : null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('create is asked once and the handle is kept', () async {
+      final window = HdrVideoWindow();
+      expect(await window.create(), 99);
+      expect(await window.create(), 99);
+      expect(calls.where((c) => c.method == 'create'), hasLength(1));
+      expect(window.handle, 99);
+    });
+
+    test('geometry and visibility drop duplicates', () async {
+      final window = HdrVideoWindow();
+      await window.create();
+      calls.clear();
+
+      const rect = Rect.fromLTWH(0, 0, 1920, 1080);
+      await window.setGeometry(rect);
+      await window.setGeometry(rect);
+      await window.setVisible(true);
+      await window.setVisible(true);
+
+      expect(calls.map((c) => c.method), ['setGeometry', 'setVisible']);
+    });
+
+    test('release only listens to the presenter that claimed it', () async {
+      final window = HdrVideoWindow();
+      await window.create();
+      final claimant = Object();
+      await window.claim(claimant, const Rect.fromLTWH(0, 0, 100, 100));
+      calls.clear();
+
+      // The outgoing player screen disposing after its successor has already
+      // taken over must not hide the window out from under it.
+      await window.release(Object());
+      expect(calls, isEmpty);
+
+      await window.release(claimant);
+      expect(calls.single.method, 'setVisible');
+      expect((calls.single.arguments as Map)['visible'], isFalse);
+    });
+  });
+
+  group('HdrOverlayChannel', () {
+    const channel = MethodChannel('moonfin/hdr_overlay');
+    late List<MethodCall> calls;
+
+    setUp(() {
+      calls = [];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return null;
+          });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('push sends rounded geometry alongside the pixels', () async {
+      await HdrOverlayChannel().push(
+        x: 10.6,
+        y: 20.2,
+        pixels: Uint8List(16),
+        width: 2,
+        height: 2,
+      );
+
+      final args = calls.single.arguments as Map;
+      expect(calls.single.method, 'push');
+      expect(args['x'], 11);
+      expect(args['y'], 20);
+      expect(args['width'], 2);
+      expect(args['height'], 2);
+      expect((args['bytes'] as Uint8List), hasLength(16));
+    });
+
+    test(
+      'a missing plugin latches off, so a non-Windows build goes quiet',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call);
+              throw MissingPluginException();
+            });
+
+        final overlay = HdrOverlayChannel();
+        await overlay.push(
+          x: 0,
+          y: 0,
+          pixels: Uint8List(4),
+          width: 1,
+          height: 1,
+        );
+        await overlay.hide();
+        await overlay.push(
+          x: 0,
+          y: 0,
+          pixels: Uint8List(4),
+          width: 1,
+          height: 1,
+        );
+
+        // The first call discovers there is no runner half; nothing after it
+        // should keep paying to find that out again, on a path that otherwise
+        // runs many times a second.
+        expect(calls, hasLength(1));
+      },
+    );
+  });
+}

--- a/test/ui/screens/playback/hdr_overlay_capture_test.dart
+++ b/test/ui/screens/playback/hdr_overlay_capture_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/playback/hdr_overlay_channel.dart';
+import 'package:moonfin/ui/screens/playback/hdr_overlay_capture.dart';
+
+void main() {
+  testWidgets('the capture boundary stays off where it can never run', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: HdrOverlayCapture(
+          enabled: false,
+          channel: HdrOverlayChannel(),
+          child: const SizedBox(key: Key('chrome')),
+        ),
+      ),
+    );
+
+    // The capture arrangement is Windows only, so no other player carries a
+    // boundary for it.
+    expect(HdrOverlayCapture.canCapture, isFalse);
+    expect(
+      find.descendant(
+        of: find.byType(HdrOverlayCapture),
+        matching: find.byType(RepaintBoundary),
+      ),
+      findsNothing,
+    );
+    expect(find.byKey(const Key('chrome')), findsOneWidget);
+  });
+}

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -8,7 +8,11 @@ project(runner LANGUAGES CXX)
 # Any new source files that you add to the application should be added here.
 add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
+  "hdr_overlay_window.cpp"
+  "hdr_video_window.cpp"
+  "hdr_window_support.cpp"
   "main.cpp"
+  "method_call_args.cpp"
   "native_game.cpp"
   "utils.cpp"
   "win32_window.cpp"

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
 constexpr UINT kResyncViewMessage = WM_APP + 2;
 
 // Heartbeat that keeps the HDR companion windows in position - see the
-// WM_TIMER note in MessageHandler. The id is 'HD', chosen not to collide with
+// WM_TIMER note in RouteMessage. The id is 'HD', chosen not to collide with
 // timers plugins set against the same window.
 constexpr UINT_PTR kHdrSyncTimerId = 0x4844;
 constexpr UINT kHdrSyncIntervalMs = 500;

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -18,6 +18,12 @@ std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
 // Posted after a nested WM_SIZE. WM_APP + 1 is native_game's.
 constexpr UINT kResyncViewMessage = WM_APP + 2;
 
+// Heartbeat that keeps the HDR companion windows in position - see the
+// WM_TIMER note in MessageHandler. The id is 'HD', chosen not to collide with
+// timers plugins set against the same window.
+constexpr UINT_PTR kHdrSyncTimerId = 0x4844;
+constexpr UINT kHdrSyncIntervalMs = 500;
+
 struct HdrDisplayState {
   bool supported = false;
   bool enabled = false;
@@ -183,6 +189,15 @@ bool FlutterWindow::OnCreate() {
       native_game_registrar_->texture_registrar(),
       native_game_registrar_.get());
 
+  hdr_video_registrar_ = std::make_unique<flutter::PluginRegistrarWindows>(
+      flutter_controller_->engine()->GetRegistrarForPlugin("HdrVideo"));
+  hdr_video_ = std::make_unique<HdrVideoWindow>(
+      flutter_controller_->engine()->messenger(), hdr_video_registrar_.get(),
+      GetHandle());
+
+  hdr_overlay_ = std::make_unique<HdrOverlayWindow>(
+      flutter_controller_->engine()->messenger(), GetHandle());
+
   if (!g_hdr_display_channel) {
     g_hdr_display_channel =
         std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
@@ -233,6 +248,10 @@ bool FlutterWindow::OnCreate() {
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
+  // Half-second heartbeat for the HDR windows' position sync - see the
+  // WM_TIMER note in MessageHandler.
+  SetTimer(GetHandle(), kHdrSyncTimerId, kHdrSyncIntervalMs, nullptr);
+
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     this->Show();
   });
@@ -246,6 +265,10 @@ bool FlutterWindow::OnCreate() {
 }
 
 void FlutterWindow::OnDestroy() {
+  KillTimer(GetHandle(), kHdrSyncTimerId);
+  hdr_overlay_ = nullptr;
+  hdr_video_ = nullptr;
+
   if (flutter_controller_) {
     flutter_controller_ = nullptr;
   }
@@ -300,6 +323,21 @@ LRESULT
 FlutterWindow::RouteMessage(HWND hwnd, UINT const message,
                             WPARAM const wparam,
                             LPARAM const lparam) noexcept {
+  // Ahead of the plugin dispatch, deliberately: the registered-delegate chain
+  // stops at the first plugin that claims a message, and window_manager
+  // registers before these windows exist, so a delegate never sees
+  // WM_WINDOWPOSCHANGED. The timer is the fallback for a lost message;
+  // wparam-checked because plugins may set their own timers on this window.
+  if (message == WM_WINDOWPOSCHANGED ||
+      (message == WM_TIMER && wparam == kHdrSyncTimerId)) {
+    if (hdr_overlay_) {
+      hdr_overlay_->SyncPosition();
+    }
+    if (hdr_video_) {
+      hdr_video_->SyncPosition();
+    }
+  }
+
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -23,8 +23,10 @@ struct HdrDisplayState {
   bool enabled = false;
 };
 
-#if defined(DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO) && \
-    defined(DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE)
+// Deliberately not guarded with `#if defined(DISPLAYCONFIG_DEVICE_INFO_...)`:
+// those names are enumerators, not macros, so such a guard always fails and
+// silently selects a stub. The APIs have been in the SDK since Windows 10
+// 1703, under this project's floor.
 
 bool GetMonitorDeviceNameFromWindow(HWND hwnd, std::wstring* device_name) {
   if (device_name == nullptr) {
@@ -148,21 +150,6 @@ bool SetHdrStateForWindow(HWND hwnd, bool enabled) {
 
   return DisplayConfigSetDeviceInfo(&request.header) == ERROR_SUCCESS;
 }
-
-#else
-
-HdrDisplayState QueryHdrStateForWindow(HWND hwnd) {
-  (void)hwnd;
-  return {};
-}
-
-bool SetHdrStateForWindow(HWND hwnd, bool enabled) {
-  (void)hwnd;
-  (void)enabled;
-  return false;
-}
-
-#endif
 
 }  // namespace
 

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -193,10 +193,11 @@ bool FlutterWindow::OnCreate() {
       flutter_controller_->engine()->GetRegistrarForPlugin("HdrVideo"));
   hdr_video_ = std::make_unique<HdrVideoWindow>(
       flutter_controller_->engine()->messenger(), hdr_video_registrar_.get(),
-      GetHandle());
+      GetHandle(), [this]() { UpdateHdrSyncTimer(); });
 
   hdr_overlay_ = std::make_unique<HdrOverlayWindow>(
-      flutter_controller_->engine()->messenger(), GetHandle());
+      flutter_controller_->engine()->messenger(), GetHandle(),
+      [this]() { UpdateHdrSyncTimer(); });
 
   if (!g_hdr_display_channel) {
     g_hdr_display_channel =
@@ -248,10 +249,6 @@ bool FlutterWindow::OnCreate() {
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
-  // Half-second heartbeat for the HDR windows' position sync - see the
-  // WM_TIMER note in MessageHandler.
-  SetTimer(GetHandle(), kHdrSyncTimerId, kHdrSyncIntervalMs, nullptr);
-
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     this->Show();
   });
@@ -264,8 +261,26 @@ bool FlutterWindow::OnCreate() {
   return true;
 }
 
+void FlutterWindow::UpdateHdrSyncTimer() {
+  const bool needed =
+      (hdr_video_ != nullptr && hdr_video_->NeedsPositionSync()) ||
+      (hdr_overlay_ != nullptr && hdr_overlay_->NeedsPositionSync());
+  if (needed == hdr_sync_timer_running_) {
+    return;
+  }
+  if (needed) {
+    // Half-second heartbeat for the HDR windows' position sync - see the
+    // WM_TIMER note in MessageHandler.
+    SetTimer(GetHandle(), kHdrSyncTimerId, kHdrSyncIntervalMs, nullptr);
+  } else {
+    KillTimer(GetHandle(), kHdrSyncTimerId);
+  }
+  hdr_sync_timer_running_ = needed;
+}
+
 void FlutterWindow::OnDestroy() {
   KillTimer(GetHandle(), kHdrSyncTimerId);
+  hdr_sync_timer_running_ = false;
   hdr_overlay_ = nullptr;
   hdr_video_ = nullptr;
 

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -8,6 +8,8 @@
 
 #include <flutter/plugin_registrar_windows.h>
 
+#include "hdr_overlay_window.h"
+#include "hdr_video_window.h"
 #include "native_game.h"
 #include "win32_window.h"
 
@@ -40,6 +42,12 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // Native HDR video output: mpv's own D3D11 window, and the layered windows
+  // the player controls are composited into above it.
+  std::unique_ptr<flutter::PluginRegistrarWindows> hdr_video_registrar_;
+  std::unique_ptr<HdrVideoWindow> hdr_video_;
+  std::unique_ptr<HdrOverlayWindow> hdr_overlay_;
 
   // Native retro-game playback.
   std::unique_ptr<flutter::PluginRegistrarWindows> native_game_registrar_;

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -37,6 +37,10 @@ class FlutterWindow : public Win32Window {
   int size_depth_ = 0;
   bool nested_size_ = false;
 
+  // Starts and stops the position heartbeat with the HDR windows, so a
+  // session that never plays HDR never pays for it.
+  void UpdateHdrSyncTimer();
+
   // The project to run.
   flutter::DartProject project_;
 
@@ -48,6 +52,8 @@ class FlutterWindow : public Win32Window {
   std::unique_ptr<flutter::PluginRegistrarWindows> hdr_video_registrar_;
   std::unique_ptr<HdrVideoWindow> hdr_video_;
   std::unique_ptr<HdrOverlayWindow> hdr_overlay_;
+
+  bool hdr_sync_timer_running_ = false;
 
   // Native retro-game playback.
   std::unique_ptr<flutter::PluginRegistrarWindows> native_game_registrar_;

--- a/windows/runner/hdr_overlay_window.cpp
+++ b/windows/runner/hdr_overlay_window.cpp
@@ -1,0 +1,214 @@
+#include "hdr_overlay_window.h"
+
+#include <flutter/standard_method_codec.h>
+
+#include "hdr_window_support.h"
+#include "method_call_args.h"
+
+namespace {
+
+constexpr const wchar_t kWindowClassName[] = L"MOONFIN_HDR_OVERLAY";
+
+}  // namespace
+
+HdrOverlayWindow::HdrOverlayWindow(flutter::BinaryMessenger* messenger,
+                                   HWND top_level)
+    : top_level_(top_level) {
+  channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      messenger, "moonfin/hdr_overlay",
+      &flutter::StandardMethodCodec::GetInstance());
+  channel_->SetMethodCallHandler([this](const auto& call, auto result) {
+    HandleMethod(call, std::move(result));
+  });
+}
+
+HdrOverlayWindow::~HdrOverlayWindow() {
+  ReleaseSurface();
+  if (window_ != nullptr) {
+    DestroyWindow(window_);
+    window_ = nullptr;
+  }
+}
+
+void HdrOverlayWindow::HandleMethod(
+    const flutter::MethodCall<flutter::EncodableValue>& call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+  const flutter::EncodableMap empty;
+  const flutter::EncodableMap& map = args != nullptr ? *args : empty;
+  const std::string& method = call.method_name();
+
+  if (method == "push") {
+    const int width = method_call_args::GetInt(map, "width", 0);
+    const int height = method_call_args::GetInt(map, "height", 0);
+    const int x = method_call_args::GetInt(map, "x", 0);
+    const int y = method_call_args::GetInt(map, "y", 0);
+
+    const auto it = map.find(flutter::EncodableValue(std::string("bytes")));
+    const std::vector<uint8_t>* pixels =
+        it != map.end() ? std::get_if<std::vector<uint8_t>>(&it->second)
+                        : nullptr;
+    if (pixels == nullptr || width <= 0 || height <= 0) {
+      result->Error("bad_args", "push needs bytes, width and height");
+      return;
+    }
+    if (pixels->size() <
+        static_cast<size_t>(width) * static_cast<size_t>(height) * 4) {
+      result->Error("short_buffer", "bytes is smaller than width * height * 4");
+      return;
+    }
+
+    const RECT rect = {x, y, x + width, y + height};
+    if (!Push(rect, *pixels, width, height)) {
+      result->Error("push_failed", "could not update the overlay window");
+      return;
+    }
+    result->Success();
+    return;
+  }
+
+  if (method == "hide") {
+    Hide();
+    result->Success();
+    return;
+  }
+
+  result->NotImplemented();
+}
+
+bool HdrOverlayWindow::Push(const RECT& rect,
+                            const std::vector<uint8_t>& pixels, int width,
+                            int height) {
+  if (top_level_ == nullptr) {
+    return false;
+  }
+
+  client_rect_ = rect;
+
+  // The rect arrives in the top-level's client coordinates, but a layered
+  // window is top-level itself and positioned in screen space.
+  POINT origin = {rect.left, rect.top};
+  ClientToScreen(top_level_, &origin);
+
+  if (window_ == nullptr) {
+    if (!hdr_window_support::EnsureWindowClass(
+            kWindowClassName, hdr_window_support::ClickThroughWndProc,
+            nullptr)) {
+      return false;
+    }
+    // WS_EX_TRANSPARENT keeps the overlay out of hit-testing, so clicks pass
+    // through to the Flutter view where the real widgets still are, and
+    // WS_EX_NOACTIVATE keeps focus there too.
+    window_ = CreateWindowEx(
+        WS_EX_LAYERED | WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW |
+            WS_EX_TRANSPARENT,
+        kWindowClassName, L"", WS_POPUP, origin.x, origin.y, width, height,
+        top_level_, nullptr, GetModuleHandle(nullptr), nullptr);
+    if (window_ == nullptr) {
+      return false;
+    }
+  }
+
+  HDC screen_dc = GetDC(nullptr);
+
+  if (bitmap_ == nullptr || width_ != width || height_ != height) {
+    ReleaseSurface();
+
+    // Top-down 32-bit DIB, which is the layout UpdateLayeredWindow wants.
+    BITMAPINFO info = {};
+    info.bmiHeader.biSize = sizeof(info.bmiHeader);
+    info.bmiHeader.biWidth = width;
+    info.bmiHeader.biHeight = -height;
+    info.bmiHeader.biPlanes = 1;
+    info.bmiHeader.biBitCount = 32;
+    info.bmiHeader.biCompression = BI_RGB;
+
+    bitmap_ =
+        CreateDIBSection(screen_dc, &info, DIB_RGB_COLORS, &bits_, nullptr, 0);
+    if (bitmap_ == nullptr || bits_ == nullptr) {
+      ReleaseSurface();
+      ReleaseDC(nullptr, screen_dc);
+      return false;
+    }
+    memory_dc_ = CreateCompatibleDC(screen_dc);
+    previous_bitmap_ = SelectObject(memory_dc_, bitmap_);
+    width_ = width;
+    height_ = height;
+  }
+
+  // Flutter's rawRgba is already premultiplied, which is what AC_SRC_ALPHA
+  // needs, so only the channel order differs. Done here rather than in Dart
+  // to keep it off the UI isolate. Word-at-a-time: RGBA in memory order reads
+  // as 0xAABBGGRR and BGRA wants 0xAARRGGBB, so only the outer two bytes move
+  // and the loop vectorises.
+  const auto* source = reinterpret_cast<const uint32_t*>(pixels.data());
+  auto* destination = static_cast<uint32_t*>(bits_);
+  const size_t count = static_cast<size_t>(width) * static_cast<size_t>(height);
+  for (size_t i = 0; i < count; ++i) {
+    const uint32_t p = source[i];
+    destination[i] = (p & 0xFF00FF00u) |          // alpha and green stay put
+                     ((p & 0x00FF0000u) >> 16) |  // blue to the low byte
+                     ((p & 0x000000FFu) << 16);   // red up to byte two
+  }
+
+  POINT destination_point = {origin.x, origin.y};
+  SIZE size = {width, height};
+  POINT source_point = {0, 0};
+  BLENDFUNCTION blend = {};
+  blend.BlendOp = AC_SRC_OVER;
+  blend.SourceConstantAlpha = 255;
+  blend.AlphaFormat = AC_SRC_ALPHA;
+
+  const BOOL ok = UpdateLayeredWindow(window_, screen_dc, &destination_point,
+                                      &size, memory_dc_, &source_point, 0,
+                                      &blend, ULW_ALPHA);
+  ReleaseDC(nullptr, screen_dc);
+  if (ok == FALSE) {
+    return false;
+  }
+
+  if (!visible_) {
+    ShowWindow(window_, SW_SHOWNOACTIVATE);
+    // Only on the transition; re-asserting the z-order per push is a window
+    // manager round trip for an ordering that has not changed.
+    SetWindowPos(window_, HWND_TOP, 0, 0, 0, 0,
+                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+    visible_ = true;
+  }
+  return true;
+}
+
+void HdrOverlayWindow::SyncPosition() {
+  if (window_ == nullptr || top_level_ == nullptr || !visible_) {
+    return;
+  }
+  POINT origin = {client_rect_.left, client_rect_.top};
+  ClientToScreen(top_level_, &origin);
+  SetWindowPos(window_, HWND_TOP, origin.x, origin.y, 0, 0,
+               SWP_NOSIZE | SWP_NOACTIVATE);
+}
+
+void HdrOverlayWindow::Hide() {
+  if (window_ == nullptr || !visible_) {
+    return;
+  }
+  ShowWindow(window_, SW_HIDE);
+  visible_ = false;
+}
+
+void HdrOverlayWindow::ReleaseSurface() {
+  if (memory_dc_ != nullptr) {
+    SelectObject(memory_dc_, previous_bitmap_);
+    DeleteDC(memory_dc_);
+    memory_dc_ = nullptr;
+  }
+  if (bitmap_ != nullptr) {
+    DeleteObject(bitmap_);
+    bitmap_ = nullptr;
+  }
+  previous_bitmap_ = nullptr;
+  bits_ = nullptr;
+  width_ = 0;
+  height_ = 0;
+}
+

--- a/windows/runner/hdr_overlay_window.cpp
+++ b/windows/runner/hdr_overlay_window.cpp
@@ -12,8 +12,10 @@ constexpr const wchar_t kWindowClassName[] = L"MOONFIN_HDR_OVERLAY";
 }  // namespace
 
 HdrOverlayWindow::HdrOverlayWindow(flutter::BinaryMessenger* messenger,
-                                   HWND top_level)
-    : top_level_(top_level) {
+                                   HWND top_level,
+                                   std::function<void()> on_window_changed)
+    : on_window_changed_(std::move(on_window_changed)),
+      top_level_(top_level) {
   channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
       messenger, "moonfin/hdr_overlay",
       &flutter::StandardMethodCodec::GetInstance());
@@ -63,6 +65,7 @@ void HdrOverlayWindow::HandleMethod(
       result->Error("push_failed", "could not update the overlay window");
       return;
     }
+    if (on_window_changed_) on_window_changed_();
     result->Success();
     return;
   }
@@ -194,6 +197,7 @@ void HdrOverlayWindow::Hide() {
   }
   ShowWindow(window_, SW_HIDE);
   visible_ = false;
+  if (on_window_changed_) on_window_changed_();
 }
 
 void HdrOverlayWindow::ReleaseSurface() {

--- a/windows/runner/hdr_overlay_window.h
+++ b/windows/runner/hdr_overlay_window.h
@@ -1,0 +1,76 @@
+#ifndef RUNNER_HDR_OVERLAY_WINDOW_H_
+#define RUNNER_HDR_OVERLAY_WINDOW_H_
+
+#include <windows.h>
+
+#include <flutter/binary_messenger.h>
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// The player chrome, drawn over the HDR video window in the overlay-capture
+// fallback (MOONFIN_HDR_DWM=0), where mpv's child window sits above the
+// Flutter view. UpdateLayeredWindow is the only Win32 API that gives per-pixel
+// alpha over an arbitrary window, which the player's scrim gradients need.
+// The default behind-the-window arrangement does not use this; see
+// hdr_video_window.h.
+//
+// Flutter renders the chrome off-screen and pushes it here as premultiplied
+// pixels covering the whole player. Readback cost tracks area, so capturing
+// only the top and bottom bands would be cheaper; that needs the player's
+// layout refactored first.
+class HdrOverlayWindow {
+ public:
+  // |top_level| is the runner window the overlay is positioned against. It is
+  // passed explicitly for the same reason as HdrVideoWindow: at construction
+  // time the Flutter view is not yet parented into the runner, so deriving
+  // the root from a registrar would land on the view itself.
+  HdrOverlayWindow(flutter::BinaryMessenger* messenger, HWND top_level);
+  ~HdrOverlayWindow();
+
+  HdrOverlayWindow(const HdrOverlayWindow&) = delete;
+  HdrOverlayWindow& operator=(const HdrOverlayWindow&) = delete;
+
+  // Re-derives the window's screen position from the client rect it was last
+  // given. The overlay is top-level, so it is positioned in screen space and
+  // does not follow the runner window on its own when that window is dragged.
+  void SyncPosition();
+
+ private:
+  void HandleMethod(
+      const flutter::MethodCall<flutter::EncodableValue>& call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  // Blits |pixels| - premultiplied RGBA, row-primary, as Flutter's
+  // ImageByteFormat.rawRgba produces it - into the overlay, creating and
+  // sizing it as needed. |rect| is in client coordinates of the top-level.
+  bool Push(const RECT& rect, const std::vector<uint8_t>& pixels, int width,
+            int height);
+  void Hide();
+
+  // Drops the cached GDI objects. They are rebuilt on the next push.
+  void ReleaseSurface();
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+  HWND top_level_ = nullptr;
+  HWND window_ = nullptr;
+  bool visible_ = false;
+
+  // The DIB and its DC are kept between pushes and rebuilt only on a size
+  // change; recreating ~30 MB per frame costs milliseconds on the thread that
+  // pumps the message loop.
+  HDC memory_dc_ = nullptr;
+  HBITMAP bitmap_ = nullptr;
+  HGDIOBJ previous_bitmap_ = nullptr;
+  void* bits_ = nullptr;
+  int width_ = 0;
+  int height_ = 0;
+
+  // Last client rect, so SyncPosition can re-derive the screen origin.
+  RECT client_rect_ = {};
+};
+
+#endif  // RUNNER_HDR_OVERLAY_WINDOW_H_

--- a/windows/runner/hdr_overlay_window.h
+++ b/windows/runner/hdr_overlay_window.h
@@ -8,6 +8,7 @@
 #include <flutter/method_channel.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -28,7 +29,10 @@ class HdrOverlayWindow {
   // passed explicitly for the same reason as HdrVideoWindow: at construction
   // time the Flutter view is not yet parented into the runner, so deriving
   // the root from a registrar would land on the view itself.
-  HdrOverlayWindow(flutter::BinaryMessenger* messenger, HWND top_level);
+  // |on_window_changed| fires whenever the overlay appears or goes away. See
+  // the same parameter on HdrVideoWindow.
+  HdrOverlayWindow(flutter::BinaryMessenger* messenger, HWND top_level,
+                   std::function<void()> on_window_changed);
   ~HdrOverlayWindow();
 
   HdrOverlayWindow(const HdrOverlayWindow&) = delete;
@@ -38,6 +42,10 @@ class HdrOverlayWindow {
   // given. The overlay is top-level, so it is positioned in screen space and
   // does not follow the runner window on its own when that window is dragged.
   void SyncPosition();
+
+  // A hidden overlay has no position to keep, so it does not need the
+  // runner's heartbeat.
+  bool NeedsPositionSync() const { return window_ != nullptr && visible_; }
 
  private:
   void HandleMethod(
@@ -55,6 +63,7 @@ class HdrOverlayWindow {
   void ReleaseSurface();
 
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+  std::function<void()> on_window_changed_;
   HWND top_level_ = nullptr;
   HWND window_ = nullptr;
   bool visible_ = false;

--- a/windows/runner/hdr_video_window.cpp
+++ b/windows/runner/hdr_video_window.cpp
@@ -1,0 +1,289 @@
+#include "hdr_video_window.h"
+
+#include <flutter/standard_method_codec.h>
+
+#include <string>
+
+#include "hdr_window_support.h"
+#include "method_call_args.h"
+
+namespace {
+
+constexpr const wchar_t kWindowClassName[] = L"MOONFIN_HDR_VIDEO";
+
+// Where a hidden video window is parked instead of SW_HIDE. Hiding a window
+// with a live D3D11 swapchain stalls mpv's presentation queue, and mpv paces
+// audio against video, so the whole file goes silent - parking off-screen
+// clips the window away while presentation carries on.
+constexpr int kParkedOrigin = -32000;
+
+}  // namespace
+
+HdrVideoWindow::HdrVideoWindow(flutter::BinaryMessenger* messenger,
+                               flutter::PluginRegistrarWindows* registrar,
+                               HWND top_level)
+    : top_level_(top_level) {
+  if (registrar != nullptr && registrar->GetView() != nullptr) {
+    flutter_view_ = registrar->GetView()->GetNativeWindow();
+  }
+
+  // Position sync is driven from the head of FlutterWindow::MessageHandler
+  // plus its heartbeat timer - not from a registered window-proc delegate,
+  // whose chain stops at the first plugin that claims a message.
+
+  channel_ = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      messenger, "moonfin/hdr_video",
+      &flutter::StandardMethodCodec::GetInstance());
+  channel_->SetMethodCallHandler([this](const auto& call, auto result) {
+    HandleMethod(call, std::move(result));
+  });
+}
+
+HdrVideoWindow::~HdrVideoWindow() { Destroy(); }
+
+void HdrVideoWindow::HandleMethod(
+    const flutter::MethodCall<flutter::EncodableValue>& call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  const auto* args = std::get_if<flutter::EncodableMap>(call.arguments());
+  const flutter::EncodableMap empty;
+  const flutter::EncodableMap& map = args != nullptr ? *args : empty;
+  const std::string& method = call.method_name();
+
+  if (method == "create") {
+    // The arrangement rides on the call, so MOONFIN_HDR_DWM has exactly one
+    // parser - hdr_composition_io.dart, on the Dart side.
+    const int mode = method_call_args::GetInt(map, "dwmMode", 0);
+    dwm_mode_ = (mode >= 1 && mode <= 4) ? mode : 0;
+    // Once per HDR engagement, not per launch, and deliberately in both
+    // arrangements: this is the line that catches a session that silently
+    // fell back to the capture arrangement in the field.
+    hdr_window_support::Log(L"create: dwm_mode=%d", dwm_mode_);
+    const int64_t handle = Create();
+    if (handle == 0) {
+      result->Error("create_failed", "could not create the video window");
+      return;
+    }
+    result->Success(flutter::EncodableValue(handle));
+    return;
+  }
+
+  if (method == "setGeometry") {
+    SetGeometry(method_call_args::GetInt(map, "x", 0),
+                method_call_args::GetInt(map, "y", 0),
+                method_call_args::GetInt(map, "width", 0),
+                method_call_args::GetInt(map, "height", 0));
+    result->Success();
+    return;
+  }
+
+  if (method == "setVisible") {
+    SetVisible(method_call_args::GetBool(map, "visible", false));
+    result->Success();
+    return;
+  }
+
+  if (method == "destroy") {
+    Destroy();
+    result->Success();
+    return;
+  }
+
+  result->NotImplemented();
+}
+
+int64_t HdrVideoWindow::Create() {
+  if (window_ != nullptr) {
+    return reinterpret_cast<int64_t>(window_);
+  }
+  if (top_level_ == nullptr) {
+    return 0;
+  }
+  if (!hdr_window_support::EnsureWindowClass(
+          kWindowClassName, hdr_window_support::ClickThroughWndProc,
+          static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH)))) {
+    return 0;
+  }
+
+  // Dart has not laid anything out when this runs, so fall back to the whole
+  // client area. A zero-area window handed to mpv as `wid` fails
+  // CreateSwapChainForHwnd and marks the session failed before the first
+  // frame.
+  if (geometry_.right <= geometry_.left || geometry_.bottom <= geometry_.top) {
+    GetClientRect(top_level_, &geometry_);
+  }
+
+  if (behind()) {
+    // A top-level window directly behind the runner window, which is given
+    // per-pixel DWM transparency so the Flutter frame composites over the
+    // video with real alpha. WS_EX_NOACTIVATE keeps focus on the runner,
+    // WS_EX_TOOLWINDOW keeps it out of the taskbar and alt-tab.
+    const RECT screen =
+        hdr_window_support::ClientRectInScreenSpace(top_level_);
+    // WS_CLIPCHILDREN keeps the class's black erase away from mpv's child,
+    // so the black shows only in genuine gaps and playback never flickers.
+    window_ = CreateWindowEx(
+        WS_EX_NOACTIVATE | WS_EX_TOOLWINDOW, kWindowClassName, L"",
+        WS_POPUP | WS_CLIPCHILDREN, screen.left, screen.top,
+        screen.right - screen.left, screen.bottom - screen.top, nullptr,
+        nullptr, GetModuleHandle(nullptr), nullptr);
+    if (window_ == nullptr) {
+      hdr_window_support::Log(L"behind Create failed: %lu", GetLastError());
+      return 0;
+    }
+    const bool composed =
+        hdr_window_support::ApplyTransparencyComposition(top_level_, dwm_mode_);
+    hdr_window_support::Log(
+        L"behind Create: hwnd=%p at (%ld,%ld)-(%ld,%ld), composition(%d)=%d",
+        window_, screen.left, screen.top, screen.right, screen.bottom,
+        dwm_mode_, composed);
+    return reinterpret_cast<int64_t>(window_);
+  }
+
+  // Without WS_CLIPSIBLINGS on the Flutter view, its swapchain present paints
+  // over any overlapping sibling and nothing ever repaints the sibling. Set
+  // before the window exists.
+  if (flutter_view_ != nullptr) {
+    const LONG_PTR view_style = GetWindowLongPtr(flutter_view_, GWL_STYLE);
+    if ((view_style & WS_CLIPSIBLINGS) == 0) {
+      SetWindowLongPtr(flutter_view_, GWL_STYLE, view_style | WS_CLIPSIBLINGS);
+      SetWindowPos(flutter_view_, nullptr, 0, 0, 0, 0,
+                   SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE |
+                       SWP_FRAMECHANGED);
+    }
+  }
+
+  // WS_EX_TRANSPARENT and the shared window proc's HTTRANSPARENT keep this
+  // window out of hit-testing, so clicks fall through to the Flutter view
+  // underneath where the player's widgets are still laid out. That is what
+  // lets input, focus and keyboard keep working untouched. WS_CLIPCHILDREN
+  // keeps the class's black erase away from mpv's child during playback.
+  window_ = CreateWindowEx(
+      WS_EX_TRANSPARENT | WS_EX_NOPARENTNOTIFY, kWindowClassName, L"",
+      WS_CHILD | WS_CLIPSIBLINGS | WS_CLIPCHILDREN, geometry_.left,
+      geometry_.top, geometry_.right - geometry_.left,
+      geometry_.bottom - geometry_.top, top_level_, nullptr,
+      GetModuleHandle(nullptr), nullptr);
+  if (window_ == nullptr) {
+    return 0;
+  }
+
+  // Above the Flutter view; the chrome is mirrored over the video by
+  // hdr_overlay_window.
+  SetWindowPos(window_, HWND_TOP, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  return reinterpret_cast<int64_t>(window_);
+}
+
+void HdrVideoWindow::SetGeometry(int x, int y, int width, int height) {
+  geometry_ = RECT{x, y, x + width, y + height};
+  if (window_ == nullptr || width <= 0 || height <= 0) {
+    return;
+  }
+  if (behind()) {
+    // A parked window keeps the new rect for when it is shown again, but
+    // must not be dragged back on screen by a geometry update - the same
+    // guard SyncPosition applies.
+    if (!parked_) {
+      PlaceBehind(false);
+    }
+    return;
+  }
+  SetWindowPos(window_, HWND_TOP, x, y, width, height, SWP_NOACTIVATE);
+}
+
+void HdrVideoWindow::SetVisible(bool visible) {
+  if (window_ == nullptr) {
+    return;
+  }
+
+  parked_ = !visible;
+  if (visible) {
+    if (behind()) {
+      // No separate ShowWindow: showing a popup hoists it over the runner and
+      // only PlaceBehind's insert-after puts it back, so the one call that
+      // does both atomically is the one to use.
+      PlaceBehind(true);
+    } else {
+      ShowWindow(window_, SW_SHOWNOACTIVATE);
+      SetWindowPos(window_, HWND_TOP, geometry_.left, geometry_.top,
+                   geometry_.right - geometry_.left,
+                   geometry_.bottom - geometry_.top, SWP_NOACTIVATE);
+    }
+    return;
+  }
+
+  // Parked off-screen rather than hidden - see kParkedOrigin.
+  SetWindowPos(window_, nullptr, kParkedOrigin, kParkedOrigin,
+               geometry_.right - geometry_.left,
+               geometry_.bottom - geometry_.top,
+               SWP_NOZORDER | SWP_NOACTIVATE);
+}
+
+void HdrVideoWindow::PlaceBehind(bool show) {
+  if (window_ == nullptr || top_level_ == nullptr) {
+    return;
+  }
+  // Minimised: the client rect is meaningless, so park until restore.
+  if (IsIconic(top_level_)) {
+    SetWindowPos(window_, nullptr, kParkedOrigin, kParkedOrigin, 0, 0,
+                 SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE);
+    return;
+  }
+
+  // The video rect Dart reports is in client coordinates; a top-level window
+  // is positioned in screen space, and inserted directly below the runner so
+  // nothing can slot between them.
+  RECT client = geometry_;
+  POINT origin = {client.left, client.top};
+  ClientToScreen(top_level_, &origin);
+  const int width = client.right - client.left;
+  const int height = client.bottom - client.top;
+  UINT flags = SWP_NOACTIVATE;
+  if (show) {
+    flags |= SWP_SHOWWINDOW;
+  }
+
+  SetLastError(0);
+  const BOOL ok = SetWindowPos(window_, top_level_, origin.x, origin.y, width,
+                               height, flags);
+  if (ok == FALSE) {
+    // This runs on the half-second heartbeat, so only failures are worth a
+    // line - a healthy session would otherwise write to disk twice a second.
+    hdr_window_support::Log(L"PlaceBehind failed: err=%lu", GetLastError());
+  }
+}
+
+void HdrVideoWindow::SyncPosition() {
+  if (window_ == nullptr || top_level_ == nullptr) {
+    return;
+  }
+
+  // Monitor-crossing detection is ahead of the arrangement gate: `wid`-mode
+  // mpv negotiates the swapchain colorspace once, at creation, in both
+  // arrangements. A resize does not renegotiate (ResizeBuffers keeps the
+  // colorspace), so Dart recreates the renderer.
+  const HMONITOR monitor =
+      MonitorFromWindow(top_level_, MONITOR_DEFAULTTONEAREST);
+  if (last_monitor_ != nullptr && monitor != last_monitor_ &&
+      channel_ != nullptr) {
+    channel_->InvokeMethod("monitorChanged", nullptr);
+    if (behind()) {
+      hdr_window_support::Log(L"monitor crossed - asked Dart to renegotiate");
+    }
+  }
+  last_monitor_ = monitor;
+
+  if (behind() && !parked_) {
+    PlaceBehind(false);
+  }
+}
+
+void HdrVideoWindow::Destroy() {
+  if (window_ != nullptr) {
+    if (behind()) {
+      hdr_window_support::RevertTransparencyComposition(top_level_);
+    }
+    DestroyWindow(window_);
+    window_ = nullptr;
+  }
+}

--- a/windows/runner/hdr_video_window.cpp
+++ b/windows/runner/hdr_video_window.cpp
@@ -21,8 +21,10 @@ constexpr int kParkedOrigin = -32000;
 
 HdrVideoWindow::HdrVideoWindow(flutter::BinaryMessenger* messenger,
                                flutter::PluginRegistrarWindows* registrar,
-                               HWND top_level)
-    : top_level_(top_level) {
+                               HWND top_level,
+                               std::function<void()> on_window_changed)
+    : on_window_changed_(std::move(on_window_changed)),
+      top_level_(top_level) {
   if (registrar != nullptr && registrar->GetView() != nullptr) {
     flutter_view_ = registrar->GetView()->GetNativeWindow();
   }
@@ -63,6 +65,7 @@ void HdrVideoWindow::HandleMethod(
       result->Error("create_failed", "could not create the video window");
       return;
     }
+    if (on_window_changed_) on_window_changed_();
     result->Success(flutter::EncodableValue(handle));
     return;
   }
@@ -284,11 +287,11 @@ void HdrVideoWindow::SyncPosition() {
 }
 
 void HdrVideoWindow::Destroy() {
-  if (window_ != nullptr) {
-    if (behind()) {
-      hdr_window_support::RevertTransparencyComposition(top_level_);
-    }
-    DestroyWindow(window_);
-    window_ = nullptr;
+  if (window_ == nullptr) return;
+  if (behind()) {
+    hdr_window_support::RevertTransparencyComposition(top_level_);
   }
+  DestroyWindow(window_);
+  window_ = nullptr;
+  if (on_window_changed_) on_window_changed_();
 }

--- a/windows/runner/hdr_video_window.cpp
+++ b/windows/runner/hdr_video_window.cpp
@@ -132,6 +132,11 @@ int64_t HdrVideoWindow::Create() {
     }
     const bool composed =
         hdr_window_support::ApplyTransparencyComposition(top_level_, dwm_mode_);
+    // Shown immediately, black, covering the client area: from here on the
+    // runner is see-through, and Flutter drops its own black background the
+    // moment engagement succeeds - before Dart has claimed this window. With
+    // nothing behind the runner in that gap the desktop shows through.
+    PlaceBehind(true);
     hdr_window_support::Log(
         L"behind Create: hwnd=%p at (%ld,%ld)-(%ld,%ld), composition(%d)=%d",
         window_, screen.left, screen.top, screen.right, screen.bottom,

--- a/windows/runner/hdr_video_window.h
+++ b/windows/runner/hdr_video_window.h
@@ -8,6 +8,7 @@
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 
+#include <functional>
 #include <memory>
 
 // The window mpv renders HDR video into, on Windows.
@@ -38,8 +39,12 @@ class HdrVideoWindow {
   // FlutterWindow::OnCreate, before SetChildContent parents the Flutter view
   // into the runner, so at that point GetAncestor(view, GA_ROOT) is the view
   // itself and anything derived from the registrar lands on the wrong window.
+  // |on_window_changed| fires whenever the native window appears or goes
+  // away, so the runner only pays for its position heartbeat while there is
+  // something to keep in position.
   HdrVideoWindow(flutter::BinaryMessenger* messenger,
-                 flutter::PluginRegistrarWindows* registrar, HWND top_level);
+                 flutter::PluginRegistrarWindows* registrar, HWND top_level,
+                 std::function<void()> on_window_changed);
   ~HdrVideoWindow();
 
   HdrVideoWindow(const HdrVideoWindow&) = delete;
@@ -50,6 +55,8 @@ class HdrVideoWindow {
   // WM_WINDOWPOSCHANGED, so it follows moves, resizes and z-order changes.
   // No-op in the child arrangement, where the window follows for free.
   void SyncPosition();
+
+  bool NeedsPositionSync() const { return window_ != nullptr; }
 
  private:
   void HandleMethod(
@@ -66,6 +73,7 @@ class HdrVideoWindow {
   void PlaceBehind(bool show);
 
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+  std::function<void()> on_window_changed_;
 
   HWND top_level_ = nullptr;
   HWND flutter_view_ = nullptr;

--- a/windows/runner/hdr_video_window.h
+++ b/windows/runner/hdr_video_window.h
@@ -1,0 +1,95 @@
+#ifndef RUNNER_HDR_VIDEO_WINDOW_H_
+#define RUNNER_HDR_VIDEO_WINDOW_H_
+
+#include <windows.h>
+
+#include <flutter/binary_messenger.h>
+#include <flutter/encodable_value.h>
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+
+#include <memory>
+
+// The window mpv renders HDR video into, on Windows.
+//
+// media_kit's texture path allocates B8G8R8A8_UNORM and mpv draws into it
+// through the OpenGL render API, so every HDR stream is flattened to 8-bit SDR
+// before Flutter composites it. target-colorspace-hint cannot fix that: it tags
+// a swapchain, and on the render API mpv owns none. So mpv needs a window of
+// its own, which is what this creates - the runner owns lifetime and geometry,
+// mpv creates and owns the D3D11 swapchain once it is handed the HWND.
+//
+// The window comes in two arrangements, chosen by MOONFIN_HDR_DWM - parsed
+// once, on the Dart side, and handed over with the `create` call:
+//
+//  - Default (technique 2; MOONFIN_HDR_DWM=1..4 picks another): a top-level
+//    window *behind* the whole runner window, with the runner window given
+//    per-pixel DWM transparency (see
+//    hdr_window_support::ApplyTransparencyComposition for the techniques).
+//    Flutter draws everything - controls, dialogs, OSD - natively over the
+//    video, and no capture is needed at all.
+//  - MOONFIN_HDR_DWM=0: the fallback - a child HWND *above* the Flutter
+//    view. Flutter's UI is then re-composited over the video by
+//    hdr_overlay_window, because nothing shows through the Flutter view from
+//    below.
+class HdrVideoWindow {
+ public:
+  // |top_level| is passed explicitly: these windows are constructed during
+  // FlutterWindow::OnCreate, before SetChildContent parents the Flutter view
+  // into the runner, so at that point GetAncestor(view, GA_ROOT) is the view
+  // itself and anything derived from the registrar lands on the wrong window.
+  HdrVideoWindow(flutter::BinaryMessenger* messenger,
+                 flutter::PluginRegistrarWindows* registrar, HWND top_level);
+  ~HdrVideoWindow();
+
+  HdrVideoWindow(const HdrVideoWindow&) = delete;
+  HdrVideoWindow& operator=(const HdrVideoWindow&) = delete;
+
+  // Re-fits a behind-the-window video window to the runner's client area and
+  // keeps it directly below in the z-order. Called from the runner's
+  // WM_WINDOWPOSCHANGED, so it follows moves, resizes and z-order changes.
+  // No-op in the child arrangement, where the window follows for free.
+  void SyncPosition();
+
+ private:
+  void HandleMethod(
+      const flutter::MethodCall<flutter::EncodableValue>& call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+  int64_t Create();
+  void SetGeometry(int x, int y, int width, int height);
+  void SetVisible(bool visible);
+  void Destroy();
+
+  // Places the behind-mode window at its screen rect, directly below the
+  // runner window. |show| also makes it visible without activating it.
+  void PlaceBehind(bool show);
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> channel_;
+
+  HWND top_level_ = nullptr;
+  HWND flutter_view_ = nullptr;
+  HWND window_ = nullptr;
+
+  // Client-area rect of the video, as Dart reports it.
+  RECT geometry_ = {};
+
+  // Set while the window is parked off-screen (SetVisible(false)), so the
+  // heartbeat's PlaceBehind does not drag it back over the runner during
+  // teardown.
+  bool parked_ = false;
+
+  // The monitor the runner was on at the last placement. In `wid` mode mpv
+  // negotiates the swapchain colorspace once, at creation, and never
+  // re-checks; on a crossing Dart is notified and cycles the renderer.
+  HMONITOR last_monitor_ = nullptr;
+
+  // 1..4 = top-level behind, with the matching transparency technique applied
+  // to the runner window (2 is the default). 0 = child above. Arrives with
+  // the `create` call.
+  int dwm_mode_ = 0;
+
+  bool behind() const { return dwm_mode_ != 0; }
+};
+
+#endif  // RUNNER_HDR_VIDEO_WINDOW_H_

--- a/windows/runner/hdr_window_support.cpp
+++ b/windows/runner/hdr_window_support.cpp
@@ -1,0 +1,157 @@
+#include "hdr_window_support.h"
+
+#include <dwmapi.h>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cwchar>
+#include <iterator>
+#include <set>
+#include <string>
+
+namespace hdr_window_support {
+
+bool EnsureWindowClass(const wchar_t* name, WNDPROC proc, HBRUSH background) {
+  static std::set<std::wstring> registered;
+  if (registered.count(name) != 0) {
+    return true;
+  }
+  WNDCLASS window_class = {};
+  window_class.lpfnWndProc = proc;
+  window_class.hInstance = GetModuleHandle(nullptr);
+  window_class.lpszClassName = name;
+  window_class.hCursor = LoadCursor(nullptr, IDC_ARROW);
+  window_class.hbrBackground = background;
+  if (RegisterClass(&window_class) == 0) {
+    return false;
+  }
+  registered.insert(name);
+  return true;
+}
+
+void Log(const wchar_t* format, ...) {
+  wchar_t path[MAX_PATH] = {};
+  if (GetTempPathW(static_cast<DWORD>(std::size(path)), path) == 0) {
+    return;
+  }
+  wcsncat_s(path, L"moonfin_hdr_dwm.log", _TRUNCATE);
+  FILE* file = nullptr;
+  if (_wfopen_s(&file, path, L"a, ccs=UTF-8") != 0 || file == nullptr) {
+    return;
+  }
+  SYSTEMTIME now = {};
+  GetLocalTime(&now);
+  fwprintf(file, L"%02u:%02u:%02u.%03u ", now.wHour, now.wMinute, now.wSecond,
+           now.wMilliseconds);
+  va_list args;
+  va_start(args, format);
+  vfwprintf(file, format, args);
+  va_end(args);
+  fwprintf(file, L"\n");
+  fclose(file);
+}
+
+RECT ClientRectInScreenSpace(HWND top_level) {
+  RECT client = {};
+  GetClientRect(top_level, &client);
+  POINT origin = {client.left, client.top};
+  ClientToScreen(top_level, &origin);
+  return RECT{origin.x, origin.y, origin.x + (client.right - client.left),
+              origin.y + (client.bottom - client.top)};
+}
+
+namespace {
+
+// SetWindowCompositionAttribute is undocumented, so its shapes are declared
+// here. Same layout flutter_acrylic and flutter_native_view use.
+struct AccentPolicy {
+  int accent_state;
+  int accent_flags;
+  unsigned int gradient_color;
+  int animation_id;
+};
+
+struct WindowCompositionAttributeData {
+  int attribute;  // WCA_ACCENT_POLICY = 19
+  void* data;
+  size_t size;
+};
+
+using SetWindowCompositionAttributePtr =
+    BOOL(WINAPI*)(HWND, WindowCompositionAttributeData*);
+
+bool SetAccentState(HWND top_level, int state) {
+  // user32 is already loaded by any process with a window and never unloads,
+  // so no LoadLibrary/FreeLibrary round trip is needed.
+  const HMODULE user32 = GetModuleHandleW(L"user32.dll");
+  if (user32 == nullptr) {
+    return false;
+  }
+  const auto set_attribute = reinterpret_cast<SetWindowCompositionAttributePtr>(
+      GetProcAddress(user32, "SetWindowCompositionAttribute"));
+  if (set_attribute == nullptr) {
+    return false;
+  }
+  AccentPolicy policy = {};
+  policy.accent_state = state;
+  // 2 = honour the gradient colour, which is fully transparent AABBGGRR so
+  // whatever sits behind the window shows through unmodified.
+  policy.accent_flags = 2;
+  policy.gradient_color = 0x00000000;
+  WindowCompositionAttributeData data = {19, &policy, sizeof(policy)};
+  return set_attribute(top_level, &data) != FALSE;
+}
+
+}  // namespace
+
+bool ApplyTransparencyComposition(HWND top_level, int technique) {
+  if (top_level == nullptr) {
+    return false;
+  }
+  bool ok = true;
+  if (technique == 1 || technique == 3) {
+    MARGINS margins = {-1, -1, -1, -1};
+    ok = SUCCEEDED(DwmExtendFrameIntoClientArea(top_level, &margins)) && ok;
+  }
+  if (technique == 2 || technique == 3) {
+    // ACCENT_ENABLE_TRANSPARENTGRADIENT
+    ok = SetAccentState(top_level, 2) && ok;
+  }
+  if (technique == 4) {
+    // Past the documented end of the accent enum; what flutter_native_view
+    // sets to show an embedded HWND through the Flutter window.
+    ok = SetAccentState(top_level, 6) && ok;
+  }
+  return ok;
+}
+
+void RevertTransparencyComposition(HWND top_level) {
+  if (top_level == nullptr) {
+    return;
+  }
+  MARGINS margins = {0, 0, 0, 0};
+  DwmExtendFrameIntoClientArea(top_level, &margins);
+  // ACCENT_DISABLED
+  SetAccentState(top_level, 0);
+}
+
+LRESULT CALLBACK ClickThroughWndProc(HWND window, UINT message, WPARAM wparam,
+                                     LPARAM lparam) noexcept {
+  switch (message) {
+    // WM_ERASEBKGND is deliberately unhandled: DefWindowProc erases with the
+    // class brush, which is where the two windows differ - see
+    // EnsureWindowClass.
+
+    // Send the hit test on to the window underneath - see the header.
+    case WM_NCHITTEST:
+      return HTTRANSPARENT;
+    // Never take activation from the Flutter view either.
+    case WM_MOUSEACTIVATE:
+      return MA_NOACTIVATE;
+    default:
+      break;
+  }
+  return DefWindowProc(window, message, wparam, lparam);
+}
+
+}  // namespace hdr_window_support

--- a/windows/runner/hdr_window_support.h
+++ b/windows/runner/hdr_window_support.h
@@ -1,0 +1,62 @@
+#ifndef RUNNER_HDR_WINDOW_SUPPORT_H_
+#define RUNNER_HDR_WINDOW_SUPPORT_H_
+
+#include <windows.h>
+
+// Shared pieces of the two native HDR companion windows (hdr_video_window,
+// hdr_overlay_window). The click-through window proc in particular must stay
+// identical between them - it is what keeps the player's mouse input working.
+namespace hdr_window_support {
+
+// Registers |name| against |proc| once per process. Returns false only if the
+// registration itself failed. |background| becomes the class brush: the video
+// window passes black, so any moment mpv is not covering it - the renderer
+// cycle on a monitor crossing, above all - reads as a brief black blink
+// rather than the desktop showing through the transparent runner (behind
+// arrangement) or a stale strip (child arrangement, where black is simply the
+// letterbox colour). The overlay passes null; UpdateLayeredWindow owns its
+// every pixel. Any class registered with a real brush must create its windows
+// with WS_CLIPCHILDREN, or the erase paints straight over mpv's child during
+// playback.
+bool EnsureWindowClass(const wchar_t* name, WNDPROC proc, HBRUSH background);
+
+// The top-level window's client area in screen coordinates - what a
+// behind-the-window companion has to cover to line up with the Flutter view.
+RECT ClientRectInScreenSpace(HWND top_level);
+
+// Makes the top-level window composite with per-pixel alpha against whatever
+// sits behind it, per `technique`:
+//   1  DwmExtendFrameIntoClientArea(-1) - the classic sheet-of-glass call
+//   2  SetWindowCompositionAttribute ACCENT_ENABLE_TRANSPARENTGRADIENT
+//   3  both
+//   4  accent state 6, past the documented enum - flutter_native_view's call
+//
+// flutter_acrylic uses the same calls. They only work over a genuinely
+// transparent Flutter frame: any opaque widget under the video paints it out.
+bool ApplyTransparencyComposition(HWND top_level, int technique);
+
+// Puts the window back to normal opaque composition.
+void RevertTransparencyComposition(HWND top_level);
+
+// Appends a printf-style line to %TEMP%\moonfin_hdr_dwm.log. The runner is
+// detached from any console, so this is the only way to see what the native
+// half actually did. Volume discipline: a handful of lines per playback is
+// fine; nothing may log on the heartbeat while healthy.
+void Log(const wchar_t* format, ...);
+
+// The window procedure both companions use.
+//
+// The load-bearing case is WM_NCHITTEST returning HTTRANSPARENT. Neither
+// window may take a hit test: the widgets that handle the click are in the
+// Flutter view underneath, still laid out at the same coordinates - only the
+// pixels moved. WS_EX_TRANSPARENT covers this for a layered top-level window
+// but not for a child, where hit-testing walks the child chain and stops at
+// the first window regardless. Without this the video window swallows every
+// mouse event and the player looks dead while the keyboard still works,
+// because keyboard follows focus, which never moved.
+LRESULT CALLBACK ClickThroughWndProc(HWND window, UINT message, WPARAM wparam,
+                                     LPARAM lparam) noexcept;
+
+}  // namespace hdr_window_support
+
+#endif  // RUNNER_HDR_WINDOW_SUPPORT_H_

--- a/windows/runner/method_call_args.cpp
+++ b/windows/runner/method_call_args.cpp
@@ -1,0 +1,38 @@
+#include "method_call_args.h"
+
+namespace method_call_args {
+
+int GetInt(const flutter::EncodableMap& map, const char* key, int fallback) {
+  const auto it = map.find(flutter::EncodableValue(std::string(key)));
+  if (it != map.end()) {
+    if (const auto* value = std::get_if<int>(&it->second)) {
+      return *value;
+    }
+    if (const auto* value = std::get_if<int64_t>(&it->second)) {
+      return static_cast<int>(*value);
+    }
+  }
+  return fallback;
+}
+
+bool GetBool(const flutter::EncodableMap& map, const char* key, bool fallback) {
+  const auto it = map.find(flutter::EncodableValue(std::string(key)));
+  if (it != map.end()) {
+    if (const auto* value = std::get_if<bool>(&it->second)) {
+      return *value;
+    }
+  }
+  return fallback;
+}
+
+std::string GetString(const flutter::EncodableMap& map, const char* key) {
+  const auto it = map.find(flutter::EncodableValue(std::string(key)));
+  if (it != map.end()) {
+    if (const auto* value = std::get_if<std::string>(&it->second)) {
+      return *value;
+    }
+  }
+  return std::string();
+}
+
+}  // namespace method_call_args

--- a/windows/runner/method_call_args.h
+++ b/windows/runner/method_call_args.h
@@ -1,0 +1,21 @@
+#ifndef RUNNER_METHOD_CALL_ARGS_H_
+#define RUNNER_METHOD_CALL_ARGS_H_
+
+#include <flutter/encodable_value.h>
+
+#include <string>
+
+// Typed readers for a method call's argument map, shared by every channel
+// handler in the runner. Each returns the fallback (or an empty string) when
+// the key is missing or holds a different type.
+namespace method_call_args {
+
+// Accepts both int32 and int64 encodings, since the standard codec picks
+// whichever fits the value.
+int GetInt(const flutter::EncodableMap& map, const char* key, int fallback);
+bool GetBool(const flutter::EncodableMap& map, const char* key, bool fallback);
+std::string GetString(const flutter::EncodableMap& map, const char* key);
+
+}  // namespace method_call_args
+
+#endif  // RUNNER_METHOD_CALL_ARGS_H_

--- a/windows/runner/native_game.cpp
+++ b/windows/runner/native_game.cpp
@@ -9,25 +9,10 @@
 #include <thread>
 #include <vector>
 
+#include "method_call_args.h"
 #include "lh_audio.h"
 
 namespace {
-
-std::string GetString(const flutter::EncodableMap& map, const char* key) {
-  auto it = map.find(flutter::EncodableValue(std::string(key)));
-  if (it != map.end()) {
-    if (auto* value = std::get_if<std::string>(&it->second)) return *value;
-  }
-  return std::string();
-}
-
-int GetInt(const flutter::EncodableMap& map, const char* key, int fallback) {
-  auto it = map.find(flutter::EncodableValue(std::string(key)));
-  if (it != map.end()) {
-    if (auto* value = std::get_if<int>(&it->second)) return *value;
-  }
-  return fallback;
-}
 
 // A pulse bit is held briefly so the overlay can send Start or Select.
 std::atomic<uint16_t> g_pulse_mask{0};
@@ -145,15 +130,15 @@ void NativeGame::HandleMethod(
     Stop();
     result->Success();
   } else if (method == "setFastForward") {
-    if (host_) lh_set_fast_forward(host_, GetInt(map, "factor", 1));
+    if (host_) lh_set_fast_forward(host_, method_call_args::GetInt(map, "factor", 1));
     result->Success();
   } else if (method == "setInput") {
-    g_dart_mask = static_cast<uint16_t>(GetInt(map, "mask", 0));
+    g_dart_mask = static_cast<uint16_t>(method_call_args::GetInt(map, "mask", 0));
     PushInput();
     result->Success();
   } else if (method == "pulseButton") {
-    int index = GetInt(map, "index", -1);
-    int duration = GetInt(map, "durationMs", 150);
+    int index = method_call_args::GetInt(map, "index", -1);
+    int duration = method_call_args::GetInt(map, "durationMs", 150);
     if (index >= 0 && index < 16) {
       uint16_t bit = static_cast<uint16_t>(1 << index);
       g_pulse_mask |= bit;
@@ -187,8 +172,8 @@ void NativeGame::HandleMethod(
   } else if (method == "getOptions" || method == "getCurrentOptions") {
     result->Success(Options(method == "getCurrentOptions"));
   } else if (method == "setOption") {
-    if (host_) lh_set_option(host_, GetString(map, "id").c_str(),
-                             GetString(map, "value").c_str());
+    if (host_) lh_set_option(host_, method_call_args::GetString(map, "id").c_str(),
+                             method_call_args::GetString(map, "value").c_str());
     result->Success();
   } else if (method == "controllerCount") {
     result->Success(flutter::EncodableValue(1));
@@ -200,11 +185,11 @@ void NativeGame::HandleMethod(
 flutter::EncodableValue NativeGame::Load(const flutter::EncodableMap& args) {
   Stop();
 
-  std::string core_path = GetString(args, "corePath");
-  std::string rom_path = GetString(args, "romPath");
-  std::string system_dir = GetString(args, "systemDir");
-  std::string save_dir = GetString(args, "saveDir");
-  std::string game_id = GetString(args, "gameId");
+  std::string core_path = method_call_args::GetString(args, "corePath");
+  std::string rom_path = method_call_args::GetString(args, "romPath");
+  std::string system_dir = method_call_args::GetString(args, "systemDir");
+  std::string save_dir = method_call_args::GetString(args, "saveDir");
+  std::string game_id = method_call_args::GetString(args, "gameId");
 
   std::vector<std::string> keys;
   std::vector<std::string> values;


### PR DESCRIPTION
# Pull Request

## Summary
Native HDR video output on Windows. mpv is given its own D3D11 window (`wid`) instead of rendering into media_kit's 8-bit `B8G8R8A8_UNORM` texture, so HDR titles reach an HDR display untouched as HDR10 (PQ, BT.2020) rather than being tone-mapped to SDR. The window sits behind the runner, which is given per-pixel DWM transparency, so the Flutter UI (controls, dialogs, OSD) draws over the video natively. Engagement is per playback and gated on HDR content + display in HDR mode + a new "Native HDR output" setting; Live TV and the mini player are unaffected. Also fixes auto HDR display switching, which could never engage because of a bad preprocessor guard.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe): N/A

## Changes Made
List the key changes included in this PR.

- Fix auto HDR switching never engaging on Windows: `DISPLAYCONFIG_DEVICE_INFO_*` are enumerators, not macros, so the `#if defined` guard always compiled the stub.
- Windows runner: new `HdrVideoWindow` (`moonfin/hdr_video`) hosting mpv's swapchain behind a DWM-transparent runner (default), with a child-window + `UpdateLayeredWindow` overlay fallback (`HdrOverlayWindow`, `moonfin/hdr_overlay`, `MOONFIN_HDR_DWM=0`); click-through window proc, position heartbeat, monitor-crossing notification. Shared `EncodableMap` readers moved to `method_call_args`.
- Dart: `HdrOutputController` decides engagement (preference → decoded `tate → presenter) and reports the reason; `MediaKitPlayerBackend` handsmpv over (`wid`, `gpu-api=d3d11`, `vo=gpu-next`, `target-colorspace-hint`), re-applies custom mpv.conf, carries subtitles across the vo swap, restores the texture path on release/failure, and recreates the renderer on monitor crossings.
- Player screen: transparent background while the native window shows thorts the video rect, `HdrOverlayCapture` mirrors the chrome in fallbackmode, black is painted while the renderer cycles so the desktop never shows through.
- Settings: "Native HDR output" toggle (Video Playback, Windows only); sR output" row with the active/inactive reason.
- mpv.conf allowlist: HDR/tone-mapping keys (`target-prim/peak/contrast`, `tone-mapping-mode`, `gamut-mapping-mode`, `target-colorspace-hint`, `hdr-compute-peak`, `target-inverse-tone-mapping`, `dither`, `dither-depth`); `gpu-api` moved to the advanced tier.
- Small cleanups: `playerVolumeIsSystemManaged` split from `useNativeVideoSurface`; unreachable subtitle sync removed from the playing-stream listener.
- `native/hdr_probe`: standalone tool to verify a `libmpv-2.dll` before trusting it with the native path (not part of the app build).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [x] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why): N/A

### Test Steps
1. Windows 11, HDR-capable display with "Use HDR" on (or Auto HDR switch a second SDR display. Build with `flutter build windows --release` andlaunch without `MOONFIN_HDR_DWM` set.
2. Play an HDR10 / Dolby Vision title: the display's HDR indicator engages, `%TEMP%\moonfin_hdr_dwm.log` shows `create: dwm_mode=2` and `composition(2)=1`, and the stream info sheet reports "HDR output: Active — HDR10 (PQ, BT.2020)". Controls, subtitle/audio pickers, volume OSD and dialogs render over the video; mouse and keyboard work.
3. Drag the window between the HDR and SDR monitors during playback: brief black blink, then playback continues with the swapchain renegotiated; no desktop visible through the UI. Play an SDR title / disable the setting: the row reports the inactive reason and the standard texture path is used. Leave the player to Live TV / the mini player: they still render.
4. `flutter analyze` (no new issues), `flutter test test/playback/hdr_output_controller_test.dart` (21/21), release build links with no new warnings.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

N/A

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced