### PR TITLE
feat-details - Tidy up Next Up (for hidden descriptions)

### DIFF
--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -71,6 +71,9 @@ class AggregatedItem {
 
   String? get primaryImageItemId => rawData['PrimaryImageItemId']?.toString();
 
+  double? get primaryImageAspectRatio =>
+      (rawData['PrimaryImageAspectRatio'] as num?)?.toDouble();
+
   List<String> get backdropImageTags => _toListOfStrings(rawData['BackdropImageTags']);
 
   String? get parentBackdropItemId =>

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4410,6 +4410,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       title: '',
       description: hideOverview ? null : episode.overview?.trim(),
       imageUrl: _imageUrl(episode),
+      aspectRatio: episode.primaryImageAspectRatio,
       progress: progress,
       remainingLabel: _remainingLabel(episode, l10n),
       focusNode: _upNextFocusNode,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4778,9 +4778,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                     ),
                     if (item.mediaSources.length > 1) ...[
                       const SizedBox(width: 16),
-                      () {
-                        final versionName = selectedSource?['Name'] as String? ?? 'Default';
-                        return Container(
+                      // The logo keeps the width it needs, so a narrow window
+                      // shortens the version name instead of overflowing the row.
+                      Flexible(
+                        child: Container(
                           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                           decoration: BoxDecoration(
                             color: AppColorScheme.accent.withValues(alpha: 0.15),
@@ -4791,14 +4792,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                             ),
                           ),
                           child: Text(
-                            versionName,
+                            selectedSource?['Name'] as String? ?? 'Default',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                             style: textTheme.bodySmall?.copyWith(
                               color: AppColorScheme.accent,
                               fontWeight: FontWeight.bold,
                             ),
                           ),
-                        );
-                      }(),
+                        ),
+                      ),
                     ],
                   ],
                 ),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -84,20 +84,24 @@ class ModernLandscapeLayout extends StatelessWidget {
                           ],
                         ),
                       ),
-                      if (upNext != null) ...[
-                        const SizedBox(width: 80),
-                        Padding(
-                          padding: EdgeInsets.only(
-                            top: isBoxSet
-                                ? 24.0 / scale
-                                : (aboveHero != null ? 48.0 / scale : 0.0),
-                          ),
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 310),
-                            child: upNext,
+                      if (upNext != null)
+                        Expanded(
+                          child: Align(
+                            alignment: Alignment.topCenter,
+                            child: Padding(
+                              padding: EdgeInsets.only(
+                                top: isBoxSet
+                                    ? 24.0 / scale
+                                    : (aboveHero != null ? 48.0 / scale : 0.0),
+                              ),
+                              child: ConstrainedBox(
+                                constraints:
+                                    const BoxConstraints(maxWidth: 310),
+                                child: upNext,
+                              ),
+                            ),
                           ),
                         ),
-                      ],
                     ],
                   ),
                 ),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -67,11 +67,6 @@ class ModernLandscapeLayout extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (aboveHero != null && !(isBoxSet && hasUpNext))
-                  Padding(
-                    padding: EdgeInsets.fromLTRB(leftPadding, (hasUpNext ? 2.0 : 8.0) / scale, 40, 0),
-                    child: aboveHero!,
-                  ),
                 Padding(
                   padding: EdgeInsets.fromLTRB(leftPadding, 10 / scale, 40, 0),
                   child: Row(
@@ -79,31 +74,27 @@ class ModernLandscapeLayout extends StatelessWidget {
                     children: [
                       SizedBox(
                         width: heroWidth,
-                        child: (isBoxSet && hasUpNext)
-                            ? Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  if (aboveHero != null) aboveHero!,
-                                  const SizedBox(height: 10),
-                                  hero,
-                                ],
-                              )
-                            : hero,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ?aboveHero,
+                            if (aboveHero != null) const SizedBox(height: 10),
+                            hero,
+                          ],
+                        ),
                       ),
                       if (upNext != null) ...[
-                        const SizedBox(width: 24),
-                        Expanded(
-                          child: Align(
-                            alignment: Alignment.topRight,
-                            child: Padding(
-                              padding: EdgeInsets.only(top: isBoxSet ? 24.0 / scale : 0.0),
-                              child: ConstrainedBox(
-                                constraints:
-                                    const BoxConstraints(maxWidth: 410),
-                                child: upNext,
-                              ),
-                            ),
+                        const SizedBox(width: 80),
+                        Padding(
+                          padding: EdgeInsets.only(
+                            top: isBoxSet
+                                ? 24.0 / scale
+                                : (aboveHero != null ? 48.0 / scale : 0.0),
+                          ),
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 310),
+                            child: upNext,
                           ),
                         ),
                       ],

--- a/lib/ui/screens/detail/modern/widgets/up_next_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/up_next_card.dart
@@ -14,6 +14,7 @@ class UpNextCard extends StatefulWidget {
   final String title;
   final String? description;
   final String? imageUrl;
+  final double? aspectRatio;
   final double progress; // 0..1
   final String? remainingLabel;
   final VoidCallback onTap;
@@ -29,6 +30,7 @@ class UpNextCard extends StatefulWidget {
     required this.title,
     required this.description,
     required this.imageUrl,
+    this.aspectRatio,
     required this.progress,
     required this.remainingLabel,
     required this.onTap,
@@ -72,6 +74,13 @@ class _UpNextCardState extends State<UpNextCard> {
     final radius = JellyfinTokens.shapes.mediumRadius;
     final muted = AppColorScheme.onSurface.withValues(alpha: 0.7);
     final hasFocus = _effectiveNode.hasFocus;
+    final hasDescription =
+        widget.description != null && widget.description!.trim().isNotEmpty;
+    final effectiveAspectRatio = (widget.aspectRatio != null &&
+            widget.aspectRatio! > 0.5 &&
+            widget.aspectRatio! < 3.0)
+        ? widget.aspectRatio!
+        : (16 / 9);
 
     if (widget.minimal) {
       return FocusableWrapper(
@@ -196,19 +205,19 @@ class _UpNextCardState extends State<UpNextCard> {
                         ),
                       ),
                     ),
-                    IntrinsicHeight(
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.fromLTRB(16, 0, 16, 14),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  if (widget.description != null &&
-                                      widget.description!.isNotEmpty) ...[
+                    if (hasDescription)
+                      IntrinsicHeight(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Expanded(
+                              child: Padding(
+                                padding:
+                                    const EdgeInsets.fromLTRB(16, 0, 16, 14),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
                                     Text(
                                       widget.description!,
                                       maxLines: 3,
@@ -216,46 +225,97 @@ class _UpNextCardState extends State<UpNextCard> {
                                       style: textTheme.bodySmall
                                           ?.copyWith(color: muted),
                                     ),
-                                  ],
-                                  const SizedBox(height: 12),
-                                  Row(
-                                    children: [
-                                      if (widget.progress > 0)
-                                        Expanded(
-                                          child: ClipRRect(
-                                            borderRadius: AppRadius.circular(2),
-                                            child: LinearProgressIndicator(
-                                              value: widget.progress.clamp(0.0, 1.0),
-                                              minHeight: 4,
-                                              backgroundColor: AppColorScheme
-                                                  .onSurface
-                                                  .withValues(alpha: 0.20),
-                                              valueColor:
-                                                  AlwaysStoppedAnimation<Color>(
-                                                      AppColorScheme.accent),
+                                    const SizedBox(height: 12),
+                                    Row(
+                                      children: [
+                                        if (widget.progress > 0)
+                                          Expanded(
+                                            child: ClipRRect(
+                                              borderRadius:
+                                                  AppRadius.circular(2),
+                                              child: LinearProgressIndicator(
+                                                value: widget.progress
+                                                    .clamp(0.0, 1.0),
+                                                minHeight: 4,
+                                                backgroundColor: AppColorScheme
+                                                    .onSurface
+                                                    .withValues(alpha: 0.20),
+                                                valueColor:
+                                                    AlwaysStoppedAnimation<
+                                                      Color
+                                                    >(AppColorScheme.accent),
+                                              ),
                                             ),
+                                          )
+                                        else
+                                          const Spacer(),
+                                        if (widget.remainingLabel != null) ...[
+                                          if (widget.progress > 0)
+                                            const SizedBox(width: 12),
+                                          Text(
+                                            widget.remainingLabel!,
+                                            style: textTheme.labelSmall
+                                                ?.copyWith(color: muted),
                                           ),
-                                        )
-                                      else
-                                        const Spacer(),
-                                      if (widget.remainingLabel != null) ...[
-                                        const SizedBox(width: 12),
-                                        Text(
-                                          widget.remainingLabel!,
-                                          style: textTheme.labelSmall
-                                              ?.copyWith(color: muted),
-                                        ),
+                                        ],
                                       ],
-                                    ],
-                                  ),
-                                ],
+                                    ),
+                                  ],
+                                ),
                               ),
                             ),
+                            _thumbnail(),
+                          ],
+                        ),
+                      )
+                    else ...[
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: AspectRatio(
+                          aspectRatio: effectiveAspectRatio,
+                          child: ClipRRect(
+                            borderRadius: AppRadius.circular(
+                              (radius.topLeft.x - 4).clamp(0, double.infinity),
+                            ),
+                            child: _thumbnail(isFullWidth: true),
                           ),
-                          _thumbnail(),
-                        ],
+                        ),
                       ),
-                    ),
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+                        child: Row(
+                          children: [
+                            if (widget.progress > 0)
+                              Expanded(
+                                child: ClipRRect(
+                                  borderRadius: AppRadius.circular(2),
+                                  child: LinearProgressIndicator(
+                                    value: widget.progress.clamp(0.0, 1.0),
+                                    minHeight: 4,
+                                    backgroundColor: AppColorScheme.onSurface
+                                        .withValues(alpha: 0.20),
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                      AppColorScheme.accent,
+                                    ),
+                                  ),
+                                ),
+                              )
+                            else
+                              const Spacer(),
+                            if (widget.remainingLabel != null) ...[
+                              if (widget.progress > 0)
+                                const SizedBox(width: 12),
+                              Text(
+                                widget.remainingLabel!,
+                                style: textTheme.labelSmall?.copyWith(
+                                  color: muted,
+                                ),
+                              ),
+                            ],
+                          ],
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),
@@ -266,9 +326,9 @@ class _UpNextCardState extends State<UpNextCard> {
     );
   }
 
