### PR TITLE
Fix deep-link warm re-nav auto-play and add optional userId pin

### DIFF
--- a/lib/data/services/deep_link_service.dart
+++ b/lib/data/services/deep_link_service.dart
@@ -39,15 +39,22 @@ class DeepLinkService {
   /// the link isn't recognized.
   ///
   /// Recognized forms:
-  ///  - `moonfin://item?id=<itemId>[&serverId=<serverId>]`
-  ///  - `moonfin://play?id=<itemId>[&serverId=<serverId>]` (starts playback)
+  ///  - `moonfin://item?id=<itemId>[&serverId=<serverId>][&userId=<userId>]`
+  ///  - `moonfin://play?id=<itemId>[&serverId=<serverId>][&userId=<userId>]`
+  ///    (starts playback)
+  ///
+  /// `userId` optionally pins a stored user for cold starts, skipping the
+  /// profile picker. It is only honored for users already signed in on this
+  /// device, and never bypasses a PIN or an always-authenticate setting.
   static String? routeForDeepLink(Uri uri) {
     if (uri.scheme != 'moonfin') return null;
     final id = uri.queryParameters['id'];
     if (id == null || id.isEmpty) return null;
     final serverId = uri.queryParameters['serverId'];
+    final userId = uri.queryParameters['userId'];
     final params = <String, String>{
       if (serverId != null && serverId.isNotEmpty) 'serverId': serverId,
+      if (userId != null && userId.isNotEmpty) 'userId': userId,
       if (uri.host == 'play') 'autoPlay': 'true',
     };
     final query = params.entries

--- a/lib/ui/navigation/deep_link_navigator.dart
+++ b/lib/ui/navigation/deep_link_navigator.dart
@@ -2,8 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 
+import '../../auth/repositories/server_repository.dart';
 import '../../auth/repositories/session_repository.dart';
+import '../../auth/store/authentication_preferences.dart';
+import '../../auth/store/authentication_store.dart';
+import '../../util/pin_code_util.dart';
 import 'app_router.dart';
 import 'destinations.dart';
 
@@ -43,6 +48,96 @@ void navigateWhenReady(String route) {
   // Detach only, never an early drop. This survives long PIN, login, and
   // server-select cold starts, and can't leak a listener if auth never lands.
   Timer(const Duration(minutes: 5), () => finish(navigate: false));
+
+  // Cold start with a pinned user: establish that stored session directly so
+  // the profile picker isn't needed. Best-effort and non-blocking — any gate
+  // or failure falls through to the picker path above, which is unchanged.
+  unawaited(_pinUserIfRequested(route, onPinned: () => finish(navigate: true)));
+}
+
+/// Cold-start user pin for a deep link that carried `userId`: establish that
+/// stored session directly so automation doesn't need the profile picker.
+/// Runs only while the app is still unauthenticated, and only after
+/// StartupScreen has settled — switching mid-restore would interleave with a
+/// second concurrent session setup. [onPinned] claims the shared navigation
+/// once the session is live, so the picker path can't double-navigate later.
+Future<void> _pinUserIfRequested(
+  String route, {
+  required void Function() onPinned,
+}) async {
+  final query = Uri.tryParse(route)?.queryParameters;
+  final userId = query?['userId'];
+  if (userId == null || userId.isEmpty) return;
+
+  // The same gates the picker applies before switching to a user: a link
+  // must never silently bypass a PIN or an always-authenticate requirement.
+  try {
+    if (GetIt.instance<AuthenticationPreferences>().shouldAlwaysAuthenticate) {
+      return;
+    }
+    if (PinCodeUtil(GetIt.instance<PreferenceStore>(), userId).isPinEnabled) {
+      return;
+    }
+  } catch (_) {
+    // Preferences unavailable — don't pin, let the picker handle it.
+    return;
+  }
+
+  if (!await _startupSettled()) return;
+  if (_isAuthenticated()) return; // startup already gave us a session
+
+  final session = GetIt.instance<SessionRepository>();
+  if (session.state != SessionState.ready) {
+    await session.stateStream
+        .firstWhere((s) => s == SessionState.ready)
+        .timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => SessionState.ready,
+        );
+  }
+
+  final serverId = _resolveServerIdForUser(userId, query?['serverId']);
+  if (serverId == null) return; // unknown or ambiguous — let the picker decide
+
+  bool pinned = false;
+  try {
+    await GetIt.instance<ServerRepository>().loadStoredServers();
+    pinned = await session.switchCurrentSession(
+      serverId: serverId,
+      userId: userId,
+    );
+  } catch (_) {
+    pinned = false;
+  }
+  if (!pinned || !_isAuthenticated()) return;
+
+  onPinned();
+}
+
+/// Polls until the app is no longer on the startup screen (StartupScreen's
+/// own restore finished or it gave up and showed the picker), capped so a
+/// stuck startup can't hold this forever — the picker fallback window still
+/// applies.
+Future<bool> _startupSettled() async {
+  for (var i = 0; i < 60; i++) {
+    if (_currentPath() != Destinations.startup) return true;
+    await Future<void>.delayed(const Duration(milliseconds: 500));
+  }
+  return _currentPath() != Destinations.startup;
+}
+
+/// Resolves which stored server [userId] belongs to. An explicit `serverId`
+/// wins when it is a known server; otherwise the user must appear on exactly
+/// one stored server — never guess across several.
+String? _resolveServerIdForUser(String userId, String? explicitServerId) {
+  final authStore = GetIt.instance<AuthenticationStore>();
+  if (explicitServerId != null &&
+      authStore.getServer(explicitServerId) != null) {
+    return explicitServerId;
+  }
+  final matches = authStore.getServers().where((server) =>
+      authStore.getUsers(server.id).any((user) => user.id == userId)).toList();
+  return matches.length == 1 ? matches.first.id : null;
 }
 
 bool _isAuthenticated() =>

--- a/lib/ui/navigation/deep_link_navigator.dart
+++ b/lib/ui/navigation/deep_link_navigator.dart
@@ -50,7 +50,7 @@ void navigateWhenReady(String route) {
   Timer(const Duration(minutes: 5), () => finish(navigate: false));
 
   // Cold start with a pinned user: establish that stored session directly so
-  // the profile picker isn't needed. Best-effort and non-blocking — any gate
+  // the profile picker isn't needed. Best effort and non blocking, so any gate
   // or failure falls through to the picker path above, which is unchanged.
   unawaited(_pinUserIfRequested(route, onPinned: () => finish(navigate: true)));
 }
@@ -58,9 +58,10 @@ void navigateWhenReady(String route) {
 /// Cold-start user pin for a deep link that carried `userId`: establish that
 /// stored session directly so automation doesn't need the profile picker.
 /// Runs only while the app is still unauthenticated, and only after
-/// StartupScreen has settled — switching mid-restore would interleave with a
-/// second concurrent session setup. [onPinned] claims the shared navigation
-/// once the session is live, so the picker path can't double-navigate later.
+/// StartupScreen has settled, since switching mid restore would interleave
+/// with a second concurrent session setup. [onPinned] claims the shared
+/// navigation once the session is live, so the picker path can't
+/// double-navigate later.
 Future<void> _pinUserIfRequested(
   String route, {
   required void Function() onPinned,
@@ -79,7 +80,7 @@ Future<void> _pinUserIfRequested(
       return;
     }
   } catch (_) {
-    // Preferences unavailable — don't pin, let the picker handle it.
+    // Preferences unavailable, so don't pin and let the picker handle it.
     return;
   }
 
@@ -97,7 +98,8 @@ Future<void> _pinUserIfRequested(
   }
 
   final serverId = _resolveServerIdForUser(userId, query?['serverId']);
-  if (serverId == null) return; // unknown or ambiguous — let the picker decide
+  // Unknown or ambiguous, so let the picker decide.
+  if (serverId == null) return;
 
   bool pinned = false;
   try {
@@ -116,7 +118,7 @@ Future<void> _pinUserIfRequested(
 
 /// Polls until the app is no longer on the startup screen (StartupScreen's
 /// own restore finished or it gave up and showed the picker), capped so a
-/// stuck startup can't hold this forever — the picker fallback window still
+/// stuck startup can't hold this forever. The picker fallback window still
 /// applies.
 Future<bool> _startupSettled() async {
   for (var i = 0; i < 60; i++) {
@@ -127,8 +129,8 @@ Future<bool> _startupSettled() async {
 }
 
 /// Resolves which stored server [userId] belongs to. An explicit `serverId`
-/// wins when it is a known server; otherwise the user must appear on exactly
-/// one stored server — never guess across several.
+/// wins when it is a known server, otherwise the user must appear on exactly
+/// one stored server. Never guess across several.
 String? _resolveServerIdForUser(String userId, String? explicitServerId) {
   final authStore = GetIt.instance<AuthenticationStore>();
   if (explicitServerId != null &&

--- a/lib/ui/navigation/playback_launcher.dart
+++ b/lib/ui/navigation/playback_launcher.dart
@@ -6,7 +6,6 @@ import 'package:go_router/go_router.dart';
 import 'package:playback_core/playback_core.dart';
 
 import '../../data/services/log_service.dart';
-import 'app_router.dart';
 import 'destinations.dart';
 
 typedef PlaybackStarter = Future<bool> Function(PlaybackLaunchSession? session);
@@ -55,9 +54,9 @@ Future<bool> launchPlayerWhilePreparing(
     // A location change (go/replace) removes the player route without
     // completing its push future, so a launch whose route is already gone can
     // hold the slot for the rest of the process and swallow every later play
-    // press. A live launch always has its route on the stack; if it isn't,
-    // the holder is dead — take over its slot.
-    if (_videoPlayerRoutePresent()) {
+    // press. A live launch always has its route on the stack, so a holder
+    // without one is dead and its slot can be taken over.
+    if (_videoPlayerRoutePresent(context)) {
       return false;
     }
     final stale = _activeVideoLaunch!;
@@ -165,7 +164,9 @@ Future<bool> launchPlayerWhilePreparing(
   }
 }
 
-bool _videoPlayerRoutePresent() {
+/// Reads the router that owns [context] rather than the app-wide one, so the
+/// answer describes the stack the launch actually pushed onto.
+bool _videoPlayerRoutePresent(BuildContext context) {
   try {
     bool present(List<RouteMatchBase> matches) {
       for (final match in matches) {
@@ -175,9 +176,11 @@ bool _videoPlayerRoutePresent() {
       return false;
     }
 
-    return present(appRouter.routerDelegate.currentConfiguration.matches);
+    return present(
+      GoRouter.of(context).routerDelegate.currentConfiguration.matches,
+    );
   } catch (_) {
-    // Router not usable: treat the slot as held — never steal on uncertainty.
+    // Router not usable, so treat the slot as held and never steal on doubt.
     return true;
   }
 }

--- a/lib/ui/navigation/playback_launcher.dart
+++ b/lib/ui/navigation/playback_launcher.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:playback_core/playback_core.dart';
 
 import '../../data/services/log_service.dart';
+import 'app_router.dart';
 import 'destinations.dart';
 
 typedef PlaybackStarter = Future<bool> Function(PlaybackLaunchSession? session);
@@ -50,7 +51,19 @@ Future<bool> launchPlayerWhilePreparing(
     return true;
   }
 
-  if (_activeVideoLaunch != null) return false;
+  if (_activeVideoLaunch != null) {
+    // A location change (go/replace) removes the player route without
+    // completing its push future, so a launch whose route is already gone can
+    // hold the slot for the rest of the process and swallow every later play
+    // press. A live launch always has its route on the stack; if it isn't,
+    // the holder is dead — take over its slot.
+    if (_videoPlayerRoutePresent()) {
+      return false;
+    }
+    final stale = _activeVideoLaunch!;
+    _activeVideoLaunch = null;
+    stale._cancelled = true;
+  }
 
   final session = PlaybackLaunchSession._();
   _activeVideoLaunch = session;
@@ -149,6 +162,23 @@ Future<bool> launchPlayerWhilePreparing(
     if (identical(_activeVideoLaunch, session)) {
       _activeVideoLaunch = null;
     }
+  }
+}
+
+bool _videoPlayerRoutePresent() {
+  try {
+    bool present(List<RouteMatchBase> matches) {
+      for (final match in matches) {
+        if (match.matchedLocation == Destinations.videoPlayer) return true;
+        if (match is ShellRouteMatch && present(match.matches)) return true;
+      }
+      return false;
+    }
+
+    return present(appRouter.routerDelegate.currentConfiguration.matches);
+  } catch (_) {
+    // Router not usable: treat the slot as held — never steal on uncertainty.
+    return true;
   }
 }
 

--- a/test/data/services/deep_link_service_test.dart
+++ b/test/data/services/deep_link_service_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/deep_link_service.dart';
+
+void main() {
+  group('routeForDeepLink', () {
+    test('returns null for non-moonfin schemes', () {
+      expect(
+        DeepLinkService.routeForDeepLink(
+          Uri.parse('https://example.com/?id=abc'),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null without an id', () {
+      expect(
+        DeepLinkService.routeForDeepLink(Uri.parse('moonfin://play?serverId=s1')),
+        isNull,
+      );
+    });
+
+    test('routes item host without autoPlay', () {
+      expect(
+        DeepLinkService.routeForDeepLink(Uri.parse('moonfin://item?id=abc123')),
+        '/item/abc123',
+      );
+    });
+
+    test('routes play host with autoPlay', () {
+      expect(
+        DeepLinkService.routeForDeepLink(Uri.parse('moonfin://play?id=abc123')),
+        '/item/abc123?autoPlay=true',
+      );
+    });
+
+    test('forwards serverId', () {
+      expect(
+        DeepLinkService.routeForDeepLink(
+          Uri.parse('moonfin://play?id=abc123&serverId=srv-1'),
+        ),
+        '/item/abc123?serverId=srv-1&autoPlay=true',
+      );
+    });
+
+    test('forwards userId alongside serverId and autoPlay', () {
+      expect(
+        DeepLinkService.routeForDeepLink(
+          Uri.parse('moonfin://play?id=abc123&serverId=srv-1&userId=user-1'),
+        ),
+        '/item/abc123?serverId=srv-1&userId=user-1&autoPlay=true',
+      );
+    });
+
+    test('forwards userId alone on item host', () {
+      expect(
+        DeepLinkService.routeForDeepLink(
+          Uri.parse('moonfin://item?id=abc123&userId=user-1'),
+        ),
+        '/item/abc123?userId=user-1',
+      );
+    });
+
+    test('ignores empty serverId and userId', () {
+      expect(
+        DeepLinkService.routeForDeepLink(
+          Uri.parse('moonfin://play?id=abc123&serverId=&userId='),
+        ),
+        '/item/abc123?autoPlay=true',
+      );
+    });
+  });
+}

--- a/test/ui/navigation/playback_launcher_test.dart
+++ b/test/ui/navigation/playback_launcher_test.dart
@@ -310,6 +310,61 @@ void main() {
     },
   );
 
+  testWidgets('a launch whose route was replaced releases the slot', (
+    tester,
+  ) async {
+    // go() drops a pushed route without completing its push future, so the
+    // launch that pushed it waits forever and used to hold the slot for the
+    // rest of the process, swallowing every later play press.
+    final manager = PlaybackManager();
+    final starts = <int>[];
+    var launches = 0;
+
+    final router = _router(
+      onLaunch: (context) {
+        launches++;
+        final launch = launches;
+        unawaited(
+          launchPlayerWhilePreparing(
+            context,
+            manager: manager,
+            destination: Destinations.videoPlayer,
+            startPlayback: (session) async {
+              starts.add(launch);
+              if (launch > 1) return false;
+              await runPlaybackStart(
+                session,
+                () => manager.playItems(const [
+                  <String, dynamic>{'Id': '1'},
+                ]),
+              );
+              return true;
+            },
+          ),
+        );
+      },
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    await tester.pumpAndSettle();
+    expect(find.text('video'), findsOneWidget);
+    expect(starts, [1]);
+
+    router.go('/');
+    await tester.pumpAndSettle();
+    expect(find.text('home'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('launch')));
+    await tester.pumpAndSettle();
+
+    // Reaching the starter at all is the proof: a held slot returns before it.
+    expect(starts, [1, 2]);
+
+    manager.dispose();
+    router.dispose();
+  });
+
   testWidgets('external playback replaces the temporary internal route once', (
     tester,
   ) async {


### PR DESCRIPTION
 Pull Request

## Summary
I was setting up some home automation to allow for directly playing titles over the Home Assistant android remote protocol and found deeplinking had some bugs and the user select screen could not be bypassed via deeplink even though I knew which profile would be watching.

Two fixes for `moonfin://play` deep links on Android TV.

Warm re-navigation (app running, fire a link to another item) landed on the detail page and never played, and after that every play press in the process silently did nothing. Root cause: `launchPlayerWhilePreparing` holds a process-wide video-launch slot across `await routeFuture`; a deep link navigates via `go()`, which removes the player route declaratively, and go_router only completes push futures through the pop path — so the slot was never released. The fix releases the slot when the holder's `/player/video` route is no longer on the stack (a live holder always has it there).

Cold start deep links still hit the profile switcher. This adds an optional `userId` deep-link param: o> so that items can be played directly on profiles. This skip only occurs if the useId is provided in the deeplink and there is no pin requirement.

Also adds unit tests for `routeForDeepLink`, which had none.

## Related Issues
None filed — happy to add one first if maintainers prefer.

## Type of Change
- [x] Bug fix
- [x] New feature (optional `userId` deep-link param)

## Changes Made
- `lib/ui/navigation/playback_launcher.dart`: release a stale video-launch slot when the holder's player route was removed by a location change without completing its push future. Such a slot held the process-wide launch gate for the rest of the app's life, swallowing every later play press.
- `lib/data/services/deep_link_service.dart`: forward an optional `userId` query param into the item route (alongside `serverId`).
- `lib/ui/navigation/deep_link_navigator.dart`: on cold start with `userId`, resolve the server (explicit `serverId` or unique match across stored servers, never guessed), run `loadStoredServers()` + `switchCurrentSession()`, then navigate. Skipped when the user has a PIN or `shouldAlwaysAuthenticate` is set; falls back to the picker path on any failure.
- `test/data/services/deep_link_service_test.dart`: unit coverage for `routeForDeepLink`.

## Platform
- [x] All / Shared code (behavior observed on Android TV; changes are in shared `lib/`)

## Testing
- [x] Tested on physical device (Android TV box)
- [x] Manual testing completed
- `flutter analyze` clean on changed files; unit tests pass.

### Test Steps
1. Fresh install, cold start: fire `moonfin://play?id=<episode>&userId=<stored user>` — profile picker is skipped and the episode auto-plays as that user.
2. While playing, fire `moonfin://play?id=<different episode>` — the new episode auto-plays (before: detail page only, then every play press in the process dead).
3. Repeat step 2 several times in one session — all play (before: locked after the first).
4. Cold start with a `userId` that has a PIN enabled (or always-authenticate on) — the picker still appears; the pin is not bypassed.

## Screenshots (if applicable)
None — behavioral fix, no UI changes.

## Checklist
- [x] Code builds successfully (`flutter build apk --debug --flavor androidTv`)
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced (`flutter analyze` clean on changed files)