### PR TITLE
bugfix-ui - Prevent Action Buttons from Overstaying their Welcome

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5855,8 +5855,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     if (label == null) return _modernFocusedFloor;
     // Matching what _buildModernChild lays out around the label.
     const iconWidth = 24.0;
-    const iconGap = 2.0;
-    const horizontalPadding = 24.0;
+    const iconGap = 8.0;
+    const horizontalPadding = 36.0;
     final painter = TextPainter(
       text: TextSpan(
         text: label,
@@ -5864,7 +5864,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         // both at the larger size can only leave room to spare.
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           fontWeight: FontWeight.bold,
-          fontSize: 13,
+          fontSize: 14,
           height: 1.1,
         ),
       ),
@@ -5873,30 +5873,27 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     )..layout();
     final measured = painter.width + iconWidth + iconGap + horizontalPadding;
     painter.dispose();
-    return measured < _modernFocusedFloor ? _modernFocusedFloor : measured;
+    return measured < 140.0 ? 140.0 : measured;
   }
 
   /// The widest a modern row of [buttonCount] buttons can get. Only one
-  /// button is focused at a time, so the worst case is everything at rest
-  /// except the one grown to its focused width, whichever of the two that
-  /// leaves wider. The sizes match what _buildModernChild lays out.
+  /// button is focused at a time, so the worst case is the primary button plus
+  /// all secondary buttons at rest, except when one secondary button is grown
+  /// to its focused width.
   double _modernRowWorstWidth(
     int buttonCount,
     double spacing,
     double playFocused,
   ) {
-    const playResting = 54.0;
     const circleResting = 52.0;
     const circleFocused = _modernFocusedFloor;
 
     final circles = buttonCount - 1;
     if (circles <= 0) return playFocused;
 
-    final playGrown = playFocused + circles * circleResting;
     final circleGrown =
-        playResting + circleFocused + (circles - 1) * circleResting;
-    return circles * spacing +
-        (playGrown > circleGrown ? playGrown : circleGrown);
+        playFocused + circleFocused + (circles - 1) * circleResting;
+    return circles * spacing + circleGrown;
   }
 
   void _focusUpTarget() {
@@ -10894,134 +10891,89 @@ class _DetailActionButtonState extends State<_DetailActionButton>
         ? (isMobile ? (hasNewline ? 56.0 : 50.0) : (hasNewline ? 64.0 : 54.0))
         : (isMobile ? 48.0 : 52.0);
 
-    if (widget.isPrimary) {
+    // Portrait spans the primary Play full width (circular secondary actions
+    // wrap beneath); landscape keeps it content-width, inline with them.
+    final fullWidth = widget.isPrimary &&
+        (context
+                .findAncestorWidgetOfExactType<DetailActionButtons>()
+                ?.fullWidthPrimary ??
+            false);
+
+    if (fullWidth) {
       final fg = showHighlight
           ? AppColorScheme.onButtonFocused
           : AppColorScheme.onAccent;
       final heartColor = (widget.icon == Icons.favorite && widget.isActive)
           ? const Color(0xFFE50914)
           : fg;
-      // Portrait spans the primary Play full width (circular secondary actions
-      // wrap beneath); landscape keeps it content-width, inline with them.
-      final fullWidth =
-          context
-              .findAncestorWidgetOfExactType<DetailActionButtons>()
-              ?.fullWidthPrimary ??
-          false;
-
-      // When expanded (focused): use ConstrainedBox with a minWidth floor
-      // so the pill always has enough room for labels like "Resume S12:E24".
-      // Flexible in the parent Row lets the pill grow beyond the minimum.
-      final Widget pill;
-      final shouldExpand = isExpanded || fullWidth || isMobile;
-      if (shouldExpand) {
-        final pillInner = Container(
-          height: height,
-          width: fullWidth ? double.infinity : null,
-          padding: EdgeInsets.only(
-            left: fullWidth ? 10 : 10,
-            right: fullWidth ? 10 : 14,
+      final pillInner = Container(
+        height: height,
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: showHighlight
+              ? AppColorScheme.buttonFocused
+              : AppColorScheme.accent,
+          borderRadius: AppRadius.circular(height / 2),
+          border: Border.all(
+            color: showHighlight ? focusColor : Colors.transparent,
+            width: 3,
           ),
-          alignment: fullWidth ? Alignment.center : null,
-          decoration: BoxDecoration(
-            color: showHighlight
-                ? AppColorScheme.buttonFocused
-                : AppColorScheme.accent,
-            borderRadius: AppRadius.circular(height / 2),
-            border: Border.all(
-              color: showHighlight ? focusColor : Colors.transparent,
-              width: 3,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AdaptiveIcon(
+              widget.icon ?? Icons.play_arrow,
+              color: heartColor,
+              size: 24,
             ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              AdaptiveIcon(
-                widget.icon ?? Icons.play_arrow,
-                color: heartColor,
-                size: 24,
-              ),
-              const SizedBox(width: 2),
-              widget.label.contains('\n')
-                  ? Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          widget.label.split('\n')[0],
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: fg,
-                                fontWeight: FontWeight.bold,
-                                fontSize: 13,
-                                height: 1.1,
-                              ),
-                        ),
-                        Text(
-                          widget.label.split('\n')[1],
-                          style: Theme.of(context).textTheme.bodyMedium
-                              ?.copyWith(
-                                color: fg.withValues(alpha: 0.8),
-                                fontWeight: FontWeight.bold,
-                                fontSize: 12,
-                                height: 1.1,
-                              ),
-                        ),
-                      ],
-                    )
-                  : Text(
-                      widget.label,
-                      maxLines: 1,
-                      softWrap: false,
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: fg,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 13,
-                        height: 1.1,
+            const SizedBox(width: 8),
+            widget.label.contains('\n')
+                ? Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        widget.label.split('\n')[0],
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: fg,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 13,
+                              height: 1.1,
+                            ),
                       ),
-                    ),
-            ],
-          ),
-        );
-        // Landscape: wrap with a minWidth so text always has room.
-        // Flexible in the parent Row allows growing beyond minWidth.
-        pill = fullWidth
-            ? pillInner
-            : ConstrainedBox(
-                constraints: const BoxConstraints(minWidth: 200),
-                child: pillInner,
-              );
-      } else {
-        // Collapsed: animate from/to a circle
-        pill = AnimatedSize(
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-          child: SizedBox.square(
-            dimension: height,
-            child: Container(
-              height: height,
-              width: height,
-              decoration: BoxDecoration(
-                color: AppColorScheme.accent,
-                borderRadius: AppRadius.circular(height / 2),
-                border: Border.all(color: Colors.transparent, width: 3),
-              ),
-              child: Center(
-                child: AdaptiveIcon(
-                  widget.icon ?? Icons.play_arrow,
-                  color: Colors.white,
-                  size: 24,
-                ),
-              ),
-            ),
-          ),
-        );
-      }
-      return fullWidth ? SizedBox(width: double.infinity, child: pill) : pill;
+                      Text(
+                        widget.label.split('\n')[1],
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: fg.withValues(alpha: 0.8),
+                              fontWeight: FontWeight.bold,
+                              fontSize: 12,
+                              height: 1.1,
+                            ),
+                      ),
+                    ],
+                  )
+                : Text(
+                    widget.label,
+                    maxLines: 1,
+                    softWrap: false,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: fg,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 14,
+                          height: 1.1,
+                        ),
+                  ),
+          ],
+        ),
+      );
+      return SizedBox(width: double.infinity, child: pillInner);
     }
 
