### PR TITLE
Fix: SyncPlay seek loops and unreachable group seeks on Apple TV

### DIFF
--- a/lib/data/services/media_segment_service.dart
+++ b/lib/data/services/media_segment_service.dart
@@ -15,6 +15,18 @@ class MediaSegmentService {
   List<MediaSegment> _segments = [];
   MediaSegment? _activeSegment;
 
+  /// Segments already skipped automatically, until playback is seen at or
+  /// before their start again.
+  ///
+  /// A skip is a seek to the segment's end, and most players land a frame
+  /// short of a seek target, which is still inside the segment. That landing
+  /// looks like a fresh entry once a sample past the end has reset
+  /// [_activeSegment]. Under SyncPlay every client lands there at once, and
+  /// each one that re-fired asked the group to skip again, which made
+  /// everyone land there again: an endless loop of group seeks. Skipping a
+  /// segment once, until a real rewind to its start, cannot loop.
+  final Set<MediaSegment> _autoSkipped = <MediaSegment>{};
+
   List<MediaSegment> get segments => _segments;
   MediaSegment? get activeSegment => _activeSegment;
 
@@ -25,6 +37,7 @@ class MediaSegmentService {
   Future<void> loadSegments(String itemId) async {
     _segments = [];
     _activeSegment = null;
+    _autoSkipped.clear();
     if (!isSupported) return;
 
     try {
@@ -38,6 +51,7 @@ class MediaSegmentService {
   void clear() {
     _segments = [];
     _activeSegment = null;
+    _autoSkipped.clear();
   }
 
   Map<MediaSegmentType, MediaSegmentAction> get actionMap =>
@@ -46,16 +60,25 @@ class MediaSegmentService {
   SegmentCheckResult checkPosition(Duration position) {
     if (_segments.isEmpty) return SegmentCheckResult.none;
 
+    // Back at or before the start is a rewind into the segment on purpose,
+    // so it is armed again. A landing just short of its end is not.
+    _autoSkipped.removeWhere((segment) => position <= segment.start);
+
     for (final segment in _segments) {
       if (position >= segment.start && position < segment.end) {
         final action = actionMap[segment.type] ?? MediaSegmentAction.nothing;
+        // Seeks travel as whole milliseconds; a truncated end would still be
+        // inside the segment.
+        final skipTo = Duration(
+          milliseconds: (segment.end.inMicroseconds + 999) ~/ 1000,
+        );
 
         if (_activeSegment?.id == segment.id) {
           if (action == MediaSegmentAction.askToSkip) {
             return SegmentCheckResult(
               action: MediaSegmentAction.askToSkip,
               segment: segment,
-              skipTo: segment.end,
+              skipTo: skipTo,
               isNew: false,
             );
           }
@@ -75,16 +98,17 @@ class MediaSegmentService {
         }
 
         if (action == MediaSegmentAction.skip) {
+          if (!_autoSkipped.add(segment)) return SegmentCheckResult.none;
           return SegmentCheckResult(
             action: MediaSegmentAction.skip,
             segment: segment,
-            skipTo: segment.end,
+            skipTo: skipTo,
           );
         }
         return SegmentCheckResult(
           action: MediaSegmentAction.askToSkip,
           segment: segment,
-          skipTo: segment.end,
+          skipTo: skipTo,
         );
       }
     }

--- a/lib/playback/aether_backend.dart
+++ b/lib/playback/aether_backend.dart
@@ -507,6 +507,19 @@ class AetherBackend implements PlayerBackend {
   @override
   bool get demuxesEmbeddedSubtitles => true;
 
+  // Same engine as the Apple TV backend, so a seek costs the same reopen.
+  // Provisional pending a trace of its own.
+  @override
+  Duration get typicalSeekLatency => const Duration(seconds: 4);
+
+  @override
+  Duration get maxSeekLatency => const Duration(seconds: 20);
+
+  // Same AVPlayer rate path as the Apple TV backend, with the same audio
+  // reconfiguration on every write.
+  @override
+  bool get supportsSmoothRateChange => false;
+
   @override
   List<EmbeddedCaptionTrack> get embeddedCaptionTracks =>
       _embeddedCaptionTracks;

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -787,6 +787,25 @@ class AppleTvBackend implements PlayerBackend {
   @override
   bool get demuxesEmbeddedSubtitles => true;
 
+  // Every seek here goes through `.seeking`, which the wrapper reports as
+  // buffering with no in-buffer fast path, and one that restarts a transcode
+  // has to open the session again before a frame is rendered. Provisional
+  // until a device trace measures the real distribution; SyncPlay measures
+  // each seek anyway and only uses these to pace itself and to decide when a
+  // gap has stopped being seek cost.
+  @override
+  Duration get typicalSeekLatency => const Duration(seconds: 4);
+
+  @override
+  Duration get maxSeekLatency => const Duration(seconds: 20);
+
+  // A rate write goes straight to the engine's AVPlayer rate. Every one of
+  // them audibly reconfigures the audio, and passthrough audio cannot play at
+  // anything but 1x, so a SyncPlay nudge every two seconds is a stutter that
+  // never stops.
+  @override
+  bool get supportsSmoothRateChange => false;
+
   @override
   List<EmbeddedCaptionTrack> get embeddedCaptionTracks =>
       _embeddedCaptionTracks;

--- a/lib/playback/playback_lifecycle_handler.dart
+++ b/lib/playback/playback_lifecycle_handler.dart
@@ -195,6 +195,13 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
       _stopBgCorrection();
       return;
     }
+    // Under SyncPlay the group moves the player, and on web the tab being
+    // hidden is exactly when a group starts a new item at a lower position.
+    // A corrective seek here would go to the whole group as a request.
+    if (_manager.hasTransportInterceptor) {
+      _stopBgCorrection();
+      return;
+    }
     if (_bgSeekInFlight) return;
 
     final currentPos = _manager.backend?.position ?? _manager.state.position;
@@ -259,6 +266,9 @@ class PlaybackLifecycleHandler with WidgetsBindingObserver {
 
     if (savedPos == null || wasPlaying == null) return;
     if (_manager.queueService.currentItem == null) return;
+    // The group may well have unpaused or seeked while we were hidden;
+    // restoring what we saved would pause or seek every member back.
+    if (_manager.hasTransportInterceptor) return;
 
     try {
       if (!wasPlaying && _manager.state.isPlaying) {

--- a/lib/playback/tizen_player_backend.dart
+++ b/lib/playback/tizen_player_backend.dart
@@ -353,6 +353,11 @@ class TizenPlayerBackend extends PlayerBackend {
   @override
   bool get canRenderBitmapSubtitles => false;
 
+  // The Tizen player does not keep audio going at rates other than 1x, so a
+  // SyncPlay rate nudge would drop the sound for as long as it lasts.
+  @override
+  bool get supportsSmoothRateChange => false;
+
   @override
   void dispose() {
     _isDisposed = true;

--- a/lib/syncplay/sync_correction_policy.dart
+++ b/lib/syncplay/sync_correction_policy.dart
@@ -3,16 +3,38 @@
 /// on their own.
 library;
 
-enum SyncCorrectionAction { hold, defer, rebaseline, skip, speed, giveUp }
+import 'dart:math' as math;
+
+enum SyncCorrectionAction { hold, defer, skip, speed, wait, giveUp }
 
 class SyncCorrectionSettings {
   final bool useSkipToSync;
+
+  /// Whether a rate nudge is an acceptable correction on this player. The
+  /// manager clears it for players whose audio does not survive a rate change,
+  /// whatever the user preference says: on those, [SyncCorrectionAction.wait]
+  /// takes over the ahead case and small lateness is tolerated.
   final bool useSpeedToSync;
   final int minDelaySkipToSyncMs;
   final int minDelaySpeedToSyncMs;
   final int maxDelaySpeedToSyncMs;
+
+  /// How long a nudge should take to close the gap, as in jellyfin-web. The
+  /// rate needed is derived from it and capped at [SyncCorrectionPolicy
+  /// .maxRateDeviation], so a large gap takes a longer nudge rather than an
+  /// absurd rate.
   final int speedToSyncDurationMs;
   final int extraTimeOffsetMs;
+
+  /// What a seek usually costs this player before it renders again. Seeds the
+  /// seek-cost allowance before anything has been measured and paces how often
+  /// corrective skips may be issued.
+  final int typicalSeekLatencyMs;
+
+  /// The longest a seek on this player may plausibly take. An attempt that has
+  /// not settled within it is abandoned rather than waited on forever, and no
+  /// learned allowance may exceed it.
+  final int maxSeekLatencyMs;
 
   const SyncCorrectionSettings({
     required this.useSkipToSync,
@@ -22,6 +44,9 @@ class SyncCorrectionSettings {
     required this.maxDelaySpeedToSyncMs,
     required this.speedToSyncDurationMs,
     this.extraTimeOffsetMs = 0,
+    this.typicalSeekLatencyMs =
+        SyncCorrectionPolicy.defaultTypicalSeekLatencyMs,
+    this.maxSeekLatencyMs = SyncCorrectionPolicy.maxSeekLatencyAllowanceMs,
   });
 }
 
@@ -31,6 +56,8 @@ class SyncCorrectionDecision {
   final int targetPositionMs;
   final double speed;
   final int speedDurationMs;
+  /// How long to hold the player paused for [SyncCorrectionAction.wait].
+  final int waitDurationMs;
   /// Positive means ahead of the group, zero when nothing was measurable.
   final int measuredDelayMs;
 
@@ -39,36 +66,211 @@ class SyncCorrectionDecision {
     this.targetPositionMs = 0,
     this.speed = 1.0,
     this.speedDurationMs = 0,
+    this.waitDurationMs = 0,
     this.measuredDelayMs = 0,
   });
 
   const SyncCorrectionDecision.defer() : this._(SyncCorrectionAction.defer);
+
+  const SyncCorrectionDecision._hold(int delayMs)
+      : this._(SyncCorrectionAction.hold, measuredDelayMs: delayMs);
+}
+
+/// One seek in flight: a skip we asked for, or one the group asked for. It is
+/// open until the player is observed rendering at the new position, which is
+/// what makes the seek's real cost measurable instead of assumed.
+class _CorrectionAttempt {
+  final int issuedAtMs;
+  final int deadlineMs;
+  final int targetMs;
+  final int fromMs;
+
+  /// How far off we were before this correction, so the result can be judged.
+  /// Null for a group seek: there was no measurement to improve on.
+  final int? preResidualMs;
+
+  bool get isOwnSkip => preResidualMs != null;
+
+  /// First sample seen at the new position with the pipeline not stalled.
+  int? landedAtMs;
+
+  /// Start of the window over which the player has been rendering real time
+  /// since landing. Restarted whenever the position stops advancing, so a
+  /// player that reports the target position before it has any frames for it
+  /// is not credited with a landing it has not made.
+  int? anchorMs;
+  int anchorPositionMs = 0;
+
+  bool settled = false;
+
+  _CorrectionAttempt({
+    required this.issuedAtMs,
+    required this.deadlineMs,
+    required this.targetMs,
+    required this.fromMs,
+    required this.preResidualMs,
+  });
+
+  void anchor(int nowMs, int positionMs) {
+    anchorMs = nowMs;
+    anchorPositionMs = positionMs;
+  }
+
+  /// Cost of this seek so far as it is known: rendering time if it has been
+  /// seen, landing time otherwise, nothing if it never landed.
+  int? get observedCostMs {
+    final start = anchorMs ?? landedAtMs;
+    if (start == null) return null;
+    return start - issuedAtMs;
+  }
 }
 
 class SyncCorrectionPolicy {
   // Backends sample position on a timer (250ms on Apple TV and media3), so
   // drift under this is quantisation noise and correcting on it just wobbles
-  // the rate every couple of seconds.
+  // the player every couple of seconds.
   static const int noiseFloorMs = 400;
-  static const int skipSettleMs = 6000;
-  // A seek the group asked for lands just as slowly as one we chose.
-  static const int seekSettleMs = 3000;
+
+  /// Default ceiling on what may be called seek cost. Backends that seek more
+  /// slowly than this raise it through
+  /// [SyncCorrectionSettings.maxSeekLatencyMs].
   static const int maxSeekLatencyAllowanceMs = 8000;
-  static const int maxConsecutiveSkips = 4;
+  static const int defaultTypicalSeekLatencyMs = 1500;
 
-  static const double _slowDownSpeed = 0.95;
-  static const double _speedUpSpeed = 1.05;
+  /// Corrective skips allowed per item. Unlike a streak this is never cleared
+  /// by a good measurement or by the group seeking, so no sequence of events
+  /// can hand out an unlimited number of jumps.
+  static const int maxSkipsPerItem = 10;
 
-  int _consecutiveSkips = 0;
-  int _seekLatencyAllowanceMs = 0;
-  int _blockedUntilMs = 0;
-  bool _awaitingSkipSettle = false;
-  bool _awaitingSyncPointSettle = false;
+  /// Consecutive skips that failed to materially close the gap before we stop
+  /// jumping at it.
+  static const int maxFailedAttempts = 3;
+
+  /// Being ahead by up to this much is answered by holding the player paused
+  /// for exactly that long. It costs no seek and no rate change, which is why
+  /// it is the correction of choice on players where either is disruptive,
+  /// and it can never overshoot into a backwards jump.
+  static const int maxWaitToSyncMs = 10000;
+
+  /// A lead shorter than this is left alone rather than answered with a pause
+  /// that would be more visible than the lead itself.
+  static const int minWaitToSyncMs = 1000;
+
+  /// The most a rate nudge may depart from 1x. Pitch correction copes with it
+  /// and it is not disruptive to watch for the few seconds a nudge lasts.
+  static const double maxRateDeviation = 0.2;
+
+  /// A skip must close the gap to at least this fraction of what it was, or it
+  /// did not work.
+  static const double _improvementRatio = 0.6;
+
+  /// How long past [SyncCorrectionSettings.maxSeekLatencyMs] an attempt may go
+  /// unsettled before it is abandoned.
+  static const int _settleGraceMs = 5000;
+
+  /// A landed seek is somewhere near its target. The band covers a keyframe
+  /// snap; anything further is judged by whether the position is closer to
+  /// where the seek was going than to where it came from.
+  static const int _landingToleranceMs = 1500;
+
+  /// A player has settled when it has advanced roughly real time for at least
+  /// this long since landing. Two 250ms samples are too few to tell rendering
+  /// from position quantisation.
+  static const int _settleWindowMs = 500;
+
+  /// Rendering band for a settle window: absorbs 250ms position quantisation
+  /// and a rate nudge, while rejecting a frozen position the player reports as
+  /// playing.
+  static const double _minSettleRate = 0.5;
+  static const double _maxSettleRate = 1.5;
+
+  /// Skips are aimed with the largest cost seen recently rather than the last
+  /// one: undershooting costs another visible jump, while overshooting lands
+  /// ahead and a wait takes that out exactly.
+  static const int _allowanceDecayMs = 500;
+
+  int? _seekLatencyAllowanceMs;
+  int _skipsUsed = 0;
+  int _failedAttempts = 0;
+  int _skipCooldownUntilMs = 0;
   bool _gaveUp = false;
 
-  int get seekLatencyAllowanceMs => _seekLatencyAllowanceMs;
-  int get consecutiveSkips => _consecutiveSkips;
+  /// Skips are suppressed but measurement and the gentler corrections continue,
+  /// so the gap keeps being reported truthfully and can still close.
+  bool _standDown = false;
+  int _standDownResidualMs = 0;
+
+  _CorrectionAttempt? _attempt;
+
+  /// Allowance used to aim a skip. Unmeasured until a seek has been observed,
+  /// in which case the backend's declared cost is the best guess: overshooting
+  /// is cheap to fix, undershooting costs a second jump.
+  int seekLatencyAllowanceFor(SyncCorrectionSettings settings) =>
+      _seekLatencyAllowanceMs ?? settings.typicalSeekLatencyMs;
+
+  /// The allowance learned from observed seeks, 0 until one has settled.
+  int get seekLatencyAllowanceMs => _seekLatencyAllowanceMs ?? 0;
+  int get skipsUsed => _skipsUsed;
+  int get failedAttempts => _failedAttempts;
+  bool get isStandingDown => _standDown;
   bool get hasGivenUp => _gaveUp;
+  bool get hasOpenAttempt => _attempt != null;
+
+  /// Feeds one player state sample. Meant to be called on every position
+  /// update the backend pushes, so a seek's landing and its first rendered
+  /// frames are timed at the backend's own resolution rather than the 2s
+  /// correction tick. [evaluate] calls it as well, so a backend that pushes
+  /// nothing still settles, just coarsely.
+  void observe({
+    required int nowMs,
+    required int positionMs,
+    required bool isPlaying,
+    required bool isBuffering,
+  }) {
+    final attempt = _attempt;
+    if (attempt == null || attempt.settled) return;
+    // Scheduled for a sync point still in the future: nothing has happened.
+    if (nowMs < attempt.issuedAtMs) return;
+
+    if (isBuffering) {
+      // A stall after an apparent landing means the player had the position
+      // before it had the frames. Start over.
+      attempt.landedAtMs = null;
+      attempt.anchorMs = null;
+      return;
+    }
+
+    if (attempt.landedAtMs == null) {
+      final toTarget = (positionMs - attempt.targetMs).abs();
+      final toOrigin = (positionMs - attempt.fromMs).abs();
+      final landed = toTarget <= _landingToleranceMs || toTarget < toOrigin;
+      if (!landed) return;
+      attempt.landedAtMs = nowMs;
+    }
+
+    if (!isPlaying) {
+      // Paused at the new position, as during the group's waiting handshake.
+      // The landing is measured; rendering can only be seen once it resumes.
+      attempt.anchorMs = null;
+      return;
+    }
+
+    final anchor = attempt.anchorMs;
+    if (anchor == null) {
+      attempt.anchor(nowMs, positionMs);
+      return;
+    }
+    final elapsed = nowMs - anchor;
+    if (elapsed < _settleWindowMs) return;
+    final rate = (positionMs - attempt.anchorPositionMs) / elapsed;
+    if (rate >= _minSettleRate && rate <= _maxSettleRate) {
+      attempt.settled = true;
+    } else {
+      // Not rendering yet: the position is parked at the target. Time the
+      // window from here so the cost includes the wait for frames.
+      attempt.anchor(nowMs, positionMs);
+    }
+  }
 
   SyncCorrectionDecision evaluate({
     required int nowMs,
@@ -81,6 +283,13 @@ class SyncCorrectionPolicy {
     required int clockJitterMs,
     required SyncCorrectionSettings settings,
   }) {
+    observe(
+      nowMs: nowMs,
+      positionMs: currentPositionMs,
+      isPlaying: isPlaying,
+      isBuffering: isBuffering,
+    );
+
     if (_gaveUp) {
       return const SyncCorrectionDecision._(SyncCorrectionAction.giveUp);
     }
@@ -90,7 +299,6 @@ class SyncCorrectionPolicy {
     // which is the loop that leaves one client scrubbing in place while the
     // rest of the group plays on.
     if (isBuffering || !isPlaying) return const SyncCorrectionDecision.defer();
-    if (nowMs < _blockedUntilMs) return const SyncCorrectionDecision.defer();
 
     final expectedMs = lastSyncPositionMs +
         (serverNowMs - lastSyncTimeMs) +
@@ -98,109 +306,227 @@ class SyncCorrectionPolicy {
     final delay = currentPositionMs - expectedMs;
     final absDelay = delay.abs();
 
-    if (_awaitingSyncPointSettle) {
-      _awaitingSyncPointSettle = false;
-      // The group extrapolates from the seek as though it were instant. It
-      // never is, so this residual is the seek's own cost, not drift, and
-      // correcting it would nudge the rate for nothing: on mpv that inserts a
-      // tempo filter mid-playback and pulls it back out a second later.
-      //
-      // Past the ceiling a seek can plausibly cost this is real drift, and
-      // absorbing it would park the baseline where the group never reaches
-      // and then report the gap as zero.
-      if (absDelay <= maxSeekLatencyAllowanceMs) {
-        _learnSeekLatency(delay);
-        return SyncCorrectionDecision._(
-          SyncCorrectionAction.rebaseline,
-          measuredDelayMs: delay,
-        );
+    final attempt = _attempt;
+    if (attempt != null) {
+      if (!attempt.settled) {
+        if (nowMs < attempt.deadlineMs) {
+          return const SyncCorrectionDecision.defer();
+        }
+        // The player never came back. Nothing here is worth learning from, and
+        // seeking at a client in this state is what pins it in place.
+        _attempt = null;
+        _noteFailure(delay);
+        return SyncCorrectionDecision._hold(delay);
       }
-    }
 
-    if (_awaitingSkipSettle) {
-      _awaitingSkipSettle = false;
-      // Without folding that cost back in, every skip loses the same amount
-      // again and the correction never converges.
-      _learnSeekLatency(delay);
+      _attempt = null;
+      _learnSeekLatency(attempt.observedCostMs, settings);
+
+      final pre = attempt.preResidualMs;
+      if (pre != null) {
+        if (absDelay <= (pre.abs() * _improvementRatio).round()) {
+          _failedAttempts = 0;
+        } else {
+          _noteFailure(delay);
+        }
+      }
+      // A group seek leaves the client behind by exactly the seek's cost. That
+      // used to be folded into the baseline, which redefined the late position
+      // as in sync and left the client quietly behind for the rest of the
+      // item. It is real lateness and is corrected like any other, by whatever
+      // means this player has for a gap that size.
     }
 
     final floor = noiseFloorMs + (clockJitterMs ~/ 2);
-    if (absDelay <= floor) {
-      _consecutiveSkips = 0;
-      return SyncCorrectionDecision._(
-        SyncCorrectionAction.hold,
-        measuredDelayMs: delay,
-      );
+    if (absDelay <= floor) return SyncCorrectionDecision._hold(delay);
+
+    if (_standDown &&
+        absDelay >
+            math.max(
+              3 * settings.minDelaySkipToSyncMs,
+              _standDownResidualMs + 5000,
+            )) {
+      // Whatever we stood down over, this is worse. Worth one more try.
+      _standDown = false;
+      _failedAttempts = 0;
     }
 
-    if (settings.useSkipToSync && absDelay > settings.minDelaySkipToSyncMs) {
-      if (_consecutiveSkips >= maxConsecutiveSkips) {
+    final canSkip = settings.useSkipToSync &&
+        !_standDown &&
+        nowMs >= _skipCooldownUntilMs;
+    final canSpeed = settings.useSpeedToSync &&
+        absDelay > settings.minDelaySpeedToSyncMs &&
+        absDelay < settings.maxDelaySpeedToSyncMs;
+
+    SyncCorrectionDecision skip() {
+      if (_skipsUsed >= maxSkipsPerItem) {
         _gaveUp = true;
         return SyncCorrectionDecision._(
           SyncCorrectionAction.giveUp,
           measuredDelayMs: delay,
         );
       }
-      _consecutiveSkips++;
-      _awaitingSkipSettle = true;
-      _blockedUntilMs = nowMs + skipSettleMs;
+      _skipsUsed++;
+      _skipCooldownUntilMs =
+          nowMs + math.max(2000, settings.typicalSeekLatencyMs);
+      final target = expectedMs + seekLatencyAllowanceFor(settings);
+      _attempt = _CorrectionAttempt(
+        issuedAtMs: nowMs,
+        deadlineMs: nowMs + settings.maxSeekLatencyMs + _settleGraceMs,
+        targetMs: target,
+        fromMs: currentPositionMs,
+        preResidualMs: delay,
+      );
       return SyncCorrectionDecision._(
         SyncCorrectionAction.skip,
-        targetPositionMs: expectedMs + _seekLatencyAllowanceMs,
+        targetPositionMs: target,
         measuredDelayMs: delay,
       );
     }
 
-    _consecutiveSkips = 0;
+    if (delay < 0) {
+      // Behind. Only a jump or a faster rate can make up time.
+      if (canSkip && absDelay > settings.minDelaySkipToSyncMs) return skip();
+      if (canSpeed) return _speed(delay, settings);
+      return SyncCorrectionDecision._hold(delay);
+    }
 
-    if (settings.useSpeedToSync &&
-        absDelay > settings.minDelaySpeedToSyncMs &&
-        absDelay < settings.maxDelaySpeedToSyncMs) {
+    // Ahead. A player that can change rate quietly slows down; any other
+    // simply waits for the group, which is exact and needs no seek. A jump
+    // backwards is the last resort, for a lead too long to sit through.
+    if (canSpeed) return _speed(delay, settings);
+    if (absDelay <= maxWaitToSyncMs) {
+      if (absDelay < minWaitToSyncMs) {
+        return SyncCorrectionDecision._hold(delay);
+      }
       return SyncCorrectionDecision._(
-        SyncCorrectionAction.speed,
-        speed: delay > 0 ? _slowDownSpeed : _speedUpSpeed,
-        speedDurationMs: settings.speedToSyncDurationMs,
+        SyncCorrectionAction.wait,
+        waitDurationMs: absDelay,
         measuredDelayMs: delay,
       );
     }
+    if (canSkip) return skip();
+    return SyncCorrectionDecision._hold(delay);
+  }
 
+  /// One nudge sized to close the whole gap, after which the next measurement
+  /// should sit inside the noise floor. A fixed ±5% for a second closed 50ms
+  /// per nudge, which is under the noise floor: it could never be seen to
+  /// work, so it fired again every tick for as long as the gap lasted.
+  SyncCorrectionDecision _speed(int delay, SyncCorrectionSettings settings) {
+    final absDelay = delay.abs();
+    final duration = math.max(1, settings.speedToSyncDurationMs);
+    final deviation = math.min(maxRateDeviation, absDelay / duration);
+    final speed = delay > 0 ? 1.0 - deviation : 1.0 + deviation;
     return SyncCorrectionDecision._(
-      SyncCorrectionAction.hold,
+      SyncCorrectionAction.speed,
+      speed: speed,
+      speedDurationMs: (absDelay / deviation).round(),
       measuredDelayMs: delay,
     );
   }
 
-  void _learnSeekLatency(int delay) {
-    if (delay < 0) {
-      final grown = _seekLatencyAllowanceMs + delay.abs();
-      _seekLatencyAllowanceMs =
-          grown > maxSeekLatencyAllowanceMs ? maxSeekLatencyAllowanceMs : grown;
-    } else {
-      final shrunk = _seekLatencyAllowanceMs - delay;
-      _seekLatencyAllowanceMs = shrunk < 0 ? 0 : shrunk;
+  void _noteFailure(int residualMs) {
+    _failedAttempts++;
+    if (_failedAttempts >= maxFailedAttempts) {
+      _standDown = true;
+      _standDownResidualMs = residualMs.abs();
     }
+  }
+
+  void _learnSeekLatency(int? observedCostMs, SyncCorrectionSettings settings) {
+    if (observedCostMs == null) return;
+    final current = _seekLatencyAllowanceMs;
+    final decayed = current == null ? 0 : current - _allowanceDecayMs;
+    final candidate = math.max(observedCostMs, decayed);
+    _seekLatencyAllowanceMs = candidate.clamp(0, settings.maxSeekLatencyMs);
   }
 
   /// The group moved the playhead, so the old baseline and any convergence
   /// attempt against it are void. The learned seek latency belongs to the
-  /// device and stream, so it survives.
+  /// device and stream, so it survives, and a previous attempt that landed
+  /// while paused (the group's waiting handshake) still teaches its cost.
   ///
-  /// A give-up is lifted here too. It belongs to the stretch the group just
-  /// left, and the new one may transcode or buffer differently.
-  void onSyncPointChanged(int nowMs) {
-    _consecutiveSkips = 0;
-    _awaitingSkipSettle = false;
-    _awaitingSyncPointSettle = true;
+  /// A stand-down is lifted here: it belongs to the stretch the group just
+  /// left, and the new one may transcode or buffer differently. The per-item
+  /// skip budget deliberately is not, so a group seeking repeatedly cannot
+  /// re-mint an unlimited number of jumps.
+  ///
+  /// [nowMs] is when the seek reaches the player, [targetPositionMs] where it
+  /// was sent and [fromPositionMs] where it was; landing is judged against
+  /// both.
+  void onSyncPointChanged(
+    int nowMs, {
+    required int targetPositionMs,
+    required int fromPositionMs,
+    required SyncCorrectionSettings settings,
+  }) {
+    _openSyncPoint(
+      nowMs,
+      targetPositionMs: targetPositionMs,
+      fromPositionMs: fromPositionMs,
+      settings: settings,
+    );
+  }
+
+  /// The same as [onSyncPointChanged], for a sync point the player was
+  /// already close enough to that nothing was sent to it: there is no landing
+  /// to wait for, only the moment it renders again to observe. Waiting for a
+  /// landing against a position the player has since played past would never
+  /// end and would be scored as a failure.
+  void onSyncPointResumed(
+    int nowMs, {
+    required int positionMs,
+    required SyncCorrectionSettings settings,
+  }) {
+    _openSyncPoint(
+      nowMs,
+      targetPositionMs: positionMs,
+      fromPositionMs: positionMs,
+      settings: settings,
+    ).landedAtMs = nowMs;
+  }
+
+  _CorrectionAttempt _openSyncPoint(
+    int nowMs, {
+    required int targetPositionMs,
+    required int fromPositionMs,
+    required SyncCorrectionSettings settings,
+  }) {
+    final previous = _attempt;
+    if (previous != null) {
+      _learnSeekLatency(previous.observedCostMs, settings);
+    }
+    _failedAttempts = 0;
+    _standDown = false;
     _gaveUp = false;
-    _blockedUntilMs = nowMs + seekSettleMs;
+    _skipCooldownUntilMs = 0;
+    return _attempt = _CorrectionAttempt(
+      issuedAtMs: nowMs,
+      deadlineMs: nowMs + settings.maxSeekLatencyMs + _settleGraceMs,
+      targetMs: targetPositionMs,
+      fromMs: fromPositionMs,
+      preResidualMs: null,
+    );
+  }
+
+  /// The seek a skip asked for was close enough that the player never moved,
+  /// so there is nothing to wait for and nothing to judge. Without this the
+  /// attempt would sit open until it timed out and be scored as a failure.
+  void onSkipDropped() {
+    _attempt = null;
+    _skipCooldownUntilMs = 0;
+    if (_skipsUsed > 0) _skipsUsed--;
   }
 
   void reset() {
-    _consecutiveSkips = 0;
-    _seekLatencyAllowanceMs = 0;
-    _blockedUntilMs = 0;
-    _awaitingSkipSettle = false;
-    _awaitingSyncPointSettle = false;
+    _seekLatencyAllowanceMs = null;
+    _skipsUsed = 0;
+    _failedAttempts = 0;
+    _skipCooldownUntilMs = 0;
     _gaveUp = false;
+    _standDown = false;
+    _standDownResidualMs = 0;
+    _attempt = null;
   }
 }

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
@@ -70,7 +71,13 @@ class SyncPlayManager extends ChangeNotifier {
   /// platforms, so shared speed state cannot be trusted for this.
   bool _speedToSyncApplied = false;
 
+  /// A pause SyncPlay applied to burn off a lead, and the timer that ends it.
+  /// Non-null exactly while the pause is ours to undo: the player's own
+  /// paused state cannot say whose pause it is.
+  Timer? _syncWaitTimer;
+
   StreamSubscription<bool>? _bufferingSub;
+  StreamSubscription<Duration>? _positionSub;
   StreamSubscription<void>? _queueChangedSub;
   bool _applyingRemoteCommand = false;
   final Map<String, String> _itemTitleCache = {};
@@ -89,6 +96,15 @@ class SyncPlayManager extends ChangeNotifier {
   int _lastSyncPositionMs = 0;
   int _lastSyncTimeMs = 0;
   bool _isBuffering = false;
+  /// A Buffering report went out, so the server is holding the group for us
+  /// and is owed a Ready when the stall ends. Without one it is not: the
+  /// server answers an unsolicited Ready with an Unpause echo, and acting on
+  /// that echo seeks the player, which on engines that raise a buffering edge
+  /// for every seek produces another Ready. That cycle is the loop.
+  bool _bufferingReported = false;
+  /// The queue loaded paused for the group's handshake; a Playing state that
+  /// arrives without an Unpause (the server ignoring our wait) starts it.
+  bool _startedPausedForHandshake = false;
   int _suppressBufferingUntilMs = 0;
   Timer? _suppressedBufferingRecheckTimer;
 
@@ -303,7 +319,7 @@ class SyncPlayManager extends ChangeNotifier {
     _lastSyncPositionMs = 0;
     _lastSyncTimeMs = 0;
     _syncCorrection.reset();
-    _restorePlaybackRate();
+    _clearLocalCorrections();
     notifyListeners();
   }
 
@@ -403,23 +419,19 @@ class SyncPlayManager extends ChangeNotifier {
     final pm = _playbackManager;
     // Waiting is a transient handshake state: the server sends an explicit
     // Pause when it wants clients paused, so pausing here would fight the
-    // in-flight Unpause. These calls also shouldn't bounce through the
-    // transport interceptor back into SyncPlay requests.
-    _applyingRemoteCommand = true;
-    try {
-      switch (_state.groupState) {
-        case SyncPlayGroupState.paused:
-          if (pm.state.isPlaying) pm.pause();
-          break;
-        case SyncPlayGroupState.playing:
-          if (!pm.state.isPlaying) pm.resume();
-          break;
-        case SyncPlayGroupState.waiting:
-        case SyncPlayGroupState.idle:
-          break;
-      }
-    } finally {
-      _applyingRemoteCommand = false;
+    // in-flight Unpause.
+    switch (_state.groupState) {
+      case SyncPlayGroupState.paused:
+        if (pm.state.isPlaying) _applyLocalPause();
+        break;
+      case SyncPlayGroupState.playing:
+        // A pause of our own is the group's position being waited for, not a
+        // player that fell out of step.
+        if (!pm.state.isPlaying && _syncWaitTimer == null) _applyLocalResume();
+        break;
+      case SyncPlayGroupState.waiting:
+      case SyncPlayGroupState.idle:
+        break;
     }
   }
 
@@ -494,6 +506,11 @@ class SyncPlayManager extends ChangeNotifier {
       case SyncPlayGroupUpdateType.stateUpdate:
         final payload = update.payload as SyncPlayStateUpdatePayload;
         _state.groupState = payload.update.state;
+        if (_startedPausedForHandshake &&
+            _state.groupState == SyncPlayGroupState.playing) {
+          _startedPausedForHandshake = false;
+          _reconcileLocalPlayback();
+        }
         if (_state.groupState == SyncPlayGroupState.waiting) {
           // Waiting can also be entered on someone else's buffering or an item
           // switch, and the group stays there until we confirm we are ready.
@@ -562,7 +579,14 @@ class SyncPlayManager extends ChangeNotifier {
         ? update.playlist[idx].itemId
         : null;
     final startMs = SyncPlayUtils.ticksToMs(update.startPositionTicks);
-    final shouldAutoPlay = update.isPlaying;
+    // A queue change puts the group into Waiting until every session has
+    // reported Ready, and the Unpause that ends it carries the position the
+    // group is paused at. Playing through that handshake means reporting
+    // Ready from seconds past the group and being dragged back by the Unpause.
+    // So the player starts paused, and the Unpause is what starts it.
+    final shouldAutoPlay =
+        update.isPlaying && _state.groupState == SyncPlayGroupState.playing;
+    _startedPausedForHandshake = update.isPlaying && !shouldAutoPlay;
 
     final localCurrentItemId =
         _itemId(_playbackManager.queueService.currentItem);
@@ -582,17 +606,9 @@ class SyncPlayManager extends ChangeNotifier {
     Timer(const Duration(milliseconds: 750), () {
       if (!_state.enabled) return;
       if (_state.currentPlaylistItemId != targetPlaylistItemId) return;
-      _applyingRemoteCommand = true;
-      try {
-        if (startMs > 0) {
-          _armBufferingSuppression();
-          _playbackManager.seekTo(Duration(milliseconds: startMs));
-        }
-        if (!shouldAutoPlay && _playbackManager.state.isPlaying) {
-          _playbackManager.pause();
-        }
-      } finally {
-        _applyingRemoteCommand = false;
+      if (startMs > 0) _seekPlayer(startMs);
+      if (!shouldAutoPlay && _playbackManager.state.isPlaying) {
+        _applyLocalPause();
       }
     });
   }
@@ -688,10 +704,21 @@ class SyncPlayManager extends ChangeNotifier {
 
     final positionMs =
         _clampedPositionMs(SyncPlayUtils.ticksToMs(command.positionTicks));
+    // The server answers any Ready it gets while already playing with the
+    // sync point it is on, unchanged. That is a confirmation, not a
+    // correction: treating it as a late Unpause and seeking to where the
+    // sync point has got to by now moves a player that was already there,
+    // and on an engine that raises a buffering edge for every seek that
+    // produces another Ready, and another echo.
+    final isEcho = _state.groupState == SyncPlayGroupState.playing &&
+        targetMs == _lastSyncTimeMs &&
+        positionMs == _lastSyncPositionMs;
+    if (isEcho) {
+      _reconcileLocalPlayback();
+      return;
+    }
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = targetMs;
-    // A fresh sync point, so don't inherit a skip streak from before the pause.
-    _syncCorrection.onSyncPointChanged(DateTime.now().millisecondsSinceEpoch);
 
     if (!advancedCorrectionEnabled) {
       if (delayMs > 0) {
@@ -736,8 +763,19 @@ class SyncPlayManager extends ChangeNotifier {
     final positionMs = _clampedPositionMs(adjusted);
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = serverNow;
-    _syncCorrection.onSyncPointChanged(DateTime.now().millisecondsSinceEpoch);
-    _performSeek(positionMs);
+    // The server has moved the group into Waiting: every other client is
+    // paused at the target until all have reported Ready, and the Unpause
+    // that follows carries that same position. A client that keeps playing
+    // through the handshake is dragged back to it by that Unpause, which is
+    // a visible jump backwards on every group seek.
+    _clearLocalCorrections();
+    if (_state.groupState == SyncPlayGroupState.playing &&
+        _playbackManager.state.isPlaying) {
+      _applyLocalPause();
+    }
+    final fromMs = _playbackManager.state.position.inMilliseconds;
+    final issued = _performSeek(positionMs);
+    _openSyncPoint(positionMs, fromMs: fromMs, seekIssued: issued);
     // Seek only ever arrives from the waiting state, which has just flagged
     // every session as buffering. A seek that lands inside the buffer never
     // stalls the pipeline, so waiting on a buffering edge to report Ready
@@ -753,7 +791,7 @@ class SyncPlayManager extends ChangeNotifier {
     } finally {
       _applyingRemoteCommand = false;
     }
-    _restorePlaybackRate();
+    _clearLocalCorrections();
     _scheduledTimer?.cancel();
     _scheduledTimer = null;
     _driftTimer?.cancel();
@@ -766,41 +804,49 @@ class SyncPlayManager extends ChangeNotifier {
   }
 
   void _performResume(int positionMs) {
-    _applyingRemoteCommand = true;
-    try {
-      if (_needsSeek(positionMs)) {
-        _armBufferingSuppression();
-        _playbackManager.seekTo(Duration(milliseconds: positionMs));
-      }
-      if (!_playbackManager.state.isPlaying) {
-        _armBufferingSuppression();
-        _playbackManager.resume();
-      }
-    } finally {
-      _applyingRemoteCommand = false;
+    _clearLocalCorrections();
+    _startedPausedForHandshake = false;
+    final fromMs = _playbackManager.state.position.inMilliseconds;
+    final issued = _performSeek(positionMs);
+    if (!_playbackManager.state.isPlaying) _applyLocalResume();
+    // A fresh sync point, opened at the instant the seek reaches the player
+    // rather than when the command arrived, so the cost measured is the
+    // seek's and not the wait for a scheduled sync point.
+    _openSyncPoint(positionMs, fromMs: fromMs, seekIssued: issued);
+  }
+
+  void _openSyncPoint(
+    int targetMs, {
+    required int fromMs,
+    required bool seekIssued,
+  }) {
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final settings = _syncCorrectionSettings;
+    if (seekIssued) {
+      _syncCorrection.onSyncPointChanged(
+        nowMs,
+        targetPositionMs: targetMs,
+        fromPositionMs: fromMs,
+        settings: settings,
+      );
+    } else {
+      _syncCorrection.onSyncPointResumed(
+        nowMs,
+        positionMs: fromMs,
+        settings: settings,
+      );
     }
-    _restorePlaybackRate();
-    if (syncCorrectionEnabled) _scheduleDriftCorrection();
   }
 
   void _performPause(int positionMs) {
-    _restorePlaybackRate();
-    _applyingRemoteCommand = true;
-    try {
-      _playbackManager.pause();
-      if (_needsSeek(positionMs)) {
-        _armBufferingSuppression();
-        _playbackManager.seekTo(Duration(milliseconds: positionMs));
-      }
-    } finally {
-      _applyingRemoteCommand = false;
-    }
+    _applyLocalPause();
+    if (_needsSeek(positionMs)) _seekPlayer(positionMs);
   }
 
   /// Pauses the player without routing back through the interceptor, for the
   /// cases where the group has no command to send us.
   void _applyLocalPause() {
-    _restorePlaybackRate();
+    _clearLocalCorrections();
     _applyingRemoteCommand = true;
     try {
       _playbackManager.pause();
@@ -809,20 +855,41 @@ class SyncPlayManager extends ChangeNotifier {
     }
   }
 
-  void _performSeek(int positionMs) {
-    if (_needsSeek(positionMs)) {
-      _applyingRemoteCommand = true;
-      try {
-        _armBufferingSuppression();
-        _playbackManager.seekTo(Duration(milliseconds: positionMs));
-      } finally {
-        _applyingRemoteCommand = false;
-      }
+  /// The counterpart of [_applyLocalPause]: starts the player where it is
+  /// without asking the group for an Unpause.
+  void _applyLocalResume() {
+    _applyingRemoteCommand = true;
+    try {
+      _armBufferingSuppression();
+      _playbackManager.resume();
+    } finally {
+      _applyingRemoteCommand = false;
     }
+  }
+
+  /// Every seek SyncPlay itself issues goes through here, so the buffering
+  /// edge the seek raises is never mistaken for a stall to report.
+  void _seekPlayer(int positionMs) {
+    _applyingRemoteCommand = true;
+    try {
+      _armBufferingSuppression(forSeek: true);
+      _playbackManager.seekTo(Duration(milliseconds: positionMs));
+    } finally {
+      _applyingRemoteCommand = false;
+    }
+  }
+
+  /// Returns whether the seek was actually issued. A target already inside
+  /// [_seekToleranceMs] never reaches the player, and a correction that moved
+  /// nothing must not be waited on or scored as a failure.
+  bool _performSeek(int positionMs) {
+    final issued = _needsSeek(positionMs);
+    if (issued) _seekPlayer(positionMs);
     if (syncCorrectionEnabled &&
         _state.groupState == SyncPlayGroupState.playing) {
       _scheduleDriftCorrection();
     }
+    return issued;
   }
 
   bool _needsSeek(int targetMs) {
@@ -830,9 +897,20 @@ class SyncPlayManager extends ChangeNotifier {
     return (currentMs - targetMs).abs() > _seekToleranceMs;
   }
 
-  void _armBufferingSuppression() {
+  /// [forSeek] widens the window to the backend's own worst-case seek cost. A
+  /// seek that outlasts the short window is not a stall to report: reporting
+  /// it pauses the whole group for the seek, and on a player that seeks slowly
+  /// that is every corrective skip.
+  void _armBufferingSuppression({bool forSeek = false}) {
+    final windowMs = forSeek
+        ? math.max(
+            _bufferingSuppressionMs,
+            _playbackManager.backend?.maxSeekLatency.inMilliseconds ??
+                SyncCorrectionPolicy.maxSeekLatencyAllowanceMs,
+          )
+        : _bufferingSuppressionMs;
     _suppressBufferingUntilMs =
-        DateTime.now().millisecondsSinceEpoch + _bufferingSuppressionMs;
+        DateTime.now().millisecondsSinceEpoch + windowMs;
   }
 
   int _clampedPositionMs(int value) {
@@ -862,6 +940,34 @@ class SyncPlayManager extends ChangeNotifier {
     _playbackManager.setPlaybackSpeed(speed);
   }
 
+  /// Holds the player paused for [durationMs] to let the group catch up. It
+  /// is exact where a rate nudge is approximate, and it needs neither a seek
+  /// nor a rate write, which on the Apple TV engine are the two things that
+  /// glitch. The pause never reaches the group, and only [_stopSyncWait] or
+  /// the timer undoes it.
+  void _applySyncWait(int durationMs) {
+    _applyLocalPause();
+    _syncWaitTimer = Timer(Duration(milliseconds: durationMs), () {
+      _syncWaitTimer = null;
+      if (_state.groupState == SyncPlayGroupState.playing) _applyLocalResume();
+      _scheduleDriftCorrection();
+    });
+  }
+
+  /// Cancels a wait SyncPlay applied. The player is left paused: every caller
+  /// is about to pause, stop or resume it itself.
+  void _stopSyncWait() {
+    _syncWaitTimer?.cancel();
+    _syncWaitTimer = null;
+  }
+
+  /// Everything SyncPlay may have applied to the player on its own: a rate
+  /// nudge or a wait. Called before any group command takes over.
+  void _clearLocalCorrections() {
+    _restorePlaybackRate();
+    _stopSyncWait();
+  }
+
   void _scheduleAction(int delayMs, void Function() action) {
     _scheduledTimer?.cancel();
     _scheduledTimer = Timer(Duration(milliseconds: delayMs < 0 ? 0 : delayMs), action);
@@ -876,33 +982,57 @@ class SyncPlayManager extends ChangeNotifier {
     _driftTimer = Timer(const Duration(seconds: 2), _performDriftCorrection);
   }
 
-  SyncCorrectionSettings get _syncCorrectionSettings => SyncCorrectionSettings(
-        useSkipToSync: useSkipToSync,
-        useSpeedToSync: useSpeedToSync,
-        minDelaySkipToSyncMs: minDelaySkipToSync,
-        minDelaySpeedToSyncMs: minDelaySpeedToSync,
-        maxDelaySpeedToSyncMs: maxDelaySpeedToSync,
-        speedToSyncDurationMs: speedToSyncDuration,
-        extraTimeOffsetMs: extraTimeOffset,
-      );
+  SyncCorrectionSettings get _syncCorrectionSettings {
+    // How slowly this player seeks is the difference between a correction that
+    // converges and one that lands short every time, so it is read from the
+    // backend rather than assumed. Null only before a player exists, where the
+    // desktop-shaped defaults are the safe answer.
+    final backend = _playbackManager.backend;
+    return SyncCorrectionSettings(
+      useSkipToSync: useSkipToSync,
+      // A rate nudge on a player whose audio does not survive one is worse
+      // than the drift it corrects, whatever the preference says.
+      useSpeedToSync:
+          useSpeedToSync && (backend?.supportsSmoothRateChange ?? true),
+      minDelaySkipToSyncMs: minDelaySkipToSync,
+      minDelaySpeedToSyncMs: minDelaySpeedToSync,
+      maxDelaySpeedToSyncMs: maxDelaySpeedToSync,
+      speedToSyncDurationMs: speedToSyncDuration,
+      extraTimeOffsetMs: extraTimeOffset,
+      typicalSeekLatencyMs: backend?.typicalSeekLatency.inMilliseconds ??
+          SyncCorrectionPolicy.defaultTypicalSeekLatencyMs,
+      maxSeekLatencyMs: backend?.maxSeekLatency.inMilliseconds ??
+          SyncCorrectionPolicy.maxSeekLatencyAllowanceMs,
+    );
+  }
 
   void _performDriftCorrection() {
     final tsm = _timeSync;
     if (tsm == null ||
         _state.groupState != SyncPlayGroupState.playing ||
         _lastSyncTimeMs == 0 ||
-        _syncCorrection.hasGivenUp) {
+        _syncCorrection.hasGivenUp ||
+        // Measuring a player we are holding paused would read as far behind.
+        // The wait's own timer resumes the ticks.
+        _syncWaitTimer != null) {
       return;
     }
     final pm = _playbackManager;
+    // Sampled once so the log below describes the same instant the policy
+    // judged, rather than a clock read a few milliseconds later.
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    final serverNowMs = tsm.getServerTimeNow();
+    final positionMs = pm.state.position.inMilliseconds;
+    final isBuffering = pm.state.isBuffering || _isBuffering;
+    final isPlaying = pm.state.isPlaying;
     final decision = _syncCorrection.evaluate(
-      nowMs: DateTime.now().millisecondsSinceEpoch,
-      serverNowMs: tsm.getServerTimeNow(),
-      currentPositionMs: pm.state.position.inMilliseconds,
+      nowMs: nowMs,
+      serverNowMs: serverNowMs,
+      currentPositionMs: positionMs,
       lastSyncPositionMs: _lastSyncPositionMs,
       lastSyncTimeMs: _lastSyncTimeMs,
-      isBuffering: pm.state.isBuffering || _isBuffering,
-      isPlaying: pm.state.isPlaying,
+      isBuffering: isBuffering,
+      isPlaying: isPlaying,
       clockJitterMs: tsm.offsetJitterMs,
       settings: _syncCorrectionSettings,
     );
@@ -911,16 +1041,18 @@ class SyncPlayManager extends ChangeNotifier {
       // Leaves the rate alone: the pipeline is stalled or paused here.
       case SyncCorrectionAction.defer:
         _scheduleDriftCorrection();
-      // Absorbs the seek's own cost so it is never mistaken for drift.
-      case SyncCorrectionAction.rebaseline:
-        _lastSyncPositionMs += decision.measuredDelayMs;
-        _scheduleDriftCorrection();
       case SyncCorrectionAction.hold:
-        _restorePlaybackRate();
+        _clearLocalCorrections();
         _scheduleDriftCorrection();
+      case SyncCorrectionAction.wait:
+        _applySyncWait(decision.waitDurationMs);
       case SyncCorrectionAction.skip:
-        _restorePlaybackRate();
-        _performSeek(_clampedPositionMs(decision.targetPositionMs));
+        _clearLocalCorrections();
+        final clamped = _clampedPositionMs(decision.targetPositionMs);
+        // A target inside _seekToleranceMs never reaches the player, so the
+        // policy has to take back the skip it already counted rather than wait
+        // out a settle window for a seek that did not happen.
+        if (!_performSeek(clamped)) _syncCorrection.onSkipDropped();
         _scheduleDriftCorrection();
       case SyncCorrectionAction.speed:
         _applyPlaybackRate(decision.speed);
@@ -936,9 +1068,9 @@ class SyncPlayManager extends ChangeNotifier {
         _restorePlaybackRate();
         _logger.w(
           'SyncPlay: sync correction disabled for this item after '
-          '${_syncCorrection.consecutiveSkips} skips failed to converge '
-          '(residual ${decision.measuredDelayMs}ms, latency allowance '
-          '${_syncCorrection.seekLatencyAllowanceMs}ms)',
+          '${_syncCorrection.skipsUsed} skips failed to converge, leaving '
+          'the client ${decision.measuredDelayMs}ms from the group '
+          '(latency allowance ${_syncCorrection.seekLatencyAllowanceMs}ms)',
         );
     }
   }
@@ -948,6 +1080,17 @@ class SyncPlayManager extends ChangeNotifier {
     if (_bufferingSub != null) return;
     final pm = _playbackManager;
     _bufferingSub = pm.state.bufferingStream.listen(_onBuffering);
+    // Every position sample goes to the policy so a seek's landing is timed at
+    // the backend's resolution, not the 2s correction tick. A cost quantised
+    // to 2s over-aims the next skip by up to that much.
+    _positionSub = pm.state.positionStream.listen((position) {
+      _syncCorrection.observe(
+        nowMs: DateTime.now().millisecondsSinceEpoch,
+        positionMs: position.inMilliseconds,
+        isPlaying: pm.state.isPlaying,
+        isBuffering: pm.state.isBuffering,
+      );
+    });
     _queueChangedSub ??= pm.queueService.queueChangedStream
         .listen((_) => _onLocalQueueChanged());
     pm.setTransportInterceptor(_interceptTransport);
@@ -956,6 +1099,8 @@ class SyncPlayManager extends ChangeNotifier {
   void _stopPlaybackObservers() {
     _bufferingSub?.cancel();
     _bufferingSub = null;
+    _positionSub?.cancel();
+    _positionSub = null;
     _queueChangedSub?.cancel();
     _queueChangedSub = null;
     _bufferingTimer?.cancel();
@@ -968,12 +1113,13 @@ class SyncPlayManager extends ChangeNotifier {
     _pendingSeekTarget = null;
     _queueSyncDebounceTimer?.cancel();
     _queueSyncDebounceTimer = null;
-    _speedToSyncTimer?.cancel();
-    _speedToSyncTimer = null;
+    _clearLocalCorrections();
     _suppressedBufferingRecheckTimer?.cancel();
     _suppressedBufferingRecheckTimer = null;
     _suppressBufferingUntilMs = 0;
     _isBuffering = false;
+    _bufferingReported = false;
+    _startedPausedForHandshake = false;
     _playbackManager.setTransportInterceptor(null);
   }
 
@@ -1060,9 +1206,14 @@ class SyncPlayManager extends ChangeNotifier {
       _suppressedBufferingRecheckTimer?.cancel();
       _suppressedBufferingRecheckTimer = null;
       // A pending report for a blip that already recovered shouldn't fire.
-      // The Ready report is never suppressed because the server waits on it.
       _bufferingTimer?.cancel();
-      _queueReadyReport();
+      // Ready answers a wait. A stall the server never heard about (our own
+      // seek, inside its suppression window) owes it nothing, and reporting
+      // anyway is what starts the Ready/Unpause/seek cycle.
+      if (_bufferingReported ||
+          _state.groupState == SyncPlayGroupState.waiting) {
+        _queueReadyReport();
+      }
     }
   }
 
@@ -1203,6 +1354,7 @@ class SyncPlayManager extends ChangeNotifier {
           positionTicks: positionTicks,
           when: _serverWhen(),
         );
+        _bufferingReported = true;
         return;
       } catch (_) {
         if (attempt == _maxHandshakeRetries - 1) return;
@@ -1236,6 +1388,7 @@ class SyncPlayManager extends ChangeNotifier {
           positionTicks: positionTicks,
           when: _serverWhen(),
         );
+        _bufferingReported = false;
         return;
       } catch (_) {
         if (attempt == _maxHandshakeRetries - 1) return;

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -376,6 +376,10 @@ class SyncPlayManager extends ChangeNotifier {
     _startTimeSync();
     _startPingLoop();
     _attachPlaybackObservers();
+    // On web the tab is hidden whenever the user looks at another window,
+    // including the device that is starting the video. Anything the group
+    // did meanwhile that no command reaches us for is picked up here.
+    unawaited(_refreshCurrentGroupStateAfterReconnect());
   }
 
   void handleRealtimeConnected() {
@@ -728,11 +732,15 @@ class SyncPlayManager extends ChangeNotifier {
 
   void _handleUnpause(SyncPlayCommand command) {
     _stopReadyHandshake();
-    final tsm = _timeSync;
-    if (tsm == null) return;
-    final serverNow = tsm.getServerTimeNow();
     final targetMs = command.whenUtcMs;
-    final delayMs = targetMs - serverNow;
+    // Time sync is stopped while the app is in the background, which on web
+    // means whenever the tab is hidden. An Unpause that arrives then is still
+    // the group's decision: dropping it leaves this client paused in Waiting
+    // while everyone else plays. Without a server clock the scheduled start
+    // cannot be honoured, so it is applied now and drift correction takes
+    // over once the clock is back.
+    final serverNow = _timeSync?.getServerTimeNow();
+    final delayMs = serverNow == null ? 0 : targetMs - serverNow;
 
     final positionMs =
         _clampedPositionMs(SyncPlayUtils.ticksToMs(command.positionTicks));

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -712,12 +712,17 @@ class SyncPlayManager extends ChangeNotifier {
     _applyingRemoteCommand = true;
     try {
       _armBufferingSuppression();
+      // Loaded paused when the group is not playing: the bring-up's own
+      // resume after its start seek would otherwise undo the pause below,
+      // and a joiner playing through the handshake reports Ready from past
+      // the group, is seeked back, plays on, and reports again, forever.
       await _playbackManager.playItems(
         items,
         startIndex: startIndex,
         startPosition: Duration(milliseconds: startMs),
+        autoPlay: shouldAutoPlay,
       );
-      if (!shouldAutoPlay) {
+      if (!shouldAutoPlay && _playbackManager.state.isPlaying) {
         await _playbackManager.pause();
       }
       _ensurePlayerRouteForItem(items[startIndex]);
@@ -836,10 +841,12 @@ class SyncPlayManager extends ChangeNotifier {
     // paused at the target until all have reported Ready, and the Unpause
     // that follows carries that same position. A client that keeps playing
     // through the handshake is dragged back to it by that Unpause, which is
-    // a visible jump backwards on every group seek.
+    // a visible jump backwards on every group seek. Whatever the group state
+    // looks like from here: a Seek is also how the server corrects a Ready
+    // reported from the wrong position, and a player left playing after
+    // that correction reports from the wrong position again.
     _clearLocalCorrections();
-    if (_state.groupState == SyncPlayGroupState.playing &&
-        _playbackManager.state.isPlaying) {
+    if (_playbackManager.state.isPlaying) {
       _applyLocalPause();
     }
     final fromMs = _playbackManager.state.position.inMilliseconds;

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -490,6 +490,16 @@ class SyncPlayManager extends ChangeNotifier {
         _state.participants = info.participants;
         _state.lastUpdateAt = info.lastUpdatedAt;
         if (info.state != null) _state.groupState = info.state!;
+        // A join to a playing or paused group puts the group into Waiting
+        // on the server, which then holds every member for this session's
+        // Ready. But the joiner is told only the state from before the
+        // join, and gets no state update for the switch, so the handshake
+        // has to be entered here or the whole group hangs on a Ready that
+        // never comes.
+        if (_state.groupState == SyncPlayGroupState.playing ||
+            _state.groupState == SyncPlayGroupState.paused) {
+          _state.groupState = SyncPlayGroupState.waiting;
+        }
         _startTimeSync();
         _startPingLoop();
         _attachPlaybackObservers();
@@ -620,7 +630,18 @@ class SyncPlayManager extends ChangeNotifier {
       if (!shouldAutoPlay && _playbackManager.state.isPlaying) {
         _applyLocalPause();
       }
+      _answerWaitingAfterQueueChange();
     });
+  }
+
+  /// A queue change made while the group waits is one the server holds the
+  /// group on until this session reports Ready. After a join that wait was
+  /// never announced by a state update, so the handshake would not start on
+  /// its own; started here it retries until the player is up and settled.
+  void _answerWaitingAfterQueueChange() {
+    if (!_state.enabled) return;
+    if (_state.groupState != SyncPlayGroupState.waiting) return;
+    _startReadyHandshake();
   }
 
   Future<void> _loadRemoteQueueLocally({
@@ -674,6 +695,7 @@ class SyncPlayManager extends ChangeNotifier {
     } finally {
       _applyingRemoteCommand = false;
     }
+    _answerWaitingAfterQueueChange();
   }
 
   void _ensurePlayerRouteForItem(AggregatedItem item) {

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -95,6 +95,10 @@ class SyncPlayManager extends ChangeNotifier {
   String? _lastCommandKey;
   int _lastSyncPositionMs = 0;
   int _lastSyncTimeMs = 0;
+  /// Where the last Seek command sent the group, and when it reached us, so
+  /// a local seek back to that same spot can be told apart from a new one.
+  int _lastGroupSeekTargetMs = 0;
+  int _lastGroupSeekAtMs = 0;
   bool _isBuffering = false;
   /// A Buffering report went out, so the server is holding the group for us
   /// and is owed a Ready when the stall ends. Without one it is not: the
@@ -316,11 +320,17 @@ class SyncPlayManager extends ChangeNotifier {
     _driftTimer?.cancel();
     _driftTimer = null;
     _lastCommandKey = null;
-    _lastSyncPositionMs = 0;
-    _lastSyncTimeMs = 0;
-    _syncCorrection.reset();
+    _forgetSyncPoint();
     _clearLocalCorrections();
     notifyListeners();
+  }
+
+  void _forgetSyncPoint() {
+    _lastSyncPositionMs = 0;
+    _lastSyncTimeMs = 0;
+    _lastGroupSeekTargetMs = 0;
+    _lastGroupSeekAtMs = 0;
+    _syncCorrection.reset();
   }
 
   void _startTimeSync() {
@@ -763,6 +773,8 @@ class SyncPlayManager extends ChangeNotifier {
     final positionMs = _clampedPositionMs(adjusted);
     _lastSyncPositionMs = positionMs;
     _lastSyncTimeMs = serverNow;
+    _lastGroupSeekTargetMs = _clampedPositionMs(raw);
+    _lastGroupSeekAtMs = DateTime.now().millisecondsSinceEpoch;
     // The server has moved the group into Waiting: every other client is
     // paused at the target until all have reported Ready, and the Unpause
     // that follows carries that same position. A client that keeps playing
@@ -797,9 +809,7 @@ class SyncPlayManager extends ChangeNotifier {
     _driftTimer?.cancel();
     _driftTimer = null;
     _state.groupState = SyncPlayGroupState.idle;
-    _lastSyncPositionMs = 0;
-    _lastSyncTimeMs = 0;
-    _syncCorrection.reset();
+    _forgetSyncPoint();
     notifyListeners();
   }
 
@@ -892,6 +902,12 @@ class SyncPlayManager extends ChangeNotifier {
     return issued;
   }
 
+  /// The backend's own worst-case seek cost, or the policy's allowance when
+  /// no backend is up.
+  int get _maxSeekLatencyMs =>
+      _playbackManager.backend?.maxSeekLatency.inMilliseconds ??
+      SyncCorrectionPolicy.maxSeekLatencyAllowanceMs;
+
   bool _needsSeek(int targetMs) {
     final currentMs = _playbackManager.state.position.inMilliseconds;
     return (currentMs - targetMs).abs() > _seekToleranceMs;
@@ -903,11 +919,7 @@ class SyncPlayManager extends ChangeNotifier {
   /// that is every corrective skip.
   void _armBufferingSuppression({bool forSeek = false}) {
     final windowMs = forSeek
-        ? math.max(
-            _bufferingSuppressionMs,
-            _playbackManager.backend?.maxSeekLatency.inMilliseconds ??
-                SyncCorrectionPolicy.maxSeekLatencyAllowanceMs,
-          )
+        ? math.max(_bufferingSuppressionMs, _maxSeekLatencyMs)
         : _bufferingSuppressionMs;
     _suppressBufferingUntilMs =
         DateTime.now().millisecondsSinceEpoch + windowMs;
@@ -1001,8 +1013,7 @@ class SyncPlayManager extends ChangeNotifier {
       extraTimeOffsetMs: extraTimeOffset,
       typicalSeekLatencyMs: backend?.typicalSeekLatency.inMilliseconds ??
           SyncCorrectionPolicy.defaultTypicalSeekLatencyMs,
-      maxSeekLatencyMs: backend?.maxSeekLatency.inMilliseconds ??
-          SyncCorrectionPolicy.maxSeekLatencyAllowanceMs,
+      maxSeekLatencyMs: _maxSeekLatencyMs,
     );
   }
 
@@ -1144,7 +1155,10 @@ class SyncPlayManager extends ChangeNotifier {
         await requestPause();
         return true;
       case TransportAction.seek:
-        _scheduleSeekRequest(position ?? _playbackManager.state.position);
+        final target = position ?? _playbackManager.state.position;
+        // Swallowed either way: under SyncPlay the player only moves on the
+        // group's command.
+        if (!_isEchoOfGroupSeek(target)) _scheduleSeekRequest(target);
         return true;
       case TransportAction.stop:
         await requestStop();
@@ -1156,6 +1170,23 @@ class SyncPlayManager extends ChangeNotifier {
         await requestPrevious();
         return true;
     }
+  }
+
+  /// Whether a local seek only asks for where the group's last Seek already
+  /// sent everyone: an auto-skip re-fired by a landing just short of a
+  /// segment end (see `MediaSegmentService._autoSkipped`). The group is
+  /// already there, so dropping it loses nothing. A seek the user makes back
+  /// to that spot once playback has moved past it still goes through.
+  bool _isEchoOfGroupSeek(Duration target) {
+    if (_lastGroupSeekAtMs == 0) return false;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    if (nowMs - _lastGroupSeekAtMs > _maxSeekLatencyMs) return false;
+    final targetMs = target.inMilliseconds;
+    if ((targetMs - _lastGroupSeekTargetMs).abs() > _seekToleranceMs) {
+      return false;
+    }
+    final currentMs = _playbackManager.state.position.inMilliseconds;
+    return currentMs <= targetMs + _seekToleranceMs;
   }
 
   void _scheduleSeekRequest(Duration position) {

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -225,6 +225,18 @@ class SyncPlayManager extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// One line per SyncPlay event, at debug level, so a stuck handshake can be
+  /// read off a log rather than guessed at. Debug builds only.
+  void _trace(String message) {
+    final ps = _playbackManager.state;
+    _logger.d(
+      'SyncPlay: $message [group ${_state.groupState.name}, player '
+      '${ps.isPlaying ? 'playing' : 'paused'}'
+      '${ps.isBuffering ? '/buffering' : ''} at '
+      '${ps.position.inMilliseconds}ms]',
+    );
+  }
+
   Future<void> fetchGroups() async {
     if (!syncPlayEnabled) {
       _availableGroups = const [];
@@ -460,11 +472,20 @@ class SyncPlayManager extends ChangeNotifier {
         currentItemId != null &&
         currentItemId.isNotEmpty &&
         command.playlistItemId != currentItemId) {
+      _trace(
+        'dropped ${command.command.name} for item ${command.playlistItemId}, '
+        'ours is $currentItemId',
+      );
       return;
     }
     final key = command.dedupeKey;
     if (key == _lastCommandKey) return;
     _lastCommandKey = key;
+    _trace(
+      'command ${command.command.name} to '
+      '${SyncPlayUtils.ticksToMs(command.positionTicks)}ms at '
+      '${command.whenUtcMs}, server now ${_timeSync?.getServerTimeNow()}',
+    );
 
     switch (command.command) {
       case SyncPlayCommandType.unpause:
@@ -530,6 +551,7 @@ class SyncPlayManager extends ChangeNotifier {
       case SyncPlayGroupUpdateType.stateUpdate:
         final payload = update.payload as SyncPlayStateUpdatePayload;
         _state.groupState = payload.update.state;
+        _trace('state update ${payload.update.state.name}');
         if (_startedPausedForHandshake &&
             _state.groupState == SyncPlayGroupState.playing) {
           _startedPausedForHandshake = false;
@@ -617,6 +639,11 @@ class SyncPlayManager extends ChangeNotifier {
     final hasActivePlayer = _playbackManager.currentResolution != null;
     final needsRemoteLoad = targetItemId != null &&
         (targetItemId != localCurrentItemId || !hasActivePlayer);
+    _trace(
+      'queue ${reason.name} item $targetItemId ($targetPlaylistItemId) from '
+      '${startMs}ms isPlaying ${update.isPlaying} autoPlay $shouldAutoPlay '
+      'reload $needsRemoteLoad',
+    );
     if (needsRemoteLoad) {
       unawaited(_loadRemoteQueueLocally(
         update: update,
@@ -910,6 +937,7 @@ class SyncPlayManager extends ChangeNotifier {
   /// Every seek SyncPlay itself issues goes through here, so the buffering
   /// edge the seek raises is never mistaken for a stall to report.
   void _seekPlayer(int positionMs) {
+    _trace('seeking player to ${positionMs}ms');
     _applyingRemoteCommand = true;
     try {
       _armBufferingSuppression(forSeek: true);
@@ -1170,6 +1198,7 @@ class SyncPlayManager extends ChangeNotifier {
   }) async {
     if (!_state.enabled || !syncPlayEnabled) return false;
     if (_applyingRemoteCommand) return false;
+    _trace('local ${action.name} intercepted');
     switch (action) {
       case TransportAction.resume:
         await requestUnpause();
@@ -1246,6 +1275,7 @@ class SyncPlayManager extends ChangeNotifier {
 
   void _onBuffering(bool buffering) {
     if (!_state.enabled) return;
+    _trace('player buffering $buffering');
     if (buffering && !_isBuffering) {
       _isBuffering = true;
       final nowMs = DateTime.now().millisecondsSinceEpoch;
@@ -1339,8 +1369,14 @@ class SyncPlayManager extends ChangeNotifier {
   /// Buffering report out that the server is right to wait on, and the recovery
   /// that ends it queues a Ready of its own.
   void _reportReadyIfSettled({bool force = false}) {
-    if (_playbackManager.currentResolution == null) return;
-    if (!force && (_playbackManager.state.isBuffering || _isBuffering)) return;
+    if (_playbackManager.currentResolution == null) {
+      _trace('not ready: no player yet');
+      return;
+    }
+    if (!force && (_playbackManager.state.isBuffering || _isBuffering)) {
+      _trace('not ready: still buffering');
+      return;
+    }
     _queueReadyReport();
   }
 
@@ -1408,6 +1444,7 @@ class SyncPlayManager extends ChangeNotifier {
       final pm = _playbackManager;
       final positionTicks =
           SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
+      _trace('sending Buffering for $playlistItemId, attempt $attempt');
       try {
         await api.sendBuffering(
           isPlaying: pm.state.isPlaying,
@@ -1442,6 +1479,7 @@ class SyncPlayManager extends ChangeNotifier {
       final pm = _playbackManager;
       final positionTicks =
           SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
+      _trace('sending Ready for $playlistItemId, attempt $attempt');
       try {
         await api.sendReady(
           isPlaying: pm.state.isPlaying,
@@ -1463,6 +1501,7 @@ class SyncPlayManager extends ChangeNotifier {
   Future<void> requestPause() async {
     if (!_state.enabled || !syncPlayEnabled) return;
     try {
+      _trace('requesting Pause');
       await _api?.sendPause();
     } catch (_) {}
   }
@@ -1470,12 +1509,14 @@ class SyncPlayManager extends ChangeNotifier {
   Future<void> requestUnpause() async {
     if (!_state.enabled || !syncPlayEnabled) return;
     try {
+      _trace('requesting Unpause');
       await _api?.sendUnpause();
     } catch (_) {}
   }
 
   Future<void> requestSeek(Duration position) async {
     if (!_state.enabled || !syncPlayEnabled) return;
+    _trace('requesting Seek to ${position.inMilliseconds}ms');
     try {
       await _api?.sendSeek(SyncPlayUtils.msToTicks(position.inMilliseconds));
     } catch (_) {}
@@ -1631,6 +1672,9 @@ class SyncPlayManager extends ChangeNotifier {
     final positionTicks =
         SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
     try {
+      _trace(
+        'sending our queue of ${ids.length} from ${positionTicks ~/ 10000}ms',
+      );
       await _api?.setNewQueue(
         itemIds: ids,
         startIndex: clamped,

--- a/lib/syncplay/syncplay_manager.dart
+++ b/lib/syncplay/syncplay_manager.dart
@@ -226,11 +226,14 @@ class SyncPlayManager extends ChangeNotifier {
   }
 
   /// One line per SyncPlay event, at debug level, so a stuck handshake can be
-  /// read off a log rather than guessed at. Debug builds only.
-  void _trace(String message) {
+  /// read off a log rather than guessed at. Debug builds only: the logger's
+  /// filter drops it in release anyway, and the closure keeps the message
+  /// from even being built there.
+  void _trace(String Function() message) {
+    if (!kDebugMode) return;
     final ps = _playbackManager.state;
     _logger.d(
-      'SyncPlay: $message [group ${_state.groupState.name}, player '
+      'SyncPlay: ${message()} [group ${_state.groupState.name}, player '
       '${ps.isPlaying ? 'playing' : 'paused'}'
       '${ps.isBuffering ? '/buffering' : ''} at '
       '${ps.position.inMilliseconds}ms]',
@@ -473,7 +476,7 @@ class SyncPlayManager extends ChangeNotifier {
         currentItemId.isNotEmpty &&
         command.playlistItemId != currentItemId) {
       _trace(
-        'dropped ${command.command.name} for item ${command.playlistItemId}, '
+        () => 'dropped ${command.command.name} for item ${command.playlistItemId}, '
         'ours is $currentItemId',
       );
       return;
@@ -482,7 +485,7 @@ class SyncPlayManager extends ChangeNotifier {
     if (key == _lastCommandKey) return;
     _lastCommandKey = key;
     _trace(
-      'command ${command.command.name} to '
+      () => 'command ${command.command.name} to '
       '${SyncPlayUtils.ticksToMs(command.positionTicks)}ms at '
       '${command.whenUtcMs}, server now ${_timeSync?.getServerTimeNow()}',
     );
@@ -551,7 +554,7 @@ class SyncPlayManager extends ChangeNotifier {
       case SyncPlayGroupUpdateType.stateUpdate:
         final payload = update.payload as SyncPlayStateUpdatePayload;
         _state.groupState = payload.update.state;
-        _trace('state update ${payload.update.state.name}');
+        _trace(() => 'state update ${payload.update.state.name}');
         if (_startedPausedForHandshake &&
             _state.groupState == SyncPlayGroupState.playing) {
           _startedPausedForHandshake = false;
@@ -640,7 +643,7 @@ class SyncPlayManager extends ChangeNotifier {
     final needsRemoteLoad = targetItemId != null &&
         (targetItemId != localCurrentItemId || !hasActivePlayer);
     _trace(
-      'queue ${reason.name} item $targetItemId ($targetPlaylistItemId) from '
+      () => 'queue ${reason.name} item $targetItemId ($targetPlaylistItemId) from '
       '${startMs}ms isPlaying ${update.isPlaying} autoPlay $shouldAutoPlay '
       'reload $needsRemoteLoad',
     );
@@ -944,7 +947,7 @@ class SyncPlayManager extends ChangeNotifier {
   /// Every seek SyncPlay itself issues goes through here, so the buffering
   /// edge the seek raises is never mistaken for a stall to report.
   void _seekPlayer(int positionMs) {
-    _trace('seeking player to ${positionMs}ms');
+    _trace(() => 'seeking player to ${positionMs}ms');
     _applyingRemoteCommand = true;
     try {
       _armBufferingSuppression(forSeek: true);
@@ -1205,7 +1208,7 @@ class SyncPlayManager extends ChangeNotifier {
   }) async {
     if (!_state.enabled || !syncPlayEnabled) return false;
     if (_applyingRemoteCommand) return false;
-    _trace('local ${action.name} intercepted');
+    _trace(() => 'local ${action.name} intercepted');
     switch (action) {
       case TransportAction.resume:
         await requestUnpause();
@@ -1282,7 +1285,7 @@ class SyncPlayManager extends ChangeNotifier {
 
   void _onBuffering(bool buffering) {
     if (!_state.enabled) return;
-    _trace('player buffering $buffering');
+    _trace(() => 'player buffering $buffering');
     if (buffering && !_isBuffering) {
       _isBuffering = true;
       final nowMs = DateTime.now().millisecondsSinceEpoch;
@@ -1377,11 +1380,11 @@ class SyncPlayManager extends ChangeNotifier {
   /// that ends it queues a Ready of its own.
   void _reportReadyIfSettled({bool force = false}) {
     if (_playbackManager.currentResolution == null) {
-      _trace('not ready: no player yet');
+      _trace(() => 'not ready: no player yet');
       return;
     }
     if (!force && (_playbackManager.state.isBuffering || _isBuffering)) {
-      _trace('not ready: still buffering');
+      _trace(() => 'not ready: still buffering');
       return;
     }
     _queueReadyReport();
@@ -1451,7 +1454,7 @@ class SyncPlayManager extends ChangeNotifier {
       final pm = _playbackManager;
       final positionTicks =
           SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
-      _trace('sending Buffering for $playlistItemId, attempt $attempt');
+      _trace(() => 'sending Buffering for $playlistItemId, attempt $attempt');
       try {
         await api.sendBuffering(
           isPlaying: pm.state.isPlaying,
@@ -1486,7 +1489,7 @@ class SyncPlayManager extends ChangeNotifier {
       final pm = _playbackManager;
       final positionTicks =
           SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
-      _trace('sending Ready for $playlistItemId, attempt $attempt');
+      _trace(() => 'sending Ready for $playlistItemId, attempt $attempt');
       try {
         await api.sendReady(
           isPlaying: pm.state.isPlaying,
@@ -1508,7 +1511,7 @@ class SyncPlayManager extends ChangeNotifier {
   Future<void> requestPause() async {
     if (!_state.enabled || !syncPlayEnabled) return;
     try {
-      _trace('requesting Pause');
+      _trace(() => 'requesting Pause');
       await _api?.sendPause();
     } catch (_) {}
   }
@@ -1516,14 +1519,14 @@ class SyncPlayManager extends ChangeNotifier {
   Future<void> requestUnpause() async {
     if (!_state.enabled || !syncPlayEnabled) return;
     try {
-      _trace('requesting Unpause');
+      _trace(() => 'requesting Unpause');
       await _api?.sendUnpause();
     } catch (_) {}
   }
 
   Future<void> requestSeek(Duration position) async {
     if (!_state.enabled || !syncPlayEnabled) return;
-    _trace('requesting Seek to ${position.inMilliseconds}ms');
+    _trace(() => 'requesting Seek to ${position.inMilliseconds}ms');
     try {
       await _api?.sendSeek(SyncPlayUtils.msToTicks(position.inMilliseconds));
     } catch (_) {}
@@ -1680,7 +1683,7 @@ class SyncPlayManager extends ChangeNotifier {
         SyncPlayUtils.msToTicks(pm.state.position.inMilliseconds);
     try {
       _trace(
-        'sending our queue of ${ids.length} from ${positionTicks ~/ 10000}ms',
+        () => 'sending our queue of ${ids.length} from ${positionTicks ~/ 10000}ms',
       );
       await _api?.setNewQueue(
         itemIds: ids,

--- a/lib/ui/screens/playback/appletv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_player_host_screen.dart
@@ -1417,6 +1417,15 @@ class _AppleTvPlayerHostScreenState extends State<AppleTvPlayerHostScreen> {
           _prompts?.onUserSeeked();
         }
       case 'userSeeked':
+        // The native player has already seeked itself; the manager is told
+        // so that whatever coordinates playback (SyncPlay's group seek) hears
+        // about it without the player being moved a second time.
+        final seekedToMs = (action['positionMs'] as num?)?.toInt();
+        if (seekedToMs != null) {
+          unawaited(
+            manager.notifyExternalSeek(Duration(milliseconds: seekedToMs)),
+          );
+        }
         _prompts?.onUserSeeked();
       case 'nextUpPlay':
         unawaited(_prompts?.handleNextUpPlay() ?? Future<void>.value());

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -2044,6 +2044,15 @@ class PlaybackManager implements AudioOwnable {
     await _backend?.seekTo(position);
   }
 
+  /// A seek the player performed on its own, from a control the manager does
+  /// not own (the native tvOS transport). The player has already moved, so
+  /// only the interceptor sees it: whoever is coordinating playback, if
+  /// anyone, gets the same notice a [seekTo] would have given.
+  Future<void> notifyExternalSeek(Duration position) async {
+    _lastKnownPosition = position;
+    await _maybeIntercept(TransportAction.seek, position: position);
+  }
+
   Future<void> setPlaybackSpeed(double speed) async {
     await _backend?.setPlaybackSpeed(speed);
     state.setPlaybackSpeed(speed);

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1179,6 +1179,10 @@ class PlaybackManager implements AudioOwnable {
     bool enableDirectPlay = true,
     bool enableDirectStream = true,
     bool enableTranscoding = true,
+    // False loads the item and leaves it paused at [startPosition]: a
+    // SyncPlay handshake wants the player at the group's position without a
+    // frame of playback until the group's own Unpause.
+    bool autoPlay = true,
   }) async {
     _clearPendingItemOverrides();
     _vetoedAudioCodecs.clear();
@@ -1236,6 +1240,7 @@ class PlaybackManager implements AudioOwnable {
       enableDirectPlay: enableDirectPlay,
       enableDirectStream: enableDirectStream,
       enableTranscoding: enableTranscoding,
+      autoPlay: autoPlay,
     );
   }
 

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -663,6 +663,13 @@ class PlaybackManager implements AudioOwnable {
     _transportInterceptor = interceptor;
   }
 
+  /// Whether transport actions are being routed to a coordinator (SyncPlay)
+  /// instead of reaching the player directly. Housekeeping that would seek
+  /// or pause on its own initiative must stand down while this is set: the
+  /// coordinator owns the position, and such a seek or pause would be sent
+  /// to every member of the group as if the user had asked for it.
+  bool get hasTransportInterceptor => _transportInterceptor != null;
+
   Future<bool> _maybeIntercept(
     TransportAction action, {
     Duration? position,

--- a/packages/playback_core/lib/src/player_backend.dart
+++ b/packages/playback_core/lib/src/player_backend.dart
@@ -149,5 +149,25 @@ abstract class PlayerBackend {
   /// stream started has to be rebuilt when this fires.
   Stream<void> get tracksChangedStream => const Stream.empty();
 
+  /// How long this player usually takes to render again after a seek. Only
+  /// paces how often SyncPlay may correct: the cost it actually compensates
+  /// for is measured from the player, never taken from here.
+  Duration get typicalSeekLatency => const Duration(milliseconds: 1500);
+
+  /// The longest a seek on this player may plausibly take. SyncPlay treats a
+  /// gap larger than this as the client being genuinely late rather than as
+  /// the seek still landing, and stops waiting on a seek that exceeds it.
+  /// Backends that restart a transcode to seek need this much higher than the
+  /// in-buffer seek a desktop player does.
+  Duration get maxSeekLatency => const Duration(seconds: 8);
+
+  /// Whether the rate can be changed a few percent mid-playback without the
+  /// audio dropping or glitching. mpv and ExoPlayer stretch audio in place;
+  /// the AVPlayer-based engines rebuild the audio pipeline on every rate write
+  /// and cannot pass Dolby audio through at anything but 1x. SyncPlay only
+  /// nudges the rate where this is true, and holds the player instead where
+  /// it is not.
+  bool get supportsSmoothRateChange => true;
+
   void dispose();
 }

--- a/test/data/services/media_segment_service_test.dart
+++ b/test/data/services/media_segment_service_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/media_segment.dart';
+import 'package:moonfin/data/services/media_segment_service.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+
+import '../../util/media_segment_fakes.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UserPreferences prefs;
+
+  setUp(() async {
+    prefs = await testPrefs();
+  });
+
+  Future<MediaSegmentService> service(
+    List<Map<String, dynamic>> segments, {
+    String actions = 'intro:skip,outro:skip',
+  }) async {
+    await prefs.set(UserPreferences.mediaSegmentActions, actions);
+    return segmentServiceWith(prefs, segments);
+  }
+
+  // An intro ending at 90.0004s, so that a landing on 90.000s is still inside.
+  final intro = segmentJson(
+    id: 'intro',
+    type: 'Intro',
+    startMs: 5000,
+    endTicks: 900004000,
+  );
+
+  group('MediaSegmentService auto-skip', () {
+    test('skips to the first whole millisecond past the segment', () async {
+      final svc = await service([intro]);
+      final result = svc.checkPosition(const Duration(seconds: 5));
+      expect(result.shouldSkip, isTrue);
+      expect(result.skipTo, const Duration(milliseconds: 90001));
+    });
+
+    test('does not skip again when the seek lands short of the end', () async {
+      final svc = await service([intro]);
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      // The seek landed a frame short, still inside the segment.
+      expect(svc.checkPosition(const Duration(seconds: 90)).isNone, isTrue);
+      // Playback moves on, then a group seek puts us back on that landing.
+      expect(
+        svc.checkPosition(const Duration(milliseconds: 90500)).isNone,
+        isTrue,
+      );
+      expect(svc.checkPosition(const Duration(seconds: 90)).isNone, isTrue);
+    });
+
+    test('a seek into the middle of a skipped segment plays it', () async {
+      final svc = await service([intro]);
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 120)).isNone, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 40)).isNone, isTrue);
+    });
+
+    test('a rewind to or before the start arms the skip again', () async {
+      final svc = await service([intro]);
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 120)).isNone, isTrue);
+      // Restart from the start of the segment itself.
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 120)).isNone, isTrue);
+      // Rewind to before it and play into it.
+      expect(svc.checkPosition(const Duration(seconds: 2)).isNone, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 6)).shouldSkip, isTrue);
+    });
+
+    test('each segment is tracked on its own', () async {
+      final outro = segmentJson(
+        id: 'outro',
+        type: 'Outro',
+        startMs: 1200000,
+        endMs: 1260000,
+      );
+      final svc = await service([intro, outro]);
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      expect(svc.checkPosition(const Duration(seconds: 90)).isNone, isTrue);
+      final result = svc.checkPosition(const Duration(seconds: 1200));
+      expect(result.shouldSkip, isTrue);
+      expect(result.segment?.type, MediaSegmentType.outro);
+      expect(svc.checkPosition(const Duration(seconds: 1259)).isNone, isTrue);
+    });
+
+    test('reloading the item forgets what was skipped', () async {
+      final svc = await service([intro]);
+      expect(svc.checkPosition(const Duration(seconds: 5)).shouldSkip, isTrue);
+      await svc.loadSegments('ep1');
+      expect(svc.checkPosition(const Duration(seconds: 40)).shouldSkip, isTrue);
+    });
+
+    test('ask-to-skip prompts are unaffected', () async {
+      final svc = await service([intro], actions: 'intro:askToSkip');
+      final first = svc.checkPosition(const Duration(seconds: 5));
+      expect(first.shouldAsk, isTrue);
+      expect(first.isNew, isTrue);
+      final again = svc.checkPosition(const Duration(seconds: 6));
+      expect(again.shouldAsk, isTrue);
+      expect(again.isNew, isFalse);
+      expect(svc.checkPosition(const Duration(seconds: 120)).isNone, isTrue);
+      // Coming back into it prompts afresh, as before.
+      expect(svc.checkPosition(const Duration(seconds: 40)).isNew, isTrue);
+    });
+  });
+}

--- a/test/playback/appletv_prompt_controller_test.dart
+++ b/test/playback/appletv_prompt_controller_test.dart
@@ -2,13 +2,12 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:moonfin/data/services/media_segment_service.dart';
 import 'package:moonfin/preference/preference_constants.dart';
 import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/ui/screens/playback/appletv_playback_prompt_controller.dart';
-import 'package:server_core/server_core.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+
+import '../util/media_segment_fakes.dart';
 
 class _FakeCommands implements AppleTvPromptCommands {
   final calls = <String>[];
@@ -102,51 +101,6 @@ class _FakeCommands implements AppleTvPromptCommands {
   }
 }
 
-class _FakeItemsApi implements ItemsApi {
-  List<Map<String, dynamic>> segments = const [];
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) {
-    if (invocation.memberName == #getMediaSegments) {
-      return Future<List<Map<String, dynamic>>>.value(segments);
-    }
-    return super.noSuchMethod(invocation);
-  }
-}
-
-class _FakeClient implements MediaServerClient {
-  final _FakeItemsApi items = _FakeItemsApi();
-
-  @override
-  ItemsApi get itemsApi => items;
-
-  @override
-  dynamic noSuchMethod(Invocation invocation) =>
-      super.noSuchMethod(invocation);
-}
-
-Map<String, dynamic> _segmentJson({
-  required String id,
-  required String type,
-  required int startMs,
-  required int endMs,
-}) {
-  return {
-    'Id': id,
-    'ItemId': 'ep1',
-    'Type': type,
-    'StartTicks': startMs * 10000,
-    'EndTicks': endMs * 10000,
-  };
-}
-
-Future<UserPreferences> _prefs() async {
-  SharedPreferences.setMockInitialValues(const {});
-  final store = PreferenceStore();
-  await store.init();
-  return UserPreferences(store);
-}
-
 AppleTvQueueSnapshot _snapshot({
   int currentIndex = 0,
   int length = 3,
@@ -200,27 +154,12 @@ class _Harness {
   }
 }
 
-Future<MediaSegmentService> _segmentServiceWith(
-  UserPreferences prefs,
-  List<Map<String, dynamic>> segments,
-) async {
-  final client = _FakeClient();
-  client.items.segments = segments;
-  final service = MediaSegmentService(
-    client,
-    FeatureDetector(serverType: ServerType.jellyfin, serverVersion: ''),
-    prefs,
-  );
-  await service.loadSegments('ep1');
-  return service;
-}
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('Next Up trigger thresholds', () {
     test('extended shows at 1000ms remaining and not at 1001ms', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 1001);
       expect(h.commands.count('showNextUp'), 0);
@@ -233,7 +172,7 @@ void main() {
     });
 
     test('minimal shows at 500ms remaining, without an image', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(UserPreferences.nextUpBehavior, NextUpBehavior.minimal);
       final h = _Harness(prefs);
 
@@ -248,7 +187,7 @@ void main() {
 
     test('countdown style comes from the media segment countdown pref',
         () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(
         UserPreferences.mediaSegmentCountdown,
         MediaSegmentCountdown.timer,
@@ -262,7 +201,7 @@ void main() {
 
   group('Next Up show guards', () {
     test('disabled behavior never shows', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(UserPreferences.nextUpBehavior, NextUpBehavior.disabled);
       final h = _Harness(prefs);
 
@@ -271,7 +210,7 @@ void main() {
     });
 
     test('dismissed stays hidden for the rest of the episode', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       h.controller.handleNextUpDismiss();
@@ -280,7 +219,7 @@ void main() {
     });
 
     test('already visible card does not re-show', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       h.tick(remainingMs: 800);
@@ -298,7 +237,7 @@ void main() {
         _snapshot(nextEligible: false),
       ];
       for (final snapshot in cases) {
-        final h = _Harness(await _prefs());
+        final h = _Harness(await testPrefs());
         h.snapshot = snapshot;
         h.tick(remainingMs: 100);
         expect(
@@ -312,7 +251,7 @@ void main() {
 
   group('suppressAutoNext lifecycle', () {
     test('set on present, cleared on dismiss', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       expect(h.commands.suppressAutoNext, isTrue);
@@ -322,7 +261,7 @@ void main() {
     });
 
     test('cleared on queue change along with card state', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       expect(h.commands.suppressAutoNext, isTrue);
@@ -335,7 +274,7 @@ void main() {
 
   group('countdown timeout', () {
     test('autoplay on advances after the configured timeout', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       final h = _Harness(prefs);
 
       fakeAsync((async) {
@@ -351,7 +290,7 @@ void main() {
     });
 
     test('autoplay off exits playback on timeout', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(UserPreferences.autoplayNextEpisode, false);
       final h = _Harness(prefs);
 
@@ -365,7 +304,7 @@ void main() {
     });
 
     test('timeout of zero never fires a timer', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(UserPreferences.nextUpTimeout, 0);
       final h = _Harness(prefs);
 
@@ -381,7 +320,7 @@ void main() {
 
   group('play and cancel paths', () {
     test('play hides the card and advances through the live queue', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       await h.controller.handleNextUpPlay();
@@ -391,7 +330,7 @@ void main() {
     });
 
     test('play falls back to cancel when the next item disappeared', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       h.snapshot = _snapshot(hasNext: false);
@@ -402,7 +341,7 @@ void main() {
     });
 
     test('rapid double play advances once', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
       await h.prefs.set(
         UserPreferences.stillWatchingBehavior,
         StillWatchingBehavior.short_,
@@ -421,7 +360,7 @@ void main() {
     });
 
     test('cancel exits playback', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       h.controller.handleNextUpCancel();
@@ -432,7 +371,7 @@ void main() {
 
   group('Still Watching', () {
     Future<_Harness> harnessAtThreshold() async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(
         UserPreferences.stillWatchingBehavior,
         StillWatchingBehavior.short_,
@@ -481,7 +420,7 @@ void main() {
     });
 
     test('below the episode threshold no prompt shows', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(
         UserPreferences.stillWatchingBehavior,
         StillWatchingBehavior.short_,
@@ -511,7 +450,7 @@ void main() {
 
     test('counter increments on queue change and resets only on continue',
         () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.controller.onQueueChanged();
       h.controller.onQueueChanged();
@@ -538,7 +477,7 @@ void main() {
   group('seek suppression', () {
     test('a seek hides the card, clears suppressAutoNext, and blocks a '
         're-show for 1200ms', () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       expect(h.commands.suppressAutoNext, isTrue);
@@ -560,7 +499,7 @@ void main() {
   group('stale card regression', () {
     test('queue change hides the card and the next episode presents fresh',
         () async {
-      final h = _Harness(await _prefs());
+      final h = _Harness(await testPrefs());
 
       h.tick(remainingMs: 900);
       expect(h.commands.lastNextUpTitle, 'Episode 2');
@@ -583,10 +522,10 @@ void main() {
   group('media segments', () {
     test('an ask intro shows the button and leaving the segment hides it',
         () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       final h = _Harness(prefs);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(id: 's1', type: 'Intro', startMs: 5000, endMs: 65000),
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(id: 's1', type: 'Intro', startMs: 5000, endMs: 65000),
       ]);
 
       h.controller.onPositionTick(
@@ -607,14 +546,14 @@ void main() {
     });
 
     test('an auto-skip intro seeks to the segment end', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(
         UserPreferences.mediaSegmentActions,
         'intro:skip,outro:askToSkip',
       );
       final h = _Harness(prefs);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(id: 's1', type: 'Intro', startMs: 5000, endMs: 65000),
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(id: 's1', type: 'Intro', startMs: 5000, endMs: 65000),
       ]);
 
       h.controller.onPositionTick(
@@ -627,10 +566,10 @@ void main() {
     });
 
     test('skipping an outro marks the item played and seeks', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       final h = _Harness(prefs);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(
           id: 's1',
           type: 'Outro',
           startMs: 2300000,
@@ -651,11 +590,11 @@ void main() {
     });
 
     test('skipping an outro with no next item exits playback', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       final h = _Harness(prefs);
       h.snapshot = _snapshot(hasNext: false);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(
           id: 's1',
           type: 'Outro',
           startMs: 2300000,
@@ -676,11 +615,11 @@ void main() {
 
     test('replace outro with next up presents the card instead of skipping',
         () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       await prefs.set(UserPreferences.replaceSkipOutroWithNextUp, true);
       final h = _Harness(prefs);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(
           id: 's1',
           type: 'Outro',
           startMs: 2300000,
@@ -698,10 +637,10 @@ void main() {
     });
 
     test('outro deferral holds the card until the end threshold', () async {
-      final prefs = await _prefs();
+      final prefs = await testPrefs();
       final h = _Harness(prefs);
-      h.segmentService = await _segmentServiceWith(prefs, [
-        _segmentJson(
+      h.segmentService = await segmentServiceWith(prefs, [
+        segmentJson(
           id: 's1',
           type: 'Outro',
           startMs: 2300000,

--- a/test/playback/playback_lifecycle_handler_test.dart
+++ b/test/playback/playback_lifecycle_handler_test.dart
@@ -58,6 +58,9 @@ void main() {
       ),
     ).thenAnswer((_) async {});
     when(() => manager.resume()).thenAnswer((_) async {});
+    when(() => manager.pause()).thenAnswer((_) async {});
+    when(() => manager.seekTo(any())).thenAnswer((_) async {});
+    when(() => manager.hasTransportInterceptor).thenReturn(false);
     handler = PlaybackLifecycleHandler(manager);
   });
 
@@ -287,6 +290,58 @@ void main() {
 
       await tester.pump(const Duration(milliseconds: 1));
       verify(() => manager.stopForBackground(any())).called(1);
+    });
+  });
+  group('under SyncPlay', () {
+    // The shape of a group starting a new item while the web tab is hidden:
+    // the position we saved on hide is far past where the new item begins.
+    Future<void> hideThenLoadNewItemAtZero(WidgetTester tester) async {
+      queue.setQueue(<dynamic>[item('Episode')]);
+      playerState.setPlaying(true);
+      playerState.setPosition(const Duration(minutes: 20));
+
+      handler.didChangeAppLifecycleState(AppLifecycleState.hidden);
+      playerState.setPosition(Duration.zero);
+      await tester.pump(const Duration(milliseconds: 600));
+    }
+
+    testWidgets('a hidden tab never seeks the group back to its old position', (
+      tester,
+    ) async {
+      when(() => manager.hasTransportInterceptor).thenReturn(true);
+
+      await hideThenLoadNewItemAtZero(tester);
+
+      verifyNever(() => manager.seekTo(any()));
+    });
+
+    testWidgets('resuming never pauses or seeks the group', (tester) async {
+      when(() => manager.hasTransportInterceptor).thenReturn(true);
+
+      await hideThenLoadNewItemAtZero(tester);
+      // The group paused for its handshake while we were hidden.
+      playerState.setPlaying(false);
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
+
+      verifyNever(() => manager.seekTo(any()));
+      verifyNever(() => manager.pause());
+    });
+
+    testWidgets('the corrections still run for a player of its own', (
+      tester,
+    ) async {
+      await hideThenLoadNewItemAtZero(tester);
+
+      verify(
+        () => manager.seekTo(const Duration(minutes: 20)),
+      ).called(greaterThanOrEqualTo(1));
+
+      // Resuming ends the background correction ticks.
+      handler.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
     });
   });
 }

--- a/test/syncplay/sync_correction_policy_test.dart
+++ b/test/syncplay/sync_correction_policy_test.dart
@@ -10,52 +10,144 @@ const _defaultSettings = SyncCorrectionSettings(
   speedToSyncDurationMs: 1000,
 );
 
-/// A client whose seeks take [seekLatencyMs] to render: after a skip the
-/// position freezes for that long, then advances with the wall clock again.
+/// A player that seeks as slowly as an Apple TV restarting a transcode and
+/// whose audio does not survive a rate change, so the manager has cleared
+/// speed-to-sync for it.
+const _appleTvSettings = SyncCorrectionSettings(
+  useSkipToSync: true,
+  useSpeedToSync: false,
+  minDelaySkipToSyncMs: 2000,
+  minDelaySpeedToSyncMs: 100,
+  maxDelaySpeedToSyncMs: 5000,
+  speedToSyncDurationMs: 1000,
+  typicalSeekLatencyMs: 4000,
+  maxSeekLatencyMs: 20000,
+);
+
+/// The sampling cadence of the Apple TV and media3 position streams.
+const _sampleMs = 250;
+
+/// The manager's correction tick.
+const _tickMs = 2000;
+
+/// A client whose seeks take [seekLatencyMs] to render: after a seek the
+/// position reads the target but freezes for that long, then advances with
+/// the wall clock again.
+///
+/// [reportsBufferingWhileSeeking] false models a player that claims to be
+/// playing while its clock is still frozen, which is what mpv looks like
+/// across an in-buffer seek and what the Apple TV engine looks like if it
+/// reports `.playing` before the seek has landed.
+///
+/// [acceptsSeeks] false models a seek the player silently ignored: the method
+/// channel swallows the rejection, so nothing distinguishes it from success
+/// except that the position never moves.
 class _FakeClient {
-  final int seekLatencyMs;
+  int seekLatencyMs;
+  final bool reportsBufferingWhileSeeking;
+  final bool acceptsSeeks;
 
   int nowMs = 0;
   int positionMs = 0;
   int stalledUntilMs = 0;
+  int pausedUntilMs = 0;
   int baselineMs = 0;
 
-  _FakeClient({required this.seekLatencyMs});
+  double _speed = 1.0;
+  int _speedUntilMs = 0;
 
-  bool get isBuffering => nowMs < stalledUntilMs;
-  bool get isPlaying => !isBuffering;
+  _FakeClient({
+    required this.seekLatencyMs,
+    this.reportsBufferingWhileSeeking = true,
+    this.acceptsSeeks = true,
+  });
+
+  bool get _isStalled => nowMs < stalledUntilMs;
+  bool get isPaused => nowMs < pausedUntilMs;
+  bool get isBuffering => reportsBufferingWhileSeeking && _isStalled;
+  bool get isPlaying => !isBuffering && !isPaused;
+  bool get nudgeActive => nowMs < _speedUntilMs;
 
   int get driftMs => positionMs - nowMs;
 
   void advance(int ms) {
     final end = nowMs + ms;
-    final resumedAt = stalledUntilMs > nowMs
-        ? (stalledUntilMs < end ? stalledUntilMs : end)
+    final frozenUntil =
+        stalledUntilMs > pausedUntilMs ? stalledUntilMs : pausedUntilMs;
+    final resumedAt = frozenUntil > nowMs
+        ? (frozenUntil < end ? frozenUntil : end)
         : nowMs;
-    positionMs += end - resumedAt;
+    // Media advances at the nudged rate until the nudge expires, then at 1x.
+    var at = resumedAt;
+    while (at < end) {
+      final nudged = _speedUntilMs > at;
+      final segmentEnd = nudged && _speedUntilMs < end ? _speedUntilMs : end;
+      positionMs += ((segmentEnd - at) * (nudged ? _speed : 1.0)).round();
+      at = segmentEnd;
+    }
     nowMs = end;
   }
 
   void stall(int ms) => stalledUntilMs = nowMs + ms;
 
+  void pause(int ms) => pausedUntilMs = nowMs + ms;
+
+  void applySpeed(double speed, int durationMs) {
+    _speed = speed;
+    _speedUntilMs = nowMs + durationMs;
+  }
+
   void seekTo(int target) {
+    if (!acceptsSeeks) return;
     positionMs = target;
     stalledUntilMs = nowMs + seekLatencyMs;
   }
 }
 
-/// Ticks at the manager's 2s cadence, applying decisions the way
-/// `SyncPlayManager._performDriftCorrection` does.
-List<SyncCorrectionDecision> _run(
+/// Feeds the policy one sample, as the manager does for every position update.
+void _observe(SyncCorrectionPolicy policy, _FakeClient client) {
+  policy.observe(
+    nowMs: client.nowMs,
+    positionMs: client.positionMs,
+    isPlaying: client.isPlaying,
+    isBuffering: client.isBuffering,
+  );
+}
+
+/// Advances [ms] of wall clock, sampling at the backend cadence throughout.
+void _advance(SyncCorrectionPolicy policy, _FakeClient client, int ms) {
+  var left = ms;
+  while (left > 0) {
+    final step = left < _sampleMs ? left : _sampleMs;
+    client.advance(step);
+    _observe(policy, client);
+    left -= step;
+  }
+}
+
+/// The group seeks to where it is now, so the target is the expected position.
+void _groupSeek(
   SyncCorrectionPolicy policy,
   _FakeClient client, {
-  required int ticks,
   SyncCorrectionSettings settings = _defaultSettings,
 }) {
-  final decisions = <SyncCorrectionDecision>[];
-  for (var i = 0; i < ticks; i++) {
-    client.advance(2000);
-    final decision = policy.evaluate(
+  final target = client.nowMs + client.baselineMs;
+  final from = client.positionMs;
+  client.seekTo(target);
+  policy.onSyncPointChanged(
+    client.nowMs,
+    targetPositionMs: target,
+    fromPositionMs: from,
+    settings: settings,
+  );
+}
+
+SyncCorrectionDecision _evaluate(
+  SyncCorrectionPolicy policy,
+  _FakeClient client, {
+  SyncCorrectionSettings settings = _defaultSettings,
+}) =>
+    policy.evaluate(
       nowMs: client.nowMs,
       serverNowMs: client.nowMs,
       currentPositionMs: client.positionMs,
@@ -66,11 +158,34 @@ List<SyncCorrectionDecision> _run(
       clockJitterMs: 0,
       settings: settings,
     );
+
+/// Ticks at the manager's 2s cadence, applying decisions the way
+/// `SyncPlayManager._performDriftCorrection` does. The manager does not
+/// measure while a nudge or a wait it applied is still running, and neither
+/// does this.
+List<SyncCorrectionDecision> _run(
+  SyncCorrectionPolicy policy,
+  _FakeClient client, {
+  required int ticks,
+  SyncCorrectionSettings settings = _defaultSettings,
+}) {
+  final decisions = <SyncCorrectionDecision>[];
+  for (var i = 0; i < ticks; i++) {
+    _advance(policy, client, _tickMs);
+    if (client.nudgeActive || client.isPaused) continue;
+    final decision = _evaluate(policy, client, settings: settings);
     decisions.add(decision);
-    if (decision.action == SyncCorrectionAction.skip) {
-      client.seekTo(decision.targetPositionMs);
-    } else if (decision.action == SyncCorrectionAction.rebaseline) {
-      client.baselineMs += decision.measuredDelayMs;
+    switch (decision.action) {
+      case SyncCorrectionAction.skip:
+        client.seekTo(decision.targetPositionMs);
+      case SyncCorrectionAction.speed:
+        client.applySpeed(decision.speed, decision.speedDurationMs);
+      case SyncCorrectionAction.wait:
+        client.pause(decision.waitDurationMs);
+      case SyncCorrectionAction.hold:
+      case SyncCorrectionAction.defer:
+      case SyncCorrectionAction.giveUp:
+        break;
     }
   }
   return decisions;
@@ -97,7 +212,7 @@ void main() {
           reason: 'each skip must fold in the latency it just measured',
         );
         expect(policy.hasGivenUp, isFalse);
-        expect(policy.seekLatencyAllowanceMs, 3000);
+        expect(policy.isStandingDown, isFalse);
         expect(
           client.driftMs.abs(),
           lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
@@ -111,19 +226,50 @@ void main() {
       },
     );
 
-    test('stops correcting when it cannot converge', () {
-      // Seek latency past the allowance cap can never be compensated for.
+    test('seek cost is measured from player samples, not the correction tick',
+        () {
+      // Timed on the 2s tick, an instant seek read as a 2s cost and a 2.1s
+      // seek as 4s. Aiming the next skip with that overshot by up to 2s every
+      // time, which on a player that cannot nudge its rate was a jump
+      // backwards.
+      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      _run(policy, client, ticks: 10);
+
+      expect(
+        policy.seekLatencyAllowanceMs,
+        inInclusiveRange(3000, 3000 + 2 * _sampleMs),
+        reason: 'the cost is known to within a sample or two',
+      );
+    });
+
+    test('stops jumping when it cannot converge, without hiding the gap', () {
+      // This used to end in a give-up that disabled correction and left the
+      // client sitting at whatever offset it happened to hold, reporting it as
+      // zero. Standing down keeps the truth visible.
       final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
       final policy = SyncCorrectionPolicy();
 
       final decisions = _run(policy, client, ticks: 400);
 
-      expect(policy.hasGivenUp, isTrue);
       expect(
         _countOf(decisions, SyncCorrectionAction.skip),
-        SyncCorrectionPolicy.maxConsecutiveSkips,
+        lessThanOrEqualTo(SyncCorrectionPolicy.maxFailedAttempts),
       );
-      expect(decisions.last.action, SyncCorrectionAction.giveUp);
+      expect(policy.isStandingDown, isTrue);
+      expect(
+        decisions.skip(decisions.length - 50).any(
+              (d) => d.action == SyncCorrectionAction.skip,
+            ),
+        isFalse,
+        reason: 'the visible jumping must stop',
+      );
+      expect(
+        decisions.last.measuredDelayMs.abs(),
+        greaterThan(SyncCorrectionPolicy.noiseFloorMs),
+        reason: 'the real gap is still reported, never absorbed to zero',
+      );
     });
 
     test('never corrects a client that is still buffering', () {
@@ -136,7 +282,7 @@ void main() {
         decisions.every((d) => d.action == SyncCorrectionAction.defer),
         isTrue,
       );
-      expect(policy.consecutiveSkips, 0);
+      expect(policy.skipsUsed, 0);
     });
 
     test('never corrects a paused client', () {
@@ -156,7 +302,7 @@ void main() {
     });
 
     test('holds off re-measuring until a skip has settled', () {
-      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+      final client = _FakeClient(seekLatencyMs: 5000)..stall(4000);
       final policy = SyncCorrectionPolicy();
 
       final decisions = _run(policy, client, ticks: 4);
@@ -171,6 +317,59 @@ void main() {
             .every((d) => d.action == SyncCorrectionAction.defer),
         isTrue,
         reason: 'measurements inside the settle window are not usable',
+      );
+    });
+
+    test('a client that never settles is not corrected forever', () {
+      // A player that stops rendering entirely must not be seeked at
+      // repeatedly: that is what pins one client in place while the group
+      // plays on.
+      final client = _FakeClient(seekLatencyMs: 600000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 200);
+
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        lessThanOrEqualTo(SyncCorrectionPolicy.maxFailedAttempts),
+      );
+      expect(
+        policy.seekLatencyAllowanceMs,
+        0,
+        reason: 'an attempt that timed out teaches us nothing about seek cost',
+      );
+    });
+
+    test('a skip aimed with a stale high cost is waited out, not jumped back',
+        () {
+      // Seek cost is not one number: a seek that restarts a transcode costs
+      // seconds, the next one into a warm buffer almost nothing. A skip aimed
+      // with the high cost then lands well ahead. Answering that with a jump
+      // backwards, aimed with the same stale cost, lands ahead again, which
+      // is the visible loop.
+      final client = _FakeClient(seekLatencyMs: 6000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      // The first skip learns the cold cost.
+      _run(policy, client, ticks: 8, settings: _appleTvSettings);
+      expect(policy.seekLatencyAllowanceMs, greaterThanOrEqualTo(6000));
+
+      // Fall behind again, but seeks are warm now.
+      client.seekLatencyMs = 500;
+      client.stall(5000);
+      final decisions =
+          _run(policy, client, ticks: 40, settings: _appleTvSettings);
+
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        1,
+        reason: 'the lead the overshoot leaves is never answered with a jump',
+      );
+      expect(_countOf(decisions, SyncCorrectionAction.wait), 1);
+      expect(
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+        reason: 'the wait is exact, so one is enough',
       );
     });
   });
@@ -212,6 +411,71 @@ void main() {
       expect(evaluate(0).action, SyncCorrectionAction.speed);
       expect(evaluate(1200).action, SyncCorrectionAction.hold);
     });
+
+    test('a position that is not advancing is never measured as drift', () {
+      // The Apple TV samples position on a 250ms timer and can report playing
+      // while the clock is still on the pre-seek frame. Trusting that sample
+      // makes the seek's own cost look like drift and seeks at it again.
+      final client = _FakeClient(
+        seekLatencyMs: 30000,
+        reportsBufferingWhileSeeking: false,
+      );
+      final policy = SyncCorrectionPolicy();
+      _groupSeek(policy, client);
+
+      final decisions = _run(policy, client, ticks: 6);
+
+      expect(
+        decisions.every((d) => d.action == SyncCorrectionAction.defer),
+        isTrue,
+        reason: 'a frozen position is not evidence of anything',
+      );
+      expect(policy.seekLatencyAllowanceMs, 0);
+    });
+
+    test('a seek with no buffering edge is still measured once it settles', () {
+      // mpv never raises a buffering edge for an in-buffer seek, so the settle
+      // test cannot rely on that flag alone.
+      final client = _FakeClient(
+        seekLatencyMs: 1200,
+        reportsBufferingWhileSeeking: false,
+      );
+      final policy = SyncCorrectionPolicy();
+      _groupSeek(policy, client);
+
+      _run(policy, client, ticks: 10);
+
+      expect(
+        policy.seekLatencyAllowanceMs,
+        inInclusiveRange(1200, 1200 + 3 * _sampleMs),
+        reason: 'the cost is the time until the position started advancing',
+      );
+    });
+
+    test(
+        'a seek that lands while paused for the handshake still teaches its '
+        'cost', () {
+      // The group's waiting handshake holds every client paused at the target
+      // until all have landed. Nothing renders, but the landing itself is
+      // observable and is what the next skip needs to know.
+      final client = _FakeClient(seekLatencyMs: 3000);
+      final policy = SyncCorrectionPolicy();
+      client.pause(60000);
+      _groupSeek(policy, client);
+      _advance(policy, client, 5000);
+
+      // The Unpause that ends the handshake is a new sync point.
+      policy.onSyncPointResumed(
+        client.nowMs,
+        positionMs: client.positionMs,
+        settings: _defaultSettings,
+      );
+
+      expect(
+        policy.seekLatencyAllowanceMs,
+        inInclusiveRange(3000, 3000 + 2 * _sampleMs),
+      );
+    });
   });
 
   group('speed correction', () {
@@ -232,13 +496,57 @@ void main() {
       final decision = decisionFor(31000);
       expect(decision.action, SyncCorrectionAction.speed);
       expect(decision.speed, lessThan(1.0));
-      expect(decision.speedDurationMs, 1000);
     });
 
     test('speeds up when behind the group', () {
       final decision = decisionFor(29000);
       expect(decision.action, SyncCorrectionAction.speed);
       expect(decision.speed, greaterThan(1.0));
+    });
+
+    test('one nudge is sized to close the whole gap', () {
+      // A fixed 5% for a second closed 50ms, under the noise floor, so it
+      // could never be seen to work and fired again on every tick for as long
+      // as the gap lasted. On mpv that is a tempo filter in and out every two
+      // seconds; on AVPlayer it is an audible glitch each time.
+      final small = decisionFor(29400);
+      expect(small.speed, closeTo(1.2, 1e-9));
+      expect(
+        small.speed * small.speedDurationMs - small.speedDurationMs,
+        closeTo(600, 1),
+        reason: 'the media gained over the nudge is the gap',
+      );
+
+      // Anything past the skip threshold is a jump instead, so the longest
+      // nudge is just under it.
+      final large = decisionFor(28500);
+      expect(
+        large.speed,
+        closeTo(1 + SyncCorrectionPolicy.maxRateDeviation, 1e-9),
+        reason: 'a large gap takes a longer nudge, not a harsher rate',
+      );
+      expect(
+        large.speed * large.speedDurationMs - large.speedDurationMs,
+        closeTo(1500, 1),
+      );
+    });
+
+    test('a nudge in flight is not fired again', () {
+      final client = _FakeClient(seekLatencyMs: 0)..stall(1500);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 30);
+
+      expect(
+        _countOf(decisions, SyncCorrectionAction.speed),
+        1,
+        reason: 'one sized nudge closes the gap; the next check is inside the '
+            'noise floor',
+      );
+      expect(
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+      );
     });
 
     test('leaves the rate alone when speed-to-sync is off', () {
@@ -251,78 +559,205 @@ void main() {
         isBuffering: false,
         isPlaying: true,
         clockJitterMs: 0,
-        settings: const SyncCorrectionSettings(
-          useSkipToSync: true,
-          useSpeedToSync: false,
-          minDelaySkipToSyncMs: 2000,
-          minDelaySpeedToSyncMs: 100,
-          maxDelaySpeedToSyncMs: 5000,
-          speedToSyncDurationMs: 1000,
-        ),
+        settings: _appleTvSettings,
       );
       expect(decision.action, SyncCorrectionAction.hold);
     });
+
+    test('landing ahead of the group is corrected by rate, not another jump',
+        () {
+      // Skips are aimed high on purpose. Answering the overshoot with a second
+      // jump would be the visible churn the whole design is avoiding.
+      final client = _FakeClient(seekLatencyMs: 1000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions = _run(policy, client, ticks: 60);
+      final firstSkip = decisions.indexWhere(
+        (d) => d.action == SyncCorrectionAction.skip,
+      );
+
+      expect(firstSkip, isNonNegative);
+      expect(
+        decisions.skip(firstSkip + 1).any(
+              (d) => d.action == SyncCorrectionAction.skip,
+            ),
+        isFalse,
+        reason: 'the residual a skip leaves is not answered with another jump',
+      );
+      expect(
+        decisions.skip(firstSkip + 1).any(
+              (d) => d.action == SyncCorrectionAction.speed,
+            ),
+        isTrue,
+        reason: 'it is taken out by the rate instead',
+      );
+      expect(
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+      );
+    });
   });
 
-  group('lifecycle', () {
-    test('a new sync point clears the skip streak but keeps the latency', () {
-      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+  group('waiting out a lead', () {
+    SyncCorrectionDecision decisionFor(int positionMs) =>
+        SyncCorrectionPolicy().evaluate(
+          nowMs: 30000,
+          serverNowMs: 30000,
+          currentPositionMs: positionMs,
+          lastSyncPositionMs: 0,
+          lastSyncTimeMs: 0,
+          isBuffering: false,
+          isPlaying: true,
+          clockJitterMs: 0,
+          settings: _appleTvSettings,
+        );
+
+    test('a player that cannot nudge its rate waits for the group instead', () {
+      // A pause needs no seek and no rate write, the two things that glitch
+      // on the Apple TV engine, and it is exact where a nudge is approximate.
+      final decision = decisionFor(33000);
+      expect(decision.action, SyncCorrectionAction.wait);
+      expect(decision.waitDurationMs, 3000);
+    });
+
+    test('a short lead is left alone rather than stalled over', () {
+      final decision =
+          decisionFor(30000 + SyncCorrectionPolicy.minWaitToSyncMs - 100);
+      expect(decision.action, SyncCorrectionAction.hold);
+      expect(decision.measuredDelayMs, greaterThan(0));
+    });
+
+    test('a lead too long to sit through is jumped back instead', () {
+      final decision =
+          decisionFor(30000 + SyncCorrectionPolicy.maxWaitToSyncMs + 2000);
+      expect(decision.action, SyncCorrectionAction.skip);
+    });
+
+    test('a wait lands the client on the group exactly', () {
+      final client = _FakeClient(seekLatencyMs: 0);
       final policy = SyncCorrectionPolicy();
-      _run(policy, client, ticks: 10);
+      client.positionMs = 3000;
 
-      expect(policy.seekLatencyAllowanceMs, greaterThan(0));
-      final learned = policy.seekLatencyAllowanceMs;
+      final decisions =
+          _run(policy, client, ticks: 10, settings: _appleTvSettings);
 
-      policy.onSyncPointChanged(client.nowMs);
-
-      expect(policy.consecutiveSkips, 0);
+      expect(_countOf(decisions, SyncCorrectionAction.wait), 1);
+      expect(_countOf(decisions, SyncCorrectionAction.skip), 0);
       expect(
-        policy.seekLatencyAllowanceMs,
-        learned,
-        reason: 'seek latency is a property of the device and stream',
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
       );
+      expect(decisions.last.action, SyncCorrectionAction.hold);
+    });
+  });
+
+  group('group seeks', () {
+    test('a sync point with no seek behind it settles on the spot', () {
+      // The server re-sends the sync point it is on when it hears a Ready
+      // mid-play, and the resume for it finds the player already inside the
+      // seek tolerance. Judged as a landing against a position the player has
+      // since played past, that attempt would never settle and would time
+      // out as a failure.
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 3000);
+      _advance(policy, client, 10000);
+      policy.onSyncPointResumed(
+        client.nowMs,
+        positionMs: client.positionMs,
+        settings: _defaultSettings,
+      );
+
+      final decisions = _run(policy, client, ticks: 3);
+
+      expect(policy.hasOpenAttempt, isFalse);
+      expect(policy.failedAttempts, 0);
+      expect(decisions.last.action, SyncCorrectionAction.hold);
     });
 
     test('a group seek is given time to land before anything is measured', () {
       final policy = SyncCorrectionPolicy();
-      final client = _FakeClient(seekLatencyMs: 1200);
-      client.seekTo(0);
-      policy.onSyncPointChanged(client.nowMs);
+      final client = _FakeClient(seekLatencyMs: 3000);
+      _groupSeek(policy, client);
 
       expect(_run(policy, client, ticks: 1).single.action,
           SyncCorrectionAction.defer);
     });
 
-    test('a group seek re-anchors instead of nudging the rate', () {
-      // The seek's own latency is not drift. Answering it with a rate nudge
-      // inserts an mpv tempo filter mid-playback and audibly glitches.
+    test('a group seek residual is corrected, never absorbed into the baseline',
+        () {
+      // The seek's own cost used to be folded into the baseline, which
+      // redefined the client's late position as in sync: it reported zero
+      // drift while sitting behind the group for the rest of the item.
       final policy = SyncCorrectionPolicy();
       final client = _FakeClient(seekLatencyMs: 1200);
-      client.seekTo(0);
-      policy.onSyncPointChanged(client.nowMs);
+      _groupSeek(policy, client);
 
       final decisions = _run(policy, client, ticks: 30);
 
-      expect(_countOf(decisions, SyncCorrectionAction.rebaseline), 1);
-      expect(
-        _countOf(decisions, SyncCorrectionAction.speed),
-        0,
-        reason: 'no rate nudge, so no tempo filter churn after a seek',
-      );
       expect(_countOf(decisions, SyncCorrectionAction.skip), 0);
       expect(
+        _countOf(decisions, SyncCorrectionAction.speed),
+        1,
+        reason: 'a residual under the skip threshold is one sized nudge',
+      );
+      expect(
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+        reason: 'the client must end up where the group actually is',
+      );
+      expect(
         policy.seekLatencyAllowanceMs,
-        1200,
+        greaterThanOrEqualTo(1200),
         reason: 'the residual is the seek latency, worth learning',
       );
     });
 
-    test('real drift after a re-anchored seek is still corrected', () {
+    test(
+        'a small residual on a player without rate nudges is tolerated, not '
+        'hidden', () {
       final policy = SyncCorrectionPolicy();
       final client = _FakeClient(seekLatencyMs: 1200);
-      client.seekTo(0);
-      policy.onSyncPointChanged(client.nowMs);
-      _run(policy, client, ticks: 4);
+      _groupSeek(policy, client, settings: _appleTvSettings);
+
+      final decisions =
+          _run(policy, client, ticks: 30, settings: _appleTvSettings);
+
+      expect(_countOf(decisions, SyncCorrectionAction.skip), 0);
+      expect(_countOf(decisions, SyncCorrectionAction.wait), 0);
+      expect(
+        decisions.last.measuredDelayMs,
+        inInclusiveRange(-1200 - _sampleMs, -1200 + _sampleMs),
+        reason: 'the gap is still reported truthfully so later drift on top '
+            'of it is corrected against the group, not against this offset',
+      );
+    });
+
+    test(
+      'a group seek residual too large to ignore is corrected, not absorbed',
+      () {
+        // The residual used to be folded into the baseline for anything up to
+        // eight seconds. It left the client seven seconds behind the group for
+        // the rest of the item while reporting zero drift the whole time.
+        final policy = SyncCorrectionPolicy();
+        final client = _FakeClient(seekLatencyMs: 7000);
+        _groupSeek(policy, client);
+
+        final decisions = _run(policy, client, ticks: 60);
+
+        expect(_countOf(decisions, SyncCorrectionAction.skip), 1);
+        expect(
+          client.driftMs.abs(),
+          lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+          reason: 'the client must end up where the group actually is',
+        );
+      },
+    );
+
+    test('real drift after a group seek is still corrected', () {
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 1200);
+      _groupSeek(policy, client);
+      _run(policy, client, ticks: 10);
 
       // A stall well after the seek is genuine drift, not seek cost.
       client.stall(5000);
@@ -332,74 +767,183 @@ void main() {
         _countOf(decisions, SyncCorrectionAction.skip) +
             _countOf(decisions, SyncCorrectionAction.speed),
         greaterThan(0),
-        reason: 're-anchoring must not blind the policy to later drift',
       );
     });
 
-    test('a new item clears a give-up', () {
+    test('an apple tv seek cost past the desktop cap still converges', () {
+      // Twelve seconds is past the 8s ceiling a desktop profile allows, so
+      // every skip used to land short by the difference, forever. It is also
+      // what a transcoding client can look like.
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 12000);
+      _groupSeek(policy, client, settings: _appleTvSettings);
+
+      final decisions = _run(
+        policy,
+        client,
+        ticks: 120,
+        settings: _appleTvSettings,
+      );
+
+      expect(policy.hasGivenUp, isFalse);
+      expect(policy.isStandingDown, isFalse);
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        1,
+        reason: 'the cost learned from the group seek aims the one skip',
+      );
+      expect(
+        policy.seekLatencyAllowanceMs,
+        greaterThanOrEqualTo(12000),
+        reason: 'the profile must allow an allowance as large as the real cost',
+      );
+      expect(
+        client.driftMs.abs(),
+        lessThanOrEqualTo(SyncCorrectionPolicy.noiseFloorMs),
+      );
+    });
+
+    test('a seek the player silently ignored is not treated as progress', () {
+      // The method channel swallows a rejected seek, so the only evidence is
+      // that the position never moved.
+      final policy = SyncCorrectionPolicy();
+      final client = _FakeClient(seekLatencyMs: 0, acceptsSeeks: false)
+        ..stall(6000);
+
+      final decisions = _run(policy, client, ticks: 200);
+
+      expect(
+        _countOf(decisions, SyncCorrectionAction.skip),
+        lessThanOrEqualTo(SyncCorrectionPolicy.maxFailedAttempts),
+        reason: 'a seek that changes nothing must not be retried forever',
+      );
+      expect(policy.isStandingDown, isTrue);
+    });
+  });
+
+  group('lifecycle', () {
+    test('a new sync point clears the failure ledger but keeps the latency',
+        () {
+      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+      _run(policy, client, ticks: 10);
+
+      expect(policy.seekLatencyAllowanceMs, greaterThan(0));
+      final learned = policy.seekLatencyAllowanceMs;
+
+      _groupSeek(policy, client);
+
+      expect(policy.failedAttempts, 0);
+      expect(
+        policy.seekLatencyAllowanceMs,
+        learned,
+        reason: 'seek latency is a property of the device and stream',
+      );
+    });
+
+    test("the first skip is aimed with the backend's declared cost", () {
+      // Overshooting is taken out by a wait or a slow-down; undershooting
+      // costs a second visible jump. So before anything has been measured the
+      // backend's own figure is the aim, not zero.
+      final client = _FakeClient(seekLatencyMs: 4000)..stall(5000);
+      final policy = SyncCorrectionPolicy();
+
+      final decisions =
+          _run(policy, client, ticks: 3, settings: _appleTvSettings);
+      final skip = decisions.firstWhere(
+        (d) => d.action == SyncCorrectionAction.skip,
+      );
+
+      expect(
+        skip.targetPositionMs - client.nowMs,
+        _appleTvSettings.typicalSeekLatencyMs,
+      );
+    });
+
+    test('a new item clears a stand-down', () {
       final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
       final policy = SyncCorrectionPolicy();
       _run(policy, client, ticks: 400);
-      expect(policy.hasGivenUp, isTrue);
+      expect(policy.isStandingDown, isTrue);
 
       policy.reset();
 
+      expect(policy.isStandingDown, isFalse);
       expect(policy.hasGivenUp, isFalse);
       expect(policy.seekLatencyAllowanceMs, 0);
-      expect(policy.consecutiveSkips, 0);
+      expect(policy.skipsUsed, 0);
     });
 
-    test('a give-up survives an ordinary measurement', () {
+    test('a stand-down keeps reporting the gap it stood down over', () {
       final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
       final policy = SyncCorrectionPolicy();
       _run(policy, client, ticks: 400);
 
-      // Even a perfectly synced measurement must not restart correcting.
-      final decision = policy.evaluate(
-        nowMs: 999000,
-        serverNowMs: 999000,
-        currentPositionMs: 999000,
-        lastSyncPositionMs: 0,
-        lastSyncTimeMs: 0,
-        isBuffering: false,
-        isPlaying: true,
-        clockJitterMs: 0,
-        settings: _defaultSettings,
+      // The same gap it stood down over must still be reported, and must not
+      // start the jumping again. Only a materially worse one re-arms.
+      final standing = _run(policy, client, ticks: 1).single;
+
+      expect(
+        standing.measuredDelayMs.abs(),
+        greaterThan(SyncCorrectionPolicy.noiseFloorMs),
+        reason: 'the gap is still measured, never absorbed to zero',
       );
-      expect(decision.action, SyncCorrectionAction.giveUp);
+      expect(
+        standing.action,
+        isNot(SyncCorrectionAction.skip),
+        reason: 'standing down suppresses the jumping, not the measuring',
+      );
     });
 
-    test('a group seek lifts a give-up', () {
+    test('a group seek lifts a stand-down', () {
       final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
       final policy = SyncCorrectionPolicy();
       _run(policy, client, ticks: 400);
+      expect(policy.isStandingDown, isTrue);
+
+      _groupSeek(policy, client);
+
+      expect(policy.isStandingDown, isFalse);
+      expect(policy.failedAttempts, 0);
+    });
+
+    test('a group seek revives correction but not an unlimited skip budget',
+        () {
+      // The streak used to be cleared by every sync point, so a group that
+      // seeks now and then handed out an unbounded number of jumps.
+      final client = _FakeClient(seekLatencyMs: 14000)..stall(4000);
+      final policy = SyncCorrectionPolicy();
+
+      var skips = 0;
+      for (var round = 0; round < 20; round++) {
+        _groupSeek(policy, client);
+        skips += _countOf(
+          _run(policy, client, ticks: 20),
+          SyncCorrectionAction.skip,
+        );
+      }
+
+      expect(
+        skips,
+        lessThanOrEqualTo(SyncCorrectionPolicy.maxSkipsPerItem),
+        reason: 'the per-item budget is the one thing a sync point cannot '
+            'clear, so no sequence of group seeks can jump forever',
+      );
       expect(policy.hasGivenUp, isTrue);
-
-      policy.onSyncPointChanged(client.nowMs);
-
-      expect(policy.hasGivenUp, isFalse);
-      expect(policy.consecutiveSkips, 0);
-      expect(
-        policy.seekLatencyAllowanceMs,
-        greaterThan(0),
-        reason: 'the learned latency belongs to the device, not the stretch',
-      );
     });
 
-    test('a residual too large to be seek cost is corrected, not absorbed', () {
+    test('a dropped seek is not counted as a correction attempt', () {
+      // A target inside the manager's seek tolerance never reaches the player,
+      // so there is nothing to wait for and nothing to judge.
+      final client = _FakeClient(seekLatencyMs: 3000)..stall(4000);
       final policy = SyncCorrectionPolicy();
-      final client = _FakeClient(seekLatencyMs: 0);
-      client.seekTo(0);
-      policy.onSyncPointChanged(client.nowMs);
-      client.stall(SyncCorrectionPolicy.maxSeekLatencyAllowanceMs + 6000);
+      _run(policy, client, ticks: 2);
+      final usedBefore = policy.skipsUsed;
 
-      final decisions = _run(policy, client, ticks: 20);
+      policy.onSkipDropped();
 
-      expect(_countOf(decisions, SyncCorrectionAction.rebaseline), 0);
-      expect(
-        _countOf(decisions, SyncCorrectionAction.skip),
-        greaterThan(0),
-      );
+      expect(policy.skipsUsed, usedBefore - 1);
+      expect(policy.failedAttempts, 0);
     });
   });
 }

--- a/test/util/media_segment_fakes.dart
+++ b/test/util/media_segment_fakes.dart
@@ -1,0 +1,69 @@
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/data/services/media_segment_service.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Serves one list of raw media segments; everything else is unimplemented.
+class FakeItemsApi implements ItemsApi {
+  List<Map<String, dynamic>> segments = const [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.memberName == #getMediaSegments) {
+      return Future<List<Map<String, dynamic>>>.value(segments);
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+class FakeClient implements MediaServerClient {
+  final FakeItemsApi items = FakeItemsApi();
+
+  @override
+  ItemsApi get itemsApi => items;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      super.noSuchMethod(invocation);
+}
+
+/// A segment as the server sends it. [endTicks] overrides [endMs] for the
+/// rare case that needs a sub-millisecond end.
+Map<String, dynamic> segmentJson({
+  required String id,
+  required String type,
+  required int startMs,
+  int endMs = 0,
+  int? endTicks,
+}) {
+  return {
+    'Id': id,
+    'ItemId': 'ep1',
+    'Type': type,
+    'StartTicks': startMs * 10000,
+    'EndTicks': endTicks ?? endMs * 10000,
+  };
+}
+
+Future<UserPreferences> testPrefs() async {
+  SharedPreferences.setMockInitialValues(const {});
+  final store = PreferenceStore();
+  await store.init();
+  return UserPreferences(store);
+}
+
+Future<MediaSegmentService> segmentServiceWith(
+  UserPreferences prefs,
+  List<Map<String, dynamic>> segments,
+) async {
+  final client = FakeClient();
+  client.items.segments = segments;
+  final service = MediaSegmentService(
+    client,
+    FeatureDetector(serverType: ServerType.jellyfin, serverVersion: ''),
+    prefs,
+  );
+  await service.loadSegments('ep1');
+  return service;
+}

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -36,7 +36,10 @@ final class AppleTvPlayerViewController: UIViewController {
     var onNextUpCancel: (() -> Void)?
     var onNextUpDismiss: (() -> Void)?
     var onSkipSegmentSelect: (() -> Void)?
-    var onUserSeek: (() -> Void)?
+    /// Fires with the target after a scrub or a direct jump the user made.
+    /// Carrying the position lets the host hand it to SyncPlay, which is the
+    /// only way a seek made on this player reaches the rest of the group.
+    var onUserSeek: ((Int) -> Void)?
     var onSearchSubtitles: (() -> Void)?
     var onSubtitleDelayChanged: ((Int) -> Void)?
     var onDownloadSubtitle: ((String) -> Void)?
@@ -1970,7 +1973,7 @@ final class AppleTvPlayerViewController: UIViewController {
         scrubCommitId += 1
         let commitId = scrubCommitId
         player.seek(to: Double(target) / 1000.0)
-        onUserSeek?()
+        onUserSeek?(target)
         renderProgress()
         updateTrickplay()
         scrubConvergeDeadline = ProcessInfo.processInfo.systemUptime + 2.0
@@ -2030,7 +2033,7 @@ final class AppleTvPlayerViewController: UIViewController {
         let durationMs = Int(player.duration * 1000)
         let clamped = durationMs > 0 ? min(durationMs, max(0, ms)) : max(0, ms)
         player.seek(to: Double(clamped) / 1000.0)
-        onUserSeek?()
+        onUserSeek?(clamped)
     }
 
     func seekFromHost(toSeconds seconds: TimeInterval) {

--- a/tvos/Runner/Playback/AppleTvVideoChannel.swift
+++ b/tvos/Runner/Playback/AppleTvVideoChannel.swift
@@ -131,6 +131,13 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
             } else {
                 player?.seek(to: ms(args["positionMs"]))
             }
+            // State is otherwise only pushed by the 0.25s timer, so until the
+            // next tick Dart still reads the pre-seek position with the player
+            // reported as playing. Anything measuring how far behind we are
+            // takes that sample as real and corrects against a position the
+            // seek has already left. Android emits on the same discontinuity
+            // for the same reason (Media3VideoView.onPositionDiscontinuity).
+            markSeekInFlight()
         case "setSpeed":
             player?.setRate((args["speed"] as? NSNumber)?.floatValue ?? 1.0)
         case "setAudioTrack":
@@ -274,8 +281,8 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
         vc.onSkipSegmentSelect = { [weak self] in
             self?.send(["event": "skipSegment"])
         }
-        vc.onUserSeek = { [weak self] in
-            self?.send(["event": "userSeeked"])
+        vc.onUserSeek = { [weak self] positionMs in
+            self?.send(["event": "userSeeked", "positionMs": positionMs])
         }
         vc.onSearchSubtitles = { [weak self] in
             self?.send(["event": "searchSubtitles"])
@@ -411,6 +418,26 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
         stateTimer = nil
     }
 
+    /// Reports the seek immediately rather than waiting for the next timer
+    /// tick. The engine has not moved its clock yet, so the position is still
+    /// the old one; what matters is that it goes out flagged as buffering, so
+    /// nothing downstream mistakes it for a settled measurement.
+    private func markSeekInFlight() {
+        guard let p = player else { return }
+        send(statePayload(p, isPlaying: false, isBuffering: true))
+    }
+
+    private func statePayload(_ p: AetherPlayerWrapper, isPlaying: Bool, isBuffering: Bool) -> [String: Any] {
+        [
+            "event": "state",
+            "positionMs": Int((p.currentTime * 1000).rounded()),
+            "durationMs": Int((p.duration * 1000).rounded()),
+            "bufferedMs": Int((p.duration * Double(p.bufferProgress) * 1000).rounded()),
+            "isPlaying": isPlaying,
+            "isBuffering": isBuffering,
+        ]
+    }
+
     private func pushState() {
         guard let p = player else { return }
         if p.state != lastLoggedState {
@@ -430,14 +457,7 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
             break
         }
 
-        send([
-            "event": "state",
-            "positionMs": Int((p.currentTime * 1000).rounded()),
-            "durationMs": Int((p.duration * 1000).rounded()),
-            "bufferedMs": Int((p.duration * Double(p.bufferProgress) * 1000).rounded()),
-            "isPlaying": isPlaying,
-            "isBuffering": isBuffering,
-        ])
+        send(statePayload(p, isPlaying: isPlaying, isBuffering: isBuffering))
 
         // Captions can turn up part way through a live stream, so a change in
         // either list re-emits tracksChanged.


### PR DESCRIPTION
# Pull Request

## Summary
SyncPlay on Apple TV looped indefinitely after a group seek (jumping back every ~2 s), audio glitched, and a seek made from the Apple TV never reached the group. A trace from the device showed a self-sustaining cycle: every buffering edge sent a `Ready`, the server answered an unsolicited `Ready` with an echo of the current `Unpause`, the late-Unpause path seeked, and on tvOS every seek raises a buffering edge, which sent the next `Ready`. The handshake and echo handling are fixed in the shared Dart code (mpv rarely hit it only because in-buffer seeks raise no edge), the drift-correction policy is reworked so it can no longer loop or silently park a client seconds behind, and the native tvOS scrub is routed into SyncPlay so it becomes a group seek like on every other platform.

A second, independent loop showed up once group seeks worked: an automatic intro/outro skip under SyncPlay re-fired forever. A skip seeks to the segment's end, most players land a frame short of the target (still inside the segment), and once a later sample had reset the active segment that landing looked like a fresh entry — so every client re-issued the skip as a group seek, which put everyone a frame short again. `MediaSegmentService` now skips a segment once (until playback is genuinely seen at or before its start again) and rounds the target up to the next whole millisecond so a truncated seek cannot land inside; `SyncPlayManager` additionally drops a local seek that merely repeats where the group's last `Seek` just sent everyone, so a client that never skipped the segment itself cannot restart the cycle.

## Related Issues
- Closes #
- Fixes #
- Related #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- `SyncPlayManager`: send `Ready` only when the server is waiting on us (a `Buffering` report went out or the group is in Waiting); recognise an `Unpause` that repeats the current sync point as an echo (never seek on it); start paused on join/queue change and let the server's `Unpause` start playback; pause on a group `Seek` during the Waiting handshake; route every SyncPlay-issued seek through one helper so its buffering edge is never reported as a stall.
- `SyncPlayManager`: remember the target and arrival time of the group's last `Seek`, and swallow a local seek that only asks for that same spot within the backend's `maxSeekLatency` (`_isEchoOfGroupSeek`) — a re-fired auto-skip, not a user seek. A user seek back to that spot after playback has moved on still goes through.
- `MediaSegmentService`: track segments already auto-skipped (`_autoSkipped`) and only re-arm one when playback is seen at or before its start; round `skipTo` up to the next whole millisecond so the seek target can never truncate back inside the segment.
- `SyncCorrectionPolicy`: correct a group-seek residual instead of folding it into the baseline; measure seek cost from the backend's position samples (`observe()`) rather than the 2 s tick; aim skips high and answer overshoot with a `wait` (exact pause, no seek, no rate write); size one rate nudge to every tick; judge skips by outcome with a failure ledger and a per-item budget.
- `PlayerBackend`: new capabilities `typicalSeekLatency`, `maxSeekLatency`, `supportsSmoothRateChange`; the Apple TV and Tizen backends opt out of rate nudges.
- `PlaybackManager.notifyExternalSeek()` + tvOS `userSeeked` now carry the position, so a screr reaches the SyncPlay interceptor.
- tvOS `AppleTvVideoChannel`: push a state event on the seek itself instead of waiting for the next periodic sample (mirrors Android's `onPositionDiscontinuity`).
- Tests: policy tests rewritten around a 250 ms-sampled fake client (38 tests); new `MediaSegering skip-once, re-arm on rewind, and millisecond rounding; media-segment fakes moved to`test/util/media_segment_fakes.dart` so they are shared with the Apple TV prompt controller tests.

## Platform
- [ ] Android
- [ ] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start a SyncPlay group from a macOS client and play a direct-play movie; join from an Applhen resumes in sync with no jump back.
2. Fast-forward from the macOS client — the Apple TV pauses briefly, lands, and resumes with the group in one move (previously: ~20 s of repeated jumps back and audio glitches).
3. Scrub from the Apple TV — the whole group follows (previously the TV was dragged back to t
4. Play an episode with an intro segment and "skip" enabled on both clients — the intro is skipped once for the whole group and playback continues (previously: every client re-fired the skip as a group seek and
the group looped at the intro's end).
5. Rewind into the intro by hand — the skip fires again as expected; it is only suppressed for landings just short of the segment end.
6. `flutter test test/syncplay/ test/data/services/media_segment_service_test.dart`

## Screenshots (if applicable)
N/A — no UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced  