### PR TITLE
feat-ui - Gotta Go Fast - CW&NU Edition

### DIFF
--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -575,7 +575,7 @@ class OfflineItemsApi implements ItemsApi {
     } else if (mediaTypes == 'Audio') {
       types = const ['Audio', 'AudioBook'];
     } else {
-      types = const ['Movie', 'Episode', 'Video', 'MusicVideo', 'AudioBook'];
+      types = const ['Movie', 'Episode', 'Video', 'MusicVideo'];
     }
     final resumable =
         _catalog.entries

--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -562,15 +562,21 @@ class OfflineItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getResumeItems({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     int? startIndex,
     int? limit,
     String? fields,
     String? enableImageTypes,
     int? imageTypeLimit,
   }) async {
-    final types = (includeItemTypes != null && includeItemTypes.isNotEmpty)
-        ? includeItemTypes
-        : const ['Movie', 'Episode', 'Video', 'MusicVideo', 'AudioBook'];
+    final List<String> types;
+    if (includeItemTypes != null && includeItemTypes.isNotEmpty) {
+      types = includeItemTypes;
+    } else if (mediaTypes == 'Audio') {
+      types = const ['Audio', 'AudioBook'];
+    } else {
+      types = const ['Movie', 'Episode', 'Video', 'MusicVideo', 'AudioBook'];
+    }
     final resumable =
         _catalog.entries
             .where((e) => types.contains(e.type) && _isResumable(e))

--- a/lib/data/repositories/multi_server_repository.dart
+++ b/lib/data/repositories/multi_server_repository.dart
@@ -205,7 +205,7 @@ class MultiServerRepository {
       sessions,
       (session) async {
         final response = await session.client.itemsApi.getResumeItems(
-          includeItemTypes: ['Movie', 'Episode'],
+          mediaTypes: 'Video',
           limit: perServer,
           fields: _fields,
           enableImageTypes: _imageTypes,
@@ -234,7 +234,7 @@ class MultiServerRepository {
       sessions.map(
         (session) => _withTimeout(() async {
           final response = await session.client.itemsApi.getResumeItems(
-            includeItemTypes: ['Audio'],
+            mediaTypes: 'Audio',
             limit: perServer,
             fields: _fields,
             enableImageTypes: _imageTypes,

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -153,7 +153,7 @@ class RowDataSource {
 
   Future<HomeRow> loadResume(String serverId, {int? startIndex}) async {
     final response = await _getResumeItemsWithFallback(
-      includeItemTypes: ['Movie', 'Episode'],
+      mediaTypes: 'Video',
       startIndex: startIndex,
       limit: _defaultLimit,
     );
@@ -168,7 +168,7 @@ class RowDataSource {
 
   Future<HomeRow> loadResumeAudio(String serverId) async {
     final response = await _getResumeItemsWithFallback(
-      includeItemTypes: ['Audio'],
+      mediaTypes: 'Audio',
       limit: _defaultLimit,
     );
     return _buildRow(
@@ -201,7 +201,7 @@ class RowDataSource {
 
   Future<HomeRow> loadResumeRelaxed(String serverId) async {
     final response = await getResumeItemsRelaxed(
-      includeItemTypes: const ['Movie', 'Episode'],
+      mediaTypes: 'Video',
       limit: _defaultLimit,
     );
     return _buildRow(
@@ -944,7 +944,7 @@ class RowDataSource {
   Future<HomeRow> loadLibraryResume(String parentId, String serverId) async {
     final response = await _getResumeItemsWithFallback(
       parentId: parentId,
-      includeItemTypes: ['Video'],
+      mediaTypes: 'Video',
       limit: _defaultLimit,
     );
     return _buildRow(
@@ -1529,13 +1529,13 @@ class RowDataSource {
         }
       case HomeRowType.resume:
         response = await _getResumeItemsWithFallback(
-          includeItemTypes: const ['Movie', 'Episode'],
+          mediaTypes: 'Video',
           startIndex: currentOffset,
           limit: _defaultLimit,
         );
       case HomeRowType.resumeAudio:
         response = await _getResumeItemsWithFallback(
-          includeItemTypes: const ['Audio'],
+          mediaTypes: 'Audio',
           startIndex: currentOffset,
           limit: _defaultLimit,
         );
@@ -1645,6 +1645,7 @@ class RowDataSource {
   Future<Map<String, dynamic>> _getResumeItemsWithFallback({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     int? startIndex,
     required int limit,
   }) async {
@@ -1653,6 +1654,7 @@ class RowDataSource {
           .getResumeItems(
             parentId: parentId,
             includeItemTypes: includeItemTypes,
+            mediaTypes: mediaTypes,
             startIndex: startIndex,
             limit: limit,
             fields: _fields,
@@ -1666,6 +1668,7 @@ class RowDataSource {
           .getResumeItems(
             parentId: parentId,
             includeItemTypes: includeItemTypes,
+            mediaTypes: mediaTypes,
             startIndex: startIndex,
             limit: limit,
             fields: _fallbackFields,
@@ -1680,6 +1683,7 @@ class RowDataSource {
       final response = await _client.itemsApi.getResumeItems(
         parentId: parentId,
         includeItemTypes: includeItemTypes,
+        mediaTypes: mediaTypes,
         startIndex: startIndex,
         limit: limit,
         fields: _fallbackFields,
@@ -1744,6 +1748,7 @@ class RowDataSource {
   Future<Map<String, dynamic>> getResumeItemsRelaxed({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     required int limit,
   }) async {
     try {
@@ -1751,6 +1756,7 @@ class RowDataSource {
           .getResumeItems(
             parentId: parentId,
             includeItemTypes: includeItemTypes,
+            mediaTypes: mediaTypes,
             limit: limit,
             fields: _fields,
             enableImageTypes: _imageTypes,
@@ -1764,6 +1770,7 @@ class RowDataSource {
             .getResumeItems(
               parentId: parentId,
               includeItemTypes: includeItemTypes,
+              mediaTypes: mediaTypes,
               limit: limit,
               fields: _minimalFields,
               enableImageTypes: _imageTypes,

--- a/lib/playback/media_browse_service.dart
+++ b/lib/playback/media_browse_service.dart
@@ -507,7 +507,7 @@ class MediaBrowseService {
     List<AggregatedItem> serverResume = const [];
     try {
       final resumeResponse = await client.itemsApi.getResumeItems(
-        includeItemTypes: const ['AudioBook', 'Audio'],
+        mediaTypes: 'Audio',
         limit: 40,
       );
       serverResume = _toItems(resumeResponse, serverId);
@@ -871,7 +871,7 @@ class MediaBrowseService {
       }
       try {
         final resumeResponse = await client.itemsApi.getResumeItems(
-          includeItemTypes: const ['Audio'],
+          mediaTypes: 'Audio',
           limit: 1,
         );
         final resume = _toItems(resumeResponse, serverId);

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -147,7 +147,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
             tasks.add(() async {
               try {
                 final response = await client.itemsApi.getResumeItems(
-                  includeItemTypes: const ['Audio'],
+                  mediaTypes: 'Audio',
                   limit: 1,
                 );
                 final items = response['Items'] as List? ?? [];

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -89,6 +89,7 @@ abstract class ItemsApi {
   Future<Map<String, dynamic>> getResumeItems({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     int? startIndex,
     int? limit,
     String? fields,

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -258,6 +258,7 @@ class EmbyItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getResumeItems({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     int? startIndex,
     int? limit,
     String? fields,
@@ -271,6 +272,8 @@ class EmbyItemsApi implements ItemsApi {
         'ParentId': ?parentId,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
+        if (mediaTypes != null)
+          'MediaTypes': mediaTypes,
         'StartIndex': ?startIndex,
         'Limit': ?limit,
         'Fields': ?_knownFields(fields),

--- a/packages/server_emby/test/emby_items_api_test.dart
+++ b/packages/server_emby/test/emby_items_api_test.dart
@@ -40,6 +40,19 @@ void main() {
     expect(request()?.queryParameters['Fields'], 'PrimaryImageAspectRatio');
   });
 
+  test('resume items send MediaTypes instead of a type list', () async {
+    final (dio, request) = _recordingDio();
+
+    await EmbyItemsApi(
+      dio,
+      () => 'user-1',
+    ).getResumeItems(mediaTypes: 'Audio', limit: 12);
+
+    expect(request()?.path, '/Users/user-1/Items/Resume');
+    expect(request()?.queryParameters['MediaTypes'], 'Audio');
+    expect(request()?.queryParameters.containsKey('IncludeItemTypes'), isFalse);
+  });
+
   test('studios drop ItemCounts too', () async {
     final (dio, request) = _recordingDio();
 

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -235,6 +235,7 @@ class JellyfinItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getResumeItems({
     String? parentId,
     List<String>? includeItemTypes,
+    String? mediaTypes,
     int? startIndex,
     int? limit,
     String? fields,
@@ -247,6 +248,8 @@ class JellyfinItemsApi implements ItemsApi {
         'ParentId': ?parentId,
         if (includeItemTypes != null)
           'IncludeItemTypes': includeItemTypes.join(','),
+        if (mediaTypes != null)
+          'MediaTypes': mediaTypes,
         'StartIndex': ?startIndex,
         'Limit': ?limit,
         'Fields': ?fields,

--- a/packages/server_jellyfin/test/jellyfin_items_api_test.dart
+++ b/packages/server_jellyfin/test/jellyfin_items_api_test.dart
@@ -55,6 +55,28 @@ void main() {
     expect(request?.queryParameters['Limit'], 15);
   });
 
+  test('resume items send MediaTypes instead of a type list', () async {
+    RequestOptions? request;
+    final dio = Dio()
+      ..interceptors.add(
+        _FakeServer((options, handler) {
+          request = options;
+          handler.resolve(
+            Response(requestOptions: options, data: <String, dynamic>{}),
+          );
+        }),
+      );
+
+    await JellyfinItemsApi(
+      dio,
+      () => 'user-1',
+    ).getResumeItems(mediaTypes: 'Video', limit: 12);
+
+    expect(request?.path, '/UserItems/Resume');
+    expect(request?.queryParameters['MediaTypes'], 'Video');
+    expect(request?.queryParameters.containsKey('IncludeItemTypes'), isFalse);
+  });
+
   test('next up pages through StartIndex', () async {
     RequestOptions? request;
     final dio = Dio()

--- a/test/offline/offline_items_api_test.dart
+++ b/test/offline/offline_items_api_test.dart
@@ -333,6 +333,40 @@ void main() {
     expect(secondPage['TotalRecordCount'], 3);
   });
 
+  test('getResumeItems splits video and audio by media type', () async {
+    for (final type in [
+      'Movie',
+      'Episode',
+      'Video',
+      'MusicVideo',
+      'Audio',
+      'AudioBook',
+    ]) {
+      await insert(
+        id: type,
+        type: type,
+        name: type,
+        positionTicks: 500,
+        metadata: {'RunTimeTicks': 1000},
+      );
+    }
+    await catalog.warm();
+
+    List<String> typesOf(Map<String, dynamic> envelope) =>
+        items(envelope).map((i) => i['Type'] as String).toList()..sort();
+
+    expect(typesOf(await api.getResumeItems(mediaTypes: 'Video')), [
+      'Episode',
+      'Movie',
+      'MusicVideo',
+      'Video',
+    ]);
+    expect(typesOf(await api.getResumeItems(mediaTypes: 'Audio')), [
+      'Audio',
+      'AudioBook',
+    ]);
+  });
+
   test('getGenres aggregates distinct genres with counts', () async {
     await insert(
       id: 'm1',


### PR DESCRIPTION
# Pull Request

## Summary
Optimizes Continue Watching, Audio Continue Listening, and library resume queries by querying `/UserItems/Resume` with `MediaTypes=Video` (and `MediaTypes=Audio`) instead of `IncludeItemTypes=Movie,Episode`. In Jellyfin and Emby server database engines, `IncludeItemTypes` triggers complex polymorphic joins across `TypedBaseItems` during resumable queries, resulting in 2–3+ second latencies, whereas `MediaTypes=Video` directly utilizes indexed `UserData` lookups for sub-100ms responses. tldr; it goes fast.

Interestingly, both Smart-TV (jellyfinApi.js) and Roku (LoadItemsTask.bs), as well as the official Jellyfin WebUI, already pass MediaTypes=Video (and MediaTypes=Audio), so this issue was isolated to Moonfin-Core.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1372 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **items_api.dart**: Added `String? mediaTypes` parameter to `getResumeItems` interface signature.
- **jellyfin_items_api.dart** & **emby_items_api.dart**: Passed `MediaTypes` query parameter to `/UserItems/Resume` endpoints.
- **offline_items_api.dart**: Added `mediaTypes` support to offline catalog resume retrieval.
- **row_data_source.dart**: Updated `loadResume`, `loadResumeRelaxed`, `loadLibraryResume`, and resume pagination to use `mediaTypes: 'Video'`, and `loadResumeAudio` to use `mediaTypes: 'Audio'`.
- **multi_server_repository.dart**: Updated multi-server aggregated resume and audio resume queries to pass `mediaTypes`.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Ran `flutter test test/offline/offline_items_api_test.dart` and `flutter test test/playback/media_browse_service_test.dart` (all tests passed).
2. Tested Windows build and verified rapid loading of Continue Watching, Next Up, and merged Continue Watching & Next Up rows.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/566be1ba-0381-4770-aee0-7e5cc50122ce

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
