### PR TITLE
feat-settings - Tricking Trickplay

### DIFF
--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -6,14 +6,21 @@ class _VideoPlaybackScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final prefs = GetIt.instance<UserPreferences>();
     return Scaffold(
       appBar: buildSettingsAppBar(
         context,
         Text(l10n.settingsVideoPlaybackPreferences),
       ),
-      body: ListView(
-        children: [
-          const _SectionHeader('Media Player Behavior'),
+      body: ListenableBuilder(
+        listenable: prefs,
+        builder: (context, _) {
+          final isTrickplayEnabled =
+              prefs.get(UserPreferences.trickPlayMode) !=
+              TrickplayMode.disabled;
+          return ListView(
+            children: [
+              const _SectionHeader('Media Player Behavior'),
           adaptiveListSection(
             children: [
               SwitchPreferenceTile(
@@ -139,7 +146,7 @@ class _VideoPlaybackScreen extends StatelessWidget {
           _SectionHeader(l10n.trickPlay),
           adaptiveListSection(
             children: [
-              const TrickplaySettingsPreview(),
+              if (isTrickplayEnabled) const TrickplaySettingsPreview(),
               EnumPreferenceTile<TrickplayMode>(
                 preference: UserPreferences.trickPlayMode,
                 title: l10n.trickPlay,
@@ -152,30 +159,32 @@ class _VideoPlaybackScreen extends StatelessWidget {
                   TrickplayMode.full => l10n.trickplayModeFull,
                 },
               ),
-              SliderPreferenceTile(
-                preference: UserPreferences.trickPlayPreviewScalePercent,
-                title: l10n.trickplayPreviewScale,
-                icon: Icons.photo_size_select_large_outlined,
-                min: 10,
-                max: 100,
-                divisions: 18,
-                labelOf: (v) => l10n.percentValue(v),
-              ),
-              SliderPreferenceTile(
-                preference: UserPreferences.trickPlayVerticalPositionPercent,
-                title: l10n.trickplayVerticalOffset,
-                icon: Icons.height,
-                min: 0,
-                max: 100,
-                divisions: 20,
-                labelOf: (v) => l10n.percentValue(v),
-              ),
-              SwitchPreferenceTile(
-                preference: UserPreferences.trickPlayFollowScrubPosition,
-                title: l10n.trickplayFollowScrubPosition,
-                subtitle: l10n.trickplayFollowScrubPositionSubtitle,
-                icon: Icons.swipe,
-              ),
+              if (isTrickplayEnabled) ...[
+                SliderPreferenceTile(
+                  preference: UserPreferences.trickPlayPreviewScalePercent,
+                  title: l10n.trickplayPreviewScale,
+                  icon: Icons.photo_size_select_large_outlined,
+                  min: 10,
+                  max: 100,
+                  divisions: 18,
+                  labelOf: (v) => l10n.percentValue(v),
+                ),
+                SliderPreferenceTile(
+                  preference: UserPreferences.trickPlayVerticalPositionPercent,
+                  title: l10n.trickplayVerticalOffset,
+                  icon: Icons.height,
+                  min: 0,
+                  max: 100,
+                  divisions: 20,
+                  labelOf: (v) => l10n.percentValue(v),
+                ),
+                SwitchPreferenceTile(
+                  preference: UserPreferences.trickPlayFollowScrubPosition,
+                  title: l10n.trickplayFollowScrubPosition,
+                  subtitle: l10n.trickplayFollowScrubPositionSubtitle,
+                  icon: Icons.swipe,
+                ),
+              ],
             ],
           ),
 
@@ -315,9 +324,11 @@ class _VideoPlaybackScreen extends StatelessWidget {
             ],
           ),
         ],
-      ),
-    );
-  }
+      );
+    },
+  ),
+);
+}
 }
 
 class _ExternalPlayerAppPickerTile extends StatefulWidget {

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -12,15 +12,9 @@ class _VideoPlaybackScreen extends StatelessWidget {
         context,
         Text(l10n.settingsVideoPlaybackPreferences),
       ),
-      body: ListenableBuilder(
-        listenable: prefs,
-        builder: (context, _) {
-          final isTrickplayEnabled =
-              prefs.get(UserPreferences.trickPlayMode) !=
-              TrickplayMode.disabled;
-          return ListView(
-            children: [
-              const _SectionHeader('Media Player Behavior'),
+      body: ListView(
+        children: [
+          const _SectionHeader('Media Player Behavior'),
           adaptiveListSection(
             children: [
               SwitchPreferenceTile(
@@ -144,48 +138,62 @@ class _VideoPlaybackScreen extends StatelessWidget {
           ),
 
           _SectionHeader(l10n.trickPlay),
-          adaptiveListSection(
-            children: [
-              if (isTrickplayEnabled) const TrickplaySettingsPreview(),
-              EnumPreferenceTile<TrickplayMode>(
-                preference: UserPreferences.trickPlayMode,
-                title: l10n.trickPlay,
-                description: l10n.showPreviewThumbnailsWhenSeeking,
-                icon: Icons.image_search,
-                labelOf: (v) => switch (v) {
-                  TrickplayMode.disabled => l10n.disabled,
-                  TrickplayMode.single => l10n.trickplayDisplayStyleSingle,
-                  TrickplayMode.strip => l10n.trickplayDisplayStyleStrip,
-                  TrickplayMode.full => l10n.trickplayModeFull,
-                },
-              ),
-              if (isTrickplayEnabled) ...[
-                SliderPreferenceTile(
-                  preference: UserPreferences.trickPlayPreviewScalePercent,
-                  title: l10n.trickplayPreviewScale,
-                  icon: Icons.photo_size_select_large_outlined,
-                  min: 10,
-                  max: 100,
-                  divisions: 18,
-                  labelOf: (v) => l10n.percentValue(v),
-                ),
-                SliderPreferenceTile(
-                  preference: UserPreferences.trickPlayVerticalPositionPercent,
-                  title: l10n.trickplayVerticalOffset,
-                  icon: Icons.height,
-                  min: 0,
-                  max: 100,
-                  divisions: 20,
-                  labelOf: (v) => l10n.percentValue(v),
-                ),
-                SwitchPreferenceTile(
-                  preference: UserPreferences.trickPlayFollowScrubPosition,
-                  title: l10n.trickplayFollowScrubPosition,
-                  subtitle: l10n.trickplayFollowScrubPositionSubtitle,
-                  icon: Icons.swipe,
-                ),
-              ],
-            ],
+          // Only this section reacts to the mode, so the rest of the page is
+          // not rebuilt every time any preference anywhere changes.
+          ListenableBuilder(
+            listenable: prefs,
+            builder: (context, _) {
+              final showsPreviews =
+                  prefs.get(UserPreferences.trickPlayMode) !=
+                  TrickplayMode.disabled;
+              return adaptiveListSection(
+                children: [
+                  EnumPreferenceTile<TrickplayMode>(
+                    preference: UserPreferences.trickPlayMode,
+                    title: l10n.trickPlay,
+                    description: l10n.showPreviewThumbnailsWhenSeeking,
+                    icon: Icons.image_search,
+                    labelOf: (v) => switch (v) {
+                      TrickplayMode.disabled => l10n.disabled,
+                      TrickplayMode.single => l10n.trickplayDisplayStyleSingle,
+                      TrickplayMode.strip => l10n.trickplayDisplayStyleStrip,
+                      TrickplayMode.full => l10n.trickplayModeFull,
+                    },
+                  ),
+                  // Everything the mode governs sits after the mode itself, so
+                  // turning it on adds rows below the one being used rather
+                  // than shifting it down and taking its focus with it.
+                  if (showsPreviews) ...[
+                    const TrickplaySettingsPreview(),
+                    SliderPreferenceTile(
+                      preference: UserPreferences.trickPlayPreviewScalePercent,
+                      title: l10n.trickplayPreviewScale,
+                      icon: Icons.photo_size_select_large_outlined,
+                      min: 10,
+                      max: 100,
+                      divisions: 18,
+                      labelOf: (v) => l10n.percentValue(v),
+                    ),
+                    SliderPreferenceTile(
+                      preference:
+                          UserPreferences.trickPlayVerticalPositionPercent,
+                      title: l10n.trickplayVerticalOffset,
+                      icon: Icons.height,
+                      min: 0,
+                      max: 100,
+                      divisions: 20,
+                      labelOf: (v) => l10n.percentValue(v),
+                    ),
+                    SwitchPreferenceTile(
+                      preference: UserPreferences.trickPlayFollowScrubPosition,
+                      title: l10n.trickplayFollowScrubPosition,
+                      subtitle: l10n.trickplayFollowScrubPositionSubtitle,
+                      icon: Icons.swipe,
+                    ),
+                  ],
+                ],
+              );
+            },
           ),
 
           const _SectionHeader('Decoding & Rendering'),
@@ -324,11 +332,9 @@ class _VideoPlaybackScreen extends StatelessWidget {
             ],
           ),
         ],
-      );
-    },
-  ),
-);
-}
+      ),
+    );
+  }
 }
 
 class _ExternalPlayerAppPickerTile extends StatefulWidget {


### PR DESCRIPTION
# Pull Request

## Summary
Trickplay is neat but adds a significant amount of noise to the Video Playback page for people who don't use the feature. This PR simply gates the trickplay preview widget and customization options (Preview Size, Distance From Seekbar, and Follow Scrub Position) in the Video Playback settings screen so they only appear when Trickplay mode is enabled.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **video_playback_screen.dart**:
  - Wrapped `_VideoPlaybackScreen` body with a `ListenableBuilder` listening to `UserPreferences`.
  - Conditionally rendered `TrickplaySettingsPreview` and the three customization preference tiles (`trickPlayPreviewScalePercent`, `trickPlayVerticalPositionPercent`, and `trickPlayFollowScrubPosition`) only when `trickPlayMode != TrickplayMode.disabled`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open **Settings** -> **Video Playback Preferences**.
2. Under the **Trick Play** section:
   - When set to **Disabled**: verify that only the primary **Trick Play** mode selector tile is visible, and the preview/customization tiles are hidden.
   - When changed to **Single Thumbnail**, **Thumbnail Strip**, or **Full-Screen**: verify that the preview box and the 3 customization tiles (Preview Size, Distance From Seekbar, Follow Scrub Position) appear immediately.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previously (always visible)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-08-31_10-16-17" src="https://github.com/user-attachments/assets/adac9b42-a73c-464e-8112-15ee8d0b290b" />

<img width="827" height="965" alt="2026-08-31_17-43-55_moonfin" src="https://github.com/user-attachments/assets/70ff1995-8c0a-43bc-919f-4e21a5ac67e4" />

### Now...

<img width="2534" height="1397" alt="2026-08-31_18-03-34_moonfin" src="https://github.com/user-attachments/assets/bdf796ce-c2cf-4634-b07b-0b4cfa6e95e3" />
<img width="2534" height="1397" alt="2026-08-31_18-03-43_moonfin" src="https://github.com/user-attachments/assets/d368b9d1-5240-41d5-bb94-4765a19ada75" />
<img width="2534" height="1397" alt="2026-08-31_18-03-52_moonfin" src="https://github.com/user-attachments/assets/c32057a3-38bd-4bbb-a642-87a4644f153b" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
