### PR TITLE
bugfix-mediabar - Recently Released Patch

### DIFF
--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -307,25 +307,31 @@ class RowDataSource {
       defaultLimit: _defaultLimit,
       maxLimit: _maxItems,
     );
-    List<String>? seriesType;
-    var recursive = false;
-    if (collectionType == 'tvshows') {
+    List<String>? includeItemTypes;
+    final normalizedType = collectionType?.toLowerCase();
+    if (normalizedType == 'tvshows' || normalizedType == 'shows') {
       final prefSeriesType = GetIt.instance<UserPreferences>().get(
         UserPreferences.recentlyReleasedSeriesType,
       );
-      seriesType = switch (prefSeriesType) {
+      includeItemTypes = switch (prefSeriesType) {
         RecentlyReleasedSeriesType.series => const ['Series'],
         RecentlyReleasedSeriesType.season => const ['Season'],
         RecentlyReleasedSeriesType.episode => const ['Episode'],
       };
-      // Seasons and episodes sit below the library rather than directly in it.
-      recursive = prefSeriesType != RecentlyReleasedSeriesType.series;
+    } else if (normalizedType == 'movies') {
+      includeItemTypes = const ['Movie'];
+    } else if (normalizedType == 'music') {
+      includeItemTypes = const ['MusicAlbum'];
+    } else if (normalizedType == 'books') {
+      includeItemTypes = const ['Book'];
+    } else if (normalizedType == 'audiobooks') {
+      includeItemTypes = const ['AudioBook', 'Audio'];
     }
     final response = await _getRecentlyReleasedItemsWithFallback(
       parentId: parentId,
       limit: fetchLimit,
-      includeItemTypes: seriesType,
-      recursive: recursive,
+      includeItemTypes: includeItemTypes,
+      recursive: true,
     );
     final items = normalizeLatestMediaItems(
       _parseItems(response, serverId),

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -307,31 +307,17 @@ class RowDataSource {
       defaultLimit: _defaultLimit,
       maxLimit: _maxItems,
     );
-    List<String>? includeItemTypes;
-    final normalizedType = collectionType?.toLowerCase();
-    if (normalizedType == 'tvshows' || normalizedType == 'shows') {
-      final prefSeriesType = GetIt.instance<UserPreferences>().get(
+    final includeItemTypes = recentlyReleasedItemTypesFor(
+      collectionType,
+      seriesType: () => GetIt.instance<UserPreferences>().get(
         UserPreferences.recentlyReleasedSeriesType,
-      );
-      includeItemTypes = switch (prefSeriesType) {
-        RecentlyReleasedSeriesType.series => const ['Series'],
-        RecentlyReleasedSeriesType.season => const ['Season'],
-        RecentlyReleasedSeriesType.episode => const ['Episode'],
-      };
-    } else if (normalizedType == 'movies') {
-      includeItemTypes = const ['Movie'];
-    } else if (normalizedType == 'music') {
-      includeItemTypes = const ['MusicAlbum'];
-    } else if (normalizedType == 'books') {
-      includeItemTypes = const ['Book'];
-    } else if (normalizedType == 'audiobooks') {
-      includeItemTypes = const ['AudioBook', 'Audio'];
-    }
+      ),
+    );
     final response = await _getRecentlyReleasedItemsWithFallback(
       parentId: parentId,
       limit: fetchLimit,
       includeItemTypes: includeItemTypes,
-      recursive: true,
+      recursive: includeItemTypes != null,
     );
     final items = normalizeLatestMediaItems(
       _parseItems(response, serverId),

--- a/lib/data/utils/latest_media_row_normalizer.dart
+++ b/lib/data/utils/latest_media_row_normalizer.dart
@@ -1,4 +1,5 @@
 import '../../l10n/app_localizations.dart';
+import '../../preference/preference_constants.dart';
 import '../models/aggregated_item.dart';
 
 int latestMediaFetchLimitForCollection(
@@ -17,6 +18,32 @@ int latestMediaFetchLimitForCollection(
 
   return defaultLimit;
 }
+
+/// The item types a Recently Released row asks a library for.
+///
+/// Asking by type is what lets the query recurse and reach a title the server
+/// left sitting inside a folder of its own. A library that reports no type, or
+/// one nothing here covers, gets null, and the caller then leaves recursion off
+/// so the row keeps to the titles sitting directly in the library.
+///
+/// [seriesType] is only called for a TV library, so nothing else has to have
+/// the setting to hand.
+List<String>? recentlyReleasedItemTypesFor(
+  String? collectionType, {
+  required RecentlyReleasedSeriesType Function() seriesType,
+}) => switch (collectionType?.toLowerCase()) {
+  'tvshows' || 'shows' => switch (seriesType()) {
+    RecentlyReleasedSeriesType.series => const ['Series'],
+    RecentlyReleasedSeriesType.season => const ['Season'],
+    RecentlyReleasedSeriesType.episode => const ['Episode'],
+  },
+  'movies' => const ['Movie'],
+  'music' => const ['MusicAlbum'],
+  // A books library holds both kinds.
+  'books' => const ['Book', 'AudioBook'],
+  'audiobooks' => const ['AudioBook', 'Audio'],
+  _ => null,
+};
 
 /// Marks a row stitched together from several libraries of one kind. Such a row
 /// has no single parent library, so nothing can ask the server for more of it.

--- a/test/data/services/recently_released_scope_test.dart
+++ b/test/data/services/recently_released_scope_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/services/row_data_source.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockClient extends Mock implements MediaServerClient {}
+
+class _MockItemsApi extends Mock implements ItemsApi {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() => GetIt.instance.reset());
+
+  Future<void> preferSeriesType(RecentlyReleasedSeriesType type) async {
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    final prefs = UserPreferences(store);
+    await prefs.set(UserPreferences.recentlyReleasedSeriesType, type);
+    GetIt.instance.registerSingleton<UserPreferences>(prefs);
+  }
+
+  Future<({String types, bool recursive})> requestFor(
+    String? collectionType,
+  ) async {
+    final itemsApi = _MockItemsApi();
+    when(
+      () => itemsApi.getRecentlyReleasedItems(
+        parentId: any(named: 'parentId'),
+        includeItemTypes: any(named: 'includeItemTypes'),
+        limit: any(named: 'limit'),
+        fields: any(named: 'fields'),
+        enableImageTypes: any(named: 'enableImageTypes'),
+        imageTypeLimit: any(named: 'imageTypeLimit'),
+        recursive: any(named: 'recursive'),
+      ),
+    ).thenAnswer((_) async => {'Items': <dynamic>[], 'TotalRecordCount': 0});
+
+    final client = _MockClient();
+    when(() => client.itemsApi).thenReturn(itemsApi);
+
+    await RowDataSource(
+      client,
+    ).loadRecentlyReleased('lib1', 'A library', 'srv1', collectionType);
+
+    final captured = verify(
+      () => itemsApi.getRecentlyReleasedItems(
+        parentId: any(named: 'parentId'),
+        includeItemTypes: captureAny(named: 'includeItemTypes'),
+        limit: any(named: 'limit'),
+        fields: any(named: 'fields'),
+        enableImageTypes: any(named: 'enableImageTypes'),
+        imageTypeLimit: any(named: 'imageTypeLimit'),
+        recursive: captureAny(named: 'recursive'),
+      ),
+    ).captured;
+    // Named arguments come back in whatever order the call recorded them.
+    final types = captured.whereType<List<String>>();
+    return (
+      types: types.isEmpty ? 'anything' : types.first.join(','),
+      recursive: captured.whereType<bool>().first,
+    );
+  }
+
+  group('a library the row knows the shape of', () {
+    test('movies are asked for below the library too', () async {
+      final request = await requestFor('movies');
+      expect(request.types, 'Movie');
+      expect(request.recursive, isTrue);
+    });
+
+    test('books ask for both kinds a books library holds', () async {
+      final request = await requestFor('books');
+      expect(request.types, 'Book,AudioBook');
+      expect(request.recursive, isTrue);
+    });
+
+    test('music stops at the album so tracks stay out of the row', () async {
+      final request = await requestFor('music');
+      expect(request.types, 'MusicAlbum');
+      expect(request.recursive, isTrue);
+    });
+
+    test('a TV library follows the setting', () async {
+      await preferSeriesType(RecentlyReleasedSeriesType.episode);
+      final request = await requestFor('tvshows');
+      expect(request.types, 'Episode');
+      expect(request.recursive, isTrue);
+    });
+  });
+
+  group('a library the row knows nothing about', () {
+    // Going below it with nothing to ask for reaches every episode and track
+    // under the library, and only a TV row folds those back up.
+    test('a mixed library keeps to its top level', () async {
+      final request = await requestFor('');
+      expect(request.types, 'anything');
+      expect(request.recursive, isFalse);
+    });
+
+    test('so does one whose kind is not covered', () async {
+      final request = await requestFor('homevideos');
+      expect(request.types, 'anything');
+      expect(request.recursive, isFalse);
+    });
+  });
+
+  test('a library that is not TV never reaches for the setting', () async {
+    expect(GetIt.instance.isRegistered<UserPreferences>(), isFalse);
+    final request = await requestFor('movies');
+    expect(request.types, 'Movie');
+    expect(request.recursive, isTrue);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Investigated Recently Released Movies issue and I believe it comes down to a missing "recursive: true" flag. So, this PR enables recursive querying and collection-specific item types on `loadRecentlyReleased` so that Recently Released home rows correctly populate for movie libraries and multi-folder library configurations. Previously, `loadRecentlyReleased` only set `recursive: true` for TV season/episode views, causing movie libraries with subfolder structures (e.g. standard Radarr folder setups) or multi-path layouts to return 0 items because the top-level directory items lack premiere dates.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1260 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **row_data_source.dart**:
  - Set `recursive: true` on `_getRecentlyReleasedItemsWithFallback` in `loadRecentlyReleased` so Jellyfin recurses across all folder hierarchies within the library.
  - Added explicit collection-specific `includeItemTypes` mapping (e.g., `['Movie']` for movies, `['MusicAlbum']` for music, `['Book']` for books, `['AudioBook', 'Audio']` for audiobooks) to directly utilize SQLite `TypedBaseItems` index queries and avoid scanning intermediate folder or container objects.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Windows / Android TV and ensure **Recently Released** is enabled under Home Sections.
2. Verify that **Recently Released** rows populate for both Movie and TV libraries, regardless of whether the server uses nested subfolders or multiple folder paths.
3. Run `flutter test test/data/` (all tests passed).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

I did not personally have this bug, but my row still populates correctly with this change.

<img width="2250" height="1389" alt="2026-09-02_16-58-18_moonfin" src="https://github.com/user-attachments/assets/0726ef0f-ffbf-4931-8072-a40dd8c700b6" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
