### PR TITLE
feat-ui - Adjust Library Dropdown for Top Navbar with some bonus flair

### DIFF
--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -1928,12 +1928,42 @@ class _LibrariesDropdownState extends State<_LibrariesDropdown> {
   // back. Registering it lets the key close it instead of leaving the page.
   void _closeFromBack() => _hideDropdown(focusButton: true);
 
+  double _calculateMenuWidth(BuildContext context, double screenWidth) {
+    final baseStyle = (Theme.of(context).textTheme.bodyMedium ??
+            const TextStyle())
+        .copyWith(
+          fontSize: 15,
+          fontWeight: FontWeight.w500,
+        );
+    final textPainter = TextPainter(
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    );
+    double maxTextWidth = 0.0;
+    for (final lib in widget.libraries) {
+      textPainter.text = TextSpan(
+        text: lib.name,
+        style: baseStyle,
+      );
+      textPainter.layout();
+      if (textPainter.width > maxTextWidth) {
+        maxTextWidth = textPainter.width;
+      }
+    }
+    textPainter.dispose();
+
+    const horizontalPadding = 44.0;
+    final contentWidth = maxTextWidth + horizontalPadding;
+    final maxAllowed = (screenWidth - 24).clamp(140.0, 320.0);
+    return contentWidth.clamp(140.0, maxAllowed);
+  }
+
   void _showDropdown({bool focusFirstItem = false}) {
     _hideTimer?.cancel();
     if (_overlayEntry != null) return;
 
     final screenWidth = MediaQuery.of(context).size.width;
-    _menuWidth = (screenWidth - 16).clamp(180.0, 280.0);
+    _menuWidth = _calculateMenuWidth(context, screenWidth);
 
     final targetBox =
         _targetKey.currentContext?.findRenderObject() as RenderBox?;
@@ -2020,7 +2050,7 @@ class _LibrariesDropdownState extends State<_LibrariesDropdown> {
       link: _layerLink,
       targetAnchor: _openToLeft ? Alignment.bottomRight : Alignment.bottomLeft,
       followerAnchor: _openToLeft ? Alignment.topRight : Alignment.topLeft,
-      offset: Offset.zero,
+      offset: const Offset(0, 4),
       child: content,
     );
 
@@ -2040,16 +2070,30 @@ class _LibrariesDropdownState extends State<_LibrariesDropdown> {
   }
 
   Widget _dropdownContent(double maxMenuHeight) {
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final borderColor = isNeon
+        ? AppColorScheme.accent
+        : ThemeRegistry.active.borders.chipBorder.color;
+
     return Container(
+      width: _menuWidth,
       constraints: BoxConstraints(
-        minWidth: 180,
-        maxWidth: _menuWidth,
         maxHeight: maxMenuHeight,
       ),
       decoration: BoxDecoration(
         color: widget.surfaceColor,
         borderRadius: AppRadius.circular(12),
+        border: Border.all(
+          color: borderColor,
+          width: 1.2,
+        ),
         boxShadow: [
+          if (isNeon)
+            BoxShadow(
+              color: AppColorScheme.accent.withValues(alpha: 0.25),
+              blurRadius: 16,
+              spreadRadius: 1,
+            ),
           BoxShadow(
             color: Colors.black.withValues(alpha: 0.5),
             blurRadius: 24,
@@ -2217,11 +2261,16 @@ class _LibraryDropdownItemState extends State<_LibraryDropdownItem> {
                 : Colors.transparent,
             child: Text(
               widget.name,
-              style: TextStyle(
-                color: (_isHovered || _isFocused) ? focusColor : Colors.white,
-                fontSize: 15,
-                fontWeight: FontWeight.w500,
-              ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: (Theme.of(context).textTheme.bodyMedium ??
+                      const TextStyle())
+                  .copyWith(
+                    color:
+                        (_isHovered || _isFocused) ? focusColor : Colors.white,
+                    fontSize: 15,
+                    fontWeight: FontWeight.w500,
+                  ),
             ),
           ),
         ),


### PR DESCRIPTION
# Pull Request

## Summary
Calculates the top navigation bar's library dropdown menu width dynamically based on active theme typography and content text length instead of enforcing a static 280px width. Tightens the dropdown positioning right below the clapperboard button with a 4px gap and adds theme-accented border styling (including Neon Pulse glow) to seamlessly connect the dropdown with the navbar.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1351 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **top_toolbar.dart**:
  - Replaced the static 280px dropdown width with `_calculateMenuWidth`, which uses `TextPainter` and the active theme's `Theme.of(context).textTheme.bodyMedium` to measure the longest library name plus horizontal padding, properly sizing menus across standard fonts and wider pixel fonts (such as 8-Bit Hero).
  - Positioned the follower overlay directly underneath the clapperboard navbar button with a 4px vertical gap (`Offset(0, 4)`).
  - Styled `_dropdownContent` with a 1.2px theme-accented border (`ThemeRegistry.active.borders.chipBorder.color`) and subtle ambient/neon glow.
  - Updated `_LibraryDropdownItem` to inherit the active theme's font family and body text metrics with ellipsis truncation handling.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on mobile (Android/iOS) and desktop across different themes (Neon Pulse, 8-Bit Hero, default).
2. Tap/click the library clapperboard icon in the top toolbar.
3. Verify that the dropdown menu width hugs the library text content with clean horizontal padding rather than stretching halfway across the screen with excess empty space.
4. Verify that wide typefaces (e.g. 8-Bit Hero) measure accurately without clipping or truncating long library names.
5. Verify the menu is attached directly underneath the navbar icon with theme-highlighted border styling and glow.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previous Dropdown
<img width="400" alt="Screenshot_20260902-131621" src="https://github.com/user-attachments/assets/9f61f1a2-4f72-4d37-bfc5-8027ea603f0c" />

### Updated Moonfin Theme
<img width="400" alt="Screenshot_20260902-133952" src="https://github.com/user-attachments/assets/2b711bc1-1a29-480d-9f08-dd23a564a2d0" />

### Updated Neon Pulse
<img width="400"  alt="Screenshot_20260902-133812" src="https://github.com/user-attachments/assets/6097b315-24ff-4c7e-9415-b91ed6cba75e" />

### Updated 8-Bit Hero
<img width="400" alt="Screenshot_20260902-134803" src="https://github.com/user-attachments/assets/d469c4de-d82a-4d58-aafc-993d481a33ed" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