-  Widget _thumbnail({bool isMinimal = false}) {
+  Widget _thumbnail({bool isMinimal = false, bool isFullWidth = false}) {
     return SizedBox(
-      width: isMinimal ? null : 150,
+      width: (isMinimal || isFullWidth) ? null : 150,
       child: Stack(
         fit: StackFit.expand,
         children: [

--- a/lib/ui/screens/detail/modern/widgets/up_next_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/up_next_card.dart
@@ -226,40 +226,7 @@ class _UpNextCardState extends State<UpNextCard> {
                                           ?.copyWith(color: muted),
                                     ),
                                     const SizedBox(height: 12),
-                                    Row(
-                                      children: [
-                                        if (widget.progress > 0)
-                                          Expanded(
-                                            child: ClipRRect(
-                                              borderRadius:
-                                                  AppRadius.circular(2),
-                                              child: LinearProgressIndicator(
-                                                value: widget.progress
-                                                    .clamp(0.0, 1.0),
-                                                minHeight: 4,
-                                                backgroundColor: AppColorScheme
-                                                    .onSurface
-                                                    .withValues(alpha: 0.20),
-                                                valueColor:
-                                                    AlwaysStoppedAnimation<
-                                                      Color
-                                                    >(AppColorScheme.accent),
-                                              ),
-                                            ),
-                                          )
-                                        else
-                                          const Spacer(),
-                                        if (widget.remainingLabel != null) ...[
-                                          if (widget.progress > 0)
-                                            const SizedBox(width: 12),
-                                          Text(
-                                            widget.remainingLabel!,
-                                            style: textTheme.labelSmall
-                                                ?.copyWith(color: muted),
-                                          ),
-                                        ],
-                                      ],
-                                    ),
+                                    _progressRow(textTheme, muted),
                                   ],
                                 ),
                               ),
@@ -283,37 +250,7 @@ class _UpNextCardState extends State<UpNextCard> {
                       ),
                       Padding(
                         padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
-                        child: Row(
-                          children: [
-                            if (widget.progress > 0)
-                              Expanded(
-                                child: ClipRRect(
-                                  borderRadius: AppRadius.circular(2),
-                                  child: LinearProgressIndicator(
-                                    value: widget.progress.clamp(0.0, 1.0),
-                                    minHeight: 4,
-                                    backgroundColor: AppColorScheme.onSurface
-                                        .withValues(alpha: 0.20),
-                                    valueColor: AlwaysStoppedAnimation<Color>(
-                                      AppColorScheme.accent,
-                                    ),
-                                  ),
-                                ),
-                              )
-                            else
-                              const Spacer(),
-                            if (widget.remainingLabel != null) ...[
-                              if (widget.progress > 0)
-                                const SizedBox(width: 12),
-                              Text(
-                                widget.remainingLabel!,
-                                style: textTheme.labelSmall?.copyWith(
-                                  color: muted,
-                                ),
-                              ),
-                            ],
-                          ],
-                        ),
+                        child: _progressRow(textTheme, muted),
                       ),
                     ],
                   ],
