### PR TITLE
feat-ui - The Case of the Missing Chevrons

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -26,6 +26,7 @@ import '../../../../util/focus/dpad_keys.dart';
 import '../../../../util/focus/focus_scroll.dart';
 import '../../../navigation/destinations.dart';
 import '../../../navigation/playback_launcher.dart';
+import '../../../widgets/horizontal_scroll_section.dart';
 import '../../../widgets/logo_view.dart';
 import '../../../widgets/marquee_text.dart';
 import '../../../widgets/media_card.dart';
@@ -1525,28 +1526,30 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
-  Widget _castTab(BuildContext context, AggregatedItem item) => SizedBox(
-        height: 200,
-        child: Focus(
-          canRequestFocus: false,
-          onFocusChange: (focused) {
-            if (focused && mounted) {
-              widget.onToggleNavbar?.call(false);
-            } else if (!focused && mounted) {
-              widget.onToggleNavbar?.call(true);
-            }
-          },
-          onKeyEvent: (node, event) {
-            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-              _focusSelectedTab();
-              return KeyEventResult.handled;
-            }
-            return KeyEventResult.ignored;
-          },
-          child: DetailCastRow(
+  Widget _castTab(BuildContext context, AggregatedItem item) => Focus(
+        canRequestFocus: false,
+        onFocusChange: (focused) {
+          if (focused && mounted) {
+            widget.onToggleNavbar?.call(false);
+          } else if (!focused && mounted) {
+            widget.onToggleNavbar?.call(true);
+          }
+        },
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: HorizontalScrollSection(
+          title: '',
+          contentSpacing: 0,
+          builder: (context, controller) => DetailCastRow(
             people: _vm.actors,
             imageApi: _vm.imageApi,
             serverId: item.serverId,
+            scrollController: controller,
             firstItemFocusNode: _castFirstFocusNode,
             onNavigateUp: _focusSelectedTab,
             onItemKeyEvent: (index, event) {
@@ -1610,28 +1613,30 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       };
     }).toList();
 
-    return SizedBox(
-      height: 200,
-      child: Focus(
-        canRequestFocus: false,
-        onFocusChange: (focused) {
-          if (focused && mounted) {
-            widget.onToggleNavbar?.call(false);
-          } else if (!focused && mounted) {
-            widget.onToggleNavbar?.call(true);
-          }
-        },
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: DetailCastRow(
+    return Focus(
+      canRequestFocus: false,
+      onFocusChange: (focused) {
+        if (focused && mounted) {
+          widget.onToggleNavbar?.call(false);
+        } else if (!focused && mounted) {
+          widget.onToggleNavbar?.call(true);
+        }
+      },
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => DetailCastRow(
           people: crew,
           imageApi: _vm.imageApi,
           serverId: item.serverId,
+          scrollController: controller,
           firstItemFocusNode: _crewFirstFocusNode,
           onNavigateUp: _focusSelectedTab,
           onItemKeyEvent: (index, event) {
@@ -1792,12 +1797,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   );
                 }
               },
-              child: SizedBox(
-                height: 200,
-                child: DetailCastRow(
+              child: HorizontalScrollSection(
+                title: '',
+                contentSpacing: 0,
+                builder: (context, controller) => DetailCastRow(
                   people: childActors,
                   imageApi: _vm.imageApi,
                   serverId: childItem.serverId,
+                  scrollController: controller,
                   firstItemFocusNode: rowFirstNode,
                   onNavigateUp: () {
                     headingNode.requestFocus();
@@ -2041,12 +2048,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   );
                 }
               },
-              child: SizedBox(
-                height: 200,
-                child: DetailCastRow(
+              child: HorizontalScrollSection(
+                title: '',
+                contentSpacing: 0,
+                builder: (context, controller) => DetailCastRow(
                   people: childCrew,
                   imageApi: _vm.imageApi,
                   serverId: childItem.serverId,
+                  scrollController: controller,
                   firstItemFocusNode: rowFirstNode,
                   onNavigateUp: () {
                     headingNode.requestFocus();
@@ -2158,87 +2167,92 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     return Padding(
       padding: const EdgeInsets.only(top: 8),
-      child: SizedBox(
-        height: cardHeight + 20,
-        child: Focus(
-          canRequestFocus: false,
-          onFocusChange: (focused) {
-            if (focused && mounted) {
-              widget.onToggleNavbar?.call(false);
-            } else if (!focused && mounted) {
-              widget.onToggleNavbar?.call(true);
-            }
-          },
-          onKeyEvent: (node, event) {
-            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-              _focusSelectedTab();
-              return KeyEventResult.handled;
-            }
-            return KeyEventResult.ignored;
-          },
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            clipBehavior: Clip.none,
-            itemCount: studios.length,
-            separatorBuilder: (_, _) => const SizedBox(width: 16),
-            itemBuilder: (context, index) {
-              final studio = studios[index];
-              final name = studio.name;
-              final imageUrl = studio.logoUrl;
+      child: Focus(
+        canRequestFocus: false,
+        onFocusChange: (focused) {
+          if (focused && mounted) {
+            widget.onToggleNavbar?.call(false);
+          } else if (!focused && mounted) {
+            widget.onToggleNavbar?.call(true);
+          }
+        },
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: HorizontalScrollSection(
+          title: '',
+          contentSpacing: 0,
+          builder: (context, controller) => SizedBox(
+            height: cardHeight + 20,
+            child: ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              clipBehavior: Clip.none,
+              itemCount: studios.length,
+              separatorBuilder: (_, _) => const SizedBox(width: 16),
+              itemBuilder: (context, index) {
+                final studio = studios[index];
+                final name = studio.name;
+                final imageUrl = studio.logoUrl;
 
-              return FocusableWrapper(
-                focusNode: index == 0 ? _studiosFirstFocusNode : null,
-                onSelect: name.isNotEmpty
-                    ? () => context.push(Destinations.studio(name))
-                    : null,
-                borderRadius: 12,
-                suppressFocusGlow: true,
-                onNavigateUp: _focusSelectedTab,
-                onNavigateRight: index == studios.length - 1 ? () {} : null,
-                child: Container(
-                  width: cardWidth,
-                  height: cardHeight,
-                  decoration: BoxDecoration(
-                    borderRadius: AppRadius.circular(12),
-                    border: Border.all(
-                      color: Colors.white.withValues(alpha: 0.15),
-                      width: 1,
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.black.withValues(alpha: 0.2),
-                        blurRadius: 6,
-                        offset: const Offset(0, 2),
+                return FocusableWrapper(
+                  focusNode: index == 0 ? _studiosFirstFocusNode : null,
+                  onSelect: name.isNotEmpty
+                      ? () => context.push(Destinations.studio(name))
+                      : null,
+                  borderRadius: 12,
+                  suppressFocusGlow: true,
+                  onNavigateUp: _focusSelectedTab,
+                  onNavigateRight: index == studios.length - 1 ? () {} : null,
+                  child: Container(
+                    width: cardWidth,
+                    height: cardHeight,
+                    decoration: BoxDecoration(
+                      borderRadius: AppRadius.circular(12),
+                      border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        width: 1,
                       ),
-                    ],
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withValues(alpha: 0.2),
+                          blurRadius: 6,
+                          offset: const Offset(0, 2),
+                        ),
+                      ],
+                    ),
+                    child: ClipRRect(
+                      borderRadius: AppRadius.circular(12),
+                      child: imageUrl != null
+                          ? OfflineAwareImage(
+                              imageUrl: imageUrl,
+                              fit: BoxFit.contain,
+                              imageBuilder: (context, imageProvider) {
+                                return Container(
+                                  color: Colors.white,
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 8,
+                                  ),
+                                  child: Image(
+                                    image: imageProvider,
+                                    fit: BoxFit.contain,
+                                  ),
+                                );
+                              },
+                              placeholder: (context, url) => _buildStudioFallback(context, name),
+                              errorWidget: (context, url, error) => _buildStudioFallback(context, name),
+                            )
+                          : _buildStudioFallback(context, name),
+                    ),
                   ),
-                  child: ClipRRect(
-                    borderRadius: AppRadius.circular(12),
-                    child: imageUrl != null
-                        ? OfflineAwareImage(
-                            imageUrl: imageUrl,
-                            fit: BoxFit.contain,
-                            imageBuilder: (context, imageProvider) {
-                              return Container(
-                                color: Colors.white,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 12,
-                                  vertical: 8,
-                                ),
-                                child: Image(
-                                  image: imageProvider,
-                                  fit: BoxFit.contain,
-                                ),
-                              );
-                            },
-                            placeholder: (context, url) => _buildStudioFallback(context, name),
-                            errorWidget: (context, url, error) => _buildStudioFallback(context, name),
-                          )
-                        : _buildStudioFallback(context, name),
-                  ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ),
       ),
@@ -2255,18 +2269,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           widget.onToggleNavbar?.call(true);
         }
       },
-      child: FilmographyRow(
-        items: movies,
-        imageApi: _vm.imageApi,
-        prefs: widget.prefs,
-        firstFocusNode: focusNode ?? _personMoviesFirstFocusNode,
-        onItemKeyEvent: (index, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => FilmographyRow(
+          items: movies,
+          imageApi: _vm.imageApi,
+          prefs: widget.prefs,
+          scrollController: controller,
+          firstFocusNode: focusNode ?? _personMoviesFirstFocusNode,
+          onItemKeyEvent: (index, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+        ),
       ),
     );
   }
@@ -2281,18 +2300,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           widget.onToggleNavbar?.call(true);
         }
       },
-      child: FilmographyRow(
-        items: series,
-        imageApi: _vm.imageApi,
-        prefs: widget.prefs,
-        firstFocusNode: focusNode ?? _personSeriesFirstFocusNode,
-        onItemKeyEvent: (index, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => FilmographyRow(
+          items: series,
+          imageApi: _vm.imageApi,
+          prefs: widget.prefs,
+          scrollController: controller,
+          firstFocusNode: focusNode ?? _personSeriesFirstFocusNode,
+          onItemKeyEvent: (index, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+        ),
       ),
     );
   }
@@ -2307,17 +2331,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           widget.onToggleNavbar?.call(true);
         }
       },
-      child: SeerrAppearancesRow(
-        items: items,
-        prefs: widget.prefs,
-        firstFocusNode: _personSeerrAppearancesFirstFocusNode,
-        onItemKeyEvent: (index, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => SeerrAppearancesRow(
+          items: items,
+          prefs: widget.prefs,
+          scrollController: controller,
+          firstFocusNode: _personSeerrAppearancesFirstFocusNode,
+          onItemKeyEvent: (index, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+        ),
       ),
     );
   }
@@ -2407,36 +2436,32 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     VoidCallback? onNavigateDown,
   }) {
     final textTheme = Theme.of(context).textTheme;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          title,
-          style: textTheme.titleMedium?.copyWith(
-            color: Colors.white,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        const SizedBox(height: 8),
-        SeerrAppearancesRow(
-          items: items,
-          prefs: widget.prefs,
-          firstFocusNode: firstFocusNode,
-          onItemKeyEvent: (index, event) {
-            if (event is! KeyDownEvent) return KeyEventResult.ignored;
-            if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-              (onNavigateUp ?? _focusSelectedTab)();
-              return KeyEventResult.handled;
-            }
-            if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
-                onNavigateDown != null) {
-              onNavigateDown();
-              return KeyEventResult.handled;
-            }
-            return KeyEventResult.ignored;
-          },
-        ),
-      ],
+    return HorizontalScrollSection(
+      title: title,
+      titleStyle: textTheme.titleMedium?.copyWith(
+        color: Colors.white,
+        fontWeight: FontWeight.w700,
+      ),
+      contentSpacing: 8,
+      builder: (context, controller) => SeerrAppearancesRow(
+        items: items,
+        prefs: widget.prefs,
+        scrollController: controller,
+        firstFocusNode: firstFocusNode,
+        onItemKeyEvent: (index, event) {
+          if (event is! KeyDownEvent) return KeyEventResult.ignored;
+          if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            (onNavigateUp ?? _focusSelectedTab)();
+            return KeyEventResult.handled;
+          }
+          if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+              onNavigateDown != null) {
+            onNavigateDown();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+      ),
     );
   }
 
@@ -2450,17 +2475,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           widget.onToggleNavbar?.call(true);
         }
       },
-      child: SeerrCrewCreditsRow(
-        items: items,
-        prefs: widget.prefs,
-        firstFocusNode: _personSeerrCrewCreditsFirstFocusNode,
-        onItemKeyEvent: (index, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => SeerrCrewCreditsRow(
+          items: items,
+          prefs: widget.prefs,
+          scrollController: controller,
+          firstFocusNode: _personSeerrCrewCreditsFirstFocusNode,
+          onItemKeyEvent: (index, event) {
+            if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+              _focusSelectedTab();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+        ),
       ),
     );
   }
@@ -2485,18 +2515,22 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         }
         return KeyEventResult.ignored;
       },
-      child: DetailChaptersRow(
-        item: item,
-        imageApi: _vm.imageApi,
-        onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
-        firstItemFocusNode: _chaptersFirstFocusNode,
+      child: HorizontalScrollSection(
+        title: '',
+        contentSpacing: 0,
+        builder: (context, controller) => DetailChaptersRow(
+          item: item,
+          imageApi: _vm.imageApi,
+          onPlayFromChapter: widget.onPlayFromChapter ?? (_) {},
+          scrollController: controller,
+          firstItemFocusNode: _chaptersFirstFocusNode,
+        ),
       ),
     );
   }
 
-  Widget _extrasTab(BuildContext context, AggregatedItem item, List<AggregatedItem> items, FocusNode? firstItemFocusNode) => SizedBox(
-        height: 200,
-        child: Focus(
+  Widget _extrasTab(BuildContext context, AggregatedItem item, List<AggregatedItem> items, FocusNode? firstItemFocusNode) =>
+        Focus(
           canRequestFocus: false,
           onFocusChange: (focused) {
             if (focused && mounted) {
@@ -2512,14 +2546,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             }
             return KeyEventResult.ignored;
           },
-          child: DetailFeaturesRow(
-            items: items,
-            imageApi: _vm.imageApi,
-            prefs: widget.prefs,
-            firstItemFocusNode: firstItemFocusNode,
+          child: HorizontalScrollSection(
+            title: '',
+            contentSpacing: 0,
+            builder: (context, controller) => DetailFeaturesRow(
+              items: items,
+              imageApi: _vm.imageApi,
+              prefs: widget.prefs,
+              scrollController: controller,
+              firstItemFocusNode: firstItemFocusNode,
+            ),
           ),
-        ),
-      );
+        );
 
   Widget _collectionsTab(BuildContext context, AggregatedItem item) {
     final collections = _vm.parentCollections;

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -2549,12 +2549,17 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           child: HorizontalScrollSection(
             title: '',
             contentSpacing: 0,
-            builder: (context, controller) => DetailFeaturesRow(
-              items: items,
-              imageApi: _vm.imageApi,
-              prefs: widget.prefs,
-              scrollController: controller,
-              firstItemFocusNode: firstItemFocusNode,
+            // The row asks for 280 but its cards only paint 139, so hold it
+            // at 200 rather than reserve space nothing fills.
+            builder: (context, controller) => SizedBox(
+              height: 200,
+              child: DetailFeaturesRow(
+                items: items,
+                imageApi: _vm.imageApi,
+                prefs: widget.prefs,
+                scrollController: controller,
+                firstItemFocusNode: firstItemFocusNode,
+              ),
             ),
           ),
         );

--- a/lib/ui/widgets/horizontal_scroll_section.dart
+++ b/lib/ui/widgets/horizontal_scroll_section.dart
@@ -118,15 +118,16 @@ class _HorizontalScrollSectionState extends State<HorizontalScrollSection> {
             padding: widget.headerPadding,
             child: Row(
               children: [
-                Expanded(
-                  child: widget.title.isNotEmpty
-                      ? Text(
-                          widget.title,
-                          style: widget.titleStyle ??
-                              Theme.of(context).textTheme.titleLarge,
-                        )
-                      : const SizedBox.shrink(),
-                ),
+                if (widget.title.isEmpty)
+                  const Spacer()
+                else
+                  Expanded(
+                    child: Text(
+                      widget.title,
+                      style: widget.titleStyle ??
+                          Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ),
                 if (widget.trailing != null) widget.trailing!,
                 if (hasControls) ...[
                   Focus(

--- a/lib/ui/widgets/horizontal_scroll_section.dart
+++ b/lib/ui/widgets/horizontal_scroll_section.dart
@@ -105,47 +105,56 @@ class _HorizontalScrollSectionState extends State<HorizontalScrollSection> {
 
   @override
   Widget build(BuildContext context) {
+    final hasControls = widget.showControls && !PlatformDetection.isTV;
+    final hasHeader =
+        widget.title.isNotEmpty || widget.trailing != null || hasControls;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Padding(
-          padding: widget.headerPadding,
-          child: Row(
-            children: [
-              Expanded(
-                child: Text(
-                  widget.title,
-                  style: widget.titleStyle ?? Theme.of(context).textTheme.titleLarge,
+        if (hasHeader)
+          Padding(
+            padding: widget.headerPadding,
+            child: Row(
+              children: [
+                Expanded(
+                  child: widget.title.isNotEmpty
+                      ? Text(
+                          widget.title,
+                          style: widget.titleStyle ??
+                              Theme.of(context).textTheme.titleLarge,
+                        )
+                      : const SizedBox.shrink(),
                 ),
-              ),
-              if (widget.trailing != null) widget.trailing!,
-              if (widget.showControls && !PlatformDetection.isTV) ...[
-                Focus(
-                  canRequestFocus: false,
-                  skipTraversal: true,
-                  descendantsAreFocusable: false,
-                  child: IconButton(
-                    icon: const Icon(Icons.chevron_left),
-                    onPressed: () => _scrollBy(-_scrollStep),
-                    visualDensity: VisualDensity.compact,
+                if (widget.trailing != null) widget.trailing!,
+                if (hasControls) ...[
+                  Focus(
+                    canRequestFocus: false,
+                    skipTraversal: true,
+                    descendantsAreFocusable: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.chevron_left),
+                      onPressed: () => _scrollBy(-_scrollStep),
+                      visualDensity: VisualDensity.compact,
+                    ),
                   ),
-                ),
-                Focus(
-                  canRequestFocus: false,
-                  skipTraversal: true,
-                  descendantsAreFocusable: false,
-                  child: IconButton(
-                    icon: const Icon(Icons.chevron_right),
-                    onPressed: () => _scrollBy(_scrollStep),
-                    visualDensity: VisualDensity.compact,
+                  Focus(
+                    canRequestFocus: false,
+                    skipTraversal: true,
+                    descendantsAreFocusable: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.chevron_right),
+                      onPressed: () => _scrollBy(_scrollStep),
+                      visualDensity: VisualDensity.compact,
+                    ),
                   ),
-                ),
+                ],
               ],
-            ],
+            ),
           ),
-        ),
-        if (widget.contentSpacing > 0) SizedBox(height: widget.contentSpacing),
+        if (hasHeader && widget.contentSpacing > 0)
+          SizedBox(height: widget.contentSpacing),
         widget.builder(context, _controller),
       ],
     );

--- a/lib/ui/widgets/horizontal_scroll_section.dart
+++ b/lib/ui/widgets/horizontal_scroll_section.dart
@@ -105,7 +105,8 @@ class _HorizontalScrollSectionState extends State<HorizontalScrollSection> {
 
   @override
   Widget build(BuildContext context) {
-    final hasControls = widget.showControls && !PlatformDetection.isTV;
+    final hasControls =
+        widget.showControls && PlatformDetection.useDesktopUi;
     final hasHeader =
         widget.title.isNotEmpty || widget.trailing != null || hasControls;
 

--- a/test/ui/screens/detail/detail_row_heights_test.dart
+++ b/test/ui/screens/detail/detail_row_heights_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/screens/detail/item_detail_screen.dart';
+import 'package:moonfin/util/platform_detection.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _ImageApi extends Mock implements ImageApi {}
+
+void main() {
+  late UserPreferences prefs;
+  late _ImageApi imageApi;
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    prefs = UserPreferences(store);
+    GetIt.instance.registerSingleton<UserPreferences>(prefs);
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.desktop);
+
+    imageApi = _ImageApi();
+    when(
+      () => imageApi.getPrimaryImageUrl(
+        any(),
+        maxWidth: any(named: 'maxWidth'),
+        maxHeight: any(named: 'maxHeight'),
+        tag: any(named: 'tag'),
+      ),
+    ).thenReturn('http://server/img');
+  });
+
+  tearDown(() {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.automatic);
+    return GetIt.instance.reset();
+  });
+
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Column(mainAxisSize: MainAxisSize.min, children: [child]),
+      ),
+    ),
+  );
+
+  testWidgets('the cast row takes its own height at every desktop scale', (
+    tester,
+  ) async {
+    for (final scale in DesktopUiScale.values) {
+      await prefs.set(UserPreferences.desktopUiScale, scale);
+      // A fresh instance each pass, or Flutter reuses the previous layout.
+      await pump(
+        tester,
+        KeyedSubtree(
+          key: ValueKey(scale),
+          child: DetailCastRow(
+            people: const [
+              {'Id': 'p1', 'Name': 'Hailee Steinfeld', 'Role': 'Vi'},
+            ],
+            imageApi: imageApi,
+            serverId: 's1',
+          ),
+        ),
+      );
+      expect(
+        tester.getSize(find.byType(DetailCastRow)).height,
+        closeTo(196 * scale.scaleFactor, 0.01),
+        reason: 'at ${scale.name}',
+      );
+      // A 200px box was clipping this row at the largest scale.
+      expect(tester.takeException(), isNull, reason: 'at ${scale.name}');
+    }
+  });
+
+  testWidgets('a 200px extras row has room for its cards at every scale', (
+    tester,
+  ) async {
+    // What `_extrasTab` holds the row at. Change one and change the other.
+    const rowHeight = 200.0;
+    for (final scale in DesktopUiScale.values) {
+      await prefs.set(UserPreferences.desktopUiScale, scale);
+      await pump(
+        tester,
+        KeyedSubtree(
+          key: ValueKey(scale),
+          child: SizedBox(
+            height: rowHeight,
+            child: DetailFeaturesRow(
+              items: [
+                AggregatedItem(
+                  id: 'v1',
+                  serverId: 's1',
+                  rawData: const {
+                    'Id': 'v1',
+                    'Name': 'Deleted Scene: The Rooftop',
+                    'Type': 'Video',
+                    'ImageTags': {'Primary': 'tag1'},
+                  },
+                ),
+              ],
+              imageApi: imageApi,
+              prefs: prefs,
+            ),
+          ),
+        ),
+      );
+      expect(
+        tester.getSize(find.byType(DetailFeaturesRow)).height,
+        rowHeight,
+        reason: 'at ${scale.name}',
+      );
+      // Holding the row under the height it asks for only works while the
+      // cards inside still fit.
+      expect(tester.takeException(), isNull, reason: 'at ${scale.name}');
+    }
+  });
+}

--- a/test/ui/widgets/horizontal_scroll_section_test.dart
+++ b/test/ui/widgets/horizontal_scroll_section_test.dart
@@ -1,8 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:moonfin/ui/widgets/horizontal_scroll_section.dart';
+import 'package:moonfin/util/platform_detection.dart';
 
 void main() {
+  setUp(() {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.desktop);
+  });
+
+  tearDown(() {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.automatic);
+  });
+
   Future<void> pump(
     WidgetTester tester, {
     required String title,
@@ -29,7 +38,7 @@ void main() {
 
   Finder chevrons() => find.byIcon(Icons.chevron_right);
 
-  testWidgets('a titled section keeps its title and its chevrons', (
+  testWidgets('a titled section keeps its title and its chevrons on desktop', (
     tester,
   ) async {
     await pump(tester, title: 'Recommendations');
@@ -38,10 +47,23 @@ void main() {
     expect(chevrons(), findsOneWidget);
   });
 
-  testWidgets('an untitled section still shows the chevrons', (tester) async {
+  testWidgets('an untitled section still shows the chevrons on desktop', (
+    tester,
+  ) async {
     await pump(tester, title: '');
 
     expect(chevrons(), findsOneWidget);
+  });
+
+  testWidgets('on phone layout, chevrons are hidden and untitled sections have no header', (
+    tester,
+  ) async {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.phone);
+    await pump(tester, title: '');
+
+    expect(chevrons(), findsNothing);
+    expect(find.byType(Spacer), findsNothing);
+    expect(tester.getSize(find.byType(HorizontalScrollSection)).height, 80);
   });
 
   testWidgets('an untitled section with no controls has no header at all', (

--- a/test/ui/widgets/horizontal_scroll_section_test.dart
+++ b/test/ui/widgets/horizontal_scroll_section_test.dart
@@ -55,16 +55,17 @@ void main() {
     expect(chevrons(), findsOneWidget);
   });
 
-  testWidgets('on phone layout, chevrons are hidden and untitled sections have no header', (
-    tester,
-  ) async {
-    PlatformDetection.setInterfaceLayout(InterfaceLayout.phone);
-    await pump(tester, title: '');
+  testWidgets(
+    'on phone layout, chevrons are hidden and untitled sections have no header',
+    (tester) async {
+      PlatformDetection.setInterfaceLayout(InterfaceLayout.phone);
+      await pump(tester, title: '');
 
-    expect(chevrons(), findsNothing);
-    expect(find.byType(Spacer), findsNothing);
-    expect(tester.getSize(find.byType(HorizontalScrollSection)).height, 80);
-  });
+      expect(chevrons(), findsNothing);
+      expect(find.byType(Spacer), findsNothing);
+      expect(tester.getSize(find.byType(HorizontalScrollSection)).height, 80);
+    },
+  );
 
   testWidgets('an untitled section with no controls has no header at all', (
     tester,

--- a/test/ui/widgets/horizontal_scroll_section_test.dart
+++ b/test/ui/widgets/horizontal_scroll_section_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/horizontal_scroll_section.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required String title,
+    bool showControls = true,
+  }) => tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: HorizontalScrollSection(
+          title: title,
+          showControls: showControls,
+          contentSpacing: 12,
+          builder: (context, controller) => SizedBox(
+            height: 80,
+            child: ListView(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              children: const [SizedBox(key: Key('row'), width: 2000)],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  Finder chevrons() => find.byIcon(Icons.chevron_right);
+
+  testWidgets('a titled section keeps its title and its chevrons', (
+    tester,
+  ) async {
+    await pump(tester, title: 'Recommendations');
+
+    expect(find.text('Recommendations'), findsOneWidget);
+    expect(chevrons(), findsOneWidget);
+  });
+
+  testWidgets('an untitled section still shows the chevrons', (tester) async {
+    await pump(tester, title: '');
+
+    expect(chevrons(), findsOneWidget);
+  });
+
+  testWidgets('an untitled section with no controls has no header at all', (
+    tester,
+  ) async {
+    // What a TV build gets. There is nothing to put in a header, so neither
+    // the header nor the gap that separates it from the row is built.
+    await pump(tester, title: '', showControls: false);
+
+    expect(chevrons(), findsNothing);
+    // The Spacer only exists to push chevrons right, so its absence is how
+    // "no header was built" reads from the outside.
+    expect(find.byType(Spacer), findsNothing);
+    // 80 is the row on its own: no header, and no contentSpacing above it.
+    expect(tester.getSize(find.byType(HorizontalScrollSection)).height, 80);
+  });
+
+  testWidgets('the chevrons scroll the row they were given', (tester) async {
+    await pump(tester, title: '');
+    final controller = tester
+        .widget<ListView>(find.byType(ListView))
+        .controller!;
+    expect(controller.offset, 0);
+
+    await tester.tap(chevrons());
+    await tester.pumpAndSettle();
+
+    expect(controller.offset, greaterThan(0));
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Bumbling around on 2.5.1 on Windows Desktop and noticed a bunch of pages with missing navigation chevrons (needed for mouse-only navigation). PR adds back/forward navigation chevrons (`<` and `>`) to horizontal scroll sections on media details pages (Cast, Chapters, Seerr Recommendations & Similar, Crew, Extras, Studios, and Filmography), enabling _smooth_ mouse navigation on Desktop platforms matching the Home Screen rows.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **horizontal_scroll_section.dart**: Enhanced `HorizontalScrollSection` to support empty titles (`title: ''`) so navigation chevrons remain right-aligned above content rows while avoiding empty header padding on TV/mobile platforms.
- **modern_detail_content.dart**:
  - Wrapped **Cast** row (**DetailCastRow**) with **HorizontalScrollSection**.
  - Wrapped **Chapters** row (**DetailChaptersRow**) with **HorizontalScrollSection**.
  - Wrapped **Seerr** rows (Recommendations and Similar) with titled **HorizontalScrollSection**.
  - Wrapped **Crew**, **Extras**, and **Studios** rows with **HorizontalScrollSection**.
  - Wrapped **Person Details** filmography and credit rows with **HorizontalScrollSection**.
  - Wrapped collection **BoxSet Cast & Crew** accordion rows with **HorizontalScrollSection**.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Desktop
2. Open a media details page (e.g. Series, Movie, Episode).
3. Navigate to the Cast tab and verify navigation chevrons appear on the right side above the actors row and scroll properly on click.
4. Navigate to the Chapters tab and verify chevrons scroll through chapter bookmarks.
5. Navigate to the Seerr tab and verify chevrons appear next to "Recommendations" and "Similar" section titles.
6. Verify D-Pad / directional remote navigation on TV remains intact and unaffected.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previously On...
<img width="2558" height="1448" alt="2026-08-31_10-44-59_moonfin" src="https://github.com/user-attachments/assets/ba980bbe-185b-4408-8d9c-bb67572adf75" />
<img width="2558" height="1448" alt="2026-08-31_10-45-15_moonfin" src="https://github.com/user-attachments/assets/d1ca07cc-e7fe-42ac-9855-7a58d091ff12" />
<img width="2534" height="1448" alt="2026-08-31_15-53-56_moonfin" src="https://github.com/user-attachments/assets/48d344a9-d33a-46b8-af0b-56c7a3100e91" />

### Decorated
<img width="2534" height="1448" alt="2026-08-31_16-24-05_moonfin" src="https://github.com/user-attachments/assets/c6bf732e-0b91-44c4-b74c-2c0f2d0fd72d" />
<img width="2534" height="1448" alt="2026-08-31_16-24-50_moonfin" src="https://github.com/user-attachments/assets/30328bee-c8bc-4a0f-9c98-e908a4fa8be2" />
<img width="2534" height="1448" alt="2026-08-31_16-23-39_moonfin" src="https://github.com/user-attachments/assets/43c69179-1065-4ecd-b7a1-8daa2e422c24" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
