### PR TITLE
feat(home) - The Impatient PR - see media changes quicker

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -45,7 +45,6 @@ import '../../widgets/quick_return_wrapper.dart';
 import '../../../util/app_exit.dart';
 import '../../../util/overview_text.dart';
 import '../../../util/global_shortcut_focus.dart';
-import '../../../util/home_refresh_helper.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/locked_focus_row.dart';
 import '../../../util/focus/dpad_keys.dart';
@@ -4474,11 +4473,8 @@ class _ContentRowsState extends State<_ContentRows>
           ),
           onLeftEdge: _onRowLeftEdge,
           onTap: (_, item) => _navigateToLibrary(context, item),
-          onLongPress: (_, item) => showContextMenu(
-            context,
-            item,
-            onChanged: () => triggerHomeAndImageCacheRefresh(),
-          ),
+          onLongPress: (_, item) =>
+              showContextMenu(context, item, onChanged: () => setState(() {})),
           itemBuilder: (ctx, item, idx, isFocused) {
             final collectionType =
                 (item.rawData['CollectionType'] as String? ?? '').toLowerCase();
@@ -4501,12 +4497,12 @@ class _ContentRowsState extends State<_ContentRows>
                   onLongPress: () => showContextMenu(
                     context,
                     item,
-                    onChanged: () => triggerHomeAndImageCacheRefresh(),
+                    onChanged: () => setState(() {}),
                   ),
                   onSecondaryTap: () => showContextMenu(
                     context,
                     item,
-                    onChanged: () => triggerHomeAndImageCacheRefresh(),
+                    onChanged: () => setState(() {}),
                   ),
                 ),
               ),
@@ -4665,11 +4661,8 @@ class _ContentRowsState extends State<_ContentRows>
             widget.viewModel.loadMoreForRow(rowIndex);
           }
         },
-        onLongPress: (_, item) => showContextMenu(
-          context,
-          item,
-          onChanged: () => triggerHomeAndImageCacheRefresh(),
-        ),
+        onLongPress: (_, item) =>
+            showContextMenu(context, item, onChanged: () => setState(() {})),
         onTap: (_, item) {
           _finishSharedPreview(releaseResources: true);
           if (row.rowType == HomeRowType.libraryTiles) {
@@ -4932,7 +4925,7 @@ class _ContentRowsState extends State<_ContentRows>
                     onLongPress: () => showContextMenu(
                       context,
                       item,
-                      onChanged: () => triggerHomeAndImageCacheRefresh(),
+                      onChanged: () => setState(() {}),
                     ),
                     onTap: () {
                       if (isV2MobileTouch) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -45,6 +45,7 @@ import '../../widgets/quick_return_wrapper.dart';
 import '../../../util/app_exit.dart';
 import '../../../util/overview_text.dart';
 import '../../../util/global_shortcut_focus.dart';
+import '../../../util/home_refresh_helper.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/locked_focus_row.dart';
 import '../../../util/focus/dpad_keys.dart';
@@ -4473,8 +4474,11 @@ class _ContentRowsState extends State<_ContentRows>
           ),
           onLeftEdge: _onRowLeftEdge,
           onTap: (_, item) => _navigateToLibrary(context, item),
-          onLongPress: (_, item) =>
-              showContextMenu(context, item, onChanged: () => setState(() {})),
+          onLongPress: (_, item) => showContextMenu(
+            context,
+            item,
+            onChanged: () => triggerHomeAndImageCacheRefresh(),
+          ),
           itemBuilder: (ctx, item, idx, isFocused) {
             final collectionType =
                 (item.rawData['CollectionType'] as String? ?? '').toLowerCase();
@@ -4497,12 +4501,12 @@ class _ContentRowsState extends State<_ContentRows>
                   onLongPress: () => showContextMenu(
                     context,
                     item,
-                    onChanged: () => setState(() {}),
+                    onChanged: () => triggerHomeAndImageCacheRefresh(),
                   ),
                   onSecondaryTap: () => showContextMenu(
                     context,
                     item,
-                    onChanged: () => setState(() {}),
+                    onChanged: () => triggerHomeAndImageCacheRefresh(),
                   ),
                 ),
               ),
@@ -4661,8 +4665,11 @@ class _ContentRowsState extends State<_ContentRows>
             widget.viewModel.loadMoreForRow(rowIndex);
           }
         },
