### PR TITLE
Respect disabled audio passthrough codecs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ app.*.map.json
 /Moonfin_Android_v*.apk
 /Moonfin_Android_v*.aab
 /*.apk
-/*.aab
 
 # iOS IPA artifacts and local signing overrides
 /Moonfin-ios.ipa

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ app.*.map.json
 /Moonfin_Android_v*.apk
 /Moonfin_Android_v*.aab
 /*.apk
+/*.aab
 
 # iOS IPA artifacts and local signing overrides
 /Moonfin-ios.ipa

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -264,8 +264,10 @@ class Media3PlayerBackend extends PlayerBackend {
       case 'activityAction':
         _activityActionController.add(map.cast<String, dynamic>());
       case 'playerError':
+        final cause = map['cause']?.toString();
         _diag(
-          'Media3 player error: ${map['errorCode'] ?? ''} ${map['message'] ?? ''}',
+          'Media3 player error: ${map['errorCode'] ?? ''} ${map['message'] ?? ''}'
+          '${cause == null || cause.isEmpty ? '' : ' caused by $cause'}',
           level: LogLevel.error,
         );
         _errorStream.add(map.cast<String, dynamic>());

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -725,8 +725,8 @@ class Media3VideoView(
     // Recreated alongside the player in createPlayer(). A TrackSelector must not
     // be shared across ExoPlayer instances: it binds to the playback thread of
     // the player it is built with, so reusing it after the player is released
-    // and rebuilt throws "DefaultTrackSelector is accessed on the wrong thread" 
-    // on the new player's  playback thread, killing that thread and freezing 
+    // and rebuilt throws "DefaultTrackSelector is accessed on the wrong thread"
+    // on the new player's  playback thread, killing that thread and freezing
     // playback.
     private lateinit var trackSelector: DefaultTrackSelector
     private val audioPipeline = ExoPlayerAudioPipeline()
@@ -778,6 +778,7 @@ class Media3VideoView(
         }
     // Guards the container/source-error transcode fallback against re-emitting.
     private var containerFallbackAttempted = false
+    private var audioFallbackAttempted = false
 
     // Last audio track mapping reported, so an unchanged one stays quiet.
     private var lastAudioTrackMapping: List<Map<String, Any?>>? = null
@@ -2322,6 +2323,7 @@ class Media3VideoView(
         stereoDownmixRetryAttemptedForCurrentSource = false
         tunnelingRetryAttemptedForCurrentSource = false
         containerFallbackAttempted = false
+        audioFallbackAttempted = false
         Media3TransferLog.reset()
         // Start each source with the downmix the user asked for or the state
         // the device has proven it needs (sticky once an AudioTrack init
@@ -3832,6 +3834,27 @@ class Media3VideoView(
             ?.startsWith("audio/") == true
     }
 
+    private fun errorIsNoValidVarintLengthMaskFound(error: PlaybackException): Boolean {
+        val exo = error as? ExoPlaybackException ?: return false
+        if (exo.type != ExoPlaybackException.TYPE_SOURCE) return false
+
+        var cause: Throwable? = exo.sourceException
+        var depth = 0
+
+        while (cause != null && depth < 3) {
+            if (cause is IllegalStateException &&
+                cause.message == "No valid varint length mask found"
+            ) {
+                return true
+            }
+
+            cause = cause.cause
+            depth++
+        }
+
+        return false
+    }
+
     private fun emitRecoverablePlayerError(
         error: PlaybackException,
         audioOffloadRetryTriggered: Boolean,
@@ -3858,6 +3881,19 @@ class Media3VideoView(
             PlaybackException.ERROR_CODE_DECODING_FAILED ->
                 if (errorIsFromAudioRenderer(error)) "unsupported_audio" else null
 
+            // Some MKVs contain trailing zero padding after the last real
+            // cluster while the Segment size extends to EOF. Media3 then reads
+            // 0x00 as an EBML length byte, but it has no leading 1-bit and is
+            // therefore not a valid varint length mask. A server audio
+            // transcode rewrites the stream without that malformed tail, so
+            // allow one retry for this specific parser failure.
+            PlaybackException.ERROR_CODE_IO_UNSPECIFIED ->
+                if (errorIsNoValidVarintLengthMaskFound(error)) {
+                    if (audioFallbackAttempted) null else "unsupported_audio"
+                } else {
+                    null
+                }
+
             else -> null
         }
 
@@ -3865,10 +3901,12 @@ class Media3VideoView(
             return
         }
 
+        // Guard against re-emitting for the same source; the Dart side also
+        // refuses to re-resolve when already transcoding, so this cannot loop.
         if (recoverableKind == "unsupported_container") {
-            // Guard against re-emitting for the same source; the Dart side also
-            // refuses to re-resolve when already transcoding, so this cannot loop.
             containerFallbackAttempted = true
+        } else if (recoverableKind == "unsupported_audio") {
+            audioFallbackAttempted = true
         }
 
         Media3Bridge.emitEvent(
@@ -3878,6 +3916,7 @@ class Media3VideoView(
                 "kind" to recoverableKind,
                 "code" to error.errorCode,
                 "message" to (error.localizedMessage ?: ""),
+                "cause" to describeCauseChain(error),
                 "audioOffloadRetryTriggered" to audioOffloadRetryTriggered,
             ),
         )

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -778,7 +778,6 @@ class Media3VideoView(
         }
     // Guards the container/source-error transcode fallback against re-emitting.
     private var containerFallbackAttempted = false
-    private var audioFallbackAttempted = false
 
     // Last audio track mapping reported, so an unchanged one stays quiet.
     private var lastAudioTrackMapping: List<Map<String, Any?>>? = null
@@ -2323,7 +2322,6 @@ class Media3VideoView(
         stereoDownmixRetryAttemptedForCurrentSource = false
         tunnelingRetryAttemptedForCurrentSource = false
         containerFallbackAttempted = false
-        audioFallbackAttempted = false
         Media3TransferLog.reset()
         // Start each source with the downmix the user asked for or the state
         // the device has proven it needs (sticky once an AudioTrack init
@@ -3881,15 +3879,16 @@ class Media3VideoView(
             PlaybackException.ERROR_CODE_DECODING_FAILED ->
                 if (errorIsFromAudioRenderer(error)) "unsupported_audio" else null
 
-            // Some MKVs contain trailing zero padding after the last real
-            // cluster while the Segment size extends to EOF. Media3 then reads
-            // 0x00 as an EBML length byte, but it has no leading 1-bit and is
-            // therefore not a valid varint length mask. A server audio
-            // transcode rewrites the stream without that malformed tail, so
-            // allow one retry for this specific parser failure.
+            // Some MKVs carry zero padding after the last real cluster while
+            // the Segment size runs to EOF. Media3 reads a 0x00 there as an
+            // EBML length byte, which has no leading 1-bit and so no valid
+            // varint length mask. The container is the malformed part, and any
+            // server transcode rewrites it without the tail.
             PlaybackException.ERROR_CODE_IO_UNSPECIFIED ->
-                if (errorIsNoValidVarintLengthMaskFound(error)) {
-                    if (audioFallbackAttempted) null else "unsupported_audio"
+                if (!containerFallbackAttempted &&
+                    errorIsNoValidVarintLengthMaskFound(error)
+                ) {
+                    "unsupported_container"
                 } else {
                     null
                 }
@@ -3901,12 +3900,10 @@ class Media3VideoView(
             return
         }
 
-        // Guard against re-emitting for the same source; the Dart side also
-        // refuses to re-resolve when already transcoding, so this cannot loop.
         if (recoverableKind == "unsupported_container") {
+            // Guard against re-emitting for the same source; the Dart side also
+            // refuses to re-resolve when already transcoding, so this cannot loop.
             containerFallbackAttempted = true
-        } else if (recoverableKind == "unsupported_audio") {
-            audioFallbackAttempted = true
         }
 
         Media3Bridge.emitEvent(

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1054,6 +1054,11 @@ class PlaybackManager implements AudioOwnable {
 
     Future<void> recoverViaTranscode() async {
       _unsupportedAudioRecoveryInFlight = true;
+      // The stop below lets a startup still inside play() return, and the
+      // next token is only taken after that stop. Retire the startup here or
+      // it finishes as a normal start and reports a start for a session whose
+      // stop already went out.
+      ++_playbackSessionToken;
       try {
         await _reResolveAtCurrentPosition(
           forceTranscode: true,
@@ -1746,7 +1751,9 @@ class PlaybackManager implements AudioOwnable {
       startupError = e;
       startupStackTrace = st;
     } finally {
-      _waitingForMedia = false;
+      if (sessionToken == _playbackSessionToken) {
+        _waitingForMedia = false;
+      }
     }
 
     if (sessionToken != _playbackSessionToken) {

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -174,7 +174,6 @@ class PlaybackManager implements AudioOwnable {
   bool _forceExternalPlayerOnce = false;
   bool _forceExternalChooserOnce = false;
   bool _unsupportedAudioRecoveryInFlight = false;
-  bool _audioTranscodeRecoveryAttempted = false;
   final Set<String> _vetoedAudioCodecs = <String>{};
   bool _suppressNextGenericBackendError = false;
   bool _teardownForReResolve = false;
@@ -1042,11 +1041,11 @@ class PlaybackManager implements AudioOwnable {
       return;
     }
 
-    // Deliberately not gated on _waitingForMedia. A stream the player can't
-    // parse gives up before it ever reaches a ready state, so gating on that
-    // left the sources this recovery exists for sitting on a spinner. The
-    // re-resolve takes the next session token, and the startup still running
-    // behind it compares tokens and hands off to _cleanupPreemptedSession.
+    // Deliberately not gated on _waitingForMedia. A container the player can't
+    // parse fails before it ever reaches a ready state, so that gate left the
+    // sources this recovery exists for sitting on a spinner. The re-resolve
+    // takes the next session token, and the startup still running behind it
+    // compares tokens and hands off to _cleanupPreemptedSession.
     bool canReResolve() =>
         resolution != null &&
         resolution.playMethod != StreamPlayMethod.transcode &&
@@ -1107,18 +1106,12 @@ class PlaybackManager implements AudioOwnable {
       return;
     }
 
-    if (_audioTranscodeRecoveryAttempted) {
-      emitFailedBringupState('Playback failed after audio transcode recovery.');
-      return;
-    }
-
     // The device just proved it can't play this audio codec, so a retry has
     // to stop offering it or the server copies the same track into the next
     // stream and the failure repeats.
     final vetoAdded = resolution != null && _vetoSelectedAudioCodec(resolution);
 
     if (canReResolve()) {
-      _audioTranscodeRecoveryAttempted = true;
       await recoverViaTranscode();
       return;
     }
@@ -1379,11 +1372,6 @@ class PlaybackManager implements AudioOwnable {
     _lastKnownPosition = startPosition;
     final sessionToken = ++_playbackSessionToken;
     final itemId = _traceItemId(item);
-    // Every start gets the one recovery back, bar the recovery's own
-    // re-resolve, which arrives here mid flight on the same item.
-    if (!_unsupportedAudioRecoveryInFlight) {
-      _audioTranscodeRecoveryAttempted = false;
-    }
     final appliedOverrides = _applyPendingItemOverridesIfNeeded(itemId);
     if (!appliedOverrides && _lastItemId != null && _lastItemId != itemId) {
       _translateTrackSelectionsForNewItem(item);

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1042,6 +1042,11 @@ class PlaybackManager implements AudioOwnable {
       return;
     }
 
+    // Deliberately not gated on _waitingForMedia. A stream the player can't
+    // parse gives up before it ever reaches a ready state, so gating on that
+    // left the sources this recovery exists for sitting on a spinner. The
+    // re-resolve takes the next session token, and the startup still running
+    // behind it compares tokens and hands off to _cleanupPreemptedSession.
     bool canReResolve() =>
         resolution != null &&
         resolution.playMethod != StreamPlayMethod.transcode &&
@@ -1374,7 +1379,9 @@ class PlaybackManager implements AudioOwnable {
     _lastKnownPosition = startPosition;
     final sessionToken = ++_playbackSessionToken;
     final itemId = _traceItemId(item);
-    if (_lastItemId != itemId) {
+    // Every start gets the one recovery back, bar the recovery's own
+    // re-resolve, which arrives here mid flight on the same item.
+    if (!_unsupportedAudioRecoveryInFlight) {
       _audioTranscodeRecoveryAttempted = false;
     }
     final appliedOverrides = _applyPendingItemOverridesIfNeeded(itemId);

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -174,6 +174,7 @@ class PlaybackManager implements AudioOwnable {
   bool _forceExternalPlayerOnce = false;
   bool _forceExternalChooserOnce = false;
   bool _unsupportedAudioRecoveryInFlight = false;
+  bool _audioTranscodeRecoveryAttempted = false;
   final Set<String> _vetoedAudioCodecs = <String>{};
   bool _suppressNextGenericBackendError = false;
   bool _teardownForReResolve = false;
@@ -1045,7 +1046,6 @@ class PlaybackManager implements AudioOwnable {
         resolution != null &&
         resolution.playMethod != StreamPlayMethod.transcode &&
         !_isOfflinePlayback &&
-        !_waitingForMedia &&
         !_unsupportedAudioRecoveryInFlight;
 
     Future<void> recoverViaTranscode() async {
@@ -1102,12 +1102,18 @@ class PlaybackManager implements AudioOwnable {
       return;
     }
 
+    if (_audioTranscodeRecoveryAttempted) {
+      emitFailedBringupState('Playback failed after audio transcode recovery.');
+      return;
+    }
+
     // The device just proved it can't play this audio codec, so a retry has
     // to stop offering it or the server copies the same track into the next
     // stream and the failure repeats.
     final vetoAdded = resolution != null && _vetoSelectedAudioCodec(resolution);
 
     if (canReResolve()) {
+      _audioTranscodeRecoveryAttempted = true;
       await recoverViaTranscode();
       return;
     }
@@ -1368,6 +1374,9 @@ class PlaybackManager implements AudioOwnable {
     _lastKnownPosition = startPosition;
     final sessionToken = ++_playbackSessionToken;
     final itemId = _traceItemId(item);
+    if (_lastItemId != itemId) {
+      _audioTranscodeRecoveryAttempted = false;
+    }
     final appliedOverrides = _applyPendingItemOverridesIfNeeded(itemId);
     if (!appliedOverrides && _lastItemId != null && _lastItemId != itemId) {
       _translateTrackSelectionsForNewItem(item);

--- a/test/playback/playback_manager_stale_session_test.dart
+++ b/test/playback/playback_manager_stale_session_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:playback_core/playback_core.dart';
 
 class _TestBackend extends Fake implements PlayerBackend {
+  final _errors = StreamController<Map<String, dynamic>>.broadcast();
   final List<String> playedUrls = <String>[];
   final List<Duration> startPositions = <Duration>[];
   int stopCalls = 0;
@@ -48,7 +49,9 @@ class _TestBackend extends Fake implements PlayerBackend {
   Stream<bool> get completedStream => const Stream<bool>.empty();
 
   @override
-  Stream<Map<String, dynamic>>? get errorStream => null;
+  Stream<Map<String, dynamic>>? get errorStream => _errors.stream;
+
+  void emitError(Map<String, dynamic> event) => _errors.add(event);
 
   @override
   bool get supportsRuntimeTrackSelection => false;
@@ -90,13 +93,17 @@ class _TestBackend extends Fake implements PlayerBackend {
   Future<void> setRepeatMode(RepeatMode mode) async {}
 
   @override
-  void dispose() {}
+  void dispose() => _errors.close();
 }
 
 class _TestResolver extends MediaStreamResolver {
   int calls = 0;
   final List<String?> requestedMediaSourceIds = <String?>[];
   final List<int?> requestedStartTicks = <int?>[];
+  final List<bool> requestedDirectPlay = <bool>[];
+  StreamPlayMethod playMethod = StreamPlayMethod.directStream;
+  bool isLocalMedia = false;
+  List<Map<String, dynamic>> mediaStreams = const [];
 
   @override
   Future<StreamResolutionResult> resolve(
@@ -114,6 +121,7 @@ class _TestResolver extends MediaStreamResolver {
     calls++;
     requestedMediaSourceIds.add(mediaSourceId);
     requestedStartTicks.add(startTimeTicks);
+    requestedDirectPlay.add(enableDirectPlay);
     final type = (mediaItem as Map<String, dynamic>)['Type'];
     final isLive = type == 'TvChannel' || type == 'LiveTvChannel';
     return StreamResolutionResult(
@@ -121,7 +129,9 @@ class _TestResolver extends MediaStreamResolver {
       mediaSourceId: 'source-$calls',
       liveStreamId: isLive ? 'live-$calls' : null,
       playSessionId: 'session-$calls',
-      playMethod: StreamPlayMethod.directStream,
+      playMethod: playMethod,
+      isLocalMedia: isLocalMedia,
+      mediaStreams: mediaStreams,
     );
   }
 }
@@ -409,6 +419,161 @@ void main() {
       manager.dispose();
     }
   });
+
+  test(
+    'unsupported audio retries once with transcoding and fails thereafter',
+    () async {
+      final backend = _TestBackend();
+      final resolver = _TestResolver();
+      final service = _TestService();
+      final manager = _manager(backend, resolver, service);
+      final item = <String, dynamic>{'Id': 'audio', 'Type': 'Movie'};
+
+      try {
+        await manager.playItems(<dynamic>[item]);
+        backend.emitError(<String, dynamic>{
+          'event': 'playerError',
+          'recoverable': true,
+          'kind': 'unsupported_audio',
+        });
+        await pumpEventQueue(times: 10);
+
+        expect(resolver.calls, 2);
+        expect(resolver.requestedDirectPlay, <bool>[true, false]);
+
+        backend.emitError(<String, dynamic>{
+          'event': 'playerError',
+          'recoverable': true,
+          'kind': 'unsupported_audio',
+        });
+        await pumpEventQueue(times: 10);
+
+        expect(resolver.calls, 2);
+        expect(manager.bringupState.phase, PlaybackBringupPhase.failed);
+        expect(
+          manager.bringupState.error,
+          'Playback failed after audio transcode recovery.',
+        );
+      } finally {
+        manager.dispose();
+      }
+    },
+  );
+
+  test('audio transcode recovery is available again for a new item', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+
+    try {
+      await manager.playItems(<dynamic>[
+        <String, dynamic>{'Id': 'first', 'Type': 'Movie'},
+      ]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+
+      await manager.playItems(<dynamic>[
+        <String, dynamic>{'Id': 'second', 'Type': 'Movie'},
+      ]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 4);
+      expect(resolver.requestedDirectPlay, <bool>[true, false, true, false]);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  test('audio offload retry does not trigger server recovery', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+    final item = <String, dynamic>{'Id': 'offload', 'Type': 'Movie'};
+
+    try {
+      await manager.playItems(<dynamic>[item]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+        'audioOffloadRetryTriggered': true,
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 1);
+      expect(manager.bringupState.phase, isNot(PlaybackBringupPhase.failed));
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  test('local media audio failure is surfaced without re-resolving', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver()..isLocalMedia = true;
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+    final item = <String, dynamic>{'Id': 'local', 'Type': 'Movie'};
+
+    try {
+      await manager.playItems(<dynamic>[item]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 1);
+      expect(manager.bringupState.phase, PlaybackBringupPhase.failed);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  test(
+    'already-transcoded audio is retried after vetoing its selected codec',
+    () async {
+      final backend = _TestBackend();
+      final resolver = _TestResolver()
+        ..playMethod = StreamPlayMethod.transcode
+        ..mediaStreams = <Map<String, dynamic>>[
+          <String, dynamic>{
+            'Type': 'Audio',
+            'Codec': 'eac3',
+            'IsDefault': true,
+          },
+        ];
+      final service = _TestService();
+      final manager = _manager(backend, resolver, service);
+      final item = <String, dynamic>{'Id': 'transcoded', 'Type': 'Movie'};
+
+      try {
+        await manager.playItems(<dynamic>[item]);
+        backend.emitError(<String, dynamic>{
+          'event': 'playerError',
+          'recoverable': true,
+          'kind': 'unsupported_audio',
+        });
+        await pumpEventQueue(times: 10);
+
+        expect(resolver.calls, 2);
+        expect(resolver.requestedDirectPlay, <bool>[true, false]);
+      } finally {
+        manager.dispose();
+      }
+    },
+  );
 }
 
 extension<T> on Iterable<T> {

--- a/test/playback/playback_manager_stale_session_test.dart
+++ b/test/playback/playback_manager_stale_session_test.dart
@@ -5,6 +5,7 @@ import 'package:playback_core/playback_core.dart';
 
 class _TestBackend extends Fake implements PlayerBackend {
   final _errors = StreamController<Map<String, dynamic>>.broadcast();
+  Completer<void>? playGate;
   final List<String> playedUrls = <String>[];
   final List<Duration> startPositions = <Duration>[];
   int stopCalls = 0;
@@ -79,6 +80,13 @@ class _TestBackend extends Fake implements PlayerBackend {
     startPositions.add(startPosition);
     currentPosition = startPosition;
     playing = true;
+    // Holds the first play open so a test can land an error while the manager
+    // is still waiting for media. Later plays run straight through.
+    final gate = playGate;
+    if (gate != null) {
+      playGate = null;
+      await gate.future;
+    }
   }
 
   @override
@@ -480,6 +488,82 @@ void main() {
       await manager.playItems(<dynamic>[
         <String, dynamic>{'Id': 'second', 'Type': 'Movie'},
       ]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 4);
+      expect(resolver.requestedDirectPlay, <bool>[true, false, true, false]);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  test('unsupported audio recovers when it lands during startup', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+
+    final gate = Completer<void>();
+    backend.playGate = gate;
+
+    try {
+      final started = manager.playItems(<dynamic>[
+        <String, dynamic>{'Id': 'startup', 'Type': 'Movie'},
+      ]);
+      await pumpEventQueue(times: 5);
+
+      // A stream the player can't parse errors before it ever reaches a ready
+      // state, so the recovery has to survive this window rather than wait on
+      // a startup that is never going to finish.
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 2);
+      expect(resolver.requestedDirectPlay, <bool>[true, false]);
+
+      // Lets the preempted startup unwind so the handoff runs too.
+      gate.complete();
+      await started;
+      await pumpEventQueue(times: 10);
+    } finally {
+      if (!gate.isCompleted) {
+        gate.complete();
+      }
+      manager.dispose();
+    }
+  });
+
+  test('playing the same item again gets the recovery back', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver();
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+
+    try {
+      await manager.playItems(<dynamic>[
+        <String, dynamic>{'Id': 'repeat', 'Type': 'Movie'},
+      ]);
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_audio',
+      });
+      await pumpEventQueue(times: 10);
+      expect(resolver.calls, 2);
+
+      // Replays the item the queue is already on, which is the path repeat and
+      // a retry from the player take. It does not go back through playItems.
+      await manager.startQueuedPlayback();
+      await pumpEventQueue(times: 10);
       backend.emitError(<String, dynamic>{
         'event': 'playerError',
         'recoverable': true,

--- a/test/playback/playback_manager_stale_session_test.dart
+++ b/test/playback/playback_manager_stale_session_test.dart
@@ -429,7 +429,7 @@ void main() {
   });
 
   test(
-    'unsupported audio retries once with transcoding and fails thereafter',
+    'a second failure with nothing new to veto does not resolve again',
     () async {
       final backend = _TestBackend();
       final resolver = _TestResolver();
@@ -439,6 +439,8 @@ void main() {
 
       try {
         await manager.playItems(<dynamic>[item]);
+        // The recovery asks for a transcode, so that is what comes back.
+        resolver.playMethod = StreamPlayMethod.transcode;
         backend.emitError(<String, dynamic>{
           'event': 'playerError',
           'recoverable': true,
@@ -449,6 +451,8 @@ void main() {
         expect(resolver.calls, 2);
         expect(resolver.requestedDirectPlay, <bool>[true, false]);
 
+        // No codec on the stream means nothing to veto, so there is no new
+        // information a third resolve could act on.
         backend.emitError(<String, dynamic>{
           'event': 'playerError',
           'recoverable': true,
@@ -457,50 +461,11 @@ void main() {
         await pumpEventQueue(times: 10);
 
         expect(resolver.calls, 2);
-        expect(manager.bringupState.phase, PlaybackBringupPhase.failed);
-        expect(
-          manager.bringupState.error,
-          'Playback failed after audio transcode recovery.',
-        );
       } finally {
         manager.dispose();
       }
     },
   );
-
-  test('audio transcode recovery is available again for a new item', () async {
-    final backend = _TestBackend();
-    final resolver = _TestResolver();
-    final service = _TestService();
-    final manager = _manager(backend, resolver, service);
-
-    try {
-      await manager.playItems(<dynamic>[
-        <String, dynamic>{'Id': 'first', 'Type': 'Movie'},
-      ]);
-      backend.emitError(<String, dynamic>{
-        'event': 'playerError',
-        'recoverable': true,
-        'kind': 'unsupported_audio',
-      });
-      await pumpEventQueue(times: 10);
-
-      await manager.playItems(<dynamic>[
-        <String, dynamic>{'Id': 'second', 'Type': 'Movie'},
-      ]);
-      backend.emitError(<String, dynamic>{
-        'event': 'playerError',
-        'recoverable': true,
-        'kind': 'unsupported_audio',
-      });
-      await pumpEventQueue(times: 10);
-
-      expect(resolver.calls, 4);
-      expect(resolver.requestedDirectPlay, <bool>[true, false, true, false]);
-    } finally {
-      manager.dispose();
-    }
-  });
 
   test('unsupported audio recovers when it lands during startup', () async {
     final backend = _TestBackend();
@@ -517,9 +482,9 @@ void main() {
       ]);
       await pumpEventQueue(times: 5);
 
-      // A stream the player can't parse errors before it ever reaches a ready
-      // state, so the recovery has to survive this window rather than wait on
-      // a startup that is never going to finish.
+      // An audio failure can land before the first play returns, a format the
+      // decoder turns down on sight for one, so the recovery has to fire in
+      // this window rather than wait on a startup that never finishes.
       backend.emitError(<String, dynamic>{
         'event': 'playerError',
         'recoverable': true,
@@ -542,16 +507,76 @@ void main() {
     }
   });
 
-  test('playing the same item again gets the recovery back', () async {
+  test('a container error during startup recovers once', () async {
     final backend = _TestBackend();
     final resolver = _TestResolver();
     final service = _TestService();
     final manager = _manager(backend, resolver, service);
 
+    final gate = Completer<void>();
+    backend.playGate = gate;
+
+    try {
+      final started = manager.playItems(<dynamic>[
+        <String, dynamic>{'Id': 'padded', 'Type': 'Movie'},
+      ]);
+      await pumpEventQueue(times: 5);
+
+      // A malformed container fails in the extractor, before the first play
+      // has returned, so the recovery has to fire inside that window.
+      resolver.playMethod = StreamPlayMethod.transcode;
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_container',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 2);
+      expect(resolver.requestedDirectPlay, <bool>[true, false]);
+
+      // Already transcoding, so a repeat has nowhere further to go.
+      backend.emitError(<String, dynamic>{
+        'event': 'playerError',
+        'recoverable': true,
+        'kind': 'unsupported_container',
+      });
+      await pumpEventQueue(times: 10);
+
+      expect(resolver.calls, 2);
+
+      gate.complete();
+      await started;
+      await pumpEventQueue(times: 10);
+    } finally {
+      if (!gate.isCompleted) {
+        gate.complete();
+      }
+      manager.dispose();
+    }
+  });
+
+  test('the veto chain runs after a transcode recovery', () async {
+    final backend = _TestBackend();
+    final resolver = _TestResolver()
+      ..mediaStreams = <Map<String, dynamic>>[
+        <String, dynamic>{'Type': 'Audio', 'Codec': 'eac3', 'IsDefault': true},
+      ];
+    final service = _TestService();
+    final manager = _manager(backend, resolver, service);
+
     try {
       await manager.playItems(<dynamic>[
-        <String, dynamic>{'Id': 'repeat', 'Type': 'Movie'},
+        <String, dynamic>{'Id': 'chain', 'Type': 'Movie'},
       ]);
+
+      // The server answers the transcode request with a different codec the
+      // device turns out not to decode either.
+      resolver
+        ..playMethod = StreamPlayMethod.transcode
+        ..mediaStreams = <Map<String, dynamic>>[
+          <String, dynamic>{'Type': 'Audio', 'Codec': 'ac3', 'IsDefault': true},
+        ];
       backend.emitError(<String, dynamic>{
         'event': 'playerError',
         'recoverable': true,
@@ -559,11 +584,10 @@ void main() {
       });
       await pumpEventQueue(times: 10);
       expect(resolver.calls, 2);
+      expect(resolver.requestedDirectPlay, <bool>[true, false]);
 
-      // Replays the item the queue is already on, which is the path repeat and
-      // a retry from the player take. It does not go back through playItems.
-      await manager.startQueuedPlayback();
-      await pumpEventQueue(times: 10);
+      // A second codec vetoed is new information, so it earns one more
+      // resolve rather than a dead stop.
       backend.emitError(<String, dynamic>{
         'event': 'playerError',
         'recoverable': true,
@@ -571,8 +595,7 @@ void main() {
       });
       await pumpEventQueue(times: 10);
 
-      expect(resolver.calls, 4);
-      expect(resolver.requestedDirectPlay, <bool>[true, false, true, false]);
+      expect(resolver.calls, 3);
     } finally {
       manager.dispose();
     }


### PR DESCRIPTION
## Summary

Disabling an audio passthrough option did not previously remove that codec from Moonfin's Jellyfin device profile.

This was particularly visible on Android TV with Media3 or mpv, which use software audio decoding. Because those players can decode many codecs locally, Moonfin continued advertising EAC3 as direct-play compatible even when EAC3 passthrough was disabled. Jellyfin therefore selected Direct Play and delivered the original EAC3 bitstream instead of transcoding it to the configured fallback codec.

This is problematic when the downstream HDMI audio chain cannot reliably handle EAC3 passthrough, even though the playback device itself reports that it can decode or pass through EAC3.

The device profile now treats passthrough-disabled codecs as unsupported for direct play. Jellyfin can consequently keep the video stream unchanged while transcoding only the audio stream to the selected fallback codec.

This also avoids a separate Media3 playback problem observed with the affected EAC3 MKV. When Jellyfin sends the original EAC3 stream, Media3 fails during playback with:

```text
IllegalStateException: No valid varint length mask found
```

Switching to the mpv legacy engine allows the file to start, but EAC3 handling and audio-track switching remain unreliable. The Fire TV itself supports Dolby Digital Plus output, so this is not simply a lack of EAC3 device capability.

This PR does not attempt to fix the Media3 parser or playback error directly. Instead, it ensures that users who disable EAC3 passthrough do not receive the problematic EAC3 stream in the first place. Jellyfin transcodes EAC3 to the configured fallback codec, such as AC3, while leaving the video untouched.

Example:

```text
Source:
H.264 video + EAC3 5.1 audio

Moonfin:
EAC3 passthrough: disabled
Audio fallback codec: AC3

Result:
Video: copied unchanged
Audio: EAC3 -> AC3
Playback: Direct Stream / audio-only transcode
```

The change applies consistently to AC3, EAC3, DTS/DCA, and TrueHD/MLP codec variants.

### AI Disclaimer
As i dont know the codebase i had help from AI and reviewed the changes it did. Manual testing also confirmed that what AI did works.

## Related Issues

- Related to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Prevent passthrough-disabled codecs from being advertised as direct-play compatible.
- Apply this behavior to players with universal software audio decoding.
- Keep the configured fallback codec available as a Jellyfin transcoding target.
- Add regression tests for disabled passthrough codecs and audio-only transcoding.

## Platform

- [x] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Install the modified Moonfin Android TV build on a Fire TV Stick 4K Max.
2. Set the audio fallback codec to AC3.
3. Enable AC3 passthrough and disable EAC3 passthrough.
4. Play an H.264 + EAC3 5.1 MKV.
5. Confirm in Jellyfin that the video is copied directly and only the audio is transcoded from EAC3 to AC3.
6. Confirm that the EAC3 stream is not delivered to the player.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced