### PR TITLE
feat-ui - Adjusting Expansion Focus Behaviour

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1112,7 +1112,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
   Widget _buildVerticalGrid() {
     final cardWidth = _cardWidth();
-    const spacing = 12.0;
+    final cardFocusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
+    final spacing = cardFocusExpansion ? 16.0 : 12.0;
     final watchedBehavior = _prefs.get(
       UserPreferences.watchedIndicatorBehavior,
     );
@@ -1528,9 +1529,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     if (_vm.isGrouping) {
       return _buildGroupedHorizontalRows();
     }
-    const spacing = 12.0;
-    final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
     final cardFocusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
+    final spacing = cardFocusExpansion ? 16.0 : 12.0;
+    final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
     final focusColor = Color(_prefs.get(UserPreferences.focusColor).colorValue);
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
 

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1113,7 +1113,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   Widget _buildVerticalGrid() {
     final cardWidth = _cardWidth();
     final cardFocusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
-    final spacing = cardFocusExpansion ? 16.0 : 12.0;
     final watchedBehavior = _prefs.get(
       UserPreferences.watchedIndicatorBehavior,
     );
@@ -1124,6 +1123,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final l10n = AppLocalizations.of(context);
         final isMobile = _isCompact(context);
         final gridPadding = isMobile ? 16.0 : _horizontalPadding;
+        final spacing = cardFocusExpansion && !isMobile
+            ? MediaCard.focusGap(cardWidth)
+            : 12.0;
         final minClamp = _vm.imageType == ImageType.banner
             ? (constraints.maxWidth < 600 ? 1 : 2)
             : 2;
@@ -1150,7 +1152,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         // finger is down.
         final focusOverhang = isMobile
             ? 0.0
-            : cellHeight * (MediaCard.focusScale - 1) / 2;
+            : MediaCard.focusGap(cellHeight, minimum: 0.0);
         final rowSpacing = math.max(8.0, focusOverhang);
         _gridGeometry = (
           perLine: crossAxisCount,
@@ -1530,7 +1532,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       return _buildGroupedHorizontalRows();
     }
     final cardFocusExpansion = _prefs.get(UserPreferences.cardFocusExpansion);
-    final spacing = cardFocusExpansion ? 16.0 : 12.0;
     final watchedBehavior = _prefs.get(UserPreferences.watchedIndicatorBehavior);
     final focusColor = Color(_prefs.get(UserPreferences.focusColor).colorValue);
     final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
@@ -1546,6 +1547,9 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
         final textHeight = (_hasSubtitles ? 46.0 : 30.0) * desktopTextScale;
 
         final cellWidth = _cardWidth();
+        final spacing = cardFocusExpansion && !isMobile
+            ? MediaCard.focusGap(cellWidth)
+            : 12.0;
         final targetImageHeight = cellWidth / ar;
         final targetCellHeight = targetImageHeight + textHeight;
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11695,10 +11695,11 @@ class DetailSimilarRow extends StatelessWidget {
         controller: scrollController,
         scrollDirection: Axis.horizontal,
         clipBehavior: Clip.none,
-        padding: const EdgeInsets.fromLTRB(6, 10, 6, 4),
+        padding: const EdgeInsets.fromLTRB(6, 12, 6, 6),
         itemCount: items.length,
-        separatorBuilder: (_, _) =>
-            SizedBox(width: isMobile ? 8 : 12 * desktopScale),
+        separatorBuilder: (_, _) => SizedBox(
+          width: (cardExpansion ? 16.0 : 12.0) * (isMobile ? 1.0 : desktopScale),
+        ),
         itemBuilder: (context, index) {
           final item = items[index];
           final ar = MediaCard.aspectRatioForType(item.type);
@@ -14448,8 +14449,9 @@ class SeerrAppearancesRow extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         clipBehavior: Clip.none,
         itemCount: items.length,
-        separatorBuilder: (_, _) =>
-            SizedBox(width: isMobile ? 8 : 12 * desktopScale),
+        separatorBuilder: (_, _) => SizedBox(
+          width: (cardExpansion ? 16.0 : 12.0) * (isMobile ? 1.0 : desktopScale),
+        ),
         itemBuilder: (context, index) {
           final item = items[index];
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -11688,6 +11688,10 @@ class DetailSimilarRow extends StatelessWidget {
     final isMobile = _isCompact(context);
     final desktopScale = _desktopUiScale(prefs: prefs);
     final cardWidth = customCardWidth ?? (isMobile ? 120.0 : 150.0 * desktopScale);
+    final baseGap = isMobile ? 8.0 : 12 * desktopScale;
+    final separatorWidth = cardExpansion && !isMobile
+        ? MediaCard.focusGap(cardWidth, minimum: baseGap)
+        : baseGap;
 
     return SizedBox(
       height: customHeight ?? (isMobile ? 228 : 282 * desktopScale),
@@ -11695,11 +11699,9 @@ class DetailSimilarRow extends StatelessWidget {
         controller: scrollController,
         scrollDirection: Axis.horizontal,
         clipBehavior: Clip.none,
-        padding: const EdgeInsets.fromLTRB(6, 12, 6, 6),
+        padding: const EdgeInsets.fromLTRB(6, 10, 6, 4),
         itemCount: items.length,
-        separatorBuilder: (_, _) => SizedBox(
-          width: (cardExpansion ? 16.0 : 12.0) * (isMobile ? 1.0 : desktopScale),
-        ),
+        separatorBuilder: (_, _) => SizedBox(width: separatorWidth),
         itemBuilder: (context, index) {
           final item = items[index];
           final ar = MediaCard.aspectRatioForType(item.type);
@@ -14441,6 +14443,10 @@ class SeerrAppearancesRow extends StatelessWidget {
     final rowHeight = isMobile ? 240.0 : cardHeight + (56 * metadataScale);
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
     final suppressFocusGlow = ThemeRegistry.active.borders.focusGlow.isNotEmpty;
+    final baseGap = isMobile ? 8.0 : 12 * desktopScale;
+    final separatorWidth = cardExpansion && !isMobile
+        ? MediaCard.focusGap(cardWidth, minimum: baseGap)
+        : baseGap;
 
     return SizedBox(
       height: rowHeight,
@@ -14449,9 +14455,7 @@ class SeerrAppearancesRow extends StatelessWidget {
         scrollDirection: Axis.horizontal,
         clipBehavior: Clip.none,
         itemCount: items.length,
-        separatorBuilder: (_, _) => SizedBox(
-          width: (cardExpansion ? 16.0 : 12.0) * (isMobile ? 1.0 : desktopScale),
-        ),
+        separatorBuilder: (_, _) => SizedBox(width: separatorWidth),
         itemBuilder: (context, index) {
           final item = items[index];
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3194,19 +3194,26 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        const spacing = 16.0;
+        const minSpacing = 12.0;
         const desiredWidth = 150.0;
         final crossAxisCount =
-            ((constraints.maxWidth + spacing) / (desiredWidth + spacing))
+            ((constraints.maxWidth + minSpacing) / (desiredWidth + minSpacing))
                 .floor()
                 .clamp(2, 8);
-        final cellWidth =
-            (constraints.maxWidth - (crossAxisCount - 1) * spacing) /
-                crossAxisCount;
+        double cellWidthWith(double gap) =>
+            (constraints.maxWidth - (crossAxisCount - 1) * gap) /
+            crossAxisCount;
+        final spacing = cardExpansion
+            ? MediaCard.focusGap(cellWidthWith(minSpacing), minimum: minSpacing)
+            : minSpacing;
+        final cellWidth = cellWidthWith(spacing);
         final cardRatio = aspectRatio;
         const textHeight = 44.0;
-        final childAspectRatio =
-            cellWidth / (cellWidth / cardRatio + textHeight);
+        final cellHeight = cellWidth / cardRatio + textHeight;
+        final childAspectRatio = cellWidth / cellHeight;
+        final rowSpacing = cardExpansion
+            ? MediaCard.focusGap(cellHeight, minimum: minSpacing)
+            : minSpacing;
         return Focus(
           canRequestFocus: false,
           onFocusChange: (focused) {
@@ -3226,12 +3233,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           child: GridView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
-            padding: const EdgeInsets.only(top: 14, bottom: 20),
+            padding: cardExpansion
+                ? EdgeInsets.symmetric(vertical: rowSpacing)
+                : EdgeInsets.zero,
             itemCount: items.length,
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: crossAxisCount,
               crossAxisSpacing: spacing,
-              mainAxisSpacing: spacing,
+              mainAxisSpacing: rowSpacing,
               childAspectRatio: childAspectRatio,
             ),
             itemBuilder: (context, i) {
@@ -3296,17 +3305,26 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     final grid = LayoutBuilder(
       builder: (context, constraints) {
-        const spacing = 16.0;
-        const runSpacing = 20.0;
+        const minSpacing = 12.0;
+        const minRunSpacing = 16.0;
         final columns = (constraints.maxWidth / (_landscape ? 160.0 : 130.0))
             .floor()
             .clamp(3, _landscape ? 10 : 6);
-        final cardWidth =
-            (((constraints.maxWidth - spacing * (columns - 1)) / columns)
-                .floorToDouble())
-            .clamp(0.0, 260.0 * _desktopUiScale(prefs: widget.prefs));
+        double cardWidthWith(double gap) =>
+            (((constraints.maxWidth - gap * (columns - 1)) / columns)
+                    .floorToDouble())
+                .clamp(0.0, 260.0 * _desktopUiScale(prefs: widget.prefs));
+        final spacing = cardExpansion
+            ? MediaCard.focusGap(cardWidthWith(minSpacing), minimum: minSpacing)
+            : minSpacing;
+        final cardWidth = cardWidthWith(spacing);
+        final runSpacing = cardExpansion
+            ? MediaCard.focusGap(cardWidth / cardRatio, minimum: minRunSpacing)
+            : minRunSpacing;
         return Padding(
-          padding: const EdgeInsets.only(top: 14, bottom: 20),
+          padding: cardExpansion
+              ? EdgeInsets.symmetric(vertical: runSpacing)
+              : EdgeInsets.zero,
           child: Wrap(
             spacing: spacing,
             runSpacing: runSpacing,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -3183,9 +3183,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _itemGrid(List<AggregatedItem> items, {double aspectRatio = 2 / 3, FocusNode? focusNode}) {
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final cardExpansion = widget.prefs.get(UserPreferences.cardFocusExpansion);
+    final focusColor = isNeon
+        ? AppColorScheme.accent
+        : Color(widget.prefs.get(UserPreferences.focusColor).colorValue);
+    final titleColor = isNeon ? AppColorScheme.accent : null;
+    final watchedBehavior =
+        widget.prefs.get(UserPreferences.watchedIndicatorBehavior);
+
     return LayoutBuilder(
       builder: (context, constraints) {
-        const spacing = 12.0;
+        const spacing = 16.0;
         const desiredWidth = 150.0;
         final crossAxisCount =
             ((constraints.maxWidth + spacing) / (desiredWidth + spacing))
@@ -3217,7 +3226,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           child: GridView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
-            padding: EdgeInsets.zero,
+            padding: const EdgeInsets.only(top: 14, bottom: 20),
             itemCount: items.length,
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: crossAxisCount,
@@ -3229,15 +3238,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               final entry = items[i];
               return MediaCard(
                 title: entry.name,
+                titleColor: titleColor,
                 focusNode: i == 0 ? (focusNode ?? _gridFirstFocusNode) : null,
+                focusColor: focusColor,
+                cardFocusExpansion: cardExpansion,
+                suppressFocusGlow: isNeon,
                 imageUrl: _imageUrl(entry),
                 width: double.infinity,
                 aspectRatio: cardRatio,
                 isPlayed: entry.isPlayed,
                 isFavorite: entry.isFavorite,
                 itemType: entry.type,
-                watchedBehavior:
-                    widget.prefs.get(UserPreferences.watchedIndicatorBehavior),
+                watchedBehavior: watchedBehavior,
                 onTap: () {
                   if (entry.serverId == 'seerr') {
                     final mediaType = entry.seerrMediaType ??
@@ -3273,10 +3285,19 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }) {
     if (items.isEmpty) return const SizedBox.shrink();
     const cardRatio = 2 / 3;
+    final isNeon = ThemeRegistry.active.id == ThemeRegistry.neonPulseId;
+    final cardExpansion = widget.prefs.get(UserPreferences.cardFocusExpansion);
+    final focusColor = isNeon
+        ? AppColorScheme.accent
+        : Color(widget.prefs.get(UserPreferences.focusColor).colorValue);
+    final titleColor = isNeon ? AppColorScheme.accent : null;
+    final watchedBehavior =
+        widget.prefs.get(UserPreferences.watchedIndicatorBehavior);
 
     final grid = LayoutBuilder(
       builder: (context, constraints) {
-        const spacing = 12.0;
+        const spacing = 16.0;
+        const runSpacing = 20.0;
         final columns = (constraints.maxWidth / (_landscape ? 160.0 : 130.0))
             .floor()
             .clamp(3, _landscape ? 10 : 6);
@@ -3284,59 +3305,68 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             (((constraints.maxWidth - spacing * (columns - 1)) / columns)
                 .floorToDouble())
             .clamp(0.0, 260.0 * _desktopUiScale(prefs: widget.prefs));
-        return Wrap(
-          spacing: spacing,
-          runSpacing: 16,
-          children: [
-            for (var i = 0; i < items.length; i++)
-              Builder(
-                builder: (cellContext) {
-                  final entry = items[i];
-                  final topRow = i < columns;
-                  return MediaCard(
-                    title: entry.name,
-                    imageUrl: _imageUrl(entry),
-                    width: cardWidth,
-                    aspectRatio: cardRatio,
-                    isPlayed: entry.isPlayed,
-                    isFavorite: entry.isFavorite,
-                    itemType: entry.type,
-                    focusNode: i == 0 ? firstFocusNode : null,
-                    onFocus: () => Scrollable.ensureVisible(
-                      cellContext,
-                      alignment: 0.5,
-                      duration: const Duration(milliseconds: 200),
-                      curve: Curves.easeOut,
-                    ),
-                    onKeyEvent: topRow
-                        ? (node, event) {
-                            if (event is KeyDownEvent &&
-                                event.logicalKey == LogicalKeyboardKey.arrowUp) {
-                              _focusSelectedTab();
-                              return KeyEventResult.handled;
+        return Padding(
+          padding: const EdgeInsets.only(top: 14, bottom: 20),
+          child: Wrap(
+            spacing: spacing,
+            runSpacing: runSpacing,
+            children: [
+              for (var i = 0; i < items.length; i++)
+                Builder(
+                  builder: (cellContext) {
+                    final entry = items[i];
+                    final topRow = i < columns;
+                    return MediaCard(
+                      title: entry.name,
+                      titleColor: titleColor,
+                      imageUrl: _imageUrl(entry),
+                      width: cardWidth,
+                      aspectRatio: cardRatio,
+                      isPlayed: entry.isPlayed,
+                      isFavorite: entry.isFavorite,
+                      itemType: entry.type,
+                      focusNode: i == 0 ? firstFocusNode : null,
+                      focusColor: focusColor,
+                      cardFocusExpansion: cardExpansion,
+                      suppressFocusGlow: isNeon,
+                      onFocus: () => Scrollable.ensureVisible(
+                        cellContext,
+                        alignment: 0.5,
+                        duration: const Duration(milliseconds: 200),
+                        curve: Curves.easeOut,
+                      ),
+                      onKeyEvent: topRow
+                          ? (node, event) {
+                              if (event is KeyDownEvent &&
+                                  event.logicalKey ==
+                                      LogicalKeyboardKey.arrowUp) {
+                                _focusSelectedTab();
+                                return KeyEventResult.handled;
+                              }
+                              return KeyEventResult.ignored;
                             }
-                            return KeyEventResult.ignored;
-                          }
-                        : null,
-                    watchedBehavior: widget.prefs
-                        .get(UserPreferences.watchedIndicatorBehavior),
-                    onTap: () {
-                      if (entry.serverId == 'seerr') {
-                        final mediaType = entry.seerrMediaType ??
-                            (entry.type == 'Series' ? 'tv' : 'movie');
-                        context.push(
-                          Destinations.seerrMedia(entry.id, mediaType: mediaType),
-                        );
-                      } else {
-                        context.push(
-                          Destinations.item(entry.id, serverId: entry.serverId),
-                        );
-                      }
-                    },
-                  );
-                },
-              ),
-          ],
+                          : null,
+                      watchedBehavior: watchedBehavior,
+                      onTap: () {
+                        if (entry.serverId == 'seerr') {
+                          final mediaType = entry.seerrMediaType ??
+                              (entry.type == 'Series' ? 'tv' : 'movie');
+                          context.push(
+                            Destinations.seerrMedia(entry.id,
+                                mediaType: mediaType),
+                          );
+                        } else {
+                          context.push(
+                            Destinations.item(entry.id,
+                                serverId: entry.serverId),
+                          );
+                        }
+                      },
+                    );
+                  },
+                ),
+            ],
+          ),
         );
       },
     );

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3543,6 +3543,12 @@ class _ContentRowsState extends State<_ContentRows>
     return posterSize.portraitHeight.toDouble() * platformScale;
   }
 
+  /// Touch never leaves a card grown, so phones keep the tighter layout.
+  double _rowItemSpacing(double itemExtent, bool cardExpansion) =>
+      cardExpansion && !PlatformDetection.useMobileUi
+      ? MediaCard.focusGap(itemExtent)
+      : 12.0;
+
   double _rowContentHeight(
     HomeRow row,
     PosterSize posterSize,
@@ -4396,7 +4402,7 @@ class _ContentRowsState extends State<_ContentRows>
           controller: _rowHorizontalController(rowIndex),
           height: rowHeight,
           itemExtent: squarePosterSide,
-          itemSpacing: 12,
+          itemSpacing: _rowItemSpacing(squarePosterSide, cardExpansion),
           leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
           clipBehavior: cardExpansion ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
@@ -4458,7 +4464,7 @@ class _ContentRowsState extends State<_ContentRows>
           controller: _rowHorizontalController(rowIndex),
           height: rowHeight,
           itemExtent: squarePosterSide,
-          itemSpacing: 12,
+          itemSpacing: _rowItemSpacing(squarePosterSide, cardExpansion),
           leadingPadding: _isHomeRowsStyleV2() ? _kHomeRowLabelInset : 0,
           clipBehavior: cardExpansion ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),
@@ -4618,7 +4624,7 @@ class _ContentRowsState extends State<_ContentRows>
           controller: _rowHorizontalController(rowIndex),
           height: maxCardHeight + (10 * metadataScale),
           itemExtent: firstCardWidth,
-          itemSpacing: (cardExpansion ? 16.0 : 12.0) * (PlatformDetection.useMobileUi ? 1.0 : desktopScale),
+          itemSpacing: _rowItemSpacing(firstCardWidth, cardExpansion),
           leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
           clipBehavior: (isRowsV2 || cardExpansion) ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4618,7 +4618,7 @@ class _ContentRowsState extends State<_ContentRows>
           controller: _rowHorizontalController(rowIndex),
           height: maxCardHeight + (10 * metadataScale),
           itemExtent: firstCardWidth,
-          itemSpacing: 12,
+          itemSpacing: (cardExpansion ? 16.0 : 12.0) * (PlatformDetection.useMobileUi ? 1.0 : desktopScale),
           leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
           clipBehavior: (isRowsV2 || cardExpansion) ? Clip.none : Clip.hardEdge,
           padding: const EdgeInsets.fromLTRB(_kHomeRowLabelInset, 5, 20, 5),

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_tvos/flutter_tvos.dart'
@@ -21,6 +23,16 @@ class MediaCard extends StatefulWidget {
   /// cards against a clip boundary or each other has to leave that much room
   /// or the focused card loses its edges.
   static double get focusScale => PlatformDetection.isAppleTV ? 1.12 : 1.05;
+
+  /// How much room to leave beside a card of [extent] so a focused one keeps
+  /// its edges.
+  ///
+  /// Cards paint in the order they are laid out, so the one after the focused
+  /// card covers whatever the growth pushed into the gap. Wide artwork grows
+  /// by the same fraction of a much larger number, so a gap that suits a
+  /// poster does not suit a banner.
+  static double focusGap(double extent, {double minimum = 12.0}) =>
+      math.max(minimum, extent * (focusScale - 1) / 2);
 
   final String? title;
   final String? subtitle;

--- a/test/ui/widgets/media_card_focus_gap_test.dart
+++ b/test/ui/widgets/media_card_focus_gap_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/media_card.dart';
+
+void main() {
+  const posterRatio = 2 / 3;
+  const bannerRatio = 1000 / 185;
+
+  Widget twoCards({
+    required double width,
+    required double aspectRatio,
+    required double gap,
+  }) => MaterialApp(
+    home: Scaffold(
+      body: Row(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          MediaCard(
+            title: 'Focused',
+            width: width,
+            aspectRatio: aspectRatio,
+            itemType: 'Movie',
+            externalIsFocused: true,
+            onTap: () {},
+          ),
+          SizedBox(width: gap),
+          MediaCard(
+            title: 'Beside it',
+            width: width,
+            aspectRatio: aspectRatio,
+            itemType: 'Movie',
+            onTap: () {},
+          ),
+        ],
+      ),
+    ),
+  );
+
+  // The layout box stays where it was put, so the growth only shows up on what
+  // sits under it. That is the rectangle the card really paints into.
+  Rect painted(WidgetTester tester, int index) => tester.getRect(
+    find
+        .descendant(
+          of: find.byType(MediaCard).at(index),
+          matching: find.byType(Column),
+        )
+        .first,
+  );
+
+  Future<double> overlap(
+    WidgetTester tester, {
+    required double width,
+    required double aspectRatio,
+    required double gap,
+  }) async {
+    await tester.binding.setSurfaceSize(const Size(2000, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      twoCards(width: width, aspectRatio: aspectRatio, gap: gap),
+    );
+    await tester.pumpAndSettle();
+    return painted(tester, 0).right - painted(tester, 1).left;
+  }
+
+  group('the gap a row leaves beside a card', () {
+    testWidgets('keeps a focused poster off the card next to it', (
+      tester,
+    ) async {
+      const width = 150.0;
+      expect(
+        await overlap(
+          tester,
+          width: width,
+          aspectRatio: posterRatio,
+          gap: MediaCard.focusGap(width),
+        ),
+        lessThanOrEqualTo(0.0),
+      );
+    });
+
+    testWidgets('keeps a focused banner off it as well', (tester) async {
+      const width = 600.0;
+      expect(
+        await overlap(
+          tester,
+          width: width,
+          aspectRatio: bannerRatio,
+          gap: MediaCard.focusGap(width),
+        ),
+        lessThanOrEqualTo(0.0),
+      );
+    });
+
+    testWidgets('the flat gap the rows used to carry is not enough', (
+      tester,
+    ) async {
+      expect(
+        await overlap(
+          tester,
+          width: 600.0,
+          aspectRatio: bannerRatio,
+          gap: 12.0,
+        ),
+        greaterThan(0.0),
+      );
+    });
+
+    test('the floor holds until the card outgrows it', () {
+      expect(MediaCard.focusGap(80), 12.0);
+      expect(MediaCard.focusGap(80, minimum: 8), 8.0);
+      expect(MediaCard.focusGap(600), greaterThan(12.0));
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
The Card Focus Expansion setting had a couple of issues - it was not being observed in the Similar tab for media details, and was causing a bit of overlap in other views when enabled. This PR wires the Card Focus Expansion Animation user preference to media detail poster grids (Similar tab and collection Movies/Shows tabs) so cards respect the expansion toggle rather than always expanding. It also adds some additional top padding and wider item spacing to prevent focused cards from crowding the tab bar above or overlapping neighboring cards. Also resolves item obstruction across the Home screen, Library browse screens, and detail Appearance rows by dynamically scaling item spacing based on focus expansion, preventing adjacent cards on the right from covering the focused card's edges or glow.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1298 
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **modern_detail_content.dart**:
  - Wired `cardFocusExpansion: widget.prefs.get(UserPreferences.cardFocusExpansion)` into `_mediaGrid` (Similar tab and collection views) and `_itemGrid` so cards stay static when the animation setting is disabled.
  - Added top and bottom padding (`EdgeInsets.only(top: 14, bottom: 20)`) to ensure scaling cards have headroom and do not collide with the tab bar above.
  - Increased card grid spacing from 12px to 16px (and 20px run spacing) for comfortable breathing room between posters.
  - Wired active theme focus colors (`focusColor`, `titleColor`, and `suppressFocusGlow`).
- **home_screen.dart**:
  - Dynamically scaled `LockedFocusRow`'s `itemSpacing` based on `cardExpansion` (16px when expansion is active vs 12px when disabled) so focused cards on TV and desktop never get clipped or painted over by subsequent items on the right.
- **library_browse_screen.dart**:
  - Scaled grid and horizontal row `spacing` between cards with `cardFocusExpansion` to eliminate right-side poster clipping on focus.
- **item_detail_screen.dart**:
  - Scaled `separatorBuilder` spacing across **DetailSimilarRow** and **SeerrAppearancesRow** based on `cardExpansion`, and adjusted row top padding to 12px.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Windows / Android TV / tvOS and navigate to a media detail page (e.g. TV series or movie).
2. Open the **Similar** tab:
   - Verify that with Focus Expansion enabled, focused cards have ample breathing room above without touching the tab bar pills, and generous spacing between adjacent cards.
   - Go to Settings -> Personalization -> disable **Focus Expansion Animation**, return to the Similar tab, and verify cards focus without growing.
3. On the Home screen (with Classic rows) and Library browse screens:
   - Navigate horizontally across content cards on TV / desktop and verify that the focused card's right border and glow are fully visible and never painted over or obstructed by cards to its right.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Original "Crowded" View
<img width="2250" height="1389" alt="2026-09-02_14-03-04_moonfin" src="https://github.com/user-attachments/assets/ab69b085-9aa0-4cf1-ae8d-88a0a4dfb057" />

### Updated with Focus Expansion ON (with padding to prevent overlaps)

Small Cards:
<img width="2250" height="1389" alt="2026-09-02_15-11-18_moonfin" src="https://github.com/user-attachments/assets/0a88a6a6-2a6f-42f7-a4d6-db1484ecab56" />

Extra Large Cards:
<img width="2250" height="1389" alt="2026-09-02_15-11-35_moonfin" src="https://github.com/user-attachments/assets/436d14e2-f5d7-450a-a85e-b0f4d303ff44" />

Similar Page:
<img width="2250" height="1389" alt="2026-09-02_15-12-31_moonfin" src="https://github.com/user-attachments/assets/9dae8a59-1ea1-4852-befe-34788c542a25" />

### Updated with Focus Expansion OFF (cards all remain same size)
<img width="2250" height="1389" alt="2026-09-02_15-12-52_moonfin" src="https://github.com/user-attachments/assets/a3aed3e4-edc8-4181-a74d-5f9427056aa3" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
