### PR TITLE
apply theme text color instead of forcing white on details screens

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3888,6 +3888,7 @@ class _HeaderSection extends StatelessWidget {
         useDesktopLayout && isMusicItem && viewModel.lyrics.isNotEmpty;
     final isCollection = item.type == 'BoxSet';
     final seerrStatus = seerrItemStatus(viewModel);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 
     final infoColumn = Column(
       crossAxisAlignment: isMobile
@@ -3963,7 +3964,9 @@ class _HeaderSection extends StatelessWidget {
           Text(
             item.name,
             style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-              color: Colors.white,
+              color: isNeon
+                  ? AppColorScheme.accent
+                  : AppColorScheme.onBackground,
               fontWeight: FontWeight.bold,
               shadows: _textShadows,
               fontSize: isMobile ? 24 : null,
@@ -4004,7 +4007,7 @@ class _HeaderSection extends StatelessWidget {
           Text(
             item.tagline!,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+              color: isNeon
                   ? AppColorScheme.accent
                   : AppColorScheme.onSurface.withValues(alpha: 0.7),
               fontStyle: FontStyle.italic,
@@ -4033,7 +4036,7 @@ class _HeaderSection extends StatelessWidget {
             onArrowLeft: onArrowLeft,
             onCollapse: onCollapseBiography,
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+              color: isNeon
                   ? AppColorScheme.onSurface
                   : AppColorScheme.onBackground,
               shadows: _textShadows,
@@ -10847,7 +10850,9 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         : (isMobile ? 48.0 : 52.0);
 
     if (widget.isPrimary) {
-      final fg = showHighlight ? AppColorScheme.onButtonFocused : Colors.white;
+      final fg = showHighlight
+          ? AppColorScheme.onButtonFocused
+          : AppColorScheme.onAccent;
       final heartColor = (widget.icon == Icons.favorite && widget.isActive)
           ? const Color(0xFFE50914)
           : fg;
@@ -13637,7 +13642,9 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                   episode.overview!,
                                   style: Theme.of(context).textTheme.bodySmall
                                       ?.copyWith(
-                                        color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                                        color: isNeon
+                                            ? AppColorScheme.onSurface
+                                            : AppColorScheme.onSurface.withValues(alpha: 0.7),
                                       ),
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1848,9 +1848,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.castMembers,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailCastRow(
@@ -1899,9 +1897,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.moreLikeThis,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailSimilarRow(
@@ -1974,9 +1970,7 @@ class _DetailContentState extends State<_DetailContent> {
 
     final l10n = AppLocalizations.of(context);
     final titleStyle = Theme.of(context).textTheme.titleLarge?.copyWith(
-      color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-          ? AppColorScheme.onSurface
-          : Colors.white,
+      color: AppColorScheme.onSurface,
       fontWeight: FontWeight.w700,
     );
     final seerrLabel =
@@ -2128,9 +2122,7 @@ class _DetailContentState extends State<_DetailContent> {
         Text(
           l10n.nextUp,
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.bold,
             shadows: _textShadows,
             fontSize: _isCompact(context) ? 17 : null,
@@ -2175,9 +2167,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.seasons,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailSeasonsRow(
@@ -2209,9 +2199,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.castMembers,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailCastRow(
@@ -2241,9 +2229,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.moreLikeThis,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailSimilarRow(
@@ -2432,9 +2418,7 @@ class _DetailContentState extends State<_DetailContent> {
               Text(
                 l10n.nextEpisode,
                 style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                  color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                      ? AppColorScheme.onSurface
-                      : Colors.white,
+                  color: AppColorScheme.onSurface,
                   fontWeight: FontWeight.bold,
                   shadows: _textShadows,
                   fontSize: _isCompact(context) ? 17 : null,
@@ -2477,9 +2461,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.moreFromThisSeason,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => _EpisodesRow(
@@ -2507,9 +2489,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.castMembers,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailCastRow(
@@ -2538,9 +2518,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.moreLikeThis,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailSimilarRow(
@@ -3775,9 +3753,7 @@ class _DetailContentState extends State<_DetailContent> {
         HorizontalScrollSection(
           title: l10n.castMembers,
           titleStyle: Theme.of(context).textTheme.titleLarge?.copyWith(
-            color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
-                ? AppColorScheme.onSurface
-                : Colors.white,
+            color: AppColorScheme.onSurface,
             fontWeight: FontWeight.w700,
           ),
           builder: (_, ctrl) => DetailCastRow(
@@ -4030,7 +4006,7 @@ class _HeaderSection extends StatelessWidget {
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                   ? AppColorScheme.accent
-                  : Colors.white.withValues(alpha: 0.7),
+                  : AppColorScheme.onSurface.withValues(alpha: 0.7),
               fontStyle: FontStyle.italic,
               shadows: _textShadows,
               fontSize: isMobile ? 13 : null,
@@ -4059,7 +4035,7 @@ class _HeaderSection extends StatelessWidget {
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
               color: ThemeRegistry.active.id == ThemeRegistry.neonPulseId
                   ? AppColorScheme.onSurface
-                  : Colors.white.withValues(alpha: 0.8),
+                  : AppColorScheme.onBackground,
               shadows: _textShadows,
               height: 1.4,
               fontSize: isMobile ? 13 : null,
@@ -4586,7 +4562,7 @@ class DetailMetadataRow extends StatelessWidget {
             style: theme.textTheme.bodySmall?.copyWith(
               color: isNeon
                   ? AppColorScheme.onSurface.withValues(alpha: 0.6)
-                  : Colors.white.withValues(alpha: 0.5),
+                  : AppColorScheme.onBackground.withValues(alpha: 0.6),
               shadows: _textShadows,
             ),
           ),
@@ -4629,13 +4605,10 @@ class DetailMetadataRow extends StatelessWidget {
   }
 
   Widget _text(ThemeData theme, String value) {
-    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     return Text(
       value,
       style: theme.textTheme.bodySmall?.copyWith(
-        color: isNeon
-            ? AppColorScheme.onSurface
-            : Colors.white.withValues(alpha: 0.9),
+        color: AppColorScheme.onSurface,
         fontWeight: FontWeight.w700,
         shadows: _textShadows,
       ),
@@ -4647,9 +4620,7 @@ class DetailMetadataRow extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
       decoration: BoxDecoration(
-        color: isNeon
-            ? AppColorScheme.accent.withValues(alpha: 0.15)
-            : Colors.white.withValues(alpha: 0.15),
+        color: AppColorScheme.accent.withValues(alpha: 0.15),
         border: isNeon
             ? Border.fromBorderSide(
                 ThemeRegistry.active.borders.chipBorder.copyWith(
@@ -4662,9 +4633,7 @@ class DetailMetadataRow extends StatelessWidget {
       child: Text(
         label,
         style: theme.textTheme.labelSmall?.copyWith(
-          color: isNeon
-              ? AppColorScheme.onSurface
-              : Colors.white.withValues(alpha: 0.9),
+          color: AppColorScheme.onSurface,
           shadows: _textShadows,
         ),
       ),
@@ -4708,9 +4677,7 @@ class DetailMetadataRow extends StatelessWidget {
       child: Text(
         label,
         style: theme.textTheme.labelSmall?.copyWith(
-          color: isNeon
-              ? AppColorScheme.onSurface
-              : Colors.white.withValues(alpha: 0.8),
+          color: AppColorScheme.onSurface,
           fontWeight: FontWeight.w600,
         ),
       ),
@@ -11215,12 +11182,12 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     final iconColor = showHighlight
         ? AppColorScheme.onButtonFocused
         : (widget.isActive
-              ? (widget.activeColor ?? (isNeon ? neonAccent : Colors.white))
-              : (isNeon ? neonAccent : Colors.white));
+              ? (widget.activeColor ?? (isNeon ? neonAccent : AppColorScheme.onButtonNormal))
+              : (isNeon ? neonAccent : AppColorScheme.onButtonNormal));
     final showLabelInside = modern && (widget.isPrimary || !isMobile);
     final labelColor = (showHighlight && showLabelInside)
         ? AppColorScheme.onButtonFocused
-        : (isNeon ? neonAccent : Colors.white);
+        : (isNeon ? neonAccent : AppColorScheme.onButtonNormal);
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,
@@ -11404,7 +11371,7 @@ class _SectionHeader extends StatelessWidget {
     return Text(
       title,
       style: Theme.of(context).textTheme.titleLarge?.copyWith(
-        color: isNeon ? AppColorScheme.accent : Colors.white,
+        color: isNeon ? AppColorScheme.accent : AppColorScheme.onBackground,
         fontWeight: FontWeight.bold,
         shadows: _textShadows,
         fontSize: _isCompact(context) ? 17 : null,
@@ -11609,7 +11576,7 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                   Text(
                     widget.name,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: isNeon ? AppColorScheme.accent : Colors.white,
+                      color: isNeon ? AppColorScheme.accent : AppColorScheme.onSurface,
                       fontWeight: FontWeight.w600,
                       fontSize: widget.isMobile ? 11 : null,
                     ),
@@ -11623,7 +11590,7 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
                         color: isNeon
                             ? AppColorScheme.onSurface
-                            : Colors.white.withValues(alpha: 0.6),
+                            : AppColorScheme.onSurface.withValues(alpha: 0.6),
                         fontSize: widget.isMobile ? 10 : 11,
                       ),
                       textAlign: TextAlign.center,
@@ -12680,7 +12647,7 @@ class _OverviewText extends StatelessWidget {
           Theme.of(context).textTheme.bodyLarge?.copyWith(
             color: isNeon
                 ? AppColorScheme.onSurface
-                : Colors.white.withValues(alpha: 0.9),
+                : AppColorScheme.onBackground,
             shadows: _textShadows,
             height: 1.5,
           ),
@@ -13187,11 +13154,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                               'E$epNum',
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: isNeon
-                                        ? AppColorScheme.onSurface.withValues(
-                                            alpha: 0.85,
-                                          )
-                                        : Colors.white.withValues(alpha: 0.5),
+                                    color: AppColorScheme.onSurface.withValues(alpha: 0.85),
                                     fontWeight: FontWeight.w600,
                                   ),
                             ),
@@ -13203,7 +13166,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                                   ?.copyWith(
                                     color: isNeon
                                         ? AppColorScheme.accent
-                                        : Colors.white,
+                                        : AppColorScheme.onSurface,
                                     fontWeight: FontWeight.w600,
                                   ),
                               maxLines: 1,
@@ -13216,11 +13179,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                               runtimeText,
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: isNeon
-                                        ? AppColorScheme.onSurface.withValues(
-                                            alpha: 0.8,
-                                          )
-                                        : Colors.white.withValues(alpha: 0.5),
+                                    color: AppColorScheme.onSurface.withValues(alpha: 0.8),
                                   ),
                             ),
                           ],
@@ -13399,7 +13358,7 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                                   ?.copyWith(
                                     color: isNeon
                                         ? AppColorScheme.accent
-                                        : Colors.white,
+                                        : AppColorScheme.onSurface,
                                     fontWeight: FontWeight.w600,
                                   ),
                               maxLines: 1,
@@ -13413,7 +13372,7 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                                     ?.copyWith(
                                       color: isNeon
                                           ? AppColorScheme.onSurface
-                                          : Colors.white.withValues(alpha: 0.7),
+                                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
                                     ),
                                 maxLines: 3,
                                 overflow: TextOverflow.ellipsis,
@@ -13656,7 +13615,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                     ?.copyWith(
                                       color: isNeon
                                           ? AppColorScheme.accent
-                                          : Colors.white,
+                                          : AppColorScheme.onSurface,
                                       fontWeight: FontWeight.w600,
                                     ),
                                 maxLines: 1,
@@ -13668,11 +13627,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                   runtimeText,
                                   style: Theme.of(context).textTheme.bodySmall
                                       ?.copyWith(
-                                        color: isNeon
-                                            ? AppColorScheme.onSurface.withValues(
-                                                alpha: 0.8,
-                                              )
-                                            : Colors.white.withValues(alpha: 0.5),
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.8),
                                       ),
                                 ),
                               ],
@@ -13682,9 +13637,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                   episode.overview!,
                                   style: Theme.of(context).textTheme.bodySmall
                                       ?.copyWith(
-                                        color: isNeon
-                                            ? AppColorScheme.onSurface
-                                            : Colors.white.withValues(alpha: 0.7),
+                                        color: AppColorScheme.onSurface.withValues(alpha: 0.7),
                                       ),
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3524,6 +3524,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     double maxWidth = 800,
     VoidCallback? onArrowRight,
   }) {
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     return ConstrainedBox(
       constraints: BoxConstraints(
         maxWidth: _landscape ? maxWidth : double.infinity,
@@ -3547,7 +3548,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         onCollapse: widget.onCollapseBiography,
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           height: 1.45,
-          color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+          color: isNeon
+              ? AppColorScheme.onSurface.withValues(alpha: 0.85)
+              : AppColorScheme.onBackground.withValues(alpha: 0.85),
         ),
       ),
     );
@@ -4143,7 +4146,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _metadataRow(BuildContext context, AggregatedItem item, Map<String, dynamic>? selectedMediaSource) {
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
-    final muted = AppColorScheme.onSurface.withValues(alpha: 0.75);
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final muted = isNeon ? AppColorScheme.onSurface.withValues(alpha: 0.75) : AppColorScheme.onBackground.withValues(alpha: 0.75);
     final style = textTheme.bodyMedium?.copyWith(color: muted);
 
     final pieces = <Widget>[];
@@ -4272,9 +4276,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       child: Text(
         label,
         style: theme.textTheme.labelSmall?.copyWith(
-          color: isNeon
-              ? AppColorScheme.onSurface
-              : Colors.white.withValues(alpha: 0.8),
+          color: AppColorScheme.onSurface,
           shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
         ),
       ),
@@ -4316,7 +4318,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             style: theme.textTheme.bodySmall?.copyWith(
               color: isNeon
                   ? AppColorScheme.onSurface.withValues(alpha: 0.6)
-                  : Colors.white.withValues(alpha: 0.5),
+                  : AppColorScheme.onBackground.withValues(alpha: 0.6),
               shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],
             ),
           ),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3512,6 +3512,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     );
   }
 
+  Color get _titleColor =>
+      ThemeRegistry.active.id == ThemeRegistry.neonPulseId
+          ? AppColorScheme.accent
+          : AppColorScheme.onBackground;
+
   List<Shadow>? _neonTextGlow(double blurRadius) =>
       ThemeRegistry.active.id == ThemeRegistry.neonPulseId
           ? [Shadow(color: AppColorScheme.accent, blurRadius: blurRadius)]
@@ -3524,7 +3529,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     double maxWidth = 800,
     VoidCallback? onArrowRight,
   }) {
-    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
     return ConstrainedBox(
       constraints: BoxConstraints(
         maxWidth: _landscape ? maxWidth : double.infinity,
@@ -3548,9 +3552,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         onCollapse: widget.onCollapseBiography,
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           height: 1.45,
-          color: isNeon
-              ? AppColorScheme.onSurface.withValues(alpha: 0.85)
-              : AppColorScheme.onBackground.withValues(alpha: 0.85),
+          color: AppColorScheme.onBackground.withValues(alpha: 0.85),
         ),
       ),
     );
@@ -3604,7 +3606,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             item.name,
             style: textTheme.displaySmall?.copyWith(
               fontWeight: FontWeight.w700,
-              color: Colors.white,
+              color: _titleColor,
             ),
           ),
           const SizedBox(height: 8),
@@ -3737,7 +3739,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               text: item.name,
               style: textTheme.displaySmall?.copyWith(
                 fontWeight: FontWeight.w700,
-                color: Colors.white,
+                color: _titleColor,
                 shadows: _neonTextGlow(12),
               ) ?? const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 28),
             ),
@@ -3929,7 +3931,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   style: (_landscape
                           ? textTheme.displaySmall
                           : textTheme.headlineMedium)
-                      ?.copyWith(fontWeight: FontWeight.w700),
+                      ?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
                 ),
               ],
             ),
@@ -3961,7 +3963,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               style: (_landscape
                       ? textTheme.displaySmall
                       : textTheme.headlineMedium)
-                  ?.copyWith(fontWeight: FontWeight.w700),
+                  ?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
             ),
           ] else if (logoTag != null && logoId != null) ...[
             Padding(
@@ -4013,7 +4015,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   style: (_landscape
                           ? textTheme.displaySmall
                           : textTheme.headlineMedium)
-                      ?.copyWith(fontWeight: FontWeight.w700),
+                      ?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
                 ),
                 if (item.mediaSources.length > 1) ...[
                   const SizedBox(width: 16),
@@ -4146,8 +4148,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   Widget _metadataRow(BuildContext context, AggregatedItem item, Map<String, dynamic>? selectedMediaSource) {
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
-    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
-    final muted = isNeon ? AppColorScheme.onSurface.withValues(alpha: 0.75) : AppColorScheme.onBackground.withValues(alpha: 0.75);
+    final muted = AppColorScheme.onBackground.withValues(alpha: 0.75);
     final style = textTheme.bodyMedium?.copyWith(color: muted);
 
     final pieces = <Widget>[];
@@ -4811,7 +4812,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   children: [
                     Text(
                       item.name,
-                      style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700),
+                      style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
                     ),
                     if (item.mediaSources.length > 1) ...[
                       const SizedBox(width: 16),

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -282,7 +282,7 @@ class _MediaCardState extends State<MediaCard> with FocusStateMixin {
     final titleStyle = baseTextStyle.copyWith(
       color:
           widget.titleColor ??
-          (isNeon ? AppColorScheme.accent : baseTextStyle.color),
+          (isNeon ? AppColorScheme.accent : AppColorScheme.onSurface),
       fontWeight: FontWeight.bold,
       fontSize: (baseTextStyle.fontSize ?? 12) + 1.0,
       shadows: const [Shadow(blurRadius: 4, color: Colors.black54)],


### PR DESCRIPTION
# Pull Request

## Summary
There were a lot of areas (mostly text) on the details screen that hardcoded white instead of using the theme color. Tried to fix them all as best as I could. 

The only one I couldn't figure out is the episode title text, that's still stuck white. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1308 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- there were a lot of instances of color: isNeon ? usetheme : white
- updated to use the correct theme color instead of hardcoding white
- most of them I just removed the isNeon? carve out, but in some cases neon uses "accent" or something else, so I kept isNeon as is and just replaced white with the correct theme color

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)

Theme editor, I made an ugly colorful theme so you can see the difference
<img width="1884" height="1087" alt="image" src="https://github.com/user-attachments/assets/f4d56b57-d80b-4134-8f97-1f0d3fdbaa24" />

Moonfin
<img width="2012" height="1090" alt="image" src="https://github.com/user-attachments/assets/5f9739a3-688c-43f8-9f7c-f8ddcbdf0e37" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