-        onLongPress: (_, item) =>
-            showContextMenu(context, item, onChanged: () => setState(() {})),
+        onLongPress: (_, item) => showContextMenu(
+          context,
+          item,
+          onChanged: () => triggerHomeAndImageCacheRefresh(),
+        ),
         onTap: (_, item) {
           _finishSharedPreview(releaseResources: true);
           if (row.rowType == HomeRowType.libraryTiles) {
@@ -4925,7 +4932,7 @@ class _ContentRowsState extends State<_ContentRows>
                     onLongPress: () => showContextMenu(
                       context,
                       item,
-                      onChanged: () => setState(() {}),
+                      onChanged: () => triggerHomeAndImageCacheRefresh(),
                     ),
                     onTap: () {
                       if (isV2MobileTouch) {

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:file_picker/file_picker.dart';
@@ -185,7 +184,7 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
   @override
   void dispose() {
     if (_hasChanged) {
-      unawaited(triggerHomeAndImageCacheRefresh());
+      refreshHomeRows();
     }
     _clearAllFocusNode.dispose();
     _sourcesFocusNode.dispose();

--- a/lib/ui/widgets/change_artwork_dialog.dart
+++ b/lib/ui/widgets/change_artwork_dialog.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:file_picker/file_picker.dart';
@@ -9,6 +10,7 @@ import 'package:server_core/server_core.dart';
 import '../../data/models/aggregated_item.dart';
 import '../../l10n/app_localizations.dart';
 import '../../util/focus/key_event_utils.dart';
+import '../../util/home_refresh_helper.dart';
 import '../../util/platform_detection.dart';
 import '../../auth/repositories/user_repository.dart';
 import '../../auth/repositories/session_repository.dart';
@@ -182,6 +184,9 @@ class _ChangeArtworkDialogState extends State<ChangeArtworkDialog> {
 
   @override
   void dispose() {
+    if (_hasChanged) {
+      unawaited(triggerHomeAndImageCacheRefresh());
+    }
     _clearAllFocusNode.dispose();
     _sourcesFocusNode.dispose();
     _languageFocusNode.dispose();

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
@@ -201,7 +199,7 @@ List<ItemContextAction> contextActionsFor(
         onSelect: () async {
           try {
             await mutations.refreshMetadata(item.id);
-            unawaited(triggerHomeAndImageCacheRefresh(scheduleFollowUp: true));
+            refreshHomeRows(followUp: true);
             if (!context.mounted) return;
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(l10n.adminMetadataRefreshRequested)),

--- a/lib/ui/widgets/focus/context_action.dart
+++ b/lib/ui/widgets/focus/context_action.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
@@ -9,6 +11,7 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../data/repositories/item_mutation_repository.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../util/home_refresh_helper.dart';
 import '../../../util/item_watch_state.dart';
 import '../../navigation/destinations.dart';
 import '../add_to_collection_dialog.dart';
@@ -198,6 +201,7 @@ List<ItemContextAction> contextActionsFor(
         onSelect: () async {
           try {
             await mutations.refreshMetadata(item.id);
+            unawaited(triggerHomeAndImageCacheRefresh(scheduleFollowUp: true));
             if (!context.mounted) return;
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(content: Text(l10n.adminMetadataRefreshRequested)),

--- a/lib/ui/widgets/identify_dialog.dart
+++ b/lib/ui/widgets/identify_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -7,6 +9,7 @@ import 'package:server_core/server_core.dart';
 import '../../l10n/app_localizations.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/focus/dpad_keys.dart';
+import '../../util/home_refresh_helper.dart';
 import '../../util/platform_detection.dart';
 import 'adaptive/adaptive_dialog.dart';
 import 'focus/focusable_button.dart';
@@ -522,6 +525,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
         result,
         replaceAllImages: replaceAllImages,
       );
+      unawaited(triggerHomeAndImageCacheRefresh(scheduleFollowUp: true));
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.adminRemoteMetadataApplied)),

--- a/lib/ui/widgets/identify_dialog.dart
+++ b/lib/ui/widgets/identify_dialog.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
@@ -525,7 +523,7 @@ class _IdentifyDialogState extends State<IdentifyDialog> {
         result,
         replaceAllImages: replaceAllImages,
       );
-      unawaited(triggerHomeAndImageCacheRefresh(scheduleFollowUp: true));
+      refreshHomeRows(followUp: true);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.adminRemoteMetadataApplied)),

--- a/lib/util/home_refresh_helper.dart
+++ b/lib/util/home_refresh_helper.dart
@@ -1,0 +1,41 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../ui/screens/home/home_view_model.dart';
+import 'tv_image_cache_stub.dart'
+    if (dart.library.io) 'tv_image_cache_io.dart';
+
+/// Evicts in-memory and disk image caches and triggers a forced reload of the
+/// Home Screen so that metadata changes, identifications, and new artwork
+/// immediately update on the Home Screen without requiring an app restart.
+Future<void> triggerHomeAndImageCacheRefresh({bool scheduleFollowUp = false}) async {
+  try {
+    PaintingBinding.instance.imageCache.clear();
+    PaintingBinding.instance.imageCache.clearLiveImages();
+    await clearImageDiskCache();
+  } catch (_) {}
+
+  if (GetIt.instance.isRegistered<HomeViewModel>()) {
+    GetIt.instance<HomeViewModel>().load(forceRefresh: true);
+  }
+
+  if (scheduleFollowUp) {
+    // When Jellyfin server executes Identify or Metadata Refresh tasks, it downloads
+    // remote artwork asynchronously over the next 2-3 seconds. A follow-up refresh
+    // picks up the new image tags once the server has finished saving them.
+    unawaited(
+      Future.delayed(const Duration(milliseconds: 2500), () async {
+        try {
+          PaintingBinding.instance.imageCache.clear();
+          PaintingBinding.instance.imageCache.clearLiveImages();
+          await clearImageDiskCache();
+        } catch (_) {}
+        if (GetIt.instance.isRegistered<HomeViewModel>()) {
+          GetIt.instance<HomeViewModel>().load(forceRefresh: true);
+        }
+      }),
+    );
+  }
+}

--- a/lib/util/home_refresh_helper.dart
+++ b/lib/util/home_refresh_helper.dart
@@ -1,41 +1,27 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
 import '../ui/screens/home/home_view_model.dart';
-import 'tv_image_cache_stub.dart'
-    if (dart.library.io) 'tv_image_cache_io.dart';
 
-/// Evicts in-memory and disk image caches and triggers a forced reload of the
-/// Home Screen so that metadata changes, identifications, and new artwork
-/// immediately update on the Home Screen without requiring an app restart.
-Future<void> triggerHomeAndImageCacheRefresh({bool scheduleFollowUp = false}) async {
-  try {
-    PaintingBinding.instance.imageCache.clear();
-    PaintingBinding.instance.imageCache.clearLiveImages();
-    await clearImageDiskCache();
-  } catch (_) {}
+Timer? _followUpTimer;
 
-  if (GetIt.instance.isRegistered<HomeViewModel>()) {
-    GetIt.instance<HomeViewModel>().load(forceRefresh: true);
-  }
+/// Every image URL carries the server's image tag, so fresh rows are enough to
+/// pick up new artwork and the image caches can stay where they are.
+void refreshHomeRows({bool followUp = false}) {
+  _reload();
+  if (!followUp) return;
 
-  if (scheduleFollowUp) {
-    // When Jellyfin server executes Identify or Metadata Refresh tasks, it downloads
-    // remote artwork asynchronously over the next 2-3 seconds. A follow-up refresh
-    // picks up the new image tags once the server has finished saving them.
-    unawaited(
-      Future.delayed(const Duration(milliseconds: 2500), () async {
-        try {
-          PaintingBinding.instance.imageCache.clear();
-          PaintingBinding.instance.imageCache.clearLiveImages();
-          await clearImageDiskCache();
-        } catch (_) {}
-        if (GetIt.instance.isRegistered<HomeViewModel>()) {
-          GetIt.instance<HomeViewModel>().load(forceRefresh: true);
-        }
-      }),
-    );
-  }
+  // The server keeps downloading remote artwork after it answers, so the first
+  // rows can still carry the old tag. A second pass picks up the new one.
+  _followUpTimer?.cancel();
+  _followUpTimer = Timer(const Duration(milliseconds: 2500), _reload);
+}
+
+void _reload() {
+  if (!GetIt.instance.isRegistered<HomeViewModel>()) return;
+  final home = GetIt.instance<HomeViewModel>();
+  // Callers reach here from dispose, where the tree is locked and the
+  // notifyListeners inside load would throw.
+  scheduleMicrotask(() => home.load(forceRefresh: true));
 }

--- a/test/util/home_refresh_helper_test.dart
+++ b/test/util/home_refresh_helper_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/ui/screens/home/home_view_model.dart';
+import 'package:moonfin/util/home_refresh_helper.dart';
+
+class _Home extends Mock implements HomeViewModel {}
+
+class _DisposeCaller extends StatefulWidget {
+  const _DisposeCaller();
+
+  @override
+  State<_DisposeCaller> createState() => _DisposeCallerState();
+}
+
+class _DisposeCallerState extends State<_DisposeCaller> {
+  @override
+  void dispose() {
+    refreshHomeRows();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox();
+}
+
+void main() {
+  late _Home home;
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    home = _Home();
+    when(
+      () => home.load(forceRefresh: any(named: 'forceRefresh')),
+    ).thenAnswer((_) async {});
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  testWidgets('does nothing when the home view model is not registered', (
+    tester,
+  ) async {
+    refreshHomeRows(followUp: true);
+    await tester.pump(const Duration(seconds: 4));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('reloads the rows once', (tester) async {
+    GetIt.instance.registerSingleton<HomeViewModel>(home);
+    refreshHomeRows();
+    await tester.pump(const Duration(seconds: 4));
+    verify(() => home.load(forceRefresh: true)).called(1);
+  });
+
+  testWidgets('a follow-up picks up artwork the server was still fetching', (
+    tester,
+  ) async {
+    GetIt.instance.registerSingleton<HomeViewModel>(home);
+    refreshHomeRows(followUp: true);
+    await tester.pump(const Duration(seconds: 1));
+    verify(() => home.load(forceRefresh: true)).called(1);
+    await tester.pump(const Duration(seconds: 3));
+    verify(() => home.load(forceRefresh: true)).called(1);
+  });
+
+  testWidgets('a second call replaces the pending follow-up', (tester) async {
+    GetIt.instance.registerSingleton<HomeViewModel>(home);
+    refreshHomeRows(followUp: true);
+    await tester.pump(const Duration(seconds: 1));
+    refreshHomeRows(followUp: true);
+    await tester.pump(const Duration(seconds: 4));
+    verify(() => home.load(forceRefresh: true)).called(3);
+  });
+
+  testWidgets('a call from dispose does not fire while the tree is locked', (
+    tester,
+  ) async {
+    // The real view model notifies its listeners as the first thing load does,
+    // so the fake has to as well or the locked tree is never exercised.
+    final loads = ValueNotifier<int>(0);
+    addTearDown(loads.dispose);
+    when(
+      () => home.load(forceRefresh: any(named: 'forceRefresh')),
+    ).thenAnswer((_) async => loads.value++);
+
+    GetIt.instance.registerSingleton<HomeViewModel>(home);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<int>(
+          valueListenable: loads,
+          builder: (_, value, _) =>
+              Column(children: [Text('loads: $value'), const _DisposeCaller()]),
+        ),
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<int>(
+          valueListenable: loads,
+          builder: (_, value, _) => Text('loads: $value'),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+    await tester.pump();
+    expect(loads.value, 1);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
When I would change artwork for a media item or use the Identify feature, the files would be modified but wouldn't appear on the home screen until the cache was invalidated. This PR forces an immediate Home Screen and image cache refresh whenever an item is identified, its artwork is changed, or metadata is refreshed, so updated titles, metadata, and newly downloaded posters/backdrops appear immediately on the Home Screen without requiring an app restart.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **home_refresh_helper.dart**:
  - Created `triggerHomeAndImageCacheRefresh({bool scheduleFollowUp = false})`.
  - Evicts Flutter's in-memory image cache (`PaintingBinding.instance.imageCache.clear()`, `clearLiveImages()`) and disk image caches (`clearImageDiskCache()`).
  - Calls `GetIt.instance<HomeViewModel>().load(forceRefresh: true)` to reload all server rows.
  - Automatically schedules a 2.5-second follow-up reload when `scheduleFollowUp` is true, ensuring new image tags are seamlessly fetched once Jellyfin's backend finishes downloading remote artwork.
- **identify_dialog.dart**:
  - Invokes `triggerHomeAndImageCacheRefresh(scheduleFollowUp: true)` upon applying remote identification results.
- **change_artwork_dialog.dart**:
  - Triggers `triggerHomeAndImageCacheRefresh()` upon dialog disposal when artwork modifications (`_hasChanged`) have been made.
- **context_action.dart**:
  - Triggers `triggerHomeAndImageCacheRefresh(scheduleFollowUp: true)` when manual metadata refresh is requested from context menus.
- **home_screen.dart**:
  - Updated context menu `onChanged` callbacks to call `triggerHomeAndImageCacheRefresh()` instead of a no-op widget rebuild.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Long-press on an item on the Home Screen (or on the Details page) and select **Identify** or **Change Artwork**.
2. Search and apply an identification or select new artwork.
3. Return to the Home Screen and observe that the metadata updates immediately, and newly downloaded artwork appears on the Home Screen rows without requiring an app restart.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/a5433ced-b651-44a3-bfcf-f5b0af3f6d2d


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