@@ -325,6 +262,33 @@ class _UpNextCardState extends State<UpNextCard> {
       ),
     );
   }
+
+  Widget _progressRow(TextTheme textTheme, Color muted) => Row(
+    children: [
+      if (widget.progress > 0)
+        Expanded(
+          child: ClipRRect(
+            borderRadius: AppRadius.circular(2),
+            child: LinearProgressIndicator(
+              value: widget.progress.clamp(0.0, 1.0),
+              minHeight: 4,
+              backgroundColor:
+                  AppColorScheme.onSurface.withValues(alpha: 0.20),
+              valueColor: AlwaysStoppedAnimation<Color>(AppColorScheme.accent),
+            ),
+          ),
+        )
+      else
+        const Spacer(),
+      if (widget.remainingLabel != null) ...[
+        if (widget.progress > 0) const SizedBox(width: 12),
+        Text(
+          widget.remainingLabel!,
+          style: textTheme.labelSmall?.copyWith(color: muted),
+        ),
+      ],
+    ],
+  );
 
   Widget _thumbnail({bool isMinimal = false, bool isFullWidth = false}) {
     return SizedBox(


### PR DESCRIPTION
# Pull Request

## Summary
With the toggle to hide episode descriptions/spoilers, the Next Up area looked a bit disproportionate/lonely. This PR enlarges the thumbnail to match the container width and neatly places the duration/progress indicators below the image when media descriptions are hidden on Details pages, while dynamically respecting the episode's image aspect ratio (16:9, 4:3, etc.).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **aggregated_item.dart**:
  - Added `primaryImageAspectRatio` getter to `AggregatedItem` to read the server-provided aspect ratio from raw metadata.
- **up_next_card.dart**:
  - Added `aspectRatio` property to `UpNextCard`.
  - When media descriptions are hidden (`hasDescription` is false), the card enlarges the thumbnail to match the container's width, respecting the dynamic aspect ratio (16:9 for widescreen, 4:3 for retro/classic TV shows, etc.) with `fit: BoxFit.cover`, and neatly places the progress bar and remaining duration text beneath the image.
  - When media descriptions are shown (`hasDescription` is true), the previous side-by-side layout is preserved.
- **modern_detail_content.dart**:
  - Passed `aspectRatio: episode.primaryImageAspectRatio` to `UpNextCard`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a series with Next Up episodes on Modern Details.
2. When **Hide Media Descriptions on Details Page** is enabled in Settings:
   - Verify that the Next Up card displays the episode label on top, a full-width thumbnail matching the container width and dynamic aspect ratio (16:9 for modern series, 4:3 for classic series), and duration/progress indicators beneath the image.
3. When **Hide Media Descriptions on Details Page** is disabled:
   - Verify that the card retains the side-by-side layout with episode description on the left and thumbnail on the right.

## Screenshots (if applicable)

### Current View

<img width="2218" height="1448" alt="2026-08-31_10-43-28_moonfin" src="https://github.com/user-attachments/assets/74efe39d-7217-40ff-8172-4a19d923f9f8" />

### 2.0 View from Series and Season pages

<img width="2409" height="1389" alt="2026-08-31_19-47-25_moonfin" src="https://github.com/user-attachments/assets/e9553892-cd82-45be-9b77-cde4ddee61e7" />
<img width="2409" height="1389" alt="2026-08-31_19-47-37_moonfin" src="https://github.com/user-attachments/assets/edb7d56c-fc26-4ccf-9307-8faa5855da0c" />
<img width="2409" height="1389" alt="2026-08-31_19-47-49_moonfin" src="https://github.com/user-attachments/assets/51efeb19-612c-44c4-bf8b-5f78ebff3197" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
