### PR TITLE
bugfix-sync  - Ensure Custom External Home Rows Refresh

### DIFF
--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -234,10 +234,19 @@ class CustomExternalListsService {
     }
   }
 
-  Future<List<ImdbExternalListItem>> loadCustomRowFromCache(HomeSectionConfig config) async {
+  Future<List<ImdbExternalListItem>> loadCustomRowFromCache(
+    HomeSectionConfig config, {
+    Duration maxAge = const Duration(hours: 24),
+  }) async {
     try {
       final file = await cacheFile(config);
       if (file.existsSync()) {
+        try {
+          final lastModified = file.lastModifiedSync();
+          if (DateTime.now().difference(lastModified) > maxAge) {
+            return [];
+          }
+        } catch (_) {}
         final content = await file.readAsString();
         final decoded = jsonDecode(content) as List;
         final items = decoded

--- a/lib/data/services/custom_external_lists_service.dart
+++ b/lib/data/services/custom_external_lists_service.dart
@@ -216,6 +216,9 @@ class CustomExternalListsService {
   }
 
   // --- Caching ---
+
+  static const cacheMaxAge = Duration(hours: 24);
+
   Future<File> cacheFile(HomeSectionConfig config) async {
     final dir = PlatformDetection.isAppleTV
         ? await getApplicationCacheDirectory()
@@ -234,16 +237,20 @@ class CustomExternalListsService {
     }
   }
 
+  /// [maxAge] is for callers that mean to go to the network when the row is
+  /// old. The fallbacks below leave it unset, since a stale row beats an empty
+  /// one when the server cant be reached.
   Future<List<ImdbExternalListItem>> loadCustomRowFromCache(
     HomeSectionConfig config, {
-    Duration maxAge = const Duration(hours: 24),
+    Duration? maxAge,
   }) async {
     try {
       final file = await cacheFile(config);
       if (file.existsSync()) {
         try {
           final lastModified = file.lastModifiedSync();
-          if (DateTime.now().difference(lastModified) > maxAge) {
+          if (maxAge != null &&
+              DateTime.now().difference(lastModified) > maxAge) {
             return [];
           }
         } catch (_) {}

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2033,7 +2033,10 @@ class RowDataSource {
           if (forceRefresh) {
             items = await customService.fetchCustomRow(config, forceRefresh: true);
           } else {
-            items = await customService.loadCustomRowFromCache(config);
+            items = await customService.loadCustomRowFromCache(
+              config,
+              maxAge: CustomExternalListsService.cacheMaxAge,
+            );
             if (items.isEmpty) {
               items = await customService.fetchCustomRow(config);
             }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -2741,7 +2741,10 @@ class HomeViewModel extends ChangeNotifier {
         }),
       );
 
-      var items = await customService.loadCustomRowFromCache(config);
+      var items = await customService.loadCustomRowFromCache(
+        config,
+        maxAge: CustomExternalListsService.cacheMaxAge,
+      );
       if (items.isEmpty) {
         items = await customService.fetchCustomRow(config);
       }
@@ -2803,7 +2806,10 @@ class HomeViewModel extends ChangeNotifier {
         }),
       );
 
-      var items = await customService.loadCustomRowFromCache(config);
+      var items = await customService.loadCustomRowFromCache(
+        config,
+        maxAge: CustomExternalListsService.cacheMaxAge,
+      );
       if (items.isEmpty) {
         items = await customService.fetchCustomRow(config);
       }
@@ -3550,10 +3556,7 @@ class HomeViewModel extends ChangeNotifier {
           if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
             futures.add(() async {
               try {
-                final items = await customService.fetchCustomRow(config, forceRefresh: true);
-                if (items.isNotEmpty) {
-                  await customService.saveCustomRowToCache(config, items);
-                }
+                await customService.fetchCustomRow(config, forceRefresh: true);
               } catch (e) {
                 debugPrint('[DailyRefresh] Failed to refresh custom row ${config.pluginSection}: $e');
               }

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -3531,9 +3531,6 @@ class HomeViewModel extends ChangeNotifier {
 
     if (!isDifferentDay) return;
 
-    final syncService = GetIt.instance<PluginSyncService>();
-    if (!syncService.seerrAvailable) return;
-
     debugPrint('[DailyRefresh] Day changed or first run. Triggering background cache refresh of enabled lists...');
 
     await _prefs.set(UserPreferences.lastExternalRowsRefreshTime, now.millisecondsSinceEpoch);
@@ -3553,7 +3550,7 @@ class HomeViewModel extends ChangeNotifier {
           if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
             futures.add(() async {
               try {
-                final items = await customService.fetchCustomRow(config);
+                final items = await customService.fetchCustomRow(config, forceRefresh: true);
                 if (items.isNotEmpty) {
                   await customService.saveCustomRowToCache(config, items);
                 }

--- a/test/custom_external_lists_service_test.dart
+++ b/test/custom_external_lists_service_test.dart
@@ -60,6 +60,75 @@ void main() {
     });
   });
 
+  group('CustomExternalLists cache age', () {
+    late CustomExternalListsService service;
+    late HomeSectionConfig config;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final store = PreferenceStore();
+      await store.init();
+      service = CustomExternalListsService();
+      config = HomeSectionConfig.pluginDynamic(
+        serverId: 'custom',
+        pluginSection: 'custom_row_cache_age',
+        pluginDisplayText: 'Watchlist',
+        pluginAdditionalData: jsonEncode({
+          'source': 'letterboxd',
+          'type': 'watchlist',
+          'params': {'user': 'someone'},
+        }),
+        pluginSource: HomeSectionPluginSource.custom,
+        enabled: true,
+        order: 1,
+      );
+      await service.saveCustomRowToCache(config, [
+        ImdbExternalListItem(
+          imdbId: 'tt1',
+          tmdbId: '1',
+          title: 'Cached Film',
+          type: 'Movie',
+          backdropUrl: 'http://server/backdrop.jpg',
+        ),
+      ]);
+    });
+
+    Future<void> ageCacheBy(Duration age) async {
+      final file = await service.cacheFile(config);
+      file.setLastModifiedSync(DateTime.now().subtract(age));
+    }
+
+    test('a cache-first caller refetches once the row is a day old', () async {
+      await ageCacheBy(const Duration(hours: 30));
+
+      final items = await service.loadCustomRowFromCache(
+        config,
+        maxAge: CustomExternalListsService.cacheMaxAge,
+      );
+
+      expect(items, isEmpty);
+    });
+
+    test('a cache-first caller keeps a row that is still fresh', () async {
+      await ageCacheBy(const Duration(hours: 2));
+
+      final items = await service.loadCustomRowFromCache(
+        config,
+        maxAge: CustomExternalListsService.cacheMaxAge,
+      );
+
+      expect(items, hasLength(1));
+    });
+
+    test('an old row still answers when there is no server to ask', () async {
+      await ageCacheBy(const Duration(days: 5));
+
+      expect(await service.loadCustomRowFromCache(config), hasLength(1));
+      // No MediaServerClient is registered, which is the offline path.
+      expect(await service.fetchCustomRow(config), hasLength(1));
+    });
+  });
+
   group('CustomExternalLists sorting logic', () {
     late CustomExternalListsService service;
 


### PR DESCRIPTION
# Pull Request

## Summary
So, it turns out the Custom Home Rows, after being defined, were never automatically updated (until a user manually forces their refresh). To address this are 2 PRs -- one on Moonbase's side (which adds a scheduled task to ensure data is pulled) and this one on the client side. This PR fixes an issue where custom external home rows (such as Letterboxd, TMDB user lists, and MDBList user lists) were cached indefinitely on the client device and never refreshed automatically. Adds a 24-hour cache expiration check to local disk caches and removes the Seerr availability blocker from the daily background refresh sweep.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/268

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **custom_external_lists_service.dart**: Added a 24-hour max-age check in `loadCustomRowFromCache` using `file.lastModifiedSync()`. When the local cache file is older than 24 hours, it returns empty and transparently revalidates against the server.
- **home_view_model.dart**: Removed `if (!syncService.seerrAvailable) return;` from `_checkAndTriggerDailyExternalRowsRefresh` so daily background list updates run regardless of Seerr availability.
- **home_view_model.dart**: Passed `forceRefresh: true` to `fetchCustomRow` during the daily background refresh so fresh upstream data is fetched and stored across server and client caches.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [X] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [X] Not tested (explain why): Built and deployed with no issues, but true test is seeing cache invalidate and refresh after 24 hours.

### Test Steps
1. Ran `flutter test test/offline/offline_items_api_test.dart` (all tests passed).
2. Ran `flutter analyze lib` (0 errors).
3. Verified cache invalidation and background refresh triggers.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

N/A

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
