### PR TITLE
(fix) Allow selection of popup menu items on livetv overlay

### DIFF
--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -802,7 +802,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
     setState(() => _infoVisible = true);
     if (PlatformDetection.isTV) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted || !_infoVisible) return;
+        if (!mounted || !_infoVisible || _isOverlayInteractionActive) return;
         _tvPlayPauseFocus.requestFocus();
       });
     }


### PR DESCRIPTION
# Pull Request

## Summary
When tuning a live tv channel when you bring up the track overlay, you can select the menus like subtitles, audio etc... but the focus of the dpad remote movement remains in the background.....leaving you unable to select anything in the menu. 

Interestingly, if you use ADB live screen mirroring on the real device, you can mouse click the menu option and it will work. Arrows nor the remote dpad will. 

This fixes that.  _(and will probably be my smallest PR ever). 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
Added 31 characters to a conditional (OR):  || _isOverlayInteractionActive

## Platform
- [X] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Tune live tv channel
2. Bring up overlay
3. Try to change subtitles with the remote

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
