### PR TITLE
feat-ui - Tidy Media Details Page

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -39,6 +39,7 @@ import 'modern/modern_detail_content.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
+import '../../widgets/quick_return_wrapper.dart';
 import '../../widgets/progress_snack_bar.dart';
 import '../../../util/remote_subtitle_labels.dart';
 import '../../../util/subtitle_appearance_schedule.dart';
@@ -540,9 +541,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         _viewModel.state == ItemDetailState.ready &&
         _showNavbar &&
         (!isAlbumOrPlaylist || _isCompact(context));
+    final showBackButton =
+        _viewModel.state != ItemDetailState.ready || showNavigationChrome;
 
     Widget body = NavigationLayout(
-      showBackButton: true,
+      showBackButton: showBackButton,
       showNavigationChrome: showNavigationChrome,
       child: _buildBody(context),
     );
@@ -1311,8 +1314,11 @@ class _DetailContentState extends State<_DetailContent> {
     final isAlbumOrPlaylist =
         item.type == 'MusicAlbum' || item.type == 'Playlist';
 
-    return Focus(
-      focusNode: _contentFocusNode,
+    return QuickReturnWrapper(
+      scrollController: _scrollController,
+      topFocusNode: widget.initialFocusNode,
+      child: Focus(
+        focusNode: _contentFocusNode,
       onKeyEvent: (node, event) {
         final primaryFocus = FocusManager.instance.primaryFocus;
         if (!identical(primaryFocus, _contentFocusNode)) {
@@ -1458,6 +1464,7 @@ class _DetailContentState extends State<_DetailContent> {
             ),
         ],
       ),
+    ),
     );
   }
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13661,13 +13661,13 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text(
-                                [
-                                  if (epNum != null)
-                                    AppLocalizations.of(
-                                      context,
-                                    ).episodeLabel(epNum),
-                                  episode.name,
-                                ].join(' - '),
+                                episode.name.isNotEmpty
+                                    ? episode.name
+                                    : (epNum != null
+                                        ? AppLocalizations.of(
+                                            context,
+                                          ).episodeLabel(epNum)
+                                        : ''),
                                 style: Theme.of(context).textTheme.titleSmall
                                     ?.copyWith(
                                       color: isNeon

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -541,8 +541,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         _viewModel.state == ItemDetailState.ready &&
         _showNavbar &&
         (!isAlbumOrPlaylist || _isCompact(context));
+    // Follows the scroll flag rather than the chrome. Albums and playlists
+    // switch the chrome off at every scroll position on TV and desktop, so
+    // gating on it leaves those pages with no way back at all.
     final showBackButton =
-        _viewModel.state != ItemDetailState.ready || showNavigationChrome;
+        _viewModel.state != ItemDetailState.ready || _showNavbar;
 
     Widget body = NavigationLayout(
       showBackButton: showBackButton,
@@ -1319,152 +1322,152 @@ class _DetailContentState extends State<_DetailContent> {
       topFocusNode: widget.initialFocusNode,
       child: Focus(
         focusNode: _contentFocusNode,
-      onKeyEvent: (node, event) {
-        final primaryFocus = FocusManager.instance.primaryFocus;
-        if (!identical(primaryFocus, _contentFocusNode)) {
+        onKeyEvent: (node, event) {
+          final primaryFocus = FocusManager.instance.primaryFocus;
+          if (!identical(primaryFocus, _contentFocusNode)) {
+            return KeyEventResult.ignored;
+          }
+          if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+              event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            final navbarPos = prefs.get(UserPreferences.navbarPosition);
+            if (navbarPos == NavbarPosition.top) {
+              _scrollMainToTop();
+              NavigationLayout.focusNavbarNotifier.value?.call();
+              return KeyEventResult.handled;
+            }
+            final isAtTop =
+                !_scrollController.hasClients || _scrollController.offset <= 0;
+            if (isAtTop) {
+              NavigationLayout.focusNavbarNotifier.value?.call();
+              return KeyEventResult.handled;
+            }
+          }
           return KeyEventResult.ignored;
-        }
-        if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
-            event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          final navbarPos = prefs.get(UserPreferences.navbarPosition);
-          if (navbarPos == NavbarPosition.top) {
-            _scrollMainToTop();
-            NavigationLayout.focusNavbarNotifier.value?.call();
-            return KeyEventResult.handled;
-          }
-          final isAtTop =
-              !_scrollController.hasClients || _scrollController.offset <= 0;
-          if (isAtTop) {
-            NavigationLayout.focusNavbarNotifier.value?.call();
-            return KeyEventResult.handled;
-          }
-        }
-        return KeyEventResult.ignored;
-      },
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          if (isReadableBook)
-            const Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(color: Color(0xFF0F182A)),
-              ),
-            ),
-          if (backdropEnabled && !isReadableBook)
-            ValueListenableBuilder<String?>(
-              valueListenable: widget.backdropUrl,
-              builder: (context, url, _) =>
-                  _Backdrop(url: url, blurAmount: blurAmount),
-            ),
-          if (isReadableBook)
-            const Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [Color(0x000F182A), Color(0x440A1324)],
-                  ),
+        },
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (isReadableBook)
+              const Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(color: Color(0xFF0F182A)),
                 ),
               ),