-    if (isMobile) {
+    if (isMobile && !widget.isPrimary) {
       // Vertical tile: circular icon with its label always shown underneath.
       final iconWidget = widget.iconBuilder != null
           ? widget.iconBuilder!(36, iconColor)
@@ -11082,6 +11034,48 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     final double minWidth = height;
     final double maxWidth = isExpanded ? 200.0 : height;
 
+    final containerColor = showHighlight
+        ? AppColorScheme.buttonFocused
+        : (widget.isPrimary
+            ? AppColorScheme.accent
+            : (widget.isActive
+                ? (widget.activeColor ?? AppColorScheme.accent).withValues(
+                    alpha: 0.18,
+                  )
+                : Colors.white.withValues(alpha: 0.06)));
+
+    final borderColor = showHighlight
+        ? focusColor
+        : (widget.isPrimary
+            ? Colors.transparent
+            : AppColorScheme.onSurface.withValues(alpha: 0.35));
+
+    final iconWidget = widget.isPrimary
+        ? AdaptiveIcon(
+            widget.icon ?? Icons.play_arrow,
+            color: (widget.icon == Icons.favorite && widget.isActive)
+                ? const Color(0xFFE50914)
+                : (showHighlight
+                    ? AppColorScheme.onButtonFocused
+                    : AppColorScheme.onAccent),
+            size: 24,
+          )
+        : (widget.iconBuilder != null
+            ? widget.iconBuilder!(36, iconColor)
+            : AdaptiveIcon(
+                widget.icon!,
+                color: (widget.icon == Icons.favorite && widget.isActive)
+                    ? const Color(0xFFE50914)
+                    : iconColor,
+                size: 24,
+              ));
+
+    final effectiveLabelColor = widget.isPrimary
+        ? (showHighlight
+            ? AppColorScheme.onButtonFocused
+            : AppColorScheme.onAccent)
+        : labelColor;
+
     return AnimatedContainer(
       duration: const Duration(milliseconds: 150),
       curve: Curves.easeOut,
@@ -11093,58 +11087,75 @@ class _DetailActionButtonState extends State<_DetailActionButton>
       ),
       decoration: BoxDecoration(
         borderRadius: AppRadius.circular(height / 2),
-        color: showHighlight
-            ? AppColorScheme.buttonFocused
-            : (widget.isActive
-                  ? (widget.activeColor ?? AppColorScheme.accent).withValues(
-                      alpha: 0.18,
-                    )
-                  : Colors.white.withValues(alpha: 0.06)),
+        color: containerColor,
         border: Border.all(
-          color: showHighlight
-              ? focusColor
-              : AppColorScheme.onSurface.withValues(alpha: 0.35),
+          color: borderColor,
           width: showHighlight ? 2.5 : 1.5,
         ),
       ),
-      child: SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        physics: const NeverScrollableScrollPhysics(),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            SizedBox(
-              width: height - 4, // keep icon centered when collapsed
-              child: Center(
-                child: widget.iconBuilder != null
-                    ? widget.iconBuilder!(36, iconColor)
-                    : AdaptiveIcon(
-                        widget.icon!,
-                        color:
-                            (widget.icon == Icons.favorite && widget.isActive)
-                            ? const Color(0xFFE50914)
-                            : iconColor,
-                        size: 24,
+      child: ClipRRect(
+        borderRadius: AppRadius.circular(height / 2),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: height - 4, // keep icon centered when collapsed
+                child: Center(child: iconWidget),
+              ),
+              if (isExpanded && widget.label.isNotEmpty) ...[
+                const SizedBox(width: 6),
+                widget.label.contains('\n')
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            widget.label.split('\n')[0],
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: effectiveLabelColor,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 13,
+                                  height: 1.1,
+                                ),
+                          ),
+                          Text(
+                            widget.label.split('\n')[1],
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyMedium
+                                ?.copyWith(
+                                  color: effectiveLabelColor.withValues(
+                                    alpha: 0.8,
+                                  ),
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 12,
+                                  height: 1.1,
+                                ),
+                          ),
+                        ],
+                      )
+                    : Text(
+                        widget.label,
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: effectiveLabelColor,
+                              fontWeight: FontWeight.bold,
+                              fontSize: 13,
+                              height: 1.1,
+                            ),
+                        textAlign: TextAlign.center,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-              ),
-            ),
-            if (isExpanded && widget.label.isNotEmpty) ...[
-              const SizedBox(width: 6),
-              Text(
-                widget.label,
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: labelColor,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 13,
-                  height: 1.1,
-                ),
-                textAlign: TextAlign.center,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5846,11 +5846,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   /// circles are actually capped to.
   static const _modernFocusedFloor = 200.0;
 
+  /// The narrowest the focused Play pill is drawn at, below
+  /// [_modernFocusedFloor] so a short label does not reserve the width of a
+  /// long one.
+  static const _modernPlayFocusedFloor = 140.0;
+
   /// The width the focused Play pill actually takes, which is its label plus
-  /// the icon, the gap and the padding around them. The circles are capped at
-  /// [_modernFocusedFloor] but the pill only has that as a floor, so a long
-  /// label makes it wider and the row has to be measured against the real
-  /// thing rather than the floor.
+  /// the icon, the gap and the padding around them. Bounded by the same cap
+  /// the pill is drawn within, so a label too long to fit is measured at the
+  /// width it ends up ellipsised to rather than the width it wanted.
   double _modernPlayFocusedWidth(String? label) {
     if (label == null) return _modernFocusedFloor;
     // Matching what _buildModernChild lays out around the label.
@@ -5873,27 +5877,33 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     )..layout();
     final measured = painter.width + iconWidth + iconGap + horizontalPadding;
     painter.dispose();
-    return measured < 140.0 ? 140.0 : measured;
+    return measured.clamp(_modernPlayFocusedFloor, _modernFocusedFloor);
   }
 
