### PR TITLE
bugfix-ui - Just Let Them Browse (Collections)

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -3827,8 +3827,7 @@ class _DetailContentState extends State<_DetailContent> {
   }
 
   bool _hasMetadata(AggregatedItem item) {
-    return item.type == 'BoxSet' ||
-        viewModel.directors.isNotEmpty ||
+    return viewModel.directors.isNotEmpty ||
         viewModel.writers.isNotEmpty ||
         item.studios.isNotEmpty;
   }


### PR DESCRIPTION
# Pull Request

## Summary
Fixes an issue where D-pad navigation on the Classic detail layout became trapped on collections/boxsets that contain no studios, directors, or writers (such as Emby collections or un-tagged Jellyfin collections). Previously, `_hasMetadata` unconditionally returned `true` for all `BoxSet` items, causing an unmounted metadata section focus node to be registered as the `downTarget` of the Action Buttons and `upTarget` of the Movies row, preventing directional navigation between the buttons and content cards.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1346 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - Removed the unconditional `item.type == 'BoxSet'` check in `_hasMetadata`.
  - Now, `_hasMetadata` only returns `true` when actual metadata (directors, writers, or studios) exists to be rendered.
  - When metadata is absent, no phantom focus node is registered, allowing focus to move seamlessly straight down from the Action Buttons into the Movies row, and straight up from the Movies row back to the Action Buttons.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a Collection / BoxSet that lacks Studio metadata (or on an Emby server) using the Classic details layout.
2. Focus the Play button (or any Action Button) and press **DOWN** on the D-pad / remote:
   - Verify focus moves smoothly and directly to the first movie card in the collection row.
3. From the Movies row, press **UP** on the D-pad:
   - Verify focus returns cleanly back up to the Action Buttons.
4. Open a Collection that *does* have Studio metadata (e.g. Marvel Studios) and verify navigation traverses Action Buttons -> Studio Chip -> Movies row as expected.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Jellyfin collections pull enough meta-data to never run into this issue, but the PR changes do not impede them.

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