-            )
-          else
-            const RepaintBoundary(child: _GradientScrim()),
-          if (useSplitLayout)
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _buildStaticPersonProfilePanel(context, item),
-                Expanded(
-                  child: CustomScrollView(
-                    controller: _scrollController,
-                    cacheExtent: 4000,
-                    slivers: [
-                      SliverPadding(
-                        padding: EdgeInsets.fromLTRB(
-                          48,
-                          MediaQuery.of(context).padding.top + 80.0,
-                          48,
-                          48 * _desktopUiScale(),
-                        ),
-                        sliver: SliverList(
-                          delegate: SliverChildListDelegate(
-                            _buildContentForType(context, item),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            )
-          else
-            CustomScrollView(
-              controller: _scrollController,
-              cacheExtent: 4000,
-              slivers: [
-                if (item.type != 'Person' &&
-                    item.type != 'MusicArtist' &&
-                    item.type != 'MusicAlbum' &&
-                    item.type != 'Playlist' &&
-                    !_isReadableBookItem(item))
-                  SliverToBoxAdapter(
-                    child: _HeaderSection(
-                      viewModel: widget.viewModel,
-                      prefs: widget.prefs,
-                      selectedMediaSource: selectedMediaSource,
-                      overviewFocusNode: headerOverviewFocusNode,
-                      onArrowUp: _tryFocusNavbar,
-                      onArrowDown: () {
-                        final type = item.type;
-                        final targetNode = switch (type) {
-                          'BoxSet' => _sectionFocusNode(
-                            'detailBoxSetActionButtons',
-                          ),
-                          _ =>
-                            widget.initialFocusNode ??
-                                _sectionFocusNode('detailActionButtons'),
-                        };
-                        _requestSectionFocus(targetNode);
-                      },
-                      onArrowLeft: () => _tryFocusSidebar(),
-                      onCollapseBiography: () => setState(() {}),
+            if (backdropEnabled && !isReadableBook)
+              ValueListenableBuilder<String?>(
+                valueListenable: widget.backdropUrl,
+                builder: (context, url, _) =>
+                    _Backdrop(url: url, blurAmount: blurAmount),
+              ),
+            if (isReadableBook)
+              const Positioned.fill(
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      colors: [Color(0x000F182A), Color(0x440A1324)],
                     ),
                   ),
-                SliverPadding(
-                  padding: isReadableBook
-                      ? EdgeInsets.fromLTRB(
-                          _isCompact(context) ? 16 : 48,
-                          MediaQuery.of(context).padding.top +
-                              (_isCompact(context) ? 60 : 80),
-                          _isCompact(context) ? 16 : 48,
-                          0,
-                        )
-                      : EdgeInsets.fromLTRB(
-                          _isCompact(context) ? 16 : 48,
-                          0,
-                          _isCompact(context) ? 16 : 48,
-                          (MediaQuery.of(context).padding.bottom + 48.0) *
-                              _desktopUiScale(),
-                        ),
-                  sliver: isAlbumOrPlaylist
-                      ? SliverToBoxAdapter(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: _buildContentForType(context, item),
-                          ),
-                        )
-                      : SliverList(
-                          delegate: SliverChildListDelegate(
-                            _buildContentForType(context, item),
-                          ),
-                        ),
                 ),
-              ],
-            ),
-        ],
+              )
+            else
+              const RepaintBoundary(child: _GradientScrim()),
+            if (useSplitLayout)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _buildStaticPersonProfilePanel(context, item),
+                  Expanded(
+                    child: CustomScrollView(
+                      controller: _scrollController,
+                      cacheExtent: 4000,
+                      slivers: [
+                        SliverPadding(
+                          padding: EdgeInsets.fromLTRB(
+                            48,
+                            MediaQuery.of(context).padding.top + 80.0,
+                            48,
+                            48 * _desktopUiScale(),
+                          ),
+                          sliver: SliverList(
+                            delegate: SliverChildListDelegate(
+                              _buildContentForType(context, item),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              )
+            else
+              CustomScrollView(
+                controller: _scrollController,
+                cacheExtent: 4000,
+                slivers: [
+                  if (item.type != 'Person' &&
+                      item.type != 'MusicArtist' &&
+                      item.type != 'MusicAlbum' &&
+                      item.type != 'Playlist' &&
+                      !_isReadableBookItem(item))
+                    SliverToBoxAdapter(
+                      child: _HeaderSection(
+                        viewModel: widget.viewModel,
+                        prefs: widget.prefs,
+                        selectedMediaSource: selectedMediaSource,
+                        overviewFocusNode: headerOverviewFocusNode,
+                        onArrowUp: _tryFocusNavbar,
+                        onArrowDown: () {
+                          final type = item.type;
+                          final targetNode = switch (type) {
+                            'BoxSet' => _sectionFocusNode(
+                              'detailBoxSetActionButtons',
+                            ),
+                            _ =>
+                              widget.initialFocusNode ??
+                                  _sectionFocusNode('detailActionButtons'),
+                          };
+                          _requestSectionFocus(targetNode);
+                        },
+                        onArrowLeft: () => _tryFocusSidebar(),
+                        onCollapseBiography: () => setState(() {}),
+                      ),
+                    ),
+                  SliverPadding(
+                    padding: isReadableBook
+                        ? EdgeInsets.fromLTRB(
+                            _isCompact(context) ? 16 : 48,
+                            MediaQuery.of(context).padding.top +
+                                (_isCompact(context) ? 60 : 80),
+                            _isCompact(context) ? 16 : 48,
+                            0,
+                          )
+                        : EdgeInsets.fromLTRB(
+                            _isCompact(context) ? 16 : 48,
+                            0,
+                            _isCompact(context) ? 16 : 48,
+                            (MediaQuery.of(context).padding.bottom + 48.0) *
+                                _desktopUiScale(),
+                          ),
+                    sliver: isAlbumOrPlaylist
+                        ? SliverToBoxAdapter(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: _buildContentForType(context, item),
+                            ),
+                          )
+                        : SliverList(
+                            delegate: SliverChildListDelegate(
+                              _buildContentForType(context, item),
+                            ),
+                          ),
+                  ),
+                ],
+              ),
+          ],
+        ),
       ),
-    ),
     );
   }
 
@@ -13473,6 +13476,21 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
   }
 }
 
