### PR TITLE
bugfix-ui - Accessing the Inaccessible Read More

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -694,6 +694,11 @@ class _DetailContentState extends State<_DetailContent> {
   late ScrollController _scrollController;
   late FocusNode _contentFocusNode;
   final Map<String, FocusNode> _sectionFocusNodes = <String, FocusNode>{};
+
+  /// The last target this screen put on the shared toolbar notifier, so it
+  /// only releases one it still owns. A screen underneath may have reclaimed
+  /// it while this one was covered.
+  FocusNode? _publishedNavbarTarget;
   final Map<FocusNode, ScrollController> _sectionScrollControllers =
       <FocusNode, ScrollController>{};
   final Set<FocusNode> _pendingSectionFocusRetries = <FocusNode>{};
@@ -1155,8 +1160,43 @@ class _DetailContentState extends State<_DetailContent> {
     _featureFocusNodes.clear();
     _nextEpisodeFocusNode.dispose();
     _seriesNextUpFocusNode.dispose();
-    NavigationLayout.focusDetailsPlayButtonNotifier.value = null;
+    if (NavigationLayout.focusDetailsPlayButtonNotifier.value ==
+        _publishedNavbarTarget) {
+      NavigationLayout.focusDetailsPlayButtonNotifier.value = null;
+    }
     super.dispose();
+  }
+
+  /// Where a Down press on the top toolbar should land, which is the overview
+  /// when there is one because that is what sits directly beneath the toolbar.
+  FocusNode? _topNavbarFocusTarget(
+    AggregatedItem item,
+    FocusNode? overviewFocusNode,
+  ) {
+    if (overviewFocusNode != null) return overviewFocusNode;
+    return switch (item.type) {
+      'Person' =>
+        widget.initialFocusNode ?? _sectionFocusNode('detailPersonFavorite'),
+      'MusicAlbum' || 'Playlist' => _albumPlayFocusNode,
+      'BoxSet' => _sectionFocusNode('detailBoxSetActionButtons'),
+      _ => widget.initialFocusNode ?? _sectionFocusNode('detailActionButtons'),
+    };
+  }
+
+  /// Hands the toolbar its target after the frame that laid the nodes out.
+  ///
+  /// Assigning during build would be a side effect on a notifier other
+  /// widgets listen to, and the nodes it names have no context until the
+  /// frame is done anyway.
+  void _publishTopNavbarTarget(AggregatedItem item, FocusNode? overview) {
+    if (!PlatformDetection.isTV) return;
+    final target = _topNavbarFocusTarget(item, overview);
+    _publishedNavbarTarget = target;
+    if (NavigationLayout.focusDetailsPlayButtonNotifier.value == target) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      NavigationLayout.focusDetailsPlayButtonNotifier.value = target;
+    });
   }
 
   Widget _buildStaticPersonProfilePanel(
@@ -1256,16 +1296,7 @@ class _DetailContentState extends State<_DetailContent> {
     final item = widget.viewModel.item!;
     final headerOverviewFocusNode = _headerOverviewFocusNode(item);
     _ensureTvAlbumPlayFocus(item);
-    final topNavbarTarget = headerOverviewFocusNode ??
-        (item.type == 'Person'
-            ? (widget.initialFocusNode ?? _sectionFocusNode('detailPersonFavorite'))
-            : (item.type == 'MusicAlbum' || item.type == 'Playlist'
-                ? _albumPlayFocusNode
-                : (item.type == 'BoxSet'
-                    ? _sectionFocusNode('detailBoxSetActionButtons')
-                    : (widget.initialFocusNode ??
-                        _sectionFocusNode('detailActionButtons')))));
-    NavigationLayout.focusDetailsPlayButtonNotifier.value = topNavbarTarget;
+    _publishTopNavbarTarget(item, headerOverviewFocusNode);
     final isReadableBook = _isReadableBookItem(item);
     final selectedMediaSource = selectedMediaSourceForItem(
       item,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1155,6 +1155,7 @@ class _DetailContentState extends State<_DetailContent> {
     _featureFocusNodes.clear();
     _nextEpisodeFocusNode.dispose();
     _seriesNextUpFocusNode.dispose();
+    NavigationLayout.focusDetailsPlayButtonNotifier.value = null;
     super.dispose();
   }
 
@@ -1255,6 +1256,16 @@ class _DetailContentState extends State<_DetailContent> {
     final item = widget.viewModel.item!;
     final headerOverviewFocusNode = _headerOverviewFocusNode(item);
     _ensureTvAlbumPlayFocus(item);
+    final topNavbarTarget = headerOverviewFocusNode ??
+        (item.type == 'Person'
+            ? (widget.initialFocusNode ?? _sectionFocusNode('detailPersonFavorite'))
+            : (item.type == 'MusicAlbum' || item.type == 'Playlist'
+                ? _albumPlayFocusNode
+                : (item.type == 'BoxSet'
+                    ? _sectionFocusNode('detailBoxSetActionButtons')
+                    : (widget.initialFocusNode ??
+                        _sectionFocusNode('detailActionButtons')))));
+    NavigationLayout.focusDetailsPlayButtonNotifier.value = topNavbarTarget;
     final isReadableBook = _isReadableBookItem(item);
     final selectedMediaSource = selectedMediaSourceForItem(
       item,
@@ -3653,6 +3664,7 @@ class _DetailContentState extends State<_DetailContent> {
     final actionButtonsFocusNode = _sectionFocusNode(
       'detailBoxSetActionButtons',
     );
+    final overviewFocusNode = _headerOverviewFocusNode(item);
     final firstFocus = initialFocusNode ?? actionButtonsFocusNode;
     final moviesFocusNode = movies.isNotEmpty
         ? _sectionFocusNode('detailBoxSetMovies')
@@ -3680,6 +3692,7 @@ class _DetailContentState extends State<_DetailContent> {
         selectedMediaSourceId: selectedMediaSourceId,
         onSelectedMediaSourceChanged: onSelectedMediaSourceChanged,
         tvPlayFocusNode: actionButtonsFocusNode,
+        upTarget: overviewFocusNode,
         onRequestFocus: _requestSectionFocus,
         downTarget: metadataFocusNode ?? boxSetDownTarget,
         autoPlay: widget.autoPlay,
@@ -4066,6 +4079,7 @@ class _HeaderSection extends StatelessWidget {
             ),
             textAlign: isMobile ? TextAlign.center : null,
           ),
+          const SizedBox(height: 8),
         ],
       ],
     );


### PR DESCRIPTION
# Pull Request

## Summary
The Classic details page had some broken navigation links. This PR fixes focus navigation and layout spacing on Classic Details screens for Collections (`BoxSet`), ensuring smooth D-Pad navigation between the action buttons, Read More overview container, and top navigation bar.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - In `_buildBoxSetContent`: Routed `upTarget: overviewFocusNode` on **DetailActionButtons** so pressing Up from Play/action buttons navigates to the Read More overview container.
  - In `_DetailContentState.build`: Initialized `NavigationLayout.focusDetailsPlayButtonNotifier` with `topNavbarTarget` (favoring `headerOverviewFocusNode` when present) so pressing Down on the top toolbar restores focus directly into the Read More container rather than jumping off-screen.
  - In `_HeaderSection.build`: Added 8px bottom padding below **_OverviewText** to match the top spacing and prevent the container outline from touching the action button shading below.


## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Select Classic Details layout in Preferences.
2. Open a Collection with an overview (e.g. Toy Story Collection).
3. Focus the Play button and press **Up**: verify focus lands on the **Read More** container.
4. Press **Select / Enter**: verify the overview expands.
5. Press **Up** from the Read More container: verify focus moves to the Top Navigation Bar.
6. Press **Down** from the Top Navigation Bar: verify focus returns directly to the Read More container.
7. Verify 8px visual padding exists between the bottom of the Read More container and the action buttons.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Want to read more? Sorry about your luck...

<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-30_14-59-34" src="https://github.com/user-attachments/assets/8a603f65-124d-420f-b382-d68b0027daec" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-30_14-59-41" src="https://github.com/user-attachments/assets/3103b663-eb56-4a4e-b229-981bf7146423" />

### Fixed

<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-31_17-16-31" src="https://github.com/user-attachments/assets/a5c1e4bd-e7f0-4104-b782-1dd44f726d51" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-31_17-16-41" src="https://github.com/user-attachments/assets/d8ef02db-f778-48ba-9351-d55cb101d9e5" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