-  /// The widest a modern row of [buttonCount] buttons can get. Only one
-  /// button is focused at a time, so the worst case is the primary button plus
-  /// all secondary buttons at rest, except when one secondary button is grown
-  /// to its focused width.
-  double _modernRowWorstWidth(
+  /// The widest a modern row of [buttonCount] buttons can get. One button
+  /// holds focus and every grown button stops at the same cap, so the widest
+  /// row is that cap plus the rest at rest, and Play rests wider than a
+  /// circle. Counting Play grown as well describes a row that cannot happen
+  /// and sends buttons to the overflow menu that had room to stay.
+  ///
+  /// Public for the width tests. Every production caller lives in this file.
+  @visibleForTesting
+  static double modernRowWorstWidth(
     int buttonCount,
     double spacing,
     double playFocused,
   ) {
+    const playResting = 54.0;
     const circleResting = 52.0;
     const circleFocused = _modernFocusedFloor;
 
     final circles = buttonCount - 1;
     if (circles <= 0) return playFocused;
 
-    final circleGrown =
-        playFocused + circleFocused + (circles - 1) * circleResting;
-    return circles * spacing + circleGrown;
+    return circles * spacing +
+        circleFocused +
+        playResting +
+        (circles - 1) * circleResting;
   }
 
   void _focusUpTarget() {
@@ -6769,7 +6779,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         .map((button) => button.label)
         .firstOrNull;
     final fitsOneLine = widget.modernStyle && rowBudget != null
-        ? _modernRowWorstWidth(
+        ? modernRowWorstWidth(
                 allButtons.length,
                 buttonSpacing,
                 _modernPlayFocusedWidth(playLabel),
@@ -11095,6 +11105,7 @@ class _DetailActionButtonState extends State<_DetailActionButton>
       ),
       child: ClipRRect(
         borderRadius: AppRadius.circular(height / 2),
+        clipBehavior: Clip.hardEdge,
         child: SingleChildScrollView(
           scrollDirection: Axis.horizontal,
           physics: const NeverScrollableScrollPhysics(),

--- a/test/ui/screens/detail/modern_action_row_width_test.dart
+++ b/test/ui/screens/detail/modern_action_row_width_test.dart
@@ -1,0 +1,51 @@
+// The row uses this to decide whether every action button fits on one line or
+// some of them move into an overflow menu. Counting Play at its grown width
+// describes a row where two buttons are grown at once, which hides buttons
+// that had room to stay.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/detail/item_detail_screen.dart';
+
+void main() {
+  // What _buildModernChild lays each button out at.
+  const playResting = 54.0;
+  const circleResting = 52.0;
+  const grownWidth = 200.0;
+  const spacing = 8.0;
+
+  double worstWidth(int buttonCount, [double playFocused = 140.0]) =>
+      DetailActionButtonsState.modernRowWorstWidth(
+        buttonCount,
+        spacing,
+        playFocused,
+      );
+
+  test('a row of only Play needs only its own focused width', () {
+    expect(worstWidth(1, 140), 140);
+    expect(worstWidth(1, 200), 200);
+  });
+
+  test('it measures one grown button and the rest at rest', () {
+    for (var circles = 1; circles <= 6; circles++) {
+      expect(
+        worstWidth(circles + 1),
+        circles * spacing +
+            grownWidth +
+            playResting +
+            (circles - 1) * circleResting,
+        reason: 'circles=$circles',
+      );
+    }
+  });
+
+  // Pinned rather than recomputed, so a formula that drifts has to answer for
+  // a number somebody can hold against a screen.
+  test('a five button row asks for 442', () {
+    expect(worstWidth(5), 442);
+  });
+
+  // Play only ever rests while a circle is grown, so how wide its label makes
+  // it cannot change what the row needs.
+  test('the Play label does not change a row that has circles', () {
+    expect(worstWidth(5, 140), worstWidth(5, 200));
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Resolves a visual layout glitch on modern detail pages where action buttons (specifically the primary Play button and Seerr Request buttons) could render text outside their pill boundary or fail to expand/collapse cleanly during focus transitions, especially with localizations with longer than expected strings.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1317 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - Unified `_buildModernChild` so both primary (Play / Resume / Request) and secondary (Audio, Subtitles, Watched, etc.) buttons on landscape/TV collapse to a circular icon button when unfocused and expand into a pill with label when focused.
  - Wrapped expanding button rows in `ClipRRect` and only mount the text label when `isExpanded` is true, ensuring text never overflows or bleeds outside rounded boundaries during width animations or with long localized strings.
  - Updated `requestSlot` in `DetailActionButtons` to pass `isPrimary: true`, `focusNode: _tvPlayFocusNode`, and `autofocus: autofocusPlay` when Seerr requests lead the actions row.
  - Updated `_modernRowWorstWidth` and `_modernPlayFocusedWidth` calculations to accurately reflect the unified resting and focused button dimensions.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open item details for various media types (movies, series, episodes, unreleased/Seerr titles)
2. Switch focus between buttons (Play -> Audio -> Subtitles -> Watched -> Favorite) and verify that:
   - The focused button expands smoothly into a pill showing icon + label.
   - All unfocused buttons collapse cleanly into circular icon buttons with no label text visible.
   - Rapid D-pad navigation produces no text clipping, bleeding, or overlapping with neighboring buttons across English and German localizations.
3. Validate mobile portrait mode to ensure primary action remains a full-width pill.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_11-35-10" src="https://github.com/user-attachments/assets/43643fb7-c577-42dd-9cc7-7d76eaf921f8" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_11-35-22" src="https://github.com/user-attachments/assets/8a6534da-78b2-459f-a6b5-c0258b930a9e" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_11-35-55" src="https://github.com/user-attachments/assets/dfb3e7b2-a37f-49c2-a227-4a7efa8ec7d7" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-02_11-36-18" src="https://github.com/user-attachments/assets/34e59193-6361-4bf7-9b85-5c63efc7859f" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
