### PR TITLE
Fix(windows): Keep the Windows launch from leaving Flutter's surface at the wrong size

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -15,6 +15,9 @@ namespace {
 std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
     g_hdr_display_channel;
 
+// Posted after a nested WM_SIZE. WM_APP + 1 is native_game's.
+constexpr UINT kResyncViewMessage = WM_APP + 2;
+
 struct HdrDisplayState {
   bool supported = false;
   bool enabled = false;
@@ -263,10 +266,53 @@ void FlutterWindow::OnDestroy() {
   Win32Window::OnDestroy();
 }
 
+void FlutterWindow::SizeChildToClientArea() {
+  if (IsIconic(GetHandle())) {
+    return;
+  }
+  const RECT frame = GetClientArea();
+  SizeChildContent(frame.right, frame.bottom);
+}
+
 LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
+  if (message == kResyncViewMessage) {
+    SizeChildToClientArea();
+    return 0;
+  }
+  if (message != WM_SIZE) {
+    return RouteMessage(hwnd, message, wparam, lparam);
+  }
+
+  // The engine pumps its task queue while answering a child resize, so a task
+  // that resizes the window re-enters here. A nested resize leaves the engine
+  // with a stale target (white, half-size or corner-drawn UI), so the child
+  // is sized once, after both have unwound.
+  ++size_depth_;
+  LRESULT result = 0;
+  if (size_depth_ == 1) {
+    result = RouteMessage(hwnd, message, wparam, lparam);
+  } else {
+    nested_size_ = true;
+    if (flutter_controller_) {
+      result = flutter_controller_
+                   ->HandleTopLevelWindowProc(hwnd, message, wparam, lparam)
+                   .value_or(0);
+    }
+  }
+  if (--size_depth_ == 0 && nested_size_) {
+    nested_size_ = false;
+    PostMessage(hwnd, kResyncViewMessage, 0, 0);
+  }
+  return result;
+}
+
+LRESULT
+FlutterWindow::RouteMessage(HWND hwnd, UINT const message,
+                            WPARAM const wparam,
+                            LPARAM const lparam) noexcept {
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -26,6 +26,15 @@ class FlutterWindow : public Win32Window {
                          LPARAM const lparam) noexcept override;
 
  private:
+  LRESULT RouteMessage(HWND window, UINT const message, WPARAM const wparam,
+                       LPARAM const lparam) noexcept;
+
+  void SizeChildToClientArea();
+
+  // WM_SIZE re-entrancy - see MessageHandler.
+  int size_depth_ = 0;
+  bool nested_size_ = false;
+
   // The project to run.
   flutter::DartProject project_;
 

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -150,7 +150,8 @@ bool Win32Window::Create(const std::wstring& title,
 }
 
 bool Win32Window::Show() {
-  return ShowWindow(window_handle_, SW_SHOWNORMAL);
+  // SW_SHOW keeps the current placement; SW_SHOWNORMAL would un-maximise.
+  return ShowWindow(window_handle_, SW_SHOW);
 }
 
 // static
@@ -199,11 +200,7 @@ Win32Window::MessageHandler(HWND hwnd,
     }
     case WM_SIZE: {
       RECT rect = GetClientArea();
-      if (child_content_ != nullptr) {
-        // Size and position the child window.
-        MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
-                   rect.bottom - rect.top, TRUE);
-      }
+      SizeChildContent(rect.right - rect.left, rect.bottom - rect.top);
       return 0;
     }
 
@@ -242,11 +239,14 @@ void Win32Window::SetChildContent(HWND content) {
   child_content_ = content;
   SetParent(content, window_handle_);
   RECT frame = GetClientArea();
-
-  MoveWindow(content, frame.left, frame.top, frame.right - frame.left,
-             frame.bottom - frame.top, true);
-
+  SizeChildContent(frame.right - frame.left, frame.bottom - frame.top);
   SetFocus(child_content_);
+}
+
+void Win32Window::SizeChildContent(int width, int height) {
+  if (child_content_ != nullptr) {
+    MoveWindow(child_content_, 0, 0, width, height, TRUE);
+  }
 }
 
 RECT Win32Window::GetClientArea() {

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -71,6 +71,8 @@ class Win32Window {
   // Called when Destroy is called.
   virtual void OnDestroy();
 
+  void SizeChildContent(int width, int height);
+
  private:
   friend class WindowClassRegistrar;
 


### PR DESCRIPTION
# Pull Request

## Summary
On Windows, launching the app sometimes left Flutter's render surface at the wrong size: the UI drawn small in the bottom-left corner, at half size, or a white window until the next resize. It happens when the app maximizes the window right before `runApp`. The engine answers that child resize by blocking the platform thread for up to 100 ms while pumping its own task queue, and the runner's first-frame `Show()` is one of those tasks: its `SW_SHOWNORMAL` restored the window, re-entering `WM_SIZE` inside the pending resize. The engine's fast path for a resize whose surface already matches sends metrics without clearing the pending target, so the next frame matching the stale target resized the surface to a size the window no longer had.

`Show()` now uses `SW_SHOW`, which keeps the current placement, so the runner never triggers the nested resize. As a guard against any other task doing the same, a `WM_SIZE` that arrives inside another is no longer passed to the child: plugins still see it, and the child is sized once from the main loop after both have unwound.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- `Win32Window::Show()` uses `SW_SHOW` instead of `SW_SHOWNORMAL`, so the engine's first-frame callback never un-maximizes the window.
- `FlutterWindow::MessageHandler` tracks `WM_SIZE` re-entrancy; a nested `WM_SIZE` is still dispatched to plugins but no longer resizes the Flutter child, which is sized once via a posted message after both handlers unwind.
- Child sizing consolidated into `Win32Window::SizeChildContent()`, shared by `WM_SIZE`, `SetChildContent` and the deferred resync.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [x] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Close the app, then set `"flutter.window_maximized":true` in `%APPDATA%\org.moonfin\Moonfin\shared_preferences.json` (the app rewrites this file on close, so set it right before launching).
2. Launch the app. Before this change this reproduces on essentially every launch, as one of the three faces above (verified with a runner-side trace of `WM_SIZE` nesting; Windows 11, 3840×2160 at 150 %, Flutter 3.44.8).
3. With this change, three consecutive launches with the same recipe came up maximized with the UI filling the window and the top-level client, `FLUTTERVIEW` child and Dart `View.physicalSize` all agreeing.

## Screenshots (if applicable)

<img width="951" height="490" alt="Screenshot 2026-09-02 200914" src="https://github.com/user-attachments/assets/98155996-b876-44c6-9480-4dfd6ad36f2f" />


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced