### PR TITLE
(fix) Retro games. Tweaks to controllers. Remote Control/Analog.

### DIFF
--- a/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/MainActivity.kt
@@ -768,6 +768,16 @@ class MainActivity : AudioServiceActivity(), GamepadsCompatibleActivity {
         return super.dispatchGenericMotionEvent(event)
     }
 
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (!hasFocus) nativePad?.releaseHeldInput()
+    }
+
+    override fun onPause() {
+        nativePad?.releaseHeldInput()
+        super.onPause()
+    }
+
     // The axis is "h" or "v" so Dart can tell which one a "none" recentre came
     // from. Without it, releasing a diagonal is ambiguous.
     private fun sendGamepadNavigate(axis: String, direction: String) {

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/NativePadInput.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/NativePadInput.kt
@@ -373,14 +373,10 @@ internal class NativePadInput(
             SWALLOW -> return true
             else -> {
                 val bit = 1 shl index
-                if (event.action == KeyEvent.ACTION_DOWN) {
-                    releaseLostHolds(state, index, bit)
-                }
-                state.keyMask = NativeDigitalKeyState.transition(
-                    state.keyMask,
-                    bit,
-                    event.action == KeyEvent.ACTION_DOWN,
-                )
+                val pressed = event.action == KeyEvent.ACTION_DOWN
+                if (pressed) releaseLostHolds(state, index, bit)
+                state.keyMask =
+                    NativeDigitalKeyState.transition(state.keyMask, bit, pressed)
                 publishMask(state)
             }
         }
@@ -865,7 +861,7 @@ internal class NativePadInput(
     }
 
     private fun analogMoved(new: Int, old: Int): Boolean =
-        analogMovedPastSendBaseline(new, old, ANALOG_MIN_SEND_DELTA)
+        analogMovedPastSendBaseline(new, old)
 
     private fun updateComposedMask(state: PadState): Int =
         if (state === keyboardState) maskComposer.setKeyboard(state.sentMask)
@@ -987,10 +983,6 @@ internal class NativePadInput(
         // low hundreds), so a stored binding can never collide with one.
         const val SYNTHETIC_KEYCODE_L2 = NativeMappingTables.SYNTHETIC_KEYCODE_L2
         const val SYNTHETIC_KEYCODE_R2 = NativeMappingTables.SYNTHETIC_KEYCODE_R2
-        // Minimum accumulated change from the last value sent to the core.
-        // About 0.4% of the int16 analog range: enough to filter sensor noise
-        // without losing gradual movement.
-        const val ANALOG_MIN_SEND_DELTA = 128
         // Every 64th publishPadState call re-reads analogDescriptorPorts. Chosen
         // to be cheap even at Gauntlet's measured ~56 ANALOG queries/frame
         // (an unrelated, much hotter path) while still reacting within a
@@ -1040,12 +1032,14 @@ internal object NativePadStateGuard {
         state === keyboardState || registeredState === state
 }
 
+// Minimum accumulated change from the last value sent to the core. About 0.4%
+// of the int16 analog range: enough to filter sensor noise without losing
+// gradual movement. Top level so the test can name it.
+internal const val ANALOG_MIN_SEND_DELTA = 128
+
 /** True once movement has accumulated far enough from the last value sent. */
-internal fun analogMovedPastSendBaseline(
-    new: Int,
-    lastSent: Int,
-    minSendDelta: Int = 128,
-): Boolean = abs(new - lastSent) > minSendDelta
+internal fun analogMovedPastSendBaseline(new: Int, lastSent: Int): Boolean =
+    abs(new - lastSent) > ANALOG_MIN_SEND_DELTA
 
 internal object NativeKeyEventPolicy {
     fun shouldIgnoreRepeat(action: Int, repeatCount: Int): Boolean =

--- a/android/app/src/main/kotlin/org/moonfin/androidtv/NativePadInput.kt
+++ b/android/app/src/main/kotlin/org/moonfin/androidtv/NativePadInput.kt
@@ -297,9 +297,22 @@ internal class NativePadInput(
         // on purpose -- never bindable either. Reordering this below capture
         // would let a rebind strand a user with no way out.
         if (keyCode == KeyEvent.KEYCODE_BACK || isVolumeKey(keyCode)) return false
-        if (event.repeatCount != 0) return true
+        if (NativeKeyEventPolicy.shouldIgnoreRepeat(event.action, event.repeatCount)) return true
 
         val connection = registry.connection(event.deviceId)
+        // Android TV implementations can cancel the currently-held remote DPAD
+        // KeyEvent when another button is dispatched, even though the DPAD switch
+        // remains physically down. A genuine ACTION_UP follows when the user
+        // eventually releases the direction. Actual focus/lifecycle loss clears
+        // every held mask in MainActivity, so ignoring this canceled edge cannot
+        // strand movement if Android never delivers that final physical release.
+        if (NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
+                action = event.action,
+                canceled = event.isCanceled,
+                keyCode = keyCode,
+                isRemote = connection?.deviceClass == NativeInputDeviceClass.REMOTE,
+            )
+        ) return true
         // Observation only: computed before any consuming branch below and
         // never gates a return, so it can never bind or swallow anything.
         emitDiagnosticsButtonIfMatching(connection, event)
@@ -362,10 +375,12 @@ internal class NativePadInput(
                 val bit = 1 shl index
                 if (event.action == KeyEvent.ACTION_DOWN) {
                     releaseLostHolds(state, index, bit)
-                    state.keyMask = state.keyMask or bit
-                } else {
-                    state.keyMask = state.keyMask and bit.inv()
                 }
+                state.keyMask = NativeDigitalKeyState.transition(
+                    state.keyMask,
+                    bit,
+                    event.action == KeyEvent.ACTION_DOWN,
+                )
                 publishMask(state)
             }
         }
@@ -800,7 +815,7 @@ internal class NativePadInput(
      * Analog counterpart of [publishMask]: sends through
      * [LibretroBridge.onPadState] instead of the mask-only path, but only
      * when the mask changed or an analog value moved by more than
-     * [ANALOG_SEND_EPSILON], so a resting stick does not cross JNI on every
+     * [ANALOG_MIN_SEND_DELTA], so a resting stick does not cross JNI on every
      * motion event.
      */
     private fun publishPadState(
@@ -823,13 +838,17 @@ internal class NativePadInput(
         val analogChanged = analogMoved(lx, state.analogLx) || analogMoved(ly, state.analogLy) ||
             analogMoved(rx, state.analogRx) || analogMoved(ry, state.analogRy) ||
             analogMoved(trigL, state.trigL) || analogMoved(trigR, state.trigR)
+        if (!maskChanged && !analogChanged) return
+        // These fields are the last state sent to the core, not the most
+        // recent Android sample. Keeping a suppressed sample here would make
+        // several small movements compare only with their immediate
+        // predecessor, so they could never accumulate past the minimum send delta.
         state.analogLx = lx
         state.analogLy = ly
         state.analogRx = rx
         state.analogRy = ry
         state.trigL = trigL
         state.trigR = trigR
-        if (!maskChanged && !analogChanged) return
         val combined = if (maskChanged) {
             state.sentMask = desiredMask
             updateComposedMask(state)
@@ -845,7 +864,8 @@ internal class NativePadInput(
         }
     }
 
-    private fun analogMoved(new: Int, old: Int): Boolean = abs(new - old) > ANALOG_SEND_EPSILON
+    private fun analogMoved(new: Int, old: Int): Boolean =
+        analogMovedPastSendBaseline(new, old, ANALOG_MIN_SEND_DELTA)
 
     private fun updateComposedMask(state: PadState): Int =
         if (state === keyboardState) maskComposer.setKeyboard(state.sentMask)
@@ -967,11 +987,10 @@ internal class NativePadInput(
         // low hundreds), so a stored binding can never collide with one.
         const val SYNTHETIC_KEYCODE_L2 = NativeMappingTables.SYNTHETIC_KEYCODE_L2
         const val SYNTHETIC_KEYCODE_R2 = NativeMappingTables.SYNTHETIC_KEYCODE_R2
-        // ~1/255 in int16 terms (32767/255 ≈ 128): the finest step the pads
-        // actually report, per the design doc's measured 8-bit resolution.
-        // A resting stick's rounding noise stays under this, a real move does
-        // not, so this is what gates crossing JNI on every motion event.
-        const val ANALOG_SEND_EPSILON = 128
+        // Minimum accumulated change from the last value sent to the core.
+        // About 0.4% of the int16 analog range: enough to filter sensor noise
+        // without losing gradual movement.
+        const val ANALOG_MIN_SEND_DELTA = 128
         // Every 64th publishPadState call re-reads analogDescriptorPorts. Chosen
         // to be cheap even at Gauntlet's measured ~56 ANALOG queries/frame
         // (an unrelated, much hotter path) while still reacting within a
@@ -1019,6 +1038,38 @@ internal class NativePadInput(
 internal object NativePadStateGuard {
     fun isCurrent(state: Any, keyboardState: Any, registeredState: Any?): Boolean =
         state === keyboardState || registeredState === state
+}
+
+/** True once movement has accumulated far enough from the last value sent. */
+internal fun analogMovedPastSendBaseline(
+    new: Int,
+    lastSent: Int,
+    minSendDelta: Int = 128,
+): Boolean = abs(new - lastSent) > minSendDelta
+
+internal object NativeKeyEventPolicy {
+    fun shouldIgnoreRepeat(action: Int, repeatCount: Int): Boolean =
+        action == KeyEvent.ACTION_DOWN && repeatCount != 0
+
+    fun shouldIgnoreCanceledRemoteDpadRelease(
+        action: Int,
+        canceled: Boolean,
+        keyCode: Int,
+        isRemote: Boolean,
+    ): Boolean =
+        isRemote && canceled && action == KeyEvent.ACTION_UP && keyCode in DPAD_DIRECTIONS
+
+    private val DPAD_DIRECTIONS = setOf(
+        KeyEvent.KEYCODE_DPAD_UP,
+        KeyEvent.KEYCODE_DPAD_DOWN,
+        KeyEvent.KEYCODE_DPAD_LEFT,
+        KeyEvent.KEYCODE_DPAD_RIGHT,
+    )
+}
+
+internal object NativeDigitalKeyState {
+    fun transition(mask: Int, bit: Int, pressed: Boolean): Int =
+        if (pressed) mask or bit else mask and bit.inv()
 }
 
 /**

--- a/android/app/src/test/kotlin/org/moonfin/androidtv/AnalogSendBaselineTest.kt
+++ b/android/app/src/test/kotlin/org/moonfin/androidtv/AnalogSendBaselineTest.kt
@@ -15,8 +15,12 @@ class AnalogSendBaselineTest {
             return publish
         }
 
-        assertFalse(offer(52))
-        assertFalse(offer(103))
-        assertTrue(offer(154))
+        // Steps too small to publish on their own, so each one only counts
+        // because the baseline stayed where the core last saw it.
+        val step = ANALOG_MIN_SEND_DELTA / 2
+        assertFalse(offer(step))
+        // Exactly the delta is still not past it.
+        assertFalse(offer(step * 2))
+        assertTrue(offer(step * 3))
     }
 }

--- a/android/app/src/test/kotlin/org/moonfin/androidtv/AnalogSendBaselineTest.kt
+++ b/android/app/src/test/kotlin/org/moonfin/androidtv/AnalogSendBaselineTest.kt
@@ -1,0 +1,22 @@
+package org.moonfin.androidtv
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnalogSendBaselineTest {
+    @Test
+    fun `sub-threshold samples accumulate against the last sent value`() {
+        var lastSent = 0
+
+        fun offer(value: Int): Boolean {
+            val publish = analogMovedPastSendBaseline(value, lastSent)
+            if (publish) lastSent = value
+            return publish
+        }
+
+        assertFalse(offer(52))
+        assertFalse(offer(103))
+        assertTrue(offer(154))
+    }
+}

--- a/android/app/src/test/kotlin/org/moonfin/androidtv/NativeKeyStateTest.kt
+++ b/android/app/src/test/kotlin/org/moonfin/androidtv/NativeKeyStateTest.kt
@@ -29,21 +29,17 @@ class NativeKeyStateTest {
 
     @Test
     fun `another remote button cannot cancel a physically held direction`() {
-        val left = 1 shl NativeMappingTables.RETRO_LEFT
-        var mask = NativeDigitalKeyState.transition(0, left, pressed = true)
-
-        val ignoreCanceledRelease = NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
-            action = KeyEvent.ACTION_UP,
-            canceled = true,
-            keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
-            isRemote = true,
+        assertTrue(
+            NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
+                action = KeyEvent.ACTION_UP,
+                canceled = true,
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                isRemote = true,
+            ),
         )
-        if (!ignoreCanceledRelease) {
-            mask = NativeDigitalKeyState.transition(mask, left, pressed = false)
-        }
-        assertTrue(ignoreCanceledRelease)
-        assertEquals(left, mask)
 
+        // The release the user actually makes still comes through, so a
+        // direction cannot be left held.
         assertFalse(
             NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
                 action = KeyEvent.ACTION_UP,

--- a/android/app/src/test/kotlin/org/moonfin/androidtv/NativeKeyStateTest.kt
+++ b/android/app/src/test/kotlin/org/moonfin/androidtv/NativeKeyStateTest.kt
@@ -1,0 +1,64 @@
+package org.moonfin.androidtv
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeKeyStateTest {
+    @Test
+    fun `releasing a face button preserves a held direction`() {
+        val left = 1 shl NativeMappingTables.RETRO_LEFT
+        val a = 1 shl NativeMappingTables.RETRO_A
+
+        var mask = NativeDigitalKeyState.transition(0, left, pressed = true)
+        mask = NativeDigitalKeyState.transition(mask, a, pressed = true)
+        assertEquals(left or a, mask)
+
+        mask = NativeDigitalKeyState.transition(mask, a, pressed = false)
+        assertEquals(left, mask)
+    }
+
+    @Test
+    fun `only repeated down events are ignored`() {
+        assertTrue(NativeKeyEventPolicy.shouldIgnoreRepeat(KeyEvent.ACTION_DOWN, repeatCount = 1))
+        assertFalse(NativeKeyEventPolicy.shouldIgnoreRepeat(KeyEvent.ACTION_DOWN, repeatCount = 0))
+        assertFalse(NativeKeyEventPolicy.shouldIgnoreRepeat(KeyEvent.ACTION_UP, repeatCount = 1))
+    }
+
+    @Test
+    fun `another remote button cannot cancel a physically held direction`() {
+        val left = 1 shl NativeMappingTables.RETRO_LEFT
+        var mask = NativeDigitalKeyState.transition(0, left, pressed = true)
+
+        val ignoreCanceledRelease = NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
+            action = KeyEvent.ACTION_UP,
+            canceled = true,
+            keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+            isRemote = true,
+        )
+        if (!ignoreCanceledRelease) {
+            mask = NativeDigitalKeyState.transition(mask, left, pressed = false)
+        }
+        assertTrue(ignoreCanceledRelease)
+        assertEquals(left, mask)
+
+        assertFalse(
+            NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
+                action = KeyEvent.ACTION_UP,
+                canceled = false,
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                isRemote = true,
+            ),
+        )
+        assertFalse(
+            NativeKeyEventPolicy.shouldIgnoreCanceledRemoteDpadRelease(
+                action = KeyEvent.ACTION_UP,
+                canceled = true,
+                keyCode = KeyEvent.KEYCODE_DPAD_LEFT,
+                isRemote = false,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary
A couple of fairly minor issues:

Fixes an issue discovered when using a remote control for gameplay for native core. Holding the dpad in a direction then pressing a button (e.g. fire) stops the dpad input. 

As part of that discovered a "math" issue with analog stick values. This change adds more precision, theoretically anyways, and is more correct. 

Also added supporting tests. 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Platform
- [X] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):



## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
