### PR TITLE
bugfix-ui - Properly Pad Mediabars on TV Clients

### DIFF
--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -908,7 +908,9 @@ class _ContentRowsState extends State<_ContentRows>
             ? 45.0
             : (PlatformDetection.useMobileUi ? 60.0 : 80.0))
         : 0.0;
-    return (safeTop + navbarHeight + 8.0).clamp(0.0, viewportHeight * 0.85);
+    final desktopScale = _desktopUiScaleFactor();
+    final topPeekSpacing = PlatformDetection.isTV ? (32.0 * desktopScale) : 8.0;
+    return (safeTop + navbarHeight + topPeekSpacing).clamp(0.0, viewportHeight * 0.85);
   }
 
   List<double> _rowTargetOffsetsForScroll({required bool fullScreenRows}) {
@@ -2301,11 +2303,15 @@ class _ContentRowsState extends State<_ContentRows>
     _suppressNextRowPreviewFromMediaBar = true;
     _forceRevealOnNextRowFocusFromMediaBar = true;
     final isBanner = _isBannerMode();
-    if (mounted && _mediaBarVisible && !isBanner) {
+    if (mounted &&
+        _mediaBarVisible &&
+        !isBanner &&
+        !_isAyaMode() &&
+        !_isBookshelfMode()) {
       _mediaBarVisible = false;
     }
     if (!isBanner && _scrollController.hasClients) {
-      final offsetAdjustment = _isBookshelfMode() ? (_overlayBottom + 8) : 0.0;
+      final offsetAdjustment = _desktopRowFocusTargetTop();
       final target = (_mediaBarHeight() - offsetAdjustment).clamp(
         0.0,
         _scrollController.position.maxScrollExtent,
@@ -2615,6 +2621,28 @@ class _ContentRowsState extends State<_ContentRows>
     final isRowsV2 = widget.prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
         !_isWideArtworkRow(row);
 
+    final fullScreenRows = _fullScreenRowsEnabled(widget.prefs);
+    if (fullScreenRows) {
+      final stackRender = context.findRenderObject();
+      final viewportHeight = (stackRender is RenderBox && stackRender.hasSize)
+          ? stackRender.size.height
+          : MediaQuery.sizeOf(context).height;
+      final desktopScale = widget.prefs
+          .get(UserPreferences.desktopUiScale)
+          .scaleFactor;
+      final ratingsEnabled =
+          widget.prefs.get(UserPreferences.enableAdditionalRatings) as bool? ??
+          false;
+      final extraHeight = ratingsEnabled ? (32.0 * desktopScale) : 0.0;
+      final rowHeight = _staticRowHeight(rowIndex) + extraHeight;
+
+      if (isRowsV2) {
+        final targetTop = (viewportHeight - rowHeight) / 2.0;
+        return targetTop.clamp(defaultTop, double.infinity);
+      }
+      return defaultTop;
+    }
+
     if (rowIndex == 0 && _rowTopOffsets.isNotEmpty) {
       if (_isMediaBarIncluded() && !_isBannerMode()) {
         return defaultTop;
@@ -2624,42 +2652,7 @@ class _ContentRowsState extends State<_ContentRows>
       }
     }
 
-    final stackRender = context.findRenderObject();
-    if (stackRender is! RenderBox || !stackRender.hasSize) {
-      return rowIndex == 0 && _rowTopOffsets.isNotEmpty ? _rowTopOffsets[0] : defaultTop;
-    }
-
-    final viewportHeight = stackRender.size.height;
-    final desktopScale = widget.prefs
-        .get(UserPreferences.desktopUiScale)
-        .scaleFactor;
-    final ratingsEnabled =
-        widget.prefs.get(UserPreferences.enableAdditionalRatings) as bool? ??
-        false;
-    final extraHeight = ratingsEnabled ? (32.0 * desktopScale) : 0.0;
-    final rowHeight = _staticRowHeight(rowIndex) + extraHeight;
-
-    if (rowIndex == 0 && _rowTopOffsets.isNotEmpty) {
-      final safeBottomMargin = 40.0 * desktopScale;
-      final preferredTop = viewportHeight - rowHeight - safeBottomMargin;
-      return preferredTop.clamp(defaultTop, _rowTopOffsets[0]);
-    }
-
-    final fullScreenRows = _fullScreenRowsEnabled(widget.prefs);
-    if (fullScreenRows) {
-      if (isRowsV2) {
-        final targetTop = (viewportHeight - rowHeight) / 2.0;
-        return targetTop.clamp(defaultTop, double.infinity);
-      }
-      return defaultTop;
-    } else {
-      final isMyMedia = row.rowType == HomeRowType.libraryTilesSmall ||
-          row.rowType == HomeRowType.libraryTiles;
-      if (isMyMedia) {
-        return defaultTop;
-      }
-      return 0.0;
-    }
+    return defaultTop;
   }
 
   Future<void> _scrollTvRowIntoOverlayBand(int rowIndex) async {
@@ -2681,9 +2674,7 @@ class _ContentRowsState extends State<_ContentRows>
   double? _restingOffsetForRow(int rowIndex) {
     if (!_scrollController.hasClients) return null;
     if (rowIndex < 0 || rowIndex >= _rowTopOffsets.length) return null;
-    final useTvBand =
-        _fullScreenRowsEnabled(widget.prefs) ||
-        (PlatformDetection.isTV && _isHomeRowsStyleV2());
+    final useTvBand = _fullScreenRowsEnabled(widget.prefs);
     final targetTop = useTvBand
         ? _tvTargetTopForRow(rowIndex)
         : _desktopRowFocusTargetTop();
@@ -2965,9 +2956,7 @@ class _ContentRowsState extends State<_ContentRows>
           _scrollController.hasClients &&
           rowIndex >= 0 &&
           rowIndex < _rowTopOffsets.length) {
-        final offsetAdjustment = _isBookshelfMode()
-            ? (_overlayBottom + 8)
-            : 0.0;
+        final offsetAdjustment = _desktopRowFocusTargetTop();
         final targetOffset = (_rowTopOffsets[rowIndex] - offsetAdjustment)
             .clamp(0.0, _scrollController.position.maxScrollExtent);
         if ((_scrollController.offset - targetOffset).abs() > 10) {
@@ -3031,9 +3020,7 @@ class _ContentRowsState extends State<_ContentRows>
             final fullScreenRows =
                 !PlatformDetection.useMobileUi &&
                 widget.prefs.get(UserPreferences.fullScreenRows);
-            final isRowsV2 = _isHomeRowsStyleV2();
-            if ((fullScreenRows || (PlatformDetection.isTV && isRowsV2)) &&
-                _scrollController.hasClients) {
+            if (fullScreenRows && _scrollController.hasClients) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 if (!mounted || !_scrollController.hasClients) {
                   if (!navComplete.isCompleted) navComplete.complete();
@@ -3056,26 +3043,6 @@ class _ContentRowsState extends State<_ContentRows>
               return;
             }
 
-            if (!PlatformDetection.isTV &&
-                _showHomeRowInfoOverlay() &&
-                _scrollController.hasClients &&
-                target < _rowTopOffsets.length) {
-              final targetOffset =
-                  (_rowTopOffsets[target] - _desktopRowFocusTargetTop()).clamp(
-                    0.0,
-                    _scrollController.position.maxScrollExtent,
-                  );
-              _scrollController
-                  .animateTo(
-                    targetOffset,
-                    duration: _focusHandoffDuration,
-                    curve: _focusHandoffCurve,
-                  )
-                  .whenComplete(() {
-                    if (!navComplete.isCompleted) navComplete.complete();
-                  });
-              return;
-            }
 
             if (_scrollController.hasClients) {
               final rowObj = _rowContainerKey(
@@ -3196,7 +3163,9 @@ class _ContentRowsState extends State<_ContentRows>
       if (!PlatformDetection.useMobileUi &&
           _mediaBarVisible &&
           !_verticalNavInFlight &&
-          !_isBannerMode()) {
+          !_isBannerMode() &&
+          !_isAyaMode() &&
+          !_isBookshelfMode()) {
         setState(() => _mediaBarVisible = false);
       }
     } else if (_activeFocusedRowIndex == rowIndex) {


### PR DESCRIPTION
# Pull Request

## Summary
Adjusts home screen mediabar peek offsets and TV row scroll target alignment to ensure compact mediabar styles (such as Aya and Bookshelf) retain proper above-peek visibility and positioning when scrolling down into multi-row home screens. Also unifies dynamic RenderBox viewport alignment across Modern and Classic row layouts to eliminate excessive offset gaps and properly position rows below the top toolbar / Info Area overlay.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **home_screen.dart**:
  - Factored compact mediabar styles (Aya, Bookshelf) into leaving-mediabar offset adjustments so the chin peeks cleanly rather than scrolling completely off or forcing a blank top void.
  - Preserved `_mediaBarVisible` for compact mediabar modes when focus leaves the bar so the peeking artwork remains visible under the top toolbar.
  - Streamlined `_tvTargetTopForRow` to apply vertical viewport centering strictly when Single Row Mode (`fullScreenRows: true`) is enabled.
  - Updated multi-row TV navigation to utilize dynamic RenderBox geometry and `_desktopRowFocusTargetTop()` with a calibrated 32px top peek offset, keeping the active row near the top while allowing comfortable space for multi-row metadata/rating badges and below-row previews.
  - Removed static `_rowTopOffsets` override branch during row navigation with Info Overlay active, eliminating large offset drift in Classic row configurations.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Android TV / Desktop with the Aya MediaBar enabled and Single Row toggle OFF.
2. Navigate down from the MediaBar to the first row (My Media) and verify that the mediabar bottom chin peeks under the top toolbar while the active row sits near the top.
3. Navigate down through subsequent content rows (Continue Watching, Recently Added) with Modern and Classic layouts (with/without Info Overlay) and verify rows settle smoothly with a tight top peek and full visibility of expanded cards, badges, and next row previews.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### 2.5.1 Stable Behaviour

How it should look like (from Desktop):
<img width="2560" height="1555" alt="2026-09-02_09-10-18_moonfin" src="https://github.com/user-attachments/assets/cce3de7f-a87d-49ae-8237-a4c2d859ac66" />

How it looks (Android TV):
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-08-17" src="https://github.com/user-attachments/assets/c69050d5-e9ed-4958-8da1-51546f3f3bca" />

### Revised Modern Rows

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-50-07" src="https://github.com/user-attachments/assets/2cecda0d-f094-41d7-9230-c7ec3847b42d" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-50-19" src="https://github.com/user-attachments/assets/74d6fab7-6a30-4643-95f7-31078a81b7ae" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-50-31" src="https://github.com/user-attachments/assets/b9204b5a-24db-4f02-b096-25c25a66daf5" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-51-22" src="https://github.com/user-attachments/assets/fe1b21e9-f894-494c-bc2e-bf516b16dc91" />

### Revised Classic Rows with Info Overlay ON

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-58-00" src="https://github.com/user-attachments/assets/519ab27c-2292-4097-b34f-c34077b92058" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-58-12" src="https://github.com/user-attachments/assets/4b3643b1-686c-48fd-a491-b7e9aca3ee90" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-58-23" src="https://github.com/user-attachments/assets/9b35eb13-5412-4230-8cea-a09275a9cf5b" />

### Revised Classic Rows with Info Overlay OFF

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_09-58-59" src="https://github.com/user-attachments/assets/8e1c2da4-854e-40ca-8be5-7ad2c4a8c8f3" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
- [X] Disappointed in myself for not being able to come up with a better title for this PR
