### PR TITLE
(fix) Retro games - preserve controller mappings per game for native core.

### DIFF
--- a/lib/ui/screens/playback/native_controller_mapping_screen.dart
+++ b/lib/ui/screens/playback/native_controller_mapping_screen.dart
@@ -143,6 +143,8 @@ class NativeControllerMappingScreenState
   int _deviceIndex = 0;
   bool _confirmingCopy = false;
   int _copySelected = 0;
+  bool _confirmingReset = false;
+  int _resetSelected = 0;
   bool _choosingControllerType = false;
   int _controllerTypeSelected = 0;
   bool _choosingPlayer = false;
@@ -204,6 +206,8 @@ class NativeControllerMappingScreenState
   int get _rowCount => _resetRow + 1;
   int get _copyConfirmRow => 0;
   int get _copyCancelRow => 1;
+  int get _resetConfirmRow => 0;
+  int get _resetCancelRow => 1;
 
   List<String> get _copyTargets => widget.devices
       .where((device) => device.supported && device.port != null)
@@ -312,6 +316,10 @@ class NativeControllerMappingScreenState
       setState(() => _confirmingCopy = false);
       return true;
     }
+    if (_confirmingReset) {
+      _cancelReset();
+      return true;
+    }
     return false;
   }
 
@@ -381,6 +389,26 @@ class NativeControllerMappingScreenState
       }
       return;
     }
+    if (_confirmingReset) {
+      switch (index) {
+        case 4:
+        case 5:
+          setState(() {
+            _resetSelected = _resetSelected == _resetConfirmRow
+                ? _resetCancelRow
+                : _resetConfirmRow;
+          });
+        case 0:
+          if (_resetSelected == _resetConfirmRow) {
+            _confirmReset();
+          } else {
+            _cancelReset();
+          }
+        case 8:
+          _cancelReset();
+      }
+      return;
+    }
     switch (index) {
       case 4:
         _move(-1);
@@ -409,7 +437,8 @@ class NativeControllerMappingScreenState
       return;
     }
 
-    final mapping = _mapping.withBinding(code, capturing);
+    // Scoped to this game, so this does not rewrite every other game.
+    final mapping = _mapping.withBindingForGame(widget.gameId, code, capturing);
     if (!mounted) return;
     setState(() {
       _mapping = mapping;
@@ -493,7 +522,7 @@ class NativeControllerMappingScreenState
       return;
     }
     if (_selected == _rowCount - 1) {
-      _reset();
+      _beginReset();
       return;
     }
     final device = _device;
@@ -504,13 +533,34 @@ class NativeControllerMappingScreenState
     unawaited(capture.begin(device.runtimeId));
   }
 
-  void _reset() {
+  void _beginReset() {
+    if (_device == null) return;
+    setState(() {
+      _confirmingReset = true;
+      // Cancel is the safe default: a reset cannot be undone.
+      _resetSelected = _resetCancelRow;
+    });
+  }
+
+  void _cancelReset() {
+    setState(() => _confirmingReset = false);
+    _revealRow(_selected);
+  }
+
+  /// Returns this game's buttons to the built-in layout for this controller.
+  ///
+  /// An empty table is not the same as no entry: no entry inherits the saved
+  /// bindings, an empty one says this game deliberately uses none.
+  void _confirmReset() {
     final device = _device;
     if (device == null) return;
-    setState(() => _mapping = NativeControllerMapping.empty);
-    unawaited(
-      widget.onMappingChanged(device.id, NativeControllerMapping.empty),
-    );
+    final mapping = _mapping.withBindingsForGame(widget.gameId, const {});
+    setState(() {
+      _mapping = mapping;
+      _confirmingReset = false;
+    });
+    _revealRow(_selected);
+    unawaited(widget.onMappingChanged(device.id, mapping));
   }
 
   void _onDiagnosticsSnapshot(ControllerDiagnosticsSnapshot snapshot) {
@@ -553,7 +603,7 @@ class NativeControllerMappingScreenState
         }
       }
     }
-    retroPad ??= _mapping.keycodeToButton[button.rawCode];
+    retroPad ??= _mapping.bindingsForGame(widget.gameId)[button.rawCode];
     return ButtonChannel(
       rawCode: button.rawCode,
       rawName: button.rawName,
@@ -734,6 +784,14 @@ class NativeControllerMappingScreenState
         : '$label - this game and controller';
   }
 
+  /// Whether these buttons are the built-in layout or something the user
+  /// changed. Reads the bindings in effect, because a reset stores an empty
+  /// table, which is still an entry.
+  String get _bindingScopeSubtitle =>
+      _mapping.bindingsForGame(widget.gameId).isEmpty
+      ? 'Default layout'
+      : 'Customised for this game';
+
   void _cycleSnap() {
     final device = _device;
     if (device == null || widget.gameId.isEmpty) return;
@@ -898,7 +956,7 @@ class NativeControllerMappingScreenState
       'a disconnected controller';
 
   int? _keycodeFor(RetroPadButton button) {
-    for (final entry in _mapping.keycodeToButton.entries) {
+    for (final entry in _mapping.bindingsForGame(widget.gameId).entries) {
       if (entry.value == button) return entry.key;
     }
     return null;
@@ -965,6 +1023,42 @@ class NativeControllerMappingScreenState
               _copyCancelRow,
               trailing: Icons.close,
               onTap: () => setState(() => _confirmingCopy = false),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (_confirmingReset) {
+      final device = _device;
+      return Flexible(
+        child: ListView(
+          controller: _scroll,
+          shrinkWrap: true,
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Text(
+                'Reset ${device?.name ?? 'this controller'} to the default '
+                'button layout for this game?\n\n'
+                'Only this game and this controller change. Your other '
+                'games keep their buttons, and this core\'s controller '
+                'type and stick snap are not touched.',
+                style: const TextStyle(color: Colors.white, fontSize: 18),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            _row(
+              'Reset buttons',
+              _resetConfirmRow,
+              trailing: Icons.restart_alt,
+              onTap: _confirmReset,
+            ),
+            _row(
+              'Cancel',
+              _resetCancelRow,
+              trailing: Icons.close,
+              onTap: _cancelReset,
             ),
           ],
         ),
@@ -1145,12 +1239,13 @@ class NativeControllerMappingScreenState
           }
           if (index == _resetRow) {
             return _row(
-              'Reset to defaults',
+              'Reset this game to defaults',
               index,
+              subtitle: _bindingScopeSubtitle,
               trailing: Icons.restart_alt,
               onTap: () {
                 setState(() => _selected = index);
-                _reset();
+                _beginReset();
               },
             );
           }
@@ -1177,6 +1272,7 @@ class NativeControllerMappingScreenState
     if (_choosingPlayer) return _playerSelected;
     if (_choosingControllerType) return _controllerTypeSelected;
     if (_confirmingCopy) return _copySelected;
+    if (_confirmingReset) return _resetSelected;
     return _selected;
   }
 

--- a/lib/ui/screens/playback/native_controller_mapping_screen.dart
+++ b/lib/ui/screens/playback/native_controller_mapping_screen.dart
@@ -549,8 +549,9 @@ class NativeControllerMappingScreenState
 
   /// Returns this game's buttons to the built-in layout for this controller.
   ///
-  /// An empty table is not the same as no entry: no entry inherits the saved
-  /// bindings, an empty one says this game deliberately uses none.
+  /// An empty table is not the same as no entry. No entry inherits the saved
+  /// bindings, while an empty one lays nothing over the runner's own defaults,
+  /// which is what puts this game back on the built-in layout.
   void _confirmReset() {
     final device = _device;
     if (device == null) return;
@@ -784,13 +785,17 @@ class NativeControllerMappingScreenState
         : '$label - this game and controller';
   }
 
-  /// Whether these buttons are the built-in layout or something the user
-  /// changed. Reads the bindings in effect, because a reset stores an empty
-  /// table, which is still an entry.
-  String get _bindingScopeSubtitle =>
-      _mapping.bindingsForGame(widget.gameId).isEmpty
-      ? 'Default layout'
-      : 'Customised for this game';
+  /// What resetting this game would change the buttons from.
+  ///
+  /// A game with no table of its own still plays on the saved bindings, so a
+  /// reset moves its buttons too. Saying which scope those came from is the
+  /// difference between a reset that does something and one that does not.
+  String get _bindingScopeSubtitle {
+    if (_mapping.bindingsForGame(widget.gameId).isEmpty) return 'Default layout';
+    return _mapping.hasGameOverride(widget.gameId)
+        ? 'Customised for this game'
+        : 'Customised for every game';
+  }
 
   void _cycleSnap() {
     final device = _device;

--- a/lib/ui/screens/playback/native_game_player_screen.dart
+++ b/lib/ui/screens/playback/native_game_player_screen.dart
@@ -74,26 +74,50 @@ PlayerOneWarning? playerOneWarningFor(
 int? desktopBitForButton(
   NativeControllerMapping? mapping,
   GamepadButton button,
-  int? fallback,
-) {
-  final bound = desktopBoundBit(mapping, button);
+  int? fallback, {
+  String gameId = '',
+}) {
+  final bound = desktopBoundBit(mapping, button, gameId: gameId);
   if (bound != null) return bound;
   if (fallback == null || mapping == null) return fallback;
-  final claimed = mapping.keycodeToButton.values
+  final claimed = mapping
+      .bindingsForGame(gameId)
+      .values
       .map((b) => 1 << b.retroPadIndex)
       .contains(fallback);
   return claimed ? null : fallback;
 }
+
+/// The per-profile binding tables to hand the native side for [gameId].
+///
+/// The mapping menu resolves through this same call, so what the core plays
+/// with and what the menu shows cannot drift. Keycodes only; controller type
+/// and stick snap go through their own channels.
+@visibleForTesting
+String controllerMappingsPayload(
+  Map<String, NativeControllerMapping> mappings,
+  String gameId,
+) => jsonEncode({
+  for (final entry in mappings.entries)
+    entry.key: {
+      for (final binding in entry.value.bindingsForGame(gameId).entries)
+        binding.key.toString(): binding.value.retroPadIndex,
+    },
+});
 
 /// The RetroPad bit a saved binding gives [button], or null when it is unbound.
 ///
 /// Split out so the desktop trigger path is testable: the gamepad stream is a
 /// static, and only Windows/Linux read it in Dart.
 @visibleForTesting
-int? desktopBoundBit(NativeControllerMapping? mapping, GamepadButton button) {
+int? desktopBoundBit(
+  NativeControllerMapping? mapping,
+  GamepadButton button, {
+  String gameId = '',
+}) {
   final code = desktopGamepadButtonCodes[button];
   if (mapping == null || code == null) return null;
-  final bound = mapping.keycodeToButton[code];
+  final bound = mapping.bindingsForGame(gameId)[code];
   return bound == null ? null : 1 << bound.retroPadIndex;
 }
 
@@ -607,7 +631,12 @@ class _NativeGamePlayerScreenState extends State<NativeGamePlayerScreen>
   /// Android's table and EmulatorJS, which clears duplicates the same way.
   int? _bitForGamepadButton(String gamepadId, GamepadButton button) {
     final mapping = _controllerMappings[desktopControllerDeviceId(gamepadId)];
-    return desktopBitForButton(mapping, button, _gamepadButtonToBit[button]);
+    return desktopBitForButton(
+      mapping,
+      button,
+      _gamepadButtonToBit[button],
+      gameId: widget.gameId,
+    );
   }
 
   // Negative stick values map to the first bit, positive to the second. The Y
@@ -634,7 +663,8 @@ class _NativeGamePlayerScreenState extends State<NativeGamePlayerScreen>
     double value,
   ) {
     final mapping = _controllerMappings[desktopControllerDeviceId(gamepadId)];
-    final bit = desktopBoundBit(mapping, trigger) ?? fallbackBit;
+    final bit =
+        desktopBoundBit(mapping, trigger, gameId: widget.gameId) ?? fallbackBit;
     // Keyed by pad too: two controllers resolve the same trigger to different
     // bits, and a shared key let one clear the bit the other was holding.
     final key = (gamepadId, trigger);
@@ -1939,10 +1969,11 @@ class _NativeGamePlayerScreenState extends State<NativeGamePlayerScreen>
     }
   }
 
-  String _controllerMappingsJson() => jsonEncode({
-    for (final entry in _controllerMappings.entries)
-      entry.key: jsonDecode(entry.value.toJson()),
-  });
+  /// Resolved for the current game here rather than natively, because the
+  /// Android parser reads one flat table per profile. Stick snap is resolved
+  /// the same way just below.
+  String _controllerMappingsJson() =>
+      controllerMappingsPayload(_controllerMappings, widget.gameId);
 
   /// Pushes the mappings to whatever applies them.
   ///
@@ -2162,15 +2193,15 @@ class _NativeGamePlayerScreenState extends State<NativeGamePlayerScreen>
         (device) => targetIds.contains(device.id),
       ))
         target.id:
-            NativeControllerMapping(
-              source.keycodeToButton,
-              controllerTypesByCore:
-                  _controllerMappings[target.id]?.controllerTypesByCore ??
-                  const {},
-              // Snap is per game and per controller; keep the target's own.
-              snapByGame:
-                  _controllerMappings[target.id]?.snapByGame ?? const {},
-            ).withControllerType(
+            (_controllerMappings[target.id] ?? NativeControllerMapping.empty)
+                // Copies the table the user is looking at, and scopes it to
+                // this game on the target too, so the copy cannot reach games
+                // the user was not looking at.
+                .withBindingsForGame(
+                  widget.gameId,
+                  source.bindingsForGame(widget.gameId),
+                )
+                .withControllerType(
               coreId,
               target.port != null &&
                       _isControllerTypeSupportedAtPort(

--- a/lib/util/native_controller_mapping.dart
+++ b/lib/util/native_controller_mapping.dart
@@ -93,10 +93,12 @@ class NativeControllerMapping {
     this.keycodeToButton, {
     this.controllerTypesByCore = const {},
     this.snapByGame = const {},
+    this.bindingsByGame = const {},
   });
 
   static const empty = NativeControllerMapping({});
 
+  /// The default bindings, used by any game without an override of its own.
   final Map<int, RetroPadButton> keycodeToButton;
 
   /// Explicit alternate layouts by canonical libretro core id. An absent entry
@@ -105,6 +107,13 @@ class NativeControllerMapping {
 
   /// Stick snap mode by game id; absent means [StickSnapMode.off].
   final Map<String, StickSnapMode> snapByGame;
+
+  /// Whole replacement binding tables by game id; an absent game inherits
+  /// [keycodeToButton].
+  ///
+  /// Replacement rather than an overlay because bindings are 1:1, and an
+  /// overlay cannot say "unbound here" without a tombstone concept.
+  final Map<String, Map<int, RetroPadButton>> bindingsByGame;
 
   /// Returns an independent immutable snapshot of this mapping.
   ///
@@ -117,6 +126,12 @@ class NativeControllerMapping {
       Map<String, int>.from(controllerTypesByCore),
     ),
     snapByGame: Map.unmodifiable(Map<String, StickSnapMode>.from(snapByGame)),
+    bindingsByGame: Map<String, Map<int, RetroPadButton>>.unmodifiable({
+      for (final entry in bindingsByGame.entries)
+        entry.key: Map<int, RetroPadButton>.unmodifiable(
+          Map<int, RetroPadButton>.from(entry.value),
+        ),
+    }),
   );
 
   factory NativeControllerMapping.fromJson(String json) {
@@ -126,18 +141,7 @@ class NativeControllerMapping {
       final sourceBindings = decoded['bindings'] is Map
           ? decoded['bindings'] as Map
           : decoded;
-      final bindings = <int, RetroPadButton>{};
-      for (final entry in sourceBindings.entries) {
-        final keycode = int.tryParse(entry.key.toString());
-        final buttonIndex = entry.value is num
-            ? (entry.value as num).toInt()
-            : int.tryParse(entry.value.toString());
-        if (keycode == null || buttonIndex == null) continue;
-        final button = RetroPadButton.values
-            .where((candidate) => candidate.retroPadIndex == buttonIndex)
-            .firstOrNull;
-        if (button != null) bindings[keycode] = button;
-      }
+      final bindings = _bindingsFrom(sourceBindings);
       final controllerTypes = <String, int>{};
       final rawTypes = decoded['controllerTypes'];
       if (rawTypes is Map) {
@@ -164,14 +168,49 @@ class NativeControllerMapping {
           }
         }
       }
+      final overrides = <String, Map<int, RetroPadButton>>{};
+      final rawOverrides = decoded['bindingsByGame'];
+      if (rawOverrides is Map) {
+        for (final entry in rawOverrides.entries) {
+          final gameId = entry.key.toString();
+          // A game whose table is unreadable falls back to the default rather
+          // than to no bindings at all.
+          if (gameId.isEmpty || entry.value is! Map) continue;
+          overrides[gameId] = Map<int, RetroPadButton>.unmodifiable(
+            _bindingsFrom(entry.value as Map),
+          );
+        }
+      }
       return NativeControllerMapping(
         Map.unmodifiable(bindings),
         controllerTypesByCore: Map.unmodifiable(controllerTypes),
         snapByGame: Map.unmodifiable(snaps),
+        bindingsByGame: Map<String, Map<int, RetroPadButton>>.unmodifiable(
+          overrides,
+        ),
       );
     } catch (_) {
       return empty;
     }
+  }
+
+  /// Reads a keycode->button table, skipping anything that is not one, which
+  /// is how the nonnumeric metadata keys fall out when this runs on the whole
+  /// document.
+  static Map<int, RetroPadButton> _bindingsFrom(Map source) {
+    final bindings = <int, RetroPadButton>{};
+    for (final entry in source.entries) {
+      final keycode = int.tryParse(entry.key.toString());
+      final buttonIndex = entry.value is num
+          ? (entry.value as num).toInt()
+          : int.tryParse(entry.value.toString());
+      if (keycode == null || buttonIndex == null) continue;
+      final button = RetroPadButton.values
+          .where((candidate) => candidate.retroPadIndex == buttonIndex)
+          .firstOrNull;
+      if (button != null) bindings[keycode] = button;
+    }
+    return bindings;
   }
 
   String toJson() => jsonEncode({
@@ -185,6 +224,14 @@ class NativeControllerMapping {
       'snapByGame': {
         for (final entry in snapByGame.entries) entry.key: entry.value.wireName,
       },
+    if (bindingsByGame.isNotEmpty)
+      'bindingsByGame': {
+        for (final entry in bindingsByGame.entries)
+          entry.key: {
+            for (final binding in entry.value.entries)
+              binding.key.toString(): binding.value.retroPadIndex,
+          },
+      },
   });
 
   NativeControllerMapping withBinding(int keycode, RetroPadButton button) {
@@ -196,8 +243,77 @@ class NativeControllerMapping {
       Map.unmodifiable(next),
       controllerTypesByCore: controllerTypesByCore,
       snapByGame: snapByGame,
+      bindingsByGame: bindingsByGame,
     );
   }
+
+  /// The bindings [gameId] actually plays with: its own table when it has one,
+  /// otherwise the default.
+  Map<int, RetroPadButton> bindingsForGame(String gameId) =>
+      bindingsByGame[gameId] ?? keycodeToButton;
+
+  /// Whether [gameId] has diverged from the default.
+  bool hasGameOverride(String gameId) => bindingsByGame.containsKey(gameId);
+
+  /// Binds within [gameId]'s own table, leaving every other game alone.
+  ///
+  /// The first edit copies the current default in, so buttons the user never
+  /// touched keep working. An empty [gameId] edits the default itself.
+  NativeControllerMapping withBindingForGame(
+    String gameId,
+    int keycode,
+    RetroPadButton button,
+  ) {
+    if (gameId.isEmpty) return withBinding(keycode, button);
+    final table = Map<int, RetroPadButton>.from(bindingsForGame(gameId));
+    // One physical key and one semantic button each have exactly one binding,
+    // within this game only.
+    table.removeWhere((_, current) => current == button);
+    table[keycode] = button;
+    return _withOverrides({
+      ...bindingsByGame,
+      gameId: Map<int, RetroPadButton>.unmodifiable(table),
+    });
+  }
+
+  /// Replaces [gameId]'s whole table with [bindings], for copy-to-all-pads and
+  /// reset. An empty [gameId] replaces the default instead.
+  NativeControllerMapping withBindingsForGame(
+    String gameId,
+    Map<int, RetroPadButton> bindings,
+  ) {
+    if (gameId.isEmpty) {
+      return NativeControllerMapping(
+        Map<int, RetroPadButton>.unmodifiable(bindings),
+        controllerTypesByCore: controllerTypesByCore,
+        snapByGame: snapByGame,
+        bindingsByGame: bindingsByGame,
+      );
+    }
+    return _withOverrides({
+      ...bindingsByGame,
+      gameId: Map<int, RetroPadButton>.unmodifiable(bindings),
+    });
+  }
+
+  /// Returns [gameId] to the default bindings.
+  NativeControllerMapping withoutGameOverride(String gameId) {
+    if (!bindingsByGame.containsKey(gameId)) return this;
+    final next = Map<String, Map<int, RetroPadButton>>.from(bindingsByGame)
+      ..remove(gameId);
+    return _withOverrides(next);
+  }
+
+  NativeControllerMapping _withOverrides(
+    Map<String, Map<int, RetroPadButton>> overrides,
+  ) => NativeControllerMapping(
+    keycodeToButton,
+    controllerTypesByCore: controllerTypesByCore,
+    snapByGame: snapByGame,
+    bindingsByGame: Map<String, Map<int, RetroPadButton>>.unmodifiable(
+      overrides,
+    ),
+  );
 
   int controllerTypeForCore(String coreId) =>
       controllerTypesByCore[coreId] ?? retroDeviceJoypad;
@@ -213,6 +329,7 @@ class NativeControllerMapping {
       keycodeToButton,
       controllerTypesByCore: Map.unmodifiable(next),
       snapByGame: snapByGame,
+      bindingsByGame: bindingsByGame,
     );
   }
 
@@ -230,6 +347,7 @@ class NativeControllerMapping {
       keycodeToButton,
       controllerTypesByCore: controllerTypesByCore,
       snapByGame: Map.unmodifiable(next),
+      bindingsByGame: bindingsByGame,
     );
   }
 }

--- a/test/ui/screens/playback/native_controller_mapping_screen_test.dart
+++ b/test/ui/screens/playback/native_controller_mapping_screen_test.dart
@@ -148,6 +148,21 @@ void main() {
           .withBindingsForGame(gameId, const {}),
     );
     expect(captionOf('Default layout'), findsOneWidget);
+
+    // Bindings saved before games had tables of their own. The row must not
+    // claim a game the user never touched, and a reset would still move it.
+    await show(NativeControllerMapping.empty.withBinding(96, RetroPadButton.a));
+    expect(captionOf('Customised for every game'), findsOneWidget);
+
+    // Another game's table says nothing about this one.
+    await show(
+      NativeControllerMapping.empty.withBindingForGame(
+        'burgertime',
+        96,
+        RetroPadButton.a,
+      ),
+    );
+    expect(captionOf('Default layout'), findsOneWidget);
   });
 
   testWidgets('reset returns this game to defaults and nothing else', (

--- a/test/ui/screens/playback/native_controller_mapping_screen_test.dart
+++ b/test/ui/screens/playback/native_controller_mapping_screen_test.dart
@@ -85,6 +85,227 @@ void main() {
     );
   }
 
+  testWidgets('the reset row says whether the buttons are stock or changed', (
+    tester,
+  ) async {
+    const gameId = 'hydro-thunder';
+    Widget harnessFor(NativeControllerMapping mapping) => MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            NativeControllerMappingScreen(
+              devices: const [deviceA],
+              mappings: {deviceA.id: mapping},
+              gameId: gameId,
+              onMappingChanged: (_, _) async {},
+              onClose: () {},
+            ),
+          ],
+        ),
+      ),
+    );
+
+    Future<void> show(NativeControllerMapping mapping) async {
+      await tester.pumpWidget(harnessFor(mapping));
+      await tester.pumpAndSettle();
+      await tester.scrollUntilVisible(
+        find.text('Reset this game to defaults'),
+        200,
+        scrollable: find.byType(Scrollable).last,
+      );
+      await tester.pumpAndSettle();
+    }
+
+    // 'Default layout' is also every unbound BUTTON row's subtitle, so scope
+    // the check to the reset row itself.
+    Finder captionOf(String text) => find.descendant(
+      of: find
+          .ancestor(
+            of: find.text('Reset this game to defaults'),
+            matching: find.byType(GestureDetector),
+          )
+          .first,
+      matching: find.text(text),
+    );
+
+    await show(NativeControllerMapping.empty);
+    expect(captionOf('Default layout'), findsOneWidget);
+
+    await show(
+      NativeControllerMapping.empty.withBindingForGame(
+        gameId,
+        96,
+        RetroPadButton.a,
+      ),
+    );
+    expect(captionOf('Customised for this game'), findsOneWidget);
+
+    // A reset stores an explicit empty table, which is still an entry. The row
+    // must report the buttons the user can see, not that bookkeeping.
+    await show(
+      NativeControllerMapping.empty
+          .withBindingForGame(gameId, 96, RetroPadButton.a)
+          .withBindingsForGame(gameId, const {}),
+    );
+    expect(captionOf('Default layout'), findsOneWidget);
+  });
+
+  testWidgets('reset returns this game to defaults and nothing else', (
+    tester,
+  ) async {
+    // The row says "this game", so it must not also throw away the pad's
+    // controller type for every core, its snap for every game, or another
+    // game's bindings -- which replacing the whole mapping with empty did.
+    const gameId = 'hydro-thunder';
+    final saved = NativeControllerMapping.empty
+        .withBindingForGame(gameId, 96, RetroPadButton.a)
+        .withBindingForGame('burgertime', 190, RetroPadButton.b)
+        .withSnap('burgertime', StickSnapMode.fourWay)
+        .withControllerType('fbneo', 5);
+    NativeControllerMapping? persisted;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              NativeControllerMappingScreen(
+                devices: const [deviceA],
+                mappings: {deviceA.id: saved},
+                gameId: gameId,
+                onMappingChanged: (_, mapping) async => persisted = mapping,
+                onClose: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Reset this game to defaults'),
+      200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset this game to defaults'));
+    await tester.pumpAndSettle();
+
+    // A reset cannot be undone, so it asks first and nothing has happened yet.
+    expect(find.text('Reset buttons'), findsOneWidget);
+    expect(persisted, isNull);
+
+    await tester.tap(find.text('Reset buttons'));
+    await tester.pumpAndSettle();
+
+    expect(persisted, isNotNull);
+    expect(persisted!.bindingsForGame(gameId), isEmpty);
+    expect(persisted!.bindingsForGame('burgertime')[190], RetroPadButton.b);
+    expect(persisted!.snapForGame('burgertime'), StickSnapMode.fourWay);
+    expect(persisted!.controllerTypeForCore('fbneo'), 5);
+  });
+
+  testWidgets('cancelling the reset confirmation changes nothing', (
+    tester,
+  ) async {
+    const gameId = 'hydro-thunder';
+    final saved = NativeControllerMapping.empty.withBindingForGame(
+      gameId,
+      96,
+      RetroPadButton.a,
+    );
+    var persistCalls = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              NativeControllerMappingScreen(
+                devices: const [deviceA],
+                mappings: {deviceA.id: saved},
+                gameId: gameId,
+                onMappingChanged: (_, _) async => persistCalls++,
+                onClose: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Reset this game to defaults'),
+      200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reset this game to defaults'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(persistCalls, 0);
+    // Back on the button list, with the mapping untouched.
+    expect(find.text('Reset this game to defaults'), findsOneWidget);
+  });
+
+  testWidgets('the reset confirmation is reachable with a controller', (
+    tester,
+  ) async {
+    // A Material dialog would strand a gamepad user here: this panel is driven
+    // by RetroPad indices, not focus traversal.
+    const gameId = 'hydro-thunder';
+    final key = GlobalKey<NativeControllerMappingScreenState>();
+    NativeControllerMapping? persisted;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              NativeControllerMappingScreen(
+                key: key,
+                devices: const [deviceA],
+                mappings: {
+                  deviceA.id: NativeControllerMapping.empty.withBindingForGame(
+                    gameId,
+                    96,
+                    RetroPadButton.a,
+                  ),
+                },
+                gameId: gameId,
+                onMappingChanged: (_, mapping) async => persisted = mapping,
+                onClose: () {},
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Reset this game to defaults'),
+      200,
+      scrollable: find.byType(Scrollable).last,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Reset this game to defaults'));
+    await tester.pumpAndSettle();
+    expect(find.text('Reset buttons'), findsOneWidget);
+
+    // Cancel is preselected, so moving once lands on Reset; 0 activates it.
+    key.currentState!.handleButton(4, true);
+    await tester.pump();
+    key.currentState!.handleButton(0, true);
+    await tester.pumpAndSettle();
+
+    expect(persisted, isNotNull);
+    expect(persisted!.bindingsForGame(gameId), isEmpty);
+  });
+
   testWidgets(
     'rebuild with a shorter device list clamps selection instead of throwing',
     (tester) async {

--- a/test/ui/screens/playback/native_game_player_screen_test.dart
+++ b/test/ui/screens/playback/native_game_player_screen_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -430,6 +431,61 @@ void main() {
       expect(desktopBoundBit(null, GamepadButton.leftTrigger), isNull);
     },
   );
+
+  group('the table handed to the native side', () {
+    // This payload IS what the core plays with. The mapping menu resolves the
+    // same way, so a regression here is invisible in the UI -- the menu would
+    // still show the right buttons while the game used the wrong ones.
+    const pad = 'android-p1';
+    const gameId = 'hydro-thunder';
+    final mapping = NativeControllerMapping.empty
+        .withBinding(96, RetroPadButton.a)
+        .withBindingForGame(gameId, 190, RetroPadButton.a)
+        .withControllerType('fbneo', 5)
+        .withSnap(gameId, StickSnapMode.fourWay);
+
+    test('sends the current game own table, not the default', () {
+      final sent =
+          jsonDecode(controllerMappingsPayload({pad: mapping}, gameId))
+              as Map<String, dynamic>;
+
+      expect(sent[pad], {'190': RetroPadButton.a.retroPadIndex});
+    });
+
+    test('sends the default for a game that has not diverged', () {
+      final sent =
+          jsonDecode(controllerMappingsPayload({pad: mapping}, 'burgertime'))
+              as Map<String, dynamic>;
+
+      expect(sent[pad], {'96': RetroPadButton.a.retroPadIndex});
+    });
+
+    test('sends a table for every connected profile', () {
+      final sent =
+          jsonDecode(
+                controllerMappingsPayload({
+                  pad: mapping,
+                  'android-p2': NativeControllerMapping.empty
+                      .withBindingForGame(gameId, 191, RetroPadButton.b),
+                }, gameId),
+              )
+              as Map<String, dynamic>;
+
+      expect(sent.keys, containsAll(<String>[pad, 'android-p2']));
+      expect(sent['android-p2'], {'191': RetroPadButton.b.retroPadIndex});
+    });
+
+    test('emits keycodes only, no metadata the parser would skip', () {
+      final sent =
+          jsonDecode(controllerMappingsPayload({pad: mapping}, gameId))
+              as Map<String, dynamic>;
+
+      final keys = (sent[pad] as Map<String, dynamic>).keys;
+      expect(keys.every((key) => int.tryParse(key) != null), isTrue);
+      expect(keys, isNot(contains('controllerTypes')));
+      expect(keys, isNot(contains('snapByGame')));
+    });
+  });
 
   test('a rebound trigger resolves to the button it was bound to', () {
     final mapping = NativeControllerMapping(const {

--- a/test/util/native_controller_mapping_test.dart
+++ b/test/util/native_controller_mapping_test.dart
@@ -9,6 +9,7 @@ import 'package:moonfin/util/native_controller_mapping.dart';
 
 void main() {
   _dataLossGuardTests();
+  _perGameBindingTests();
   test('round-trips through JSON', () {
     const mapping = NativeControllerMapping({
       96: RetroPadButton.a,
@@ -247,4 +248,251 @@ void _dataLossGuardTests() {
       expect(restored.snapForGame('g'), StickSnapMode.off);
     });
   });
+}
+
+/// Bindings are a global default per controller, overridable per game.
+///
+/// They used to be global ONLY, so remapping a button while playing
+/// one game silently rewrote every other game's bindings -- and withBinding's
+/// 1:1 rule DELETED the key the other game had on that button.
+void _perGameBindingTests() {
+  group('per-game bindings', () {
+    const global = NativeControllerMapping({
+      96: RetroPadButton.a,
+      97: RetroPadButton.b,
+    });
+
+    test('a game with no override of its own uses the global default', () {
+      expect(global.bindingsForGame('hydro-thunder'), global.keycodeToButton);
+      expect(global.hasGameOverride('hydro-thunder'), isFalse);
+    });
+
+    test('editing one game leaves another game untouched', () {
+      final edited = global.withBindingForGame(
+        'burgertime',
+        190,
+        RetroPadButton.a,
+      );
+
+      expect(edited.bindingsForGame('burgertime')[190], RetroPadButton.a);
+      expect(edited.bindingsForGame('burgertime')[96], isNull);
+      // The whole point: Hydro Thunder still has its own A on keycode 96.
+      expect(edited.bindingsForGame('hydro-thunder')[96], RetroPadButton.a);
+      expect(edited.bindingsForGame('hydro-thunder')[190], isNull);
+    });
+
+    test('the first edit inherits the global default, then diverges', () {
+      final edited = global.withBindingForGame(
+        'burgertime',
+        190,
+        RetroPadButton.x,
+      );
+
+      // B was never touched for this game, so it came across from the default.
+      expect(edited.bindingsForGame('burgertime')[97], RetroPadButton.b);
+      expect(edited.bindingsForGame('burgertime')[190], RetroPadButton.x);
+    });
+
+    test('a per-game edit never rewrites the global default', () {
+      final edited = global.withBindingForGame(
+        'burgertime',
+        190,
+        RetroPadButton.a,
+      );
+
+      expect(edited.keycodeToButton, global.keycodeToButton);
+      // A game added later still inherits the untouched default.
+      expect(edited.bindingsForGame('spy-hunter')[96], RetroPadButton.a);
+    });
+
+    test('1:1 replacement applies within the game, not across games', () {
+      final edited = global
+          .withBindingForGame('burgertime', 190, RetroPadButton.a)
+          .withBindingForGame('burgertime', 191, RetroPadButton.a);
+
+      expect(edited.bindingsForGame('burgertime')[190], isNull);
+      expect(edited.bindingsForGame('burgertime')[191], RetroPadButton.a);
+      expect(edited.bindingsForGame('hydro-thunder')[96], RetroPadButton.a);
+    });
+
+    test('an empty game id edits the global default', () {
+      final edited = global.withBindingForGame('', 190, RetroPadButton.a);
+
+      expect(edited.keycodeToButton[190], RetroPadButton.a);
+      expect(edited.bindingsByGame, isEmpty);
+    });
+
+    test('dropping an override returns the game to the default', () {
+      final edited = global.withBindingForGame(
+        'burgertime',
+        190,
+        RetroPadButton.a,
+      );
+
+      final reset = edited.withoutGameOverride('burgertime');
+
+      expect(reset.hasGameOverride('burgertime'), isFalse);
+      expect(reset.bindingsForGame('burgertime'), global.keycodeToButton);
+    });
+
+    test('round-trips overrides through JSON', () {
+      final mapping = global
+          .withBindingForGame('burgertime', 190, RetroPadButton.a)
+          .withSnap('burgertime', StickSnapMode.fourWay)
+          .withControllerType('fbneo', 5);
+
+      final restored = NativeControllerMapping.fromJson(mapping.toJson());
+
+      expect(restored.keycodeToButton, global.keycodeToButton);
+      expect(restored.bindingsForGame('burgertime')[190], RetroPadButton.a);
+      expect(restored.bindingsForGame('hydro-thunder')[96], RetroPadButton.a);
+      expect(restored.snapForGame('burgertime'), StickSnapMode.fourWay);
+      expect(restored.controllerTypeForCore('fbneo'), 5);
+    });
+
+    test('a document written before overrides existed still loads', () {
+      final restored = NativeControllerMapping.fromJson(
+        '{"96":0,"97":1,"controllerTypes":{"fbneo":5}}',
+      );
+
+      // Every game inherits what the user had, so nobody loses a mapping on
+      // the upgrade; the first per-game edit is what starts the divergence.
+      expect(restored.bindingsForGame('hydro-thunder')[96], RetroPadButton.a);
+      expect(restored.bindingsByGame, isEmpty);
+    });
+
+    test('no overrides means no bindingsByGame key on the wire', () {
+      expect(global.toJson().contains('bindingsByGame'), isFalse);
+    });
+
+    test('a malformed override is dropped, not fatal', () {
+      final restored = NativeControllerMapping.fromJson(
+        '{"96":0,"bindingsByGame":{"g":"nonsense","h":{"190":0}}}',
+      );
+
+      expect(restored.hasGameOverride('g'), isFalse);
+      expect(restored.bindingsForGame('h')[190], RetroPadButton.a);
+    });
+
+    test('withBindingsForGame replaces only that game, not the default', () {
+      final copied = global.withBindingsForGame('burgertime', {
+        190: RetroPadButton.a,
+      });
+
+      expect(copied.bindingsForGame('burgertime'), {190: RetroPadButton.a});
+      expect(copied.keycodeToButton, global.keycodeToButton);
+      expect(copied.bindingsForGame('hydro-thunder')[96], RetroPadButton.a);
+    });
+
+    test('the reported Hydro Thunder sequence, through the save layer', () async {
+      // The owner's report, step for step: map a pad while playing one game,
+      // play others and remap there, come back. Runs against the real save
+      // and load helpers so the wire format is what carries the guarantee,
+      // not just the in-memory model.
+      final api = _InMemoryGamesApi();
+      const pad = 'android-abc';
+      const hydroThunder = 'hydro-thunder';
+      const burgerTime = 'burgertime';
+
+      await saveControllerMapping(
+        api,
+        pad,
+        NativeControllerMapping.empty.withBindingForGame(
+          hydroThunder,
+          96,
+          RetroPadButton.a,
+        ),
+      );
+
+      // A different game, a different session: load, remap, save.
+      final inBurgerTime = await loadControllerMapping(api, pad);
+      await saveControllerMapping(
+        api,
+        pad,
+        inBurgerTime.withBindingForGame(burgerTime, 190, RetroPadButton.a),
+      );
+
+      // Back in Hydro Thunder via Continue.
+      final back = await loadControllerMapping(api, pad);
+
+      expect(
+        back.bindingsForGame(hydroThunder)[96],
+        RetroPadButton.a,
+        reason: 'remapping in another game must not clear this one',
+      );
+      expect(back.bindingsForGame(burgerTime)[190], RetroPadButton.a);
+      expect(back.bindingsForGame(burgerTime)[96], isNull);
+    });
+
+    test('every controller keeps its own mapping for the same game', () async {
+      // A game is set up with more than one pad. Each controller's mapping for
+      // that game must survive on its own: P2's edit must not disturb P1, and
+      // neither may reach the other games either pad plays.
+      final api = _InMemoryGamesApi();
+      const gameId = 'hydro-thunder';
+
+      for (final pad in ['android-p1', 'android-p2']) {
+        await saveControllerMapping(
+          api,
+          pad,
+          NativeControllerMapping.empty.withBindingForGame(
+            'burgertime',
+            190,
+            RetroPadButton.y,
+          ),
+        );
+      }
+
+      // Both pads get mapped for this game, in the order the user does it.
+      for (final entry in {'android-p1': 96, 'android-p2': 97}.entries) {
+        final current = await loadControllerMapping(api, entry.key);
+        await saveControllerMapping(
+          api,
+          entry.key,
+          current.withBindingForGame(gameId, entry.value, RetroPadButton.a),
+        );
+      }
+
+      final p1 = await loadControllerMapping(api, 'android-p1');
+      final p2 = await loadControllerMapping(api, 'android-p2');
+
+      expect(p1.bindingsForGame(gameId), {96: RetroPadButton.a});
+      expect(p2.bindingsForGame(gameId), {97: RetroPadButton.a});
+      // Neither pad's other game was touched by setting this one up.
+      expect(p1.bindingsForGame('burgertime')[190], RetroPadButton.y);
+      expect(p2.bindingsForGame('burgertime')[190], RetroPadButton.y);
+      // And the two pads are separate documents, not one shared one.
+      expect(api.saves.keys, hasLength(2));
+    });
+
+    test('copy keeps overrides independent of the source', () {
+      final source = global.withBindingForGame(
+        'burgertime',
+        190,
+        RetroPadButton.a,
+      );
+
+      final copy = source.copy();
+
+      expect(copy.bindingsForGame('burgertime')[190], RetroPadButton.a);
+      expect(
+        () => (copy.bindingsByGame as Map)['x'] = <int, RetroPadButton>{},
+        throwsUnsupportedError,
+      );
+    });
+  });
+}
+
+/// A GamesApi that really stores what it is given, so a test can assert on the
+/// document that survives a save/load round trip.
+class _InMemoryGamesApi extends Mock implements GamesApi {
+  final Map<String, List<int>> saves = {};
+
+  @override
+  Future<List<int>?> getSave(String id, {String? kind}) async => saves[id];
+
+  @override
+  Future<void> putSave(String id, List<int> bytes, {String? kind}) async {
+    saves[id] = bytes;
+  }
 }


### PR DESCRIPTION
# Pull Request

## Summary
Fixing one of my own bugs/misses. Controller mappings clobber each other between games and systems on native core gameplay. Fix to preserve that and controller mappings reset function cleanup to make it clear what it is you are resetting. EmulatorJS is untouched.

Also added an indicator showing IF they have been customized or not.

## Type of Change
- [X] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

Change to support persistence of controller mappings and associated tests to validate and guard against regression(s) for native core gameplay.

## Platform
- [X] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

## Screenshots (if applicable)

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/d598fe7d-6f0b-42e0-9827-de8a84275e5f" />


<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/a7a7e697-4c66-424a-9297-9906e013dc96" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