+/// Numbers the episode without spelling out the word, which is what made long
+/// titles unreadable on a phone. An episode with no title of its own still
+/// gets the spelled out label, since a bare number says nothing on its own.
+///
+/// Public for the title tests. Every production caller lives in this file.
+@visibleForTesting
+String episodeCardTitle(BuildContext context, String name, int? number) {
+  if (name.isEmpty) {
+    return number == null
+        ? ''
+        : AppLocalizations.of(context).episodeLabel(number);
+  }
+  return number == null ? name : 'E$number: $name';
+}
+
 class DetailEpisodeCard extends StatefulWidget {
   final AggregatedItem episode;
   final ImageApi imageApi;
@@ -13661,13 +13679,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
                               Text(
-                                episode.name.isNotEmpty
-                                    ? episode.name
-                                    : (epNum != null
-                                        ? AppLocalizations.of(
-                                            context,
-                                          ).episodeLabel(epNum)
-                                        : ''),
+                                episodeCardTitle(context, episode.name, epNum),
                                 style: Theme.of(context).textTheme.titleSmall
                                     ?.copyWith(
                                       color: isNeon

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -34,6 +34,7 @@ import '../../../widgets/rating_display.dart';
 import '../../../widgets/focus/focusable_wrapper.dart';
 import '../../../widgets/focus/focusable_toolbar_button.dart';
 import '../../../widgets/navigation_layout.dart';
+import '../../../widgets/quick_return_wrapper.dart';
 import '../../../widgets/top_toolbar.dart';
 import '../../../../data/repositories/seerr_repository.dart';
 import '../../../../data/repositories/tmdb_repository.dart';
@@ -4908,7 +4909,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           )
         : null;
 
-    return _landscape
+    final layout = _landscape
         ? ModernLandscapeLayout(
             backdrop: backdrop,
             hero: hero,
@@ -4929,6 +4930,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             topInset: topInset,
             scrollController: _scrollController,
           );
+
+    return QuickReturnWrapper(
+      scrollController: _scrollController,
+      topFocusNode: widget.initialFocusNode,
+      child: layout,
+    );
   }
 }
 

--- a/test/ui/screens/detail/episode_card_title_test.dart
+++ b/test/ui/screens/detail/episode_card_title_test.dart
@@ -1,0 +1,56 @@
+// This card carries no number badge of its own, so whatever comes back here is
+// the only place the episode number shows.
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/ui/screens/detail/item_detail_screen.dart';
+
+void main() {
+  late BuildContext ctx;
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            ctx = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+
+  testWidgets('a title keeps its number and loses the word', (tester) async {
+    await pump(tester);
+
+    expect(
+      episodeCardTitle(ctx, 'The Winter Soldier', 1),
+      'E1: The Winter Soldier',
+    );
+    expect(episodeCardTitle(ctx, 'Pilot', 12), 'E12: Pilot');
+  });
+
+  testWidgets('an episode with no number is just its title', (tester) async {
+    await pump(tester);
+
+    expect(episodeCardTitle(ctx, 'Special', null), 'Special');
+  });
+
+  testWidgets('a card with no title of its own still reads', (tester) async {
+    await pump(tester);
+
+    final title = episodeCardTitle(ctx, '', 5);
+    expect(title, contains('5'));
+    // A bare E5 says nothing on a card with nothing beside it.
+    expect(title, isNot('E5'));
+  });
+
+  testWidgets('nothing at all gives an empty title', (tester) async {
+    await pump(tester);
+
+    expect(episodeCardTitle(ctx, '', null), '');
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
This PR adjusts a few small UI issues on the details page. Specifically, it 1) synchronizes the detail page back button with the top navigation bar's visibility gate so it fades out together when scrolling down instead of remaining pinned over content. 2) adds the Quick Return shortcut wrapper across detail screens so mobile and desktop users can tap to return to the top and Android TV users can return to the top via the remote back key. And 3) removes the redundant "Episode X - " title prefix from episode list cards so episode names are better representations of their content (especially on narrow mobile screens).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #1376 
- Fixes #1354 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - Gated `NavigationLayout`'s `showBackButton` parameter to match `showNavigationChrome` so the back button hides together with the top navigation bar when scrolling down and reappears when scrolled back to top.
  - Wrapped classic `_DetailContent` in **QuickReturnWrapper** to provide scroll-to-top functionality.
  - Updated **DetailEpisodeCard** to render `episode.name` directly (falling back to localized episode label if empty), avoiding redundant "Episode X - " prefixes that truncate titles on mobile.
- **modern_detail_content.dart**:
  - Wrapped **ModernDetailContent** layouts (**ModernLandscapeLayout** and **ModernPortraitLayout**) in **QuickReturnWrapper** so the floating "Scroll to top" button appears in the lower-right corner on mobile/desktop as soon as the screen is scrolled down past 20px, and TV remote back key safely returns to top and focuses the initial action.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a TV series detail page on mobile (Android/iOS) and desktop.
2. Verify episode list cards display the episode name cleanly without "Episode X - " prepended.
3. Scroll down past the hero section:
   - Verify the top navigation bar and back button fade out together.
   - Verify no floating back arrow remains pinned over the episode tabs or metadata cards.
   - Verify the floating "Scroll to top" button appears in the bottom-right corner.
4. Tap the "Scroll to top" button:
   - Verify the screen smoothly scrolls back to the top and both the navigation bar and back button fade back in.
5. On Android TV, verify that scrolling down and pressing the Back key on the remote returns the screen to the top and focuses the primary action button.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/444961b8-e2d7-47b5-a09c-43e58cc63d11

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
