### PR TITLE
Add Seerr custom sliders and Foreseerr list compatibility

### DIFF
--- a/lib/data/models/home_row.dart
+++ b/lib/data/models/home_row.dart
@@ -21,6 +21,7 @@ enum HomeRowType {
   activeRecordings,
   mediaBar,
   pluginDynamic,
+  seerr,
   liveTvFavorites,
 }
 

--- a/lib/data/repositories/seerr_repository.dart
+++ b/lib/data/repositories/seerr_repository.dart
@@ -5,6 +5,7 @@ import '../../auth/repositories/session_repository.dart';
 import '../services/seerr/seerr_api_models.dart';
 import '../services/seerr/seerr_http_client.dart';
 import '../services/seerr/seerr_models.dart';
+import '../services/seerr/seerr_slider_catalog.dart';
 
 class SeerrRepository {
   final PreferenceStore _store;
@@ -432,13 +433,37 @@ class SeerrRepository {
   Future<void> removeFromWatchlist({required int tmdbId, required String mediaType}) =>
       _withClient((c) => c.removeFromWatchlist(tmdbId: tmdbId, mediaType: mediaType));
 
+  Future<List<SeerrDiscoverSlider>> getDiscoverSliders() => _withClient(
+    (c) async => (await c.getDiscoverSliders())
+        .map(SeerrDiscoverSlider.fromJson)
+        .toList(),
+  );
+
+  Future<SeerrDiscoverPage> getCatalog(
+    String path, {
+    Map<String, String> query = const {},
+    int page = 1,
+    String? mediaTypeHint,
+  }) => _withClient(
+    (c) async => SeerrDiscoverPage.fromJson(
+      await c.getCatalog(
+        path,
+        query: query,
+        page: page,
+        mediaTypeHint: mediaTypeHint,
+      ),
+    ),
+  );
+
   Future<SeerrDiscoverPage> discoverMovies({
     int page = 1,
     String sortBy = 'popularity.desc',
     String? genre,
     int? studio,
-    int? keywords,
+    String? keywords,
     String? language,
+    String? watchRegion,
+    String? watchProviders,
     double? voteAverageGte,
     int? voteCountGte,
     int? withRuntimeGte,
@@ -454,6 +479,8 @@ class SeerrRepository {
         studio: studio,
         keywords: keywords,
         language: language,
+        watchRegion: watchRegion,
+        watchProviders: watchProviders,
         voteAverageGte: voteAverageGte,
         voteCountGte: voteCountGte,
         withRuntimeGte: withRuntimeGte,
@@ -469,8 +496,10 @@ class SeerrRepository {
     String sortBy = 'popularity.desc',
     String? genre,
     int? network,
-    int? keywords,
+    String? keywords,
     String? language,
+    String? watchRegion,
+    String? watchProviders,
     String? status,
     double? voteAverageGte,
     int? voteCountGte,
@@ -487,6 +516,8 @@ class SeerrRepository {
         network: network,
         keywords: keywords,
         language: language,
+        watchRegion: watchRegion,
+        watchProviders: watchProviders,
         status: status,
         voteAverageGte: voteAverageGte,
         voteCountGte: voteCountGte,

--- a/lib/data/repositories/seerr_repository.dart
+++ b/lib/data/repositories/seerr_repository.dart
@@ -843,6 +843,40 @@ class SeerrRepository {
     return settings;
   }
 
+  /// Foreseer-style pre-gate for discover slider catalog fetches.
+  Future<SeerrSliderFetchGate> loadSliderFetchGate() async {
+    Map<String, dynamic> settings;
+    try {
+      settings = await getPublicSettings();
+    } catch (_) {
+      return const SeerrSliderFetchGate();
+    }
+    final gate = SeerrSliderFetchGate.fromPublicSettings(settings);
+    return SeerrSliderFetchGate.fromPublicSettings(
+      settings,
+      traktLinked: gate.traktConfigured == true
+          ? await _linkedAccountConnected('trakt')
+          : null,
+      anilistLinked: gate.anilistConfigured == true
+          ? await _linkedAccountConnected('anilist')
+          : null,
+      simklLinked: gate.simklConfigured == true
+          ? await _linkedAccountConnected('simkl')
+          : null,
+    );
+  }
+
+  Future<bool?> _linkedAccountConnected(String provider) async {
+    try {
+      final user = await getCurrentUser();
+      return await _withClient(
+        (c) => c.getLinkedAccountConnected(user.id, provider),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
   Future<List<SeerrServiceServer>> getRadarrServers() => _withClient(
     (c) async => (await c.getRadarrServers())
         .cast<Map<String, dynamic>>()

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1346,6 +1346,18 @@ class PluginSyncService extends ChangeNotifier {
         for (final custom in existingCustom) {
           sections.add(custom.copyWith(order: order++));
         }
+        final incomingSeerr = sections
+            .where((s) => s.isSeerrCustomSlider)
+            .map((s) => s.pluginAdditionalData)
+            .toSet();
+        final existingSeerr = _prefs.homeSectionsConfig.where(
+          (c) =>
+              c.isSeerrCustomSlider &&
+              !incomingSeerr.contains(c.pluginAdditionalData),
+        );
+        for (final slider in existingSeerr) {
+          sections.add(slider.copyWith(order: order++));
+        }
         _appendDisabledBuiltinSections(sections, order);
         await _prefs.setHomeSectionsConfig(sections);
         await _syncSeerrHomeRowsWithSections(sections);

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1347,13 +1347,13 @@ class PluginSyncService extends ChangeNotifier {
           sections.add(custom.copyWith(order: order++));
         }
         final incomingSliderIds = sections
-            .where((s) => s.isSeerrCustomSlider)
+            .where((s) => s.isSeerrSlider)
             .map((s) => s.sliderId)
             .whereType<String>()
             .toSet();
         final existingSliders = _prefs.homeSectionsConfig.where(
           (c) =>
-              c.isSeerrCustomSlider &&
+              c.isSeerrSlider &&
               c.sliderId != null &&
               c.sliderId!.isNotEmpty &&
               !incomingSliderIds.contains(c.sliderId),
@@ -1373,7 +1373,7 @@ class PluginSyncService extends ChangeNotifier {
       // Preserve plugin-discovered and Seerr slider rows so they survive a
       // server-driven preference sync that only sent homeRowOrder.
       final pluginEntries = _prefs.homeSectionsConfig
-          .where((c) => c.isPluginDynamic || c.isSeerrCustomSlider)
+          .where((c) => c.isPluginDynamic || c.isSeerrSlider)
           .toList(growable: false);
       if (serverOrder.isEmpty) {
         await _applyFallbackHomeRows(preserve: pluginEntries);
@@ -1576,7 +1576,8 @@ class PluginSyncService extends ChangeNotifier {
     List<HomeSectionConfig> sections,
   ) async {
     final enabledByType = {
-      for (final section in sections) section.type: section.enabled,
+      for (final section in sections)
+        if (section.isBuiltin) section.type: section.enabled,
     };
     final updated = _seerrPrefs.homeRowsConfig
         .map(

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1314,7 +1314,7 @@ class PluginSyncService extends ChangeNotifier {
         for (final e in homeSectionsRaw)
           if (e is Map && HomeSectionConfig.isSupportedJson(Map<String, dynamic>.from(e)))
             HomeSectionConfig.fromJson(Map<String, dynamic>.from(e)),
-      ];
+      ].where((c) => c.isPersistable).toList();
       if (parsed.isNotEmpty) {
         parsed.sort((a, b) => a.order.compareTo(b.order));
         final sections = <HomeSectionConfig>[];
@@ -1346,16 +1346,19 @@ class PluginSyncService extends ChangeNotifier {
         for (final custom in existingCustom) {
           sections.add(custom.copyWith(order: order++));
         }
-        final incomingSeerr = sections
+        final incomingSliderIds = sections
             .where((s) => s.isSeerrCustomSlider)
-            .map((s) => s.pluginAdditionalData)
+            .map((s) => s.sliderId)
+            .whereType<String>()
             .toSet();
-        final existingSeerr = _prefs.homeSectionsConfig.where(
+        final existingSliders = _prefs.homeSectionsConfig.where(
           (c) =>
               c.isSeerrCustomSlider &&
-              !incomingSeerr.contains(c.pluginAdditionalData),
+              c.sliderId != null &&
+              c.sliderId!.isNotEmpty &&
+              !incomingSliderIds.contains(c.sliderId),
         );
-        for (final slider in existingSeerr) {
+        for (final slider in existingSliders) {
           sections.add(slider.copyWith(order: order++));
         }
         _appendDisabledBuiltinSections(sections, order);
@@ -1367,10 +1370,10 @@ class PluginSyncService extends ChangeNotifier {
 
     if (!appliedHomeSections && resolved['homeRowOrder'] is List) {
       final serverOrder = (resolved['homeRowOrder'] as List).cast<String>();
-      // Preserve any plugin-discovered dynamic sections so they survive a
-      // server-driven preference sync.
+      // Preserve plugin-discovered and Seerr slider rows so they survive a
+      // server-driven preference sync that only sent homeRowOrder.
       final pluginEntries = _prefs.homeSectionsConfig
-          .where((c) => c.isPluginDynamic)
+          .where((c) => c.isPluginDynamic || c.isSeerrCustomSlider)
           .toList(growable: false);
       if (serverOrder.isEmpty) {
         await _applyFallbackHomeRows(preserve: pluginEntries);
@@ -1379,7 +1382,9 @@ class PluginSyncService extends ChangeNotifier {
         var order = 0;
         for (final name in serverOrder) {
           final type = prefs.HomeSectionType.fromSerialized(name);
-          if (type == prefs.HomeSectionType.none) continue;
+          if (type == prefs.HomeSectionType.none) {
+            continue;
+          }
           sections.add(
             HomeSectionConfig(type: type, enabled: true, order: order++),
           );
@@ -1389,7 +1394,9 @@ class PluginSyncService extends ChangeNotifier {
         } else {
           final enabledTypes = sections.map((s) => s.type).toSet();
           for (final type in prefs.HomeSectionType.values) {
-            if (type == prefs.HomeSectionType.none) continue;
+            if (type == prefs.HomeSectionType.none) {
+              continue;
+            }
             if (_isTmdbSectionType(type)) {
               final localEnabled = _prefs.get(_tmdbPrefForType(type));
               final idx = sections.indexWhere((s) => s.type == type);
@@ -1551,7 +1558,8 @@ class PluginSyncService extends ChangeNotifier {
   ) {
     final present = sections.map((s) => s.type).toSet();
     for (final type in prefs.HomeSectionType.values) {
-      if (type == prefs.HomeSectionType.none || present.contains(type)) {
+      if (type == prefs.HomeSectionType.none ||
+          present.contains(type)) {
         continue;
       }
       sections.add(
@@ -1846,10 +1854,9 @@ class PluginSyncService extends ChangeNotifier {
       'mdblistRatingSources': _csvToList(UserPreferences.enabledRatings)
           .map((s) => _clientToServerRatingSource[s] ?? s)
           .toList(),
-      'homeRowOrder': _prefs.homeSectionsConfig
-          .where((c) => c.enabled)
-          .map((c) => c.type.serializedName)
-          .toList(),
+      'homeRowOrder': HomeSectionConfig.homeRowOrderNames(
+        _prefs.homeSectionsConfig,
+      ),
       'homeSections':
           _prefs.homeSectionsConfig.map((c) => c.toJson()).toList(),
       'seerrRows': {

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2202,6 +2202,12 @@ class RowDataSource {
             rowType: HomeRowType.pluginDynamic,
           );
         }
+      case HomeSectionPluginSource.seerr:
+        return HomeRow(
+          id: rowId,
+          title: title,
+          rowType: HomeRowType.pluginDynamic,
+        );
     }
   }
 

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -1667,6 +1667,7 @@ class RowDataSource {
       case HomeRowType.activeRecordings:
       case HomeRowType.mediaBar:
       case HomeRowType.pluginDynamic:
+      case HomeRowType.seerr:
         return (row.items, row.totalCount);
     }
 
@@ -2202,12 +2203,6 @@ class RowDataSource {
             rowType: HomeRowType.pluginDynamic,
           );
         }
-      case HomeSectionPluginSource.seerr:
-        return HomeRow(
-          id: rowId,
-          title: title,
-          rowType: HomeRowType.pluginDynamic,
-        );
     }
   }
 

--- a/lib/data/services/seerr/seerr_catalog_item.dart
+++ b/lib/data/services/seerr/seerr_catalog_item.dart
@@ -1,0 +1,56 @@
+/// TMDB id a catalog/watchlist item can be opened with.
+///
+/// Two payloads share this helper:
+/// * Stock Seerr / TMDB discover: `id` is the TMDB id, no mapping fields.
+/// * List tiles (WatchlistItem): `tmdbId` is the TMDB id when mapped;
+///   `mappingState.state` is `mapped` / `unmapped` / `ambiguous` / `pending`.
+///   `id` on an unmapped tile may be a Trakt/AniList/MDBList id and must not
+///   be sent to `/movie/{id}` or `/tv/{id}`.
+int? seerrCatalogTmdbId(Map<String, dynamic> item) {
+  final state = seerrCatalogMappingState(item);
+  if (state != null && state != 'mapped') return null;
+
+  final tmdbId = item['tmdbId'];
+  if (state != null || tmdbId != null) return _positiveInt(tmdbId);
+
+  return _positiveInt(item['id']);
+}
+
+int? _positiveInt(Object? value) {
+  final parsed = switch (value) {
+    num number => number.toInt(),
+    String text => int.tryParse(text),
+    _ => null,
+  };
+  if (parsed != null && parsed > 0) return parsed;
+  return null;
+}
+
+String? seerrCatalogMappingState(Map<String, dynamic> item) {
+  final raw = item['mappingState'];
+  if (raw is Map) return raw['state']?.toString();
+  if (raw is String) return raw;
+  return null;
+}
+
+/// Shapes a catalog/watchlist result for [SeerrDiscoverItem], or `null` when
+/// there is no TMDB id to open.
+Map<String, dynamic>? normalizeSeerrCatalogItem(
+  Map<String, dynamic> raw, {
+  String? mediaTypeHint,
+}) {
+  final item = Map<String, dynamic>.from(raw);
+  if (item['mediaType'] == 'person') return null;
+
+  final tmdbId = seerrCatalogTmdbId(item);
+  if (tmdbId == null) return null;
+  item['id'] = tmdbId;
+
+  if (item.containsKey('media') && !item.containsKey('mediaInfo')) {
+    item['mediaInfo'] = item['media'];
+  }
+  if (item['mediaType'] == null && mediaTypeHint != null) {
+    item['mediaType'] = mediaTypeHint;
+  }
+  return item;
+}

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 
 import '../log_service.dart';
+import 'seerr_catalog_item.dart';
 import 'seerr_error.dart';
 import 'seerr_models.dart';
 
@@ -464,14 +465,15 @@ class SeerrHttpClient {
     );
     _requireSuccess(response, 'getWatchlist');
     final body = Map<String, dynamic>.from(response.data as Map<String, dynamic>);
-    final results = (body['results'] as List? ?? []).map((raw) {
-      final item = Map<String, dynamic>.from(raw as Map<String, dynamic>);
-      if (item['tmdbId'] != null) item['id'] = item['tmdbId'];
-      if (item.containsKey('media') && !item.containsKey('mediaInfo')) {
-        item['mediaInfo'] = item['media'];
-      }
-      return item;
-    }).toList();
+    final results = (body['results'] as List? ?? [])
+        .whereType<Map>()
+        .map(
+          (raw) => normalizeSeerrCatalogItem(
+            Map<String, dynamic>.from(raw),
+          ),
+        )
+        .whereType<Map<String, dynamic>>()
+        .toList();
     return {...body, 'results': results};
   }
 
@@ -533,12 +535,10 @@ class SeerrHttpClient {
   }) {
     final results = (body['results'] as List? ?? []).map((raw) {
       if (raw is! Map) return null;
-      final item = Map<String, dynamic>.from(raw);
-      if (item['mediaType'] == 'person') return null;
-      if (item['mediaType'] == null && mediaTypeHint != null) {
-        item['mediaType'] = mediaTypeHint;
-      }
-      return item;
+      return normalizeSeerrCatalogItem(
+        Map<String, dynamic>.from(raw),
+        mediaTypeHint: mediaTypeHint,
+      );
     }).whereType<Map<String, dynamic>>().toList();
 
     final currentPage = (body['page'] as num?)?.toInt() ?? page;

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -475,6 +475,87 @@ class SeerrHttpClient {
     return {...body, 'results': results};
   }
 
+  Future<List<Map<String, dynamic>>> getDiscoverSliders() async {
+    final response = await _dio.get(
+      _apiUrl('settings/discover'),
+      options: _authOptions(),
+    );
+    _requireSuccess(response, 'getDiscoverSliders');
+    final data = response.data;
+    if (data is! List) {
+      throw const FormatException('getDiscoverSliders: expected a list');
+    }
+    return data.map((raw) {
+      if (raw is! Map) {
+        throw const FormatException(
+          'getDiscoverSliders: expected slider objects',
+        );
+      }
+      return Map<String, dynamic>.from(raw);
+    }).toList();
+  }
+
+  Future<Map<String, dynamic>> getCatalog(
+    String path, {
+    Map<String, String> query = const {},
+    int page = 1,
+    String? mediaTypeHint,
+  }) async {
+    final response = await _dio.get(
+      _apiUrl(path),
+      queryParameters: {
+        ...query,
+        'page': page,
+      },
+      options: _authOptions(),
+    );
+    _requireSuccess(response, 'getCatalog');
+    final data = response.data;
+    if (data is! Map) {
+      return {
+        'page': page,
+        'totalPages': 1,
+        'totalResults': 0,
+        'results': <Map<String, dynamic>>[],
+      };
+    }
+    return _normalizeCatalogBody(
+      Map<String, dynamic>.from(data),
+      page: page,
+      mediaTypeHint: mediaTypeHint,
+    );
+  }
+
+  Map<String, dynamic> _normalizeCatalogBody(
+    Map<String, dynamic> body, {
+    required int page,
+    String? mediaTypeHint,
+  }) {
+    final results = (body['results'] as List? ?? []).map((raw) {
+      if (raw is! Map) return null;
+      final item = Map<String, dynamic>.from(raw);
+      if (item['mediaType'] == 'person') return null;
+      if (item['mediaType'] == null && mediaTypeHint != null) {
+        item['mediaType'] = mediaTypeHint;
+      }
+      return item;
+    }).whereType<Map<String, dynamic>>().toList();
+
+    final currentPage = (body['page'] as num?)?.toInt() ?? page;
+    var totalPages = (body['totalPages'] as num?)?.toInt() ?? 0;
+    if (totalPages <= 0) {
+      totalPages = body['hasMore'] == true ? currentPage + 1 : currentPage;
+    }
+
+    return {
+      ...body,
+      'page': currentPage,
+      'totalPages': totalPages,
+      'totalResults': (body['totalResults'] as num?)?.toInt() ?? results.length,
+      'results': results,
+    };
+  }
+
   // Seerr hands the language parameter on both discover endpoints to TMDB as
   // the original language filter, so naming one hides every production made in
   // any other language. Leaving it off falls back to whatever language the
@@ -484,8 +565,10 @@ class SeerrHttpClient {
     String sortBy = 'popularity.desc',
     String? genre,
     int? studio,
-    int? keywords,
+    String? keywords,
     String? language,
+    String? watchRegion,
+    String? watchProviders,
     double? voteAverageGte,
     int? voteCountGte,
     int? withRuntimeGte,
@@ -502,6 +585,8 @@ class SeerrHttpClient {
         'studio': ?studio,
         'keywords': ?keywords,
         'language': ?language,
+        'watchRegion': ?watchRegion,
+        'watchProviders': ?watchProviders,
         'voteAverageGte': ?voteAverageGte?.toString(),
         'voteCountGte': ?voteCountGte?.toString(),
         'withRuntimeGte': ?withRuntimeGte?.toString(),
@@ -520,8 +605,10 @@ class SeerrHttpClient {
     String sortBy = 'popularity.desc',
     String? genre,
     int? network,
-    int? keywords,
+    String? keywords,
     String? language,
+    String? watchRegion,
+    String? watchProviders,
     String? status,
     double? voteAverageGte,
     int? voteCountGte,
@@ -539,6 +626,8 @@ class SeerrHttpClient {
         'network': ?network,
         'keywords': ?keywords,
         'language': ?language,
+        'watchRegion': ?watchRegion,
+        'watchProviders': ?watchProviders,
         'status': ?status,
         'voteAverageGte': ?voteAverageGte?.toString(),
         'voteCountGte': ?voteCountGte?.toString(),

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -9,6 +9,30 @@ import 'seerr_catalog_item.dart';
 import 'seerr_error.dart';
 import 'seerr_models.dart';
 
+/// Percent-encode a Seerr/TMDB query value with `%20` for spaces.
+///
+/// Dio `queryParameters` uses `Uri.encodeQueryComponent`, which turns spaces
+/// into `+`. Seerr/TMDB treat that as a literal plus and return empty search
+/// results for multi-word queries.
+String encodeSeerrQueryComponent(String value) {
+  return Uri.encodeComponent(value)
+      .replaceAll("'", '%27')
+      .replaceAll('!', '%21')
+      .replaceAll('*', '%2A')
+      .replaceAll('(', '%28')
+      .replaceAll(')', '%29');
+}
+
+String seerrEncodedQueryString(Map<String, String> params) {
+  return params.entries
+      .map(
+        (e) =>
+            '${encodeSeerrQueryComponent(e.key)}='
+            '${encodeSeerrQueryComponent(e.value)}',
+      )
+      .join('&');
+}
+
 class SeerrHttpClient {
   final MoonfinProxyConfig proxyConfig;
 
@@ -503,12 +527,9 @@ class SeerrHttpClient {
     int page = 1,
     String? mediaTypeHint,
   }) async {
+    final qs = seerrEncodedQueryString({...query, 'page': '$page'});
     final response = await _dio.get(
-      _apiUrl(path),
-      queryParameters: {
-        ...query,
-        'page': page,
-      },
+      '${_apiUrl(path)}?$qs',
       options: _authOptions(),
     );
     _requireSuccess(response, 'getCatalog');
@@ -660,20 +681,10 @@ class SeerrHttpClient {
     int offset = 0,
   }) async {
     final page = (offset ~/ limit) + 1;
-    // Percent-encode query string explicitly using %20 for spaces and %27 for
-    // apostrophes. Passing query directly to Dio queryParameters uses
-    // x-www-form-urlencoded format (+ for spaces), which causes Seerr/TMDB
-    // to search for literal '+' characters and return 0 results.
-    final encodedQuery = Uri.encodeComponent(query)
-        .replaceAll("'", '%27')
-        .replaceAll('!', '%21')
-        .replaceAll('*', '%2A')
-        .replaceAll('(', '%28')
-        .replaceAll(')', '%29');
-
-    var url = '${_apiUrl('search')}?query=$encodedQuery&page=$page';
+    var url =
+        '${_apiUrl('search')}?${seerrEncodedQueryString({'query': query, 'page': '$page'})}';
     if (mediaType != null) {
-      url += '&type=${Uri.encodeComponent(mediaType)}';
+      url += '&type=${encodeSeerrQueryComponent(mediaType)}';
     }
 
     final response = await _dio.get(

--- a/lib/data/services/seerr/seerr_http_client.dart
+++ b/lib/data/services/seerr/seerr_http_client.dart
@@ -805,6 +805,24 @@ class SeerrHttpClient {
     return response.data as Map<String, dynamic>;
   }
 
+  /// Foreseer linked-account status. Null when the route is missing (Jellyseerr)
+  /// or the body has no `connected` flag.
+  Future<bool?> getLinkedAccountConnected(int userId, String provider) async {
+    final response = await _dio.get(
+      _apiUrl('user/$userId/settings/linked-accounts/$provider'),
+      options: _authOptions(),
+    );
+    if (response.statusCode == null ||
+        response.statusCode! < 200 ||
+        response.statusCode! > 299) {
+      return null;
+    }
+    final data = response.data;
+    if (data is! Map) return null;
+    final connected = data['connected'];
+    return connected is bool ? connected : null;
+  }
+
   Future<bool> testConnection() async {
     try {
       final response = await _dio.get(

--- a/lib/data/services/seerr/seerr_slider_catalog.dart
+++ b/lib/data/services/seerr/seerr_slider_catalog.dart
@@ -1,5 +1,5 @@
-/// Numeric `type` values on `GET /settings/discover`, matching Seerr's
-/// DiscoverSliderType. Custom rows the client can render as a title list.
+/// Numeric `type` values on `GET /settings/discover`, matching Seerr /
+/// Foreseerr DiscoverSliderType.
 abstract final class SeerrSliderType {
   static const tmdbMovieKeyword = 13;
   static const tmdbMovieGenre = 14;
@@ -10,7 +10,67 @@ abstract final class SeerrSliderType {
   static const tmdbNetwork = 19;
   static const tmdbMovieStreaming = 20;
   static const tmdbTvStreaming = 21;
+  static const traktRecommendations = 22;
+  static const traktWatchlist = 23;
+  static const traktList = 24;
+  static const traktHistory = 25;
+  static const anilistTrending = 26;
+  static const anilistSeason = 27;
+  static const anilistWatching = 28;
+  static const anilistPlanning = 29;
+  static const anilistCompleted = 30;
+  static const anilistList = 31;
+  static const anilistPopular = 32;
+  static const anilistTop = 33;
+  static const anilistNextSeason = 34;
+  static const mdblistList = 35;
+  static const simklTrending = 36;
+  static const simklPlanToWatch = 37;
+  static const simklWatching = 44;
+  static const simklOnHold = 45;
+  static const simklCompleted = 46;
+  static const simklDropped = 47;
 }
+
+/// Moonfin already renders types 1–12 as [SeerrRowType] rows.
+bool seerrSliderIsLocalMoonfinBuiltin(int type) => type >= 1 && type <= 12;
+
+/// Simkl Best/Premieres: no TMDB ids. Numbers stay reserved.
+bool seerrSliderIsRetired(int type) => type >= 38 && type <= 43;
+
+/// Admin-named rows (TMDB custom + list URLs). Built-ins use l10n instead.
+bool seerrSliderUsesServerTitle(int type) =>
+    (type >= SeerrSliderType.tmdbMovieKeyword &&
+        type <= SeerrSliderType.tmdbTvStreaming) ||
+    type == SeerrSliderType.traktList ||
+    type == SeerrSliderType.anilistList ||
+    type == SeerrSliderType.mdblistList;
+
+/// English fallback when UI has no [AppLocalizations] yet. Keep in lockstep
+/// with `app_en.arb` `seerr*` keys.
+String seerrSliderFallbackTitle(int type) => switch (type) {
+      SeerrSliderType.traktRecommendations => 'Trakt Recommendations',
+      SeerrSliderType.traktWatchlist => 'Trakt Watchlist',
+      SeerrSliderType.traktList => 'Trakt List',
+      SeerrSliderType.traktHistory => 'Trakt History',
+      SeerrSliderType.anilistTrending => 'AniList Trending',
+      SeerrSliderType.anilistSeason => 'AniList This Season',
+      SeerrSliderType.anilistWatching => 'AniList Watching',
+      SeerrSliderType.anilistPlanning => 'AniList Planning',
+      SeerrSliderType.anilistCompleted => 'AniList Completed',
+      SeerrSliderType.anilistList => 'AniList List',
+      SeerrSliderType.anilistPopular => 'AniList Popular',
+      SeerrSliderType.anilistTop => 'AniList Top 100',
+      SeerrSliderType.anilistNextSeason => 'AniList Next Season',
+      SeerrSliderType.mdblistList => 'MDBList List',
+      SeerrSliderType.simklTrending => 'Simkl Trending',
+      SeerrSliderType.simklPlanToWatch => 'Simkl Plan to Watch',
+      SeerrSliderType.simklWatching => 'Simkl Watching',
+      SeerrSliderType.simklOnHold => 'Simkl On Hold',
+      SeerrSliderType.simklCompleted => 'Simkl Completed',
+      SeerrSliderType.simklDropped => 'Simkl Dropped',
+      _ => '',
+    };
 
 class SeerrDiscoverSlider {
   final int id;
@@ -20,6 +80,7 @@ class SeerrDiscoverSlider {
   final bool enabled;
   final String? title;
   final String? data;
+  final String? sort;
 
   const SeerrDiscoverSlider({
     required this.id,
@@ -29,6 +90,7 @@ class SeerrDiscoverSlider {
     this.enabled = true,
     this.title,
     this.data,
+    this.sort,
   });
 
   factory SeerrDiscoverSlider.fromJson(Map<String, dynamic> json) {
@@ -40,17 +102,20 @@ class SeerrDiscoverSlider {
       enabled: json['enabled'] != false,
       title: json['title']?.toString(),
       data: json['data']?.toString(),
+      sort: json['sort']?.toString(),
     );
   }
 }
 
 class SeerrSliderCatalog {
+  final int type;
   final String path;
   final Map<String, String> query;
   final String title;
   final String? mediaTypeHint;
 
   const SeerrSliderCatalog({
+    required this.type,
     required this.path,
     required this.query,
     required this.title,
@@ -58,15 +123,35 @@ class SeerrSliderCatalog {
   });
 }
 
-/// Turns a custom discover slider into a catalog request, or `null` when this
+/// Turns a discover slider into a catalog request, or `null` when this
 /// client should skip the row.
 SeerrSliderCatalog? resolveSeerrSliderCatalog(SeerrDiscoverSlider slider) {
-  if (slider.id <= 0 || !slider.enabled || slider.isBuiltIn) return null;
-  final title = slider.title?.trim() ?? '';
-  final data = slider.data?.trim() ?? '';
-  if (title.isEmpty || data.isEmpty) return null;
+  if (slider.id <= 0 || !slider.enabled) return null;
+  if (seerrSliderIsLocalMoonfinBuiltin(slider.type)) return null;
+  if (seerrSliderIsRetired(slider.type)) return null;
 
-  return _catalogForType(slider.type, data, title);
+  final serverTitle = slider.title?.trim() ?? '';
+  final data = slider.data?.trim() ?? '';
+  final needsData = seerrSliderUsesServerTitle(slider.type);
+  if (needsData && (serverTitle.isEmpty || data.isEmpty)) return null;
+
+  final catalog = _catalogForType(
+    slider.type,
+    data,
+    needsData ? serverTitle : seerrSliderFallbackTitle(slider.type),
+  );
+  if (catalog == null) return null;
+
+  final sort = slider.sort?.trim();
+  if (sort == null || sort.isEmpty) return catalog;
+
+  return SeerrSliderCatalog(
+    type: catalog.type,
+    path: catalog.path,
+    query: {...catalog.query, 'sort': sort},
+    title: catalog.title,
+    mediaTypeHint: catalog.mediaTypeHint,
+  );
 }
 
 List<(SeerrDiscoverSlider, SeerrSliderCatalog)> resolveSeerrCustomSliders(
@@ -83,57 +168,59 @@ List<(SeerrDiscoverSlider, SeerrSliderCatalog)> resolveSeerrCustomSliders(
 }
 
 SeerrSliderCatalog? _catalogForType(int type, String data, String title) {
+  SeerrSliderCatalog row(
+    String path, {
+    Map<String, String> query = const {},
+    String? mediaTypeHint,
+  }) =>
+      SeerrSliderCatalog(
+        type: type,
+        path: path,
+        query: query,
+        title: title,
+        mediaTypeHint: mediaTypeHint,
+      );
+
   switch (type) {
     case SeerrSliderType.tmdbMovieKeyword:
-      return SeerrSliderCatalog(
-        path: 'discover/movies',
+      return row(
+        'discover/movies',
         query: {'keywords': data},
-        title: title,
         mediaTypeHint: 'movie',
       );
     case SeerrSliderType.tmdbTvKeyword:
-      return SeerrSliderCatalog(
-        path: 'discover/tv',
+      return row(
+        'discover/tv',
         query: {'keywords': data},
-        title: title,
         mediaTypeHint: 'tv',
       );
     case SeerrSliderType.tmdbMovieGenre:
-      return SeerrSliderCatalog(
-        path: 'discover/movies',
+      return row(
+        'discover/movies',
         query: {'genre': data},
-        title: title,
         mediaTypeHint: 'movie',
       );
     case SeerrSliderType.tmdbTvGenre:
-      return SeerrSliderCatalog(
-        path: 'discover/tv',
+      return row(
+        'discover/tv',
         query: {'genre': data},
-        title: title,
         mediaTypeHint: 'tv',
       );
     case SeerrSliderType.tmdbSearch:
-      return SeerrSliderCatalog(
-        path: 'search',
-        query: {'query': data},
-        title: title,
-      );
+      return row('search', query: {'query': data});
     case SeerrSliderType.tmdbStudio:
-      return SeerrSliderCatalog(
-        path: 'discover/movies/studio/$data',
-        query: const {},
-        title: title,
+      return row(
+        'discover/movies/studio/$data',
         mediaTypeHint: 'movie',
       );
     case SeerrSliderType.tmdbNetwork:
-      return SeerrSliderCatalog(
-        path: 'discover/tv/network/$data',
-        query: const {},
-        title: title,
+      return row(
+        'discover/tv/network/$data',
         mediaTypeHint: 'tv',
       );
     case SeerrSliderType.tmdbMovieStreaming:
       return _streamingCatalog(
+        type: type,
         path: 'discover/movies',
         data: data,
         title: title,
@@ -141,10 +228,66 @@ SeerrSliderCatalog? _catalogForType(int type, String data, String title) {
       );
     case SeerrSliderType.tmdbTvStreaming:
       return _streamingCatalog(
+        type: type,
         path: 'discover/tv',
         data: data,
         title: title,
         mediaTypeHint: 'tv',
+      );
+    case SeerrSliderType.traktRecommendations:
+      return row('discover/trakt/recommendations');
+    case SeerrSliderType.traktWatchlist:
+      return row('discover/trakt/watchlist');
+    case SeerrSliderType.traktList:
+      return row('discover/trakt/list', query: {'url': data});
+    case SeerrSliderType.traktHistory:
+      return row('discover/trakt/history');
+    case SeerrSliderType.anilistTrending:
+      return row('discover/anilist/trending');
+    case SeerrSliderType.anilistSeason:
+      return row('discover/anilist/season');
+    case SeerrSliderType.anilistWatching:
+      return row('discover/anilist/watching');
+    case SeerrSliderType.anilistPlanning:
+      return row('discover/anilist/planning');
+    case SeerrSliderType.anilistCompleted:
+      return row('discover/anilist/completed');
+    case SeerrSliderType.anilistList:
+      return row('discover/anilist/list', query: {'name': data});
+    case SeerrSliderType.anilistPopular:
+      return row('discover/anilist/popular');
+    case SeerrSliderType.anilistTop:
+      return row('discover/anilist/top');
+    case SeerrSliderType.anilistNextSeason:
+      return row('discover/anilist/next-season');
+    case SeerrSliderType.mdblistList:
+      return row('discover/mdblist/list', query: {'url': data});
+    case SeerrSliderType.simklTrending:
+      return row('discover/simkl/trending');
+    case SeerrSliderType.simklPlanToWatch:
+      return row(
+        'discover/simkl/library',
+        query: const {'status': 'plantowatch'},
+      );
+    case SeerrSliderType.simklWatching:
+      return row(
+        'discover/simkl/library',
+        query: const {'status': 'watching'},
+      );
+    case SeerrSliderType.simklOnHold:
+      return row(
+        'discover/simkl/library',
+        query: const {'status': 'hold'},
+      );
+    case SeerrSliderType.simklCompleted:
+      return row(
+        'discover/simkl/library',
+        query: const {'status': 'completed'},
+      );
+    case SeerrSliderType.simklDropped:
+      return row(
+        'discover/simkl/library',
+        query: const {'status': 'dropped'},
       );
     default:
       return null;
@@ -152,6 +295,7 @@ SeerrSliderCatalog? _catalogForType(int type, String data, String title) {
 }
 
 SeerrSliderCatalog? _streamingCatalog({
+  required int type,
   required String path,
   required String data,
   required String title,
@@ -163,6 +307,7 @@ SeerrSliderCatalog? _streamingCatalog({
   final provider = parts[1].trim();
   if (region.isEmpty || provider.isEmpty) return null;
   return SeerrSliderCatalog(
+    type: type,
     path: path,
     query: {'watchRegion': region, 'watchProviders': provider},
     title: title,

--- a/lib/data/services/seerr/seerr_slider_catalog.dart
+++ b/lib/data/services/seerr/seerr_slider_catalog.dart
@@ -1,0 +1,179 @@
+/// Numeric `type` values on `GET /settings/discover`, matching Seerr's
+/// DiscoverSliderType. Custom rows the client can render as a title list.
+abstract final class SeerrSliderType {
+  static const tmdbMovieKeyword = 13;
+  static const tmdbMovieGenre = 14;
+  static const tmdbTvKeyword = 15;
+  static const tmdbTvGenre = 16;
+  static const tmdbSearch = 17;
+  static const tmdbStudio = 18;
+  static const tmdbNetwork = 19;
+  static const tmdbMovieStreaming = 20;
+  static const tmdbTvStreaming = 21;
+}
+
+class SeerrDiscoverSlider {
+  final int id;
+  final int type;
+  final int order;
+  final bool isBuiltIn;
+  final bool enabled;
+  final String? title;
+  final String? data;
+
+  const SeerrDiscoverSlider({
+    required this.id,
+    required this.type,
+    this.order = 0,
+    this.isBuiltIn = false,
+    this.enabled = true,
+    this.title,
+    this.data,
+  });
+
+  factory SeerrDiscoverSlider.fromJson(Map<String, dynamic> json) {
+    return SeerrDiscoverSlider(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      type: (json['type'] as num?)?.toInt() ?? 0,
+      order: (json['order'] as num?)?.toInt() ?? 0,
+      isBuiltIn: json['isBuiltIn'] == true,
+      enabled: json['enabled'] != false,
+      title: json['title']?.toString(),
+      data: json['data']?.toString(),
+    );
+  }
+}
+
+class SeerrSliderCatalog {
+  final String path;
+  final Map<String, String> query;
+  final String title;
+  final String? mediaTypeHint;
+
+  const SeerrSliderCatalog({
+    required this.path,
+    required this.query,
+    required this.title,
+    this.mediaTypeHint,
+  });
+}
+
+/// Turns a custom discover slider into a catalog request, or `null` when this
+/// client should skip the row.
+SeerrSliderCatalog? resolveSeerrSliderCatalog(SeerrDiscoverSlider slider) {
+  if (slider.id <= 0 || !slider.enabled || slider.isBuiltIn) return null;
+  final title = slider.title?.trim() ?? '';
+  final data = slider.data?.trim() ?? '';
+  if (title.isEmpty || data.isEmpty) return null;
+
+  return _catalogForType(slider.type, data, title);
+}
+
+List<(SeerrDiscoverSlider, SeerrSliderCatalog)> resolveSeerrCustomSliders(
+  Iterable<SeerrDiscoverSlider> sliders,
+) {
+  final resolved = <(SeerrDiscoverSlider, SeerrSliderCatalog)>[];
+  final ordered = sliders.toList()..sort((a, b) => a.order.compareTo(b.order));
+  for (final slider in ordered) {
+    final catalog = resolveSeerrSliderCatalog(slider);
+    if (catalog == null) continue;
+    resolved.add((slider, catalog));
+  }
+  return resolved;
+}
+
+SeerrSliderCatalog? _catalogForType(int type, String data, String title) {
+  switch (type) {
+    case SeerrSliderType.tmdbMovieKeyword:
+      return SeerrSliderCatalog(
+        path: 'discover/movies',
+        query: {'keywords': data},
+        title: title,
+        mediaTypeHint: 'movie',
+      );
+    case SeerrSliderType.tmdbTvKeyword:
+      return SeerrSliderCatalog(
+        path: 'discover/tv',
+        query: {'keywords': data},
+        title: title,
+        mediaTypeHint: 'tv',
+      );
+    case SeerrSliderType.tmdbMovieGenre:
+      return SeerrSliderCatalog(
+        path: 'discover/movies',
+        query: {'genre': data},
+        title: title,
+        mediaTypeHint: 'movie',
+      );
+    case SeerrSliderType.tmdbTvGenre:
+      return SeerrSliderCatalog(
+        path: 'discover/tv',
+        query: {'genre': data},
+        title: title,
+        mediaTypeHint: 'tv',
+      );
+    case SeerrSliderType.tmdbSearch:
+      return SeerrSliderCatalog(
+        path: 'search',
+        query: {'query': data},
+        title: title,
+      );
+    case SeerrSliderType.tmdbStudio:
+      return SeerrSliderCatalog(
+        path: 'discover/movies/studio/$data',
+        query: const {},
+        title: title,
+        mediaTypeHint: 'movie',
+      );
+    case SeerrSliderType.tmdbNetwork:
+      return SeerrSliderCatalog(
+        path: 'discover/tv/network/$data',
+        query: const {},
+        title: title,
+        mediaTypeHint: 'tv',
+      );
+    case SeerrSliderType.tmdbMovieStreaming:
+      return _streamingCatalog(
+        path: 'discover/movies',
+        data: data,
+        title: title,
+        mediaTypeHint: 'movie',
+      );
+    case SeerrSliderType.tmdbTvStreaming:
+      return _streamingCatalog(
+        path: 'discover/tv',
+        data: data,
+        title: title,
+        mediaTypeHint: 'tv',
+      );
+    default:
+      return null;
+  }
+}
+
+SeerrSliderCatalog? _streamingCatalog({
+  required String path,
+  required String data,
+  required String title,
+  required String mediaTypeHint,
+}) {
+  final parts = data.split(',');
+  if (parts.length < 2) return null;
+  final region = parts[0].trim();
+  final provider = parts[1].trim();
+  if (region.isEmpty || provider.isEmpty) return null;
+  return SeerrSliderCatalog(
+    path: path,
+    query: {'watchRegion': region, 'watchProviders': provider},
+    title: title,
+    mediaTypeHint: mediaTypeHint,
+  );
+}
+
+/// Stable D-pad column id. Index is not part of this: custom rows
+/// appearing or vanishing would otherwise reuse another row's memory.
+String seerrDiscoverFocusHubKey({int? sliderId, String? typeName}) {
+  if (sliderId != null) return 'seerr_discover_slider_$sliderId';
+  if (typeName != null) return 'seerr_discover_$typeName';
+  return 'seerr_discover_unknown';
+}

--- a/lib/data/services/seerr/seerr_slider_catalog.dart
+++ b/lib/data/services/seerr/seerr_slider_catalog.dart
@@ -38,13 +38,26 @@ bool seerrSliderIsLocalMoonfinBuiltin(int type) => type >= 1 && type <= 12;
 /// Simkl Best/Premieres: no TMDB ids. Numbers stay reserved.
 bool seerrSliderIsRetired(int type) => type >= 38 && type <= 43;
 
-/// Admin-named rows (TMDB custom + list URLs). Built-ins use l10n instead.
-bool seerrSliderUsesServerTitle(int type) =>
-    (type >= SeerrSliderType.tmdbMovieKeyword &&
-        type <= SeerrSliderType.tmdbTvStreaming) ||
-    type == SeerrSliderType.traktList ||
-    type == SeerrSliderType.anilistList ||
-    type == SeerrSliderType.mdblistList;
+/// Admin-named keyword/genre/studio/list sliders keep the server title.
+bool seerrSliderUsesServerTitle(int type) {
+  switch (type) {
+    case SeerrSliderType.tmdbMovieKeyword:
+    case SeerrSliderType.tmdbMovieGenre:
+    case SeerrSliderType.tmdbTvKeyword:
+    case SeerrSliderType.tmdbTvGenre:
+    case SeerrSliderType.tmdbSearch:
+    case SeerrSliderType.tmdbStudio:
+    case SeerrSliderType.tmdbNetwork:
+    case SeerrSliderType.tmdbMovieStreaming:
+    case SeerrSliderType.tmdbTvStreaming:
+    case SeerrSliderType.traktList:
+    case SeerrSliderType.anilistList:
+    case SeerrSliderType.mdblistList:
+      return true;
+    default:
+      return false;
+  }
+}
 
 /// English fallback when UI has no [AppLocalizations] yet. Keep in lockstep
 /// with `app_en.arb` `seerr*` keys.

--- a/lib/data/services/seerr/seerr_slider_catalog.dart
+++ b/lib/data/services/seerr/seerr_slider_catalog.dart
@@ -38,6 +38,127 @@ bool seerrSliderIsLocalMoonfinBuiltin(int type) => type >= 1 && type <= 12;
 /// Simkl Best/Premieres: no TMDB ids. Numbers stay reserved.
 bool seerrSliderIsRetired(int type) => type >= 38 && type <= 43;
 
+/// Provider that backs a discover slider. TMDB keyword/genre rows have none.
+enum SeerrSliderProvider { none, trakt, anilist, simkl, mdblist }
+
+SeerrSliderProvider seerrSliderProvider(int type) {
+  switch (type) {
+    case SeerrSliderType.traktRecommendations:
+    case SeerrSliderType.traktWatchlist:
+    case SeerrSliderType.traktList:
+    case SeerrSliderType.traktHistory:
+      return SeerrSliderProvider.trakt;
+    case SeerrSliderType.anilistTrending:
+    case SeerrSliderType.anilistSeason:
+    case SeerrSliderType.anilistWatching:
+    case SeerrSliderType.anilistPlanning:
+    case SeerrSliderType.anilistCompleted:
+    case SeerrSliderType.anilistList:
+    case SeerrSliderType.anilistPopular:
+    case SeerrSliderType.anilistTop:
+    case SeerrSliderType.anilistNextSeason:
+      return SeerrSliderProvider.anilist;
+    case SeerrSliderType.simklTrending:
+    case SeerrSliderType.simklPlanToWatch:
+    case SeerrSliderType.simklWatching:
+    case SeerrSliderType.simklOnHold:
+    case SeerrSliderType.simklCompleted:
+    case SeerrSliderType.simklDropped:
+      return SeerrSliderProvider.simkl;
+    case SeerrSliderType.mdblistList:
+      return SeerrSliderProvider.mdblist;
+    default:
+      return SeerrSliderProvider.none;
+  }
+}
+
+/// Foreseer skips the catalog request until the user has linked this provider.
+bool seerrSliderRequiresLinkedAccount(int type) {
+  switch (type) {
+    case SeerrSliderType.traktRecommendations:
+    case SeerrSliderType.traktWatchlist:
+    case SeerrSliderType.traktHistory:
+    case SeerrSliderType.anilistWatching:
+    case SeerrSliderType.anilistPlanning:
+    case SeerrSliderType.anilistCompleted:
+    case SeerrSliderType.simklPlanToWatch:
+    case SeerrSliderType.simklWatching:
+    case SeerrSliderType.simklOnHold:
+    case SeerrSliderType.simklCompleted:
+    case SeerrSliderType.simklDropped:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Whether this client should call the catalog endpoint.
+///
+/// `null` flags mean "unknown" (Jellyseerr has no these keys / linked-account
+/// routes): try the fetch and hide on error. Skip only when Foreseer said the
+/// provider is off or the account is not linked.
+class SeerrSliderFetchGate {
+  final bool? traktConfigured;
+  final bool? anilistConfigured;
+  final bool? simklConfigured;
+  final bool? mdblistConfigured;
+  final bool? traktLinked;
+  final bool? anilistLinked;
+  final bool? simklLinked;
+
+  const SeerrSliderFetchGate({
+    this.traktConfigured,
+    this.anilistConfigured,
+    this.simklConfigured,
+    this.mdblistConfigured,
+    this.traktLinked,
+    this.anilistLinked,
+    this.simklLinked,
+  });
+
+  factory SeerrSliderFetchGate.fromPublicSettings(
+    Map<String, dynamic> settings, {
+    bool? traktLinked,
+    bool? anilistLinked,
+    bool? simklLinked,
+  }) =>
+      SeerrSliderFetchGate(
+        traktConfigured: _optionalBool(settings, 'traktConfigured'),
+        anilistConfigured: _optionalBool(settings, 'anilistConfigured'),
+        simklConfigured: _optionalBool(settings, 'simklConfigured'),
+        mdblistConfigured: _optionalBool(settings, 'mdblistConfigured'),
+        traktLinked: traktLinked,
+        anilistLinked: anilistLinked,
+        simklLinked: simklLinked,
+      );
+
+  bool canFetch(int type) {
+    final provider = seerrSliderProvider(type);
+    final configured = switch (provider) {
+      SeerrSliderProvider.none => true,
+      SeerrSliderProvider.trakt => traktConfigured,
+      SeerrSliderProvider.anilist => anilistConfigured,
+      SeerrSliderProvider.simkl => simklConfigured,
+      SeerrSliderProvider.mdblist => mdblistConfigured,
+    };
+    if (configured == false) return false;
+    if (!seerrSliderRequiresLinkedAccount(type)) return true;
+    final linked = switch (provider) {
+      SeerrSliderProvider.trakt => traktLinked,
+      SeerrSliderProvider.anilist => anilistLinked,
+      SeerrSliderProvider.simkl => simklLinked,
+      SeerrSliderProvider.mdblist || SeerrSliderProvider.none => true,
+    };
+    return linked != false;
+  }
+}
+
+bool? _optionalBool(Map<String, dynamic> json, String key) {
+  if (!json.containsKey(key)) return null;
+  final value = json[key];
+  return value is bool ? value : null;
+}
+
 /// Admin-named keyword/genre/studio/list sliders keep the server title.
 bool seerrSliderUsesServerTitle(int type) {
   switch (type) {
@@ -167,7 +288,7 @@ SeerrSliderCatalog? resolveSeerrSliderCatalog(SeerrDiscoverSlider slider) {
   );
 }
 
-List<(SeerrDiscoverSlider, SeerrSliderCatalog)> resolveSeerrCustomSliders(
+List<(SeerrDiscoverSlider, SeerrSliderCatalog)> resolveSeerrSliders(
   Iterable<SeerrDiscoverSlider> sliders,
 ) {
   final resolved = <(SeerrDiscoverSlider, SeerrSliderCatalog)>[];

--- a/lib/data/services/seerr/seerr_slider_home_sections.dart
+++ b/lib/data/services/seerr/seerr_slider_home_sections.dart
@@ -1,0 +1,60 @@
+import '../../../preference/home_section_config.dart';
+import 'seerr_slider_catalog.dart';
+
+/// pluginDynamic identity for one Seerr custom Discover slider on Home.
+abstract final class SeerrHomeSliderSection {
+  static const serverId = 'seerr';
+  static const pluginSection = 'slider';
+}
+
+/// Upserts a disabled home section per custom slider. Existing enable/order
+/// flags stay. Sliders that left the server are dropped.
+List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
+  List<HomeSectionConfig> current,
+  Iterable<(SeerrDiscoverSlider, SeerrSliderCatalog)> sliders,
+) {
+  final byId = <int, (SeerrDiscoverSlider, SeerrSliderCatalog)>{
+    for (final pair in sliders) pair.$1.id: pair,
+  };
+  final kept = <HomeSectionConfig>[];
+  final seen = <int>{};
+
+  for (final config in current) {
+    if (!config.isSeerrCustomSlider) {
+      kept.add(config);
+      continue;
+    }
+    final id = int.tryParse(config.pluginAdditionalData ?? '');
+    final pair = id == null ? null : byId[id];
+    if (id == null || pair == null || !seen.add(id)) continue;
+    final title = pair.$2.title;
+    kept.add(
+      config.pluginDisplayText == title
+          ? config
+          : config.copyWith(pluginDisplayText: title),
+    );
+  }
+
+  var order = kept.fold<int>(-1, (m, c) => c.order > m ? c.order : m) + 1;
+  for (final (slider, catalog) in sliders) {
+    if (seen.contains(slider.id)) continue;
+    kept.add(
+      HomeSectionConfig.pluginDynamic(
+        serverId: SeerrHomeSliderSection.serverId,
+        pluginSection: SeerrHomeSliderSection.pluginSection,
+        pluginAdditionalData: '${slider.id}',
+        pluginDisplayText: catalog.title,
+        pluginSource: HomeSectionPluginSource.seerr,
+        enabled: false,
+        order: order++,
+      ),
+    );
+  }
+  return kept;
+}
+
+int? seerrCustomSliderIdFromStableId(String id) {
+  const prefix = 'pluginDynamic:seerr:seerr:slider:';
+  if (!id.startsWith(prefix)) return null;
+  return int.tryParse(id.substring(prefix.length));
+}

--- a/lib/data/services/seerr/seerr_slider_home_sections.dart
+++ b/lib/data/services/seerr/seerr_slider_home_sections.dart
@@ -1,10 +1,10 @@
 import '../../../preference/home_section_config.dart';
 import 'seerr_slider_catalog.dart';
 
-/// Upserts a disabled home section per custom slider. Existing enable/order
+/// Upserts a disabled home section per discover slider. Existing enable/order
 /// flags stay. Sliders that left the server are dropped. Refreshes
 /// [HomeSectionConfig.sliderType] and [HomeSectionConfig.pluginDisplayText].
-List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
+List<HomeSectionConfig> mergeSeerrSliderHomeSections(
   List<HomeSectionConfig> current,
   Iterable<(SeerrDiscoverSlider, SeerrSliderCatalog)> sliders,
 ) {
@@ -15,7 +15,7 @@ List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
   final seen = <int>{};
 
   for (final config in current) {
-    if (!config.isSeerrCustomSlider) {
+    if (!config.isSeerrSlider) {
       kept.add(config);
       continue;
     }
@@ -41,7 +41,7 @@ List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
   return kept;
 }
 
-int? seerrCustomSliderIdFromStableId(String id) {
+int? seerrSliderIdFromStableId(String id) {
   const prefix = 'seerrSlider:';
   if (id.startsWith(prefix)) {
     return int.tryParse(id.substring(prefix.length));

--- a/lib/data/services/seerr/seerr_slider_home_sections.dart
+++ b/lib/data/services/seerr/seerr_slider_home_sections.dart
@@ -1,14 +1,9 @@
 import '../../../preference/home_section_config.dart';
 import 'seerr_slider_catalog.dart';
 
-/// pluginDynamic identity for one Seerr custom Discover slider on Home.
-abstract final class SeerrHomeSliderSection {
-  static const serverId = 'seerr';
-  static const pluginSection = 'slider';
-}
-
 /// Upserts a disabled home section per custom slider. Existing enable/order
-/// flags stay. Sliders that left the server are dropped.
+/// flags stay. Sliders that left the server are dropped. Refreshes
+/// [HomeSectionConfig.sliderType] and [HomeSectionConfig.pluginDisplayText].
 List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
   List<HomeSectionConfig> current,
   Iterable<(SeerrDiscoverSlider, SeerrSliderCatalog)> sliders,
@@ -24,27 +19,20 @@ List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
       kept.add(config);
       continue;
     }
-    final id = int.tryParse(config.pluginAdditionalData ?? '');
+    final id = config.seerrSliderId;
     final pair = id == null ? null : byId[id];
     if (id == null || pair == null || !seen.add(id)) continue;
-    final title = pair.$2.title;
-    kept.add(
-      config.pluginDisplayText == title
-          ? config
-          : config.copyWith(pluginDisplayText: title),
-    );
+    kept.add(_withSliderCatalog(config, pair.$2));
   }
 
   var order = kept.fold<int>(-1, (m, c) => c.order > m ? c.order : m) + 1;
   for (final (slider, catalog) in sliders) {
     if (seen.contains(slider.id)) continue;
     kept.add(
-      HomeSectionConfig.pluginDynamic(
-        serverId: SeerrHomeSliderSection.serverId,
-        pluginSection: SeerrHomeSliderSection.pluginSection,
-        pluginAdditionalData: '${slider.id}',
-        pluginDisplayText: catalog.title,
-        pluginSource: HomeSectionPluginSource.seerr,
+      HomeSectionConfig.seerrSlider(
+        sliderId: '${slider.id}',
+        sliderType: catalog.type,
+        pluginDisplayText: _displayTextForCatalog(catalog),
         enabled: false,
         order: order++,
       ),
@@ -54,7 +42,33 @@ List<HomeSectionConfig> mergeSeerrCustomSliderHomeSections(
 }
 
 int? seerrCustomSliderIdFromStableId(String id) {
-  const prefix = 'pluginDynamic:seerr:seerr:slider:';
-  if (!id.startsWith(prefix)) return null;
-  return int.tryParse(id.substring(prefix.length));
+  const prefix = 'seerrSlider:';
+  if (id.startsWith(prefix)) {
+    return int.tryParse(id.substring(prefix.length));
+  }
+  const legacy = 'pluginDynamic:seerr:seerr:slider:';
+  if (id.startsWith(legacy)) {
+    return int.tryParse(id.substring(legacy.length));
+  }
+  return null;
+}
+
+HomeSectionConfig _withSliderCatalog(
+  HomeSectionConfig config,
+  SeerrSliderCatalog catalog,
+) {
+  final displayText = _displayTextForCatalog(catalog) ?? config.pluginDisplayText;
+  if (config.sliderType == catalog.type &&
+      config.pluginDisplayText == displayText) {
+    return config;
+  }
+  return config.copyWith(
+    sliderType: catalog.type,
+    pluginDisplayText: displayText,
+  );
+}
+
+String? _displayTextForCatalog(SeerrSliderCatalog catalog) {
+  final title = catalog.title.trim();
+  return title.isEmpty ? null : title;
 }

--- a/lib/data/viewmodels/seerr_browse_view_model.dart
+++ b/lib/data/viewmodels/seerr_browse_view_model.dart
@@ -440,7 +440,7 @@ class SeerrBrowseViewModel extends ChangeNotifier {
         sortBy: _state.sortBy.value,
         genre: genre,
         network: filterType == 'network' ? id : null,
-        keywords: filterType == 'keyword' ? id : null,
+        keywords: filterType == 'keyword' ? id?.toString() : null,
         language: language,
         status: _state.tvStatuses.isEmpty
             ? null
@@ -458,7 +458,7 @@ class SeerrBrowseViewModel extends ChangeNotifier {
       sortBy: _state.sortBy.value,
       genre: genre,
       studio: filterType == 'studio' ? id : null,
-      keywords: filterType == 'keyword' ? id : null,
+      keywords: filterType == 'keyword' ? id?.toString() : null,
       language: language,
       voteAverageGte: voteAverageGte,
       voteCountGte: voteCountGte,

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -6,10 +6,13 @@ import '../../preference/preference_constants.dart';
 import '../../preference/seerr_preferences.dart';
 import '../repositories/seerr_repository.dart';
 import '../services/seerr/seerr_api_models.dart';
+import '../services/seerr/seerr_slider_catalog.dart';
 import '../utils/bounded_concurrency.dart';
 
 class SeerrDiscoverRow {
-  final SeerrRowType type;
+  final SeerrRowType? type;
+  final SeerrDiscoverSlider? slider;
+  final SeerrSliderCatalog? catalog;
   final List<SeerrDiscoverItem> items;
   final List<SeerrGenre> genres;
   final List<SeerrNetwork> networks;
@@ -19,7 +22,9 @@ class SeerrDiscoverRow {
   final int totalPages;
 
   const SeerrDiscoverRow({
-    required this.type,
+    this.type,
+    this.slider,
+    this.catalog,
     this.items = const [],
     this.genres = const [],
     this.networks = const [],
@@ -40,6 +45,8 @@ class SeerrDiscoverRow {
   }) =>
       SeerrDiscoverRow(
         type: type,
+        slider: slider,
+        catalog: catalog,
         items: items ?? this.items,
         genres: genres ?? this.genres,
         networks: networks ?? this.networks,
@@ -50,12 +57,22 @@ class SeerrDiscoverRow {
       );
 
   bool get hasMore => page < totalPages;
-  bool get isGenreRow => type == SeerrRowType.movieGenres || type == SeerrRowType.seriesGenres;
+  bool get isCustomSlider => catalog != null;
+  bool get isGenreRow =>
+      type == SeerrRowType.movieGenres || type == SeerrRowType.seriesGenres;
   bool get isNetworkRow => type == SeerrRowType.networks;
   bool get isStudioRow => type == SeerrRowType.studios;
   bool get isShortcutsRow => type == SeerrRowType.shortcuts;
   bool get isMediaRow =>
       !isGenreRow && !isNetworkRow && !isStudioRow && !isShortcutsRow;
+  String? get title => slider?.title;
+
+  /// Stable D-pad column id. Index is not part of this: custom rows
+  /// appearing or vanishing would otherwise reuse another row's memory.
+  String get focusHubKey => seerrDiscoverFocusHubKey(
+        sliderId: slider?.id,
+        typeName: type?.name,
+      );
 }
 
 class SeerrDiscoverViewModel extends ChangeNotifier {
@@ -152,6 +169,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       notifyListeners();
 
       await _loadAllRows();
+      await _appendCustomSliders();
     } catch (e) {
       _error = e.toString();
       debugPrint('[SeerrDiscover] Failed to load: $e');
@@ -193,7 +211,9 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
   Future<void> applyRowConfig() async {
     if (_rows.isEmpty) return;
     final activeTypes = _visibleRows(_prefs.activeRows);
-    final rowMap = {for (final r in _rows) r.type: r};
+    final rowMap = {
+      for (final r in _rows) ?r.type: r,
+    };
     final newRows = <SeerrDiscoverRow>[];
     for (final type in activeTypes) {
       final existing = rowMap[type];
@@ -206,6 +226,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     }
     _rows = newRows;
     notifyListeners();
+    await _appendCustomSliders();
   }
 
   Future<void> loadMore(int rowIndex) async {
@@ -218,7 +239,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     notifyListeners();
 
     try {
-      final page = await _loadPage(row.type, row.page + 1);
+      final page = await _loadPage(row, row.page + 1);
       if (page != null) {
         List<SeerrDiscoverItem> newItems;
         if (row.type == SeerrRowType.yourWatchlist) {
@@ -253,7 +274,16 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
   Future<void> _loadRow(int index) async {
     final row = _rows[index];
     try {
-      switch (row.type) {
+      if (row.isCustomSlider) {
+        await _loadCatalogRow(index);
+        return;
+      }
+      final type = row.type;
+      if (type == null) {
+        _updateRow(index, row.copyWith(isLoading: false));
+        return;
+      }
+      switch (type) {
         case SeerrRowType.shortcuts:
           await _loadShortcutArtwork(index);
         case SeerrRowType.recentRequests:
@@ -276,8 +306,12 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
             studios: popularStudios,
             isLoading: false,
           ));
-        default:
-          final page = await _loadPage(row.type, 1);
+        case SeerrRowType.trending:
+        case SeerrRowType.popularMovies:
+        case SeerrRowType.popularSeries:
+        case SeerrRowType.upcomingMovies:
+        case SeerrRowType.upcomingSeries:
+          final page = await _loadPage(row, 1);
           if (page != null) {
             final filtered = _filterItems(page.results);
             _updateRow(index, row.copyWith(
@@ -294,6 +328,22 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       debugPrint('[SeerrDiscover] Failed to load row ${row.type}: $e');
       _updateRow(index, row.copyWith(isLoading: false));
     }
+  }
+
+  Future<void> _loadCatalogRow(int index) async {
+    final row = _rows[index];
+    final page = await _loadPage(row, 1);
+    if (page == null) {
+      _updateRow(index, row.copyWith(isLoading: false));
+      return;
+    }
+    final filtered = _filterItems(page.results);
+    _updateRow(index, row.copyWith(
+      items: filtered,
+      page: page.page,
+      totalPages: page.totalPages,
+      isLoading: false,
+    ));
   }
 
   /// Artwork for the shortcut tiles. One trending read covers every tile, and
@@ -475,7 +525,17 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     }
   }
 
-  Future<SeerrDiscoverPage?> _loadPage(SeerrRowType type, int page) async {
+  Future<SeerrDiscoverPage?> _loadPage(SeerrDiscoverRow row, int page) async {
+    final catalog = row.catalog;
+    if (catalog != null) {
+      return _repo.getCatalog(
+        catalog.path,
+        query: catalog.query,
+        page: page,
+        mediaTypeHint: catalog.mediaTypeHint,
+      );
+    }
+    final type = row.type;
     final limit = _prefs.fetchLimit.limit;
     final offset = (page - 1) * limit;
     switch (type) {
@@ -493,6 +553,40 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
         return _repo.getWatchlist(page: page);
       default:
         return null;
+    }
+  }
+
+  Future<void> _appendCustomSliders() async {
+    try {
+      final sliders = await _repo.getDiscoverSliders();
+      final resolved = resolveSeerrCustomSliders(sliders);
+      _rows = _rows.where((row) => !row.isCustomSlider).toList();
+      if (resolved.isEmpty) {
+        notifyListeners();
+        return;
+      }
+
+      final start = _rows.length;
+      _rows = [
+        ..._rows,
+        for (final (slider, catalog) in resolved)
+          SeerrDiscoverRow(
+            slider: slider,
+            catalog: catalog,
+            isLoading: true,
+          ),
+      ];
+      notifyListeners();
+
+      final indices = List.generate(resolved.length, (i) => start + i);
+      await mapBounded<int, void>(indices, 2, (index) => _loadRow(index));
+
+      _rows = _rows
+          .where((row) => !row.isCustomSlider || row.items.isNotEmpty)
+          .toList();
+      notifyListeners();
+    } catch (e) {
+      debugPrint('[SeerrDiscover] Failed to load custom sliders: $e');
     }
   }
 

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -177,6 +177,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
+    await applyRowConfig();
   }
 
   Future<void> refresh() async {
@@ -209,24 +210,29 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
           : rows.where((t) => t != SeerrRowType.recentlyAdded).toList();
 
   Future<void> applyRowConfig() async {
-    if (_rows.isEmpty) return;
+    if (_isLoading || _rows.isEmpty) return;
     final activeTypes = _visibleRows(_prefs.activeRows);
+    final currentLocal = [
+      for (final row in _rows)
+        if (row.type != null) row.type!,
+    ];
+    if (listEquals(currentLocal, activeTypes)) return;
+
     final rowMap = {
       for (final r in _rows) ?r.type: r,
     };
-    final newRows = <SeerrDiscoverRow>[];
+    final custom = [for (final r in _rows) if (r.isCustomSlider) r];
+    final local = <SeerrDiscoverRow>[];
     for (final type in activeTypes) {
       final existing = rowMap[type];
-      if (existing != null) {
-        newRows.add(existing);
-      } else {
+      if (existing == null) {
         await refresh();
         return;
       }
+      local.add(existing);
     }
-    _rows = newRows;
+    _rows = [...local, ...custom];
     notifyListeners();
-    await _appendCustomSliders();
   }
 
   Future<void> loadMore(int rowIndex) async {

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -57,7 +57,7 @@ class SeerrDiscoverRow {
       );
 
   bool get hasMore => page < totalPages;
-  bool get isCustomSlider => catalog != null;
+  bool get isSeerrSlider => catalog != null;
   bool get isGenreRow =>
       type == SeerrRowType.movieGenres || type == SeerrRowType.seriesGenres;
   bool get isNetworkRow => type == SeerrRowType.networks;
@@ -81,6 +81,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
 
   List<SeerrDiscoverRow> _rows = [];
   List<SeerrDiscoverRow> get rows => _rows;
+  SeerrSliderFetchGate _seerrSliderFetchGate = const SeerrSliderFetchGate();
 
   bool _canViewRecentlyAdded = true;
 
@@ -169,7 +170,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       notifyListeners();
 
       await _loadAllRows();
-      await _appendCustomSliders();
+      await _appendSeerrSliders();
     } catch (e) {
       _error = e.toString();
       debugPrint('[SeerrDiscover] Failed to load: $e');
@@ -221,7 +222,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     final rowMap = {
       for (final r in _rows) ?r.type: r,
     };
-    final custom = [for (final r in _rows) if (r.isCustomSlider) r];
+    final custom = [for (final r in _rows) if (r.isSeerrSlider) r];
     final local = <SeerrDiscoverRow>[];
     for (final type in activeTypes) {
       final existing = rowMap[type];
@@ -280,7 +281,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
   Future<void> _loadRow(int index) async {
     final row = _rows[index];
     try {
-      if (row.isCustomSlider) {
+      if (row.isSeerrSlider) {
         await _loadCatalogRow(index);
         return;
       }
@@ -534,6 +535,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
   Future<SeerrDiscoverPage?> _loadPage(SeerrDiscoverRow row, int page) async {
     final catalog = row.catalog;
     if (catalog != null) {
+      if (!_seerrSliderFetchGate.canFetch(catalog.type)) return null;
       return _repo.getCatalog(
         catalog.path,
         query: catalog.query,
@@ -562,11 +564,14 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     }
   }
 
-  Future<void> _appendCustomSliders() async {
+  Future<void> _appendSeerrSliders() async {
     try {
       final sliders = await _repo.getDiscoverSliders();
-      final resolved = resolveSeerrCustomSliders(sliders);
-      _rows = _rows.where((row) => !row.isCustomSlider).toList();
+      _seerrSliderFetchGate = await _repo.loadSliderFetchGate();
+      final resolved = resolveSeerrSliders(sliders)
+          .where((pair) => _seerrSliderFetchGate.canFetch(pair.$2.type))
+          .toList();
+      _rows = _rows.where((row) => !row.isSeerrSlider).toList();
       if (resolved.isEmpty) {
         notifyListeners();
         return;
@@ -588,11 +593,11 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
       await mapBounded<int, void>(indices, 2, (index) => _loadRow(index));
 
       _rows = _rows
-          .where((row) => !row.isCustomSlider || row.items.isNotEmpty)
+          .where((row) => !row.isSeerrSlider || row.items.isNotEmpty)
           .toList();
       notifyListeners();
     } catch (e) {
-      debugPrint('[SeerrDiscover] Failed to load custom sliders: $e');
+      debugPrint('[SeerrDiscover] Failed to load sliders: $e');
     }
   }
 

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -58,6 +58,7 @@ class SeerrDiscoverRow {
 
   bool get hasMore => page < totalPages;
   bool get isSeerrSlider => catalog != null;
+  String get debugLabel => catalog?.path ?? type?.name ?? 'unknown';
   bool get isGenreRow =>
       type == SeerrRowType.movieGenres || type == SeerrRowType.seriesGenres;
   bool get isNetworkRow => type == SeerrRowType.networks;
@@ -266,7 +267,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
         _rows[rowIndex] = row.copyWith(isLoading: false);
       }
     } catch (e) {
-      debugPrint('[SeerrDiscover] Failed to load more for ${row.type}: $e');
+      debugPrint('[SeerrDiscover] Failed to load more for ${row.debugLabel}: $e');
       _rows = List.of(_rows);
       _rows[rowIndex] = row.copyWith(isLoading: false);
     }
@@ -332,7 +333,7 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
           }
       }
     } catch (e) {
-      debugPrint('[SeerrDiscover] Failed to load row ${row.type}: $e');
+      debugPrint('[SeerrDiscover] Failed to load row ${row.debugLabel}: $e');
       _updateRow(index, row.copyWith(isLoading: false));
     }
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5688,6 +5688,86 @@
   "@yourWatchlist": {
     "description": "Seerr row: watchlist"
   },
+  "seerrTraktRecommendations": "Trakt Recommendations",
+  "@seerrTraktRecommendations": {
+    "description": "Foreseerr Discover row: Trakt recommendations"
+  },
+  "seerrTraktWatchlist": "Trakt Watchlist",
+  "@seerrTraktWatchlist": {
+    "description": "Foreseerr Discover row: Trakt watchlist"
+  },
+  "seerrTraktHistory": "Trakt History",
+  "@seerrTraktHistory": {
+    "description": "Foreseerr Discover row: Trakt history"
+  },
+  "seerrTraktList": "Trakt List",
+  "@seerrTraktList": {
+    "description": "Fallback title for an unnamed Foreseerr Trakt list slider"
+  },
+  "seerrAnilistTrending": "AniList Trending",
+  "@seerrAnilistTrending": {
+    "description": "Foreseerr Discover row: AniList trending"
+  },
+  "seerrAnilistThisSeason": "AniList This Season",
+  "@seerrAnilistThisSeason": {
+    "description": "Foreseerr Discover row: AniList current season"
+  },
+  "seerrAnilistPopular": "AniList Popular",
+  "@seerrAnilistPopular": {
+    "description": "Foreseerr Discover row: AniList popular"
+  },
+  "seerrAnilistTop100": "AniList Top 100",
+  "@seerrAnilistTop100": {
+    "description": "Foreseerr Discover row: AniList top 100"
+  },
+  "seerrAnilistNextSeason": "AniList Next Season",
+  "@seerrAnilistNextSeason": {
+    "description": "Foreseerr Discover row: AniList next season"
+  },
+  "seerrAnilistWatching": "AniList Watching",
+  "@seerrAnilistWatching": {
+    "description": "Foreseerr Discover row: AniList watching"
+  },
+  "seerrAnilistPlanning": "AniList Planning",
+  "@seerrAnilistPlanning": {
+    "description": "Foreseerr Discover row: AniList planning"
+  },
+  "seerrAnilistCompleted": "AniList Completed",
+  "@seerrAnilistCompleted": {
+    "description": "Foreseerr Discover row: AniList completed"
+  },
+  "seerrAnilistList": "AniList List",
+  "@seerrAnilistList": {
+    "description": "Fallback title for an unnamed Foreseerr AniList list slider"
+  },
+  "seerrMdblistList": "MDBList List",
+  "@seerrMdblistList": {
+    "description": "Fallback title for an unnamed Foreseerr MDBList slider"
+  },
+  "seerrSimklTrending": "Simkl Trending",
+  "@seerrSimklTrending": {
+    "description": "Foreseerr Discover row: Simkl trending"
+  },
+  "seerrSimklPlanToWatch": "Simkl Plan to Watch",
+  "@seerrSimklPlanToWatch": {
+    "description": "Foreseerr Discover row: Simkl plan to watch"
+  },
+  "seerrSimklWatching": "Simkl Watching",
+  "@seerrSimklWatching": {
+    "description": "Foreseerr Discover row: Simkl watching"
+  },
+  "seerrSimklOnHold": "Simkl On Hold",
+  "@seerrSimklOnHold": {
+    "description": "Foreseerr Discover row: Simkl on hold"
+  },
+  "seerrSimklCompleted": "Simkl Completed",
+  "@seerrSimklCompleted": {
+    "description": "Foreseerr Discover row: Simkl completed"
+  },
+  "seerrSimklDropped": "Simkl Dropped",
+  "@seerrSimklDropped": {
+    "description": "Foreseerr Discover row: Simkl dropped"
+  },
   "resetRowsToDefaults": "Reset rows to defaults",
   "@resetRowsToDefaults": {
     "description": "Tooltip for reset rows to defaults"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7696,6 +7696,126 @@ abstract class AppLocalizations {
   /// **'Your Watchlist'**
   String get yourWatchlist;
 
+  /// Foreseerr Discover row: Trakt recommendations
+  ///
+  /// In en, this message translates to:
+  /// **'Trakt Recommendations'**
+  String get seerrTraktRecommendations;
+
+  /// Foreseerr Discover row: Trakt watchlist
+  ///
+  /// In en, this message translates to:
+  /// **'Trakt Watchlist'**
+  String get seerrTraktWatchlist;
+
+  /// Foreseerr Discover row: Trakt history
+  ///
+  /// In en, this message translates to:
+  /// **'Trakt History'**
+  String get seerrTraktHistory;
+
+  /// Fallback title for an unnamed Foreseerr Trakt list slider
+  ///
+  /// In en, this message translates to:
+  /// **'Trakt List'**
+  String get seerrTraktList;
+
+  /// Foreseerr Discover row: AniList trending
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Trending'**
+  String get seerrAnilistTrending;
+
+  /// Foreseerr Discover row: AniList current season
+  ///
+  /// In en, this message translates to:
+  /// **'AniList This Season'**
+  String get seerrAnilistThisSeason;
+
+  /// Foreseerr Discover row: AniList popular
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Popular'**
+  String get seerrAnilistPopular;
+
+  /// Foreseerr Discover row: AniList top 100
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Top 100'**
+  String get seerrAnilistTop100;
+
+  /// Foreseerr Discover row: AniList next season
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Next Season'**
+  String get seerrAnilistNextSeason;
+
+  /// Foreseerr Discover row: AniList watching
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Watching'**
+  String get seerrAnilistWatching;
+
+  /// Foreseerr Discover row: AniList planning
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Planning'**
+  String get seerrAnilistPlanning;
+
+  /// Foreseerr Discover row: AniList completed
+  ///
+  /// In en, this message translates to:
+  /// **'AniList Completed'**
+  String get seerrAnilistCompleted;
+
+  /// Fallback title for an unnamed Foreseerr AniList list slider
+  ///
+  /// In en, this message translates to:
+  /// **'AniList List'**
+  String get seerrAnilistList;
+
+  /// Fallback title for an unnamed Foreseerr MDBList slider
+  ///
+  /// In en, this message translates to:
+  /// **'MDBList List'**
+  String get seerrMdblistList;
+
+  /// Foreseerr Discover row: Simkl trending
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl Trending'**
+  String get seerrSimklTrending;
+
+  /// Foreseerr Discover row: Simkl plan to watch
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl Plan to Watch'**
+  String get seerrSimklPlanToWatch;
+
+  /// Foreseerr Discover row: Simkl watching
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl Watching'**
+  String get seerrSimklWatching;
+
+  /// Foreseerr Discover row: Simkl on hold
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl On Hold'**
+  String get seerrSimklOnHold;
+
+  /// Foreseerr Discover row: Simkl completed
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl Completed'**
+  String get seerrSimklCompleted;
+
+  /// Foreseerr Discover row: Simkl dropped
+  ///
+  /// In en, this message translates to:
+  /// **'Simkl Dropped'**
+  String get seerrSimklDropped;
+
   /// Tooltip for reset rows to defaults
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -4243,6 +4243,66 @@ class AppLocalizationsAf extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Stel rye terug na verstek';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -4244,6 +4244,66 @@ class AppLocalizationsAr extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'إعادة تعيين الصفوف إلى الإعدادات الافتراضية';
 

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -4258,6 +4258,66 @@ class AppLocalizationsBe extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Скінуць радкі да значэнняў па змаўчанні';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4258,6 +4258,66 @@ class AppLocalizationsBg extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Възстановяване на редовете по подразбиране';
 

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -4229,6 +4229,66 @@ class AppLocalizationsBn extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'সারি ডিফল্টে রিসেট করুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -4292,6 +4292,66 @@ class AppLocalizationsCa extends AppLocalizations {
   String get yourWatchlist => 'La teva llista de seguiment';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Restableix les files als valors predeterminats';
 

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4248,6 +4248,66 @@ class AppLocalizationsCs extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Resetovat řádky na výchozí hodnoty';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -4263,6 +4263,66 @@ class AppLocalizationsCy extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Ailosod rhesi i ragosodiadau';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4236,6 +4236,66 @@ class AppLocalizationsDa extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Nulstil rækker til standardindstillinger';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4341,6 +4341,66 @@ class AppLocalizationsDe extends AppLocalizations {
   String get yourWatchlist => 'Deine Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Reihen auf Standard zurücksetzen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4283,6 +4283,66 @@ class AppLocalizationsEl extends AppLocalizations {
   String get yourWatchlist => 'Η λίστα παρακολούθησής σας';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Επαναφέρετε τις σειρές στις προεπιλογές';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4217,6 +4217,66 @@ class AppLocalizationsEn extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Reset rows to defaults';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -4235,6 +4235,66 @@ class AppLocalizationsEo extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Restarigu vicojn al defaŭltoj';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4266,6 +4266,66 @@ class AppLocalizationsEs extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Restablecer filas a valores predeterminados';
 

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4241,6 +4241,66 @@ class AppLocalizationsEt extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Lähtestage read vaikeseadetele';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -4216,6 +4216,66 @@ class AppLocalizationsFa extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'سطرها را به حالت پیش فرض بازنشانی کنید';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4256,6 +4256,66 @@ class AppLocalizationsFi extends AppLocalizations {
   String get yourWatchlist => 'Aktiivilistallasi';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Palauta rivit oletusarvoihin';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4288,6 +4288,66 @@ class AppLocalizationsFr extends AppLocalizations {
   String get yourWatchlist => 'Ma liste';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Réinitialiser les rangées par défaut';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -4281,6 +4281,66 @@ class AppLocalizationsGl extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Restablecer as filas aos valores predeterminados';
 

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -4202,6 +4202,66 @@ class AppLocalizationsHe extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'אפס שורות לברירות המחדל';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -4228,6 +4228,66 @@ class AppLocalizationsHi extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'पंक्तियों को डिफ़ॉल्ट पर रीसेट करें';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4359,6 +4359,66 @@ class AppLocalizationsHr extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Vrati retke na zadane vrijednosti';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4266,6 +4266,66 @@ class AppLocalizationsHu extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'A sorok visszaállítása az alapértelmezett értékekre';
 

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -4241,6 +4241,66 @@ class AppLocalizationsId extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Reset baris ke default';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4262,6 +4262,66 @@ class AppLocalizationsIt extends AppLocalizations {
   String get yourWatchlist => 'La tua Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Ripristina righe predefinite';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -4153,6 +4153,66 @@ class AppLocalizationsJa extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => '行をデフォルトにリセットする';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -4255,6 +4255,66 @@ class AppLocalizationsKk extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Жолдарды әдепкі мәндерге қайтарыңыз';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -4260,6 +4260,66 @@ class AppLocalizationsKn extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'ಸಾಲುಗಳನ್ನು ಡೀಫಾಲ್ಟ್‌ಗೆ ಮರುಹೊಂದಿಸಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -4136,6 +4136,66 @@ class AppLocalizationsKo extends AppLocalizations {
   String get yourWatchlist => '내 관심 목록';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => '행을 기본값으로 재설정';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4257,6 +4257,66 @@ class AppLocalizationsLt extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Iš naujo nustatyti eilutes į numatytuosius nustatymus';
 

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4255,6 +4255,66 @@ class AppLocalizationsLv extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Atiestatīt rindas uz noklusējuma iestatījumiem';
 

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -4258,6 +4258,66 @@ class AppLocalizationsMk extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Ресетирајте ги редовите на стандардни';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -4263,6 +4263,66 @@ class AppLocalizationsMl extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'വരികൾ ഡിഫോൾട്ടിലേക്ക് പുനഃസജ്ജമാക്കുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -4246,6 +4246,66 @@ class AppLocalizationsMn extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Мөрүүдийг өгөгдмөл болгож дахин тохируулна уу';
 

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4233,6 +4233,66 @@ class AppLocalizationsNb extends AppLocalizations {
   String get yourWatchlist => 'Din visningsliste';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Tilbakestill rader til standardverdier';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4259,6 +4259,66 @@ class AppLocalizationsNl extends AppLocalizations {
   String get yourWatchlist => 'Jouw kijklijst';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Zet rijen terug naar de standaardwaarden';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -4226,6 +4226,66 @@ class AppLocalizationsPa extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'ਕਤਾਰਾਂ ਨੂੰ ਪੂਰਵ-ਨਿਰਧਾਰਤ \'ਤੇ ਰੀਸੈਟ ਕਰੋ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4388,6 +4388,66 @@ class AppLocalizationsPl extends AppLocalizations {
   String get yourWatchlist => 'Do obejrzenia';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Przywróć domyślny układ sekcji';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4259,6 +4259,66 @@ class AppLocalizationsPt extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Restaurar linhas para os padrões';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4268,6 +4268,66 @@ class AppLocalizationsRo extends AppLocalizations {
   String get yourWatchlist => 'Lista de vizionare';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Resetați rândurile la valorile implicite';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -4269,6 +4269,66 @@ class AppLocalizationsRu extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Сбросить строки к значениям по умолчанию';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -4238,6 +4238,66 @@ class AppLocalizationsSi extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'පේළි පෙරනිමියට නැවත සකසන්න';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4261,6 +4261,66 @@ class AppLocalizationsSk extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Obnovte predvolené hodnoty riadkov';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4264,6 +4264,66 @@ class AppLocalizationsSl extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Ponastavi vrstice na privzete';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -4269,6 +4269,66 @@ class AppLocalizationsSq extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Rivendosni rreshtat në parazgjedhje';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4358,6 +4358,66 @@ class AppLocalizationsSr extends AppLocalizations {
   String get yourWatchlist => 'Ваша листа за гледање';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults =>
       'Ресетујте редове на подразумеване вредности';
 

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4242,6 +4242,66 @@ class AppLocalizationsSv extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Återställ rader till standardvärden';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -4265,6 +4265,66 @@ class AppLocalizationsSw extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Weka upya safu mlalo ziwe chaguomsingi';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -4267,6 +4267,66 @@ class AppLocalizationsTa extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'வரிசைகளை இயல்புநிலைக்கு மீட்டமைக்கவும்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -4259,6 +4259,66 @@ class AppLocalizationsTe extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'అడ్డు వరుసలను డిఫాల్ట్‌లకు రీసెట్ చేయండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -4210,6 +4210,66 @@ class AppLocalizationsTh extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'รีเซ็ตแถวเป็นค่าเริ่มต้น';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -4272,6 +4272,66 @@ class AppLocalizationsTl extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'I-reset ang mga hilera sa mga default';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -4247,6 +4247,66 @@ class AppLocalizationsTr extends AppLocalizations {
   String get yourWatchlist => 'İzleme Listen';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Satırları varsayılanlara sıfırla';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -4245,6 +4245,66 @@ class AppLocalizationsUg extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'قۇرلارنى سۈكۈتتىكى ھالەتكە قايتۇرۇش';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -4263,6 +4263,66 @@ class AppLocalizationsUk extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Скинути рядки до значень за замовчуванням';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -4244,6 +4244,66 @@ class AppLocalizationsVi extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => 'Đặt lại các hàng về mặc định';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -4119,6 +4119,66 @@ class AppLocalizationsYue extends AppLocalizations {
   String get yourWatchlist => 'Your Watchlist';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => '將行重設為預設值';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4090,6 +4090,66 @@ class AppLocalizationsZh extends AppLocalizations {
   String get yourWatchlist => '我的观看清单';
 
   @override
+  String get seerrTraktRecommendations => 'Trakt Recommendations';
+
+  @override
+  String get seerrTraktWatchlist => 'Trakt Watchlist';
+
+  @override
+  String get seerrTraktHistory => 'Trakt History';
+
+  @override
+  String get seerrTraktList => 'Trakt List';
+
+  @override
+  String get seerrAnilistTrending => 'AniList Trending';
+
+  @override
+  String get seerrAnilistThisSeason => 'AniList This Season';
+
+  @override
+  String get seerrAnilistPopular => 'AniList Popular';
+
+  @override
+  String get seerrAnilistTop100 => 'AniList Top 100';
+
+  @override
+  String get seerrAnilistNextSeason => 'AniList Next Season';
+
+  @override
+  String get seerrAnilistWatching => 'AniList Watching';
+
+  @override
+  String get seerrAnilistPlanning => 'AniList Planning';
+
+  @override
+  String get seerrAnilistCompleted => 'AniList Completed';
+
+  @override
+  String get seerrAnilistList => 'AniList List';
+
+  @override
+  String get seerrMdblistList => 'MDBList List';
+
+  @override
+  String get seerrSimklTrending => 'Simkl Trending';
+
+  @override
+  String get seerrSimklPlanToWatch => 'Simkl Plan to Watch';
+
+  @override
+  String get seerrSimklWatching => 'Simkl Watching';
+
+  @override
+  String get seerrSimklOnHold => 'Simkl On Hold';
+
+  @override
+  String get seerrSimklCompleted => 'Simkl Completed';
+
+  @override
+  String get seerrSimklDropped => 'Simkl Dropped';
+
+  @override
   String get resetRowsToDefaults => '将栏目重置为默认值';
 
   @override

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -31,7 +31,11 @@ enum HomeSectionPluginSource {
 
   playlists('playlists'),
 
-  custom('custom');
+  custom('custom'),
+
+  /// Seerr `GET /settings/discover` custom sliders. One home row per slider;
+  /// they are not [HomeSectionType] / [SeerrRowType] values.
+  seerr('seerr');
 
   const HomeSectionPluginSource(this.serializedName);
   final String serializedName;
@@ -159,11 +163,14 @@ class HomeSectionConfig {
   static String? _normalizedServerId(
     String? serverId,
     HomeSectionPluginSource source,
-  ) =>
-      (serverId == null || serverId.isEmpty) &&
-              source == HomeSectionPluginSource.custom
-          ? 'custom'
-          : serverId;
+  ) {
+    if (serverId != null && serverId.isNotEmpty) return serverId;
+    return switch (source) {
+      HomeSectionPluginSource.custom => 'custom',
+      HomeSectionPluginSource.seerr => 'seerr',
+      _ => serverId,
+    };
+  }
 
   /// Stable identifier suitable for use as a row id / list key. Plugin
   /// entries combine the originating plugin, server, section and additional
@@ -179,6 +186,8 @@ class HomeSectionConfig {
 
   bool get isBuiltin => kind == HomeSectionKind.builtin;
   bool get isPluginDynamic => kind == HomeSectionKind.pluginDynamic;
+  bool get isSeerrCustomSlider =>
+      isPluginDynamic && pluginSource == HomeSectionPluginSource.seerr;
 
   static List<HomeSectionConfig> defaults() => const [
     HomeSectionConfig(

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -7,9 +7,14 @@ import 'preference_constants.dart';
 /// `pluginDynamic` entries are dynamic rows discovered from a third-party
 /// Jellyfin plugin and are scoped to a specific server. The originating
 /// plugin is identified by [HomeSectionPluginSource].
+/// `seerrSlider` entries are Seerr `GET /settings/discover` sliders.
+/// Identity is [HomeSectionConfig.sliderId]. [type] is [HomeSectionType.none],
+/// same as [pluginDynamic]; JSON still writes `seerr_slider` so Plugin can
+/// tell them apart from other `none` rows.
 enum HomeSectionKind {
   builtin('builtin'),
-  pluginDynamic('pluginDynamic');
+  pluginDynamic('pluginDynamic'),
+  seerrSlider('seerrSlider');
 
   const HomeSectionKind(this.serializedName);
   final String serializedName;
@@ -31,11 +36,7 @@ enum HomeSectionPluginSource {
 
   playlists('playlists'),
 
-  custom('custom'),
-
-  /// Seerr `GET /settings/discover` custom sliders. One home row per slider;
-  /// they are not [HomeSectionType] / [SeerrRowType] values.
-  seerr('seerr');
+  custom('custom');
 
   const HomeSectionPluginSource(this.serializedName);
   final String serializedName;
@@ -55,11 +56,18 @@ class HomeSectionConfig {
   final int order;
 
   // pluginDynamic-only fields. Always null for builtin entries.
+  // seerrSlider reuses pluginDisplayText for the persisted label.
   final String? serverId;
   final String? pluginSection;
   final String? pluginAdditionalData;
   final String? pluginDisplayText;
   final HomeSectionPluginSource pluginSource;
+
+  /// seerrSlider identity. Null for every other kind.
+  final String? sliderId;
+
+  /// Raw Seerr `DiscoverSliderType`. Null for every other kind.
+  final int? sliderType;
 
   const HomeSectionConfig({
     this.kind = HomeSectionKind.builtin,
@@ -71,6 +79,8 @@ class HomeSectionConfig {
     this.pluginAdditionalData,
     this.pluginDisplayText,
     this.pluginSource = HomeSectionPluginSource.collections,
+    this.sliderId,
+    this.sliderType,
   });
 
   factory HomeSectionConfig.pluginDynamic({
@@ -93,15 +103,50 @@ class HomeSectionConfig {
     pluginSource: pluginSource,
   );
 
+  /// Wire `type` for seerrSlider rows. Not a [HomeSectionType] value.
+  static const seerrSliderSerializedType = 'seerr_slider';
+
+  factory HomeSectionConfig.seerrSlider({
+    required String sliderId,
+    int? sliderType,
+    String? pluginDisplayText,
+    bool enabled = false,
+    int order = 0,
+  }) => HomeSectionConfig(
+    kind: HomeSectionKind.seerrSlider,
+    type: HomeSectionType.none,
+    enabled: enabled,
+    order: order,
+    pluginDisplayText: pluginDisplayText,
+    sliderId: sliderId,
+    sliderType: sliderType,
+  );
+
   factory HomeSectionConfig.fromJson(Map<String, dynamic> json) {
     final kindRaw = json['kind'] as String?;
+    final pluginSourceRaw = json['pluginSource'] as String?;
+    final typeName = json['type'] as String? ?? 'none';
+    if (kindRaw == HomeSectionKind.seerrSlider.serializedName ||
+        (kindRaw == HomeSectionKind.pluginDynamic.serializedName &&
+            pluginSourceRaw == 'seerr') ||
+        typeName == seerrSliderSerializedType ||
+        _legacySeerrSliderTypeNames.containsKey(typeName)) {
+      final id =
+          json['sliderId']?.toString() ?? json['pluginAdditionalData']?.toString();
+      return HomeSectionConfig(
+        kind: HomeSectionKind.seerrSlider,
+        type: HomeSectionType.none,
+        enabled: json['enabled'] as bool? ?? true,
+        order: json['order'] as int? ?? 0,
+        pluginDisplayText: json['pluginDisplayText'] as String?,
+        sliderId: id,
+        sliderType: _sliderTypeFromJson(json),
+      );
+    }
     final kind = kindRaw == null
         ? HomeSectionKind.builtin
         : HomeSectionKind.fromSerialized(kindRaw);
-    final typeName = json['type'] as String? ?? 'none';
-    final pluginSource = HomeSectionPluginSource.fromSerialized(
-      json['pluginSource'] as String?,
-    );
+    final pluginSource = HomeSectionPluginSource.fromSerialized(pluginSourceRaw);
     return HomeSectionConfig(
       kind: kind,
       type: HomeSectionType.fromSerialized(typeName),
@@ -121,6 +166,16 @@ class HomeSectionConfig {
       'enabled': enabled,
       'order': order,
     };
+    if (kind == HomeSectionKind.seerrSlider) {
+      json['kind'] = kind.serializedName;
+      json['type'] = seerrSliderSerializedType;
+      if (sliderId != null) json['sliderId'] = sliderId;
+      if (sliderType != null) json['sliderType'] = sliderType;
+      if (pluginDisplayText != null) {
+        json['pluginDisplayText'] = pluginDisplayText;
+      }
+      return json;
+    }
     if (kind != HomeSectionKind.builtin) {
       json['kind'] = kind.serializedName;
       json['pluginSource'] = pluginSource.serializedName;
@@ -146,6 +201,8 @@ class HomeSectionConfig {
     String? pluginAdditionalData,
     String? pluginDisplayText,
     HomeSectionPluginSource? pluginSource,
+    String? sliderId,
+    int? sliderType,
   }) => HomeSectionConfig(
     kind: kind ?? this.kind,
     type: type ?? this.type,
@@ -156,6 +213,8 @@ class HomeSectionConfig {
     pluginAdditionalData: pluginAdditionalData ?? this.pluginAdditionalData,
     pluginDisplayText: pluginDisplayText ?? this.pluginDisplayText,
     pluginSource: pluginSource ?? this.pluginSource,
+    sliderId: sliderId ?? this.sliderId,
+    sliderType: sliderType ?? this.sliderType,
   );
 
   /// Custom rows belong to no server, and an empty serverId coming back from a saved
@@ -167,7 +226,6 @@ class HomeSectionConfig {
     if (serverId != null && serverId.isNotEmpty) return serverId;
     return switch (source) {
       HomeSectionPluginSource.custom => 'custom',
-      HomeSectionPluginSource.seerr => 'seerr',
       _ => serverId,
     };
   }
@@ -176,6 +234,9 @@ class HomeSectionConfig {
   /// entries combine the originating plugin, server, section and additional
   /// data so multiple instances of the same section can coexist.
   String get stableId {
+    if (kind == HomeSectionKind.seerrSlider) {
+      return 'seerrSlider:${sliderId ?? ''}';
+    }
     if (kind == HomeSectionKind.pluginDynamic) {
       final effectiveServerId =
           _normalizedServerId(serverId, pluginSource) ?? '';
@@ -186,8 +247,34 @@ class HomeSectionConfig {
 
   bool get isBuiltin => kind == HomeSectionKind.builtin;
   bool get isPluginDynamic => kind == HomeSectionKind.pluginDynamic;
-  bool get isSeerrCustomSlider =>
-      isPluginDynamic && pluginSource == HomeSectionPluginSource.seerr;
+  bool get isSeerrCustomSlider => kind == HomeSectionKind.seerrSlider;
+
+  /// False for slider rows with no id, and for the seerrSlider sentinel saved
+  /// as a builtin (legacy `homeRowOrder` pollution).
+  bool get isPersistable {
+    if (isSeerrCustomSlider) {
+      return sliderId != null && sliderId!.isNotEmpty;
+    }
+    if (isBuiltin && type == HomeSectionType.none) {
+      return false;
+    }
+    return true;
+  }
+
+  int? get seerrSliderId => int.tryParse(sliderId ?? '');
+
+  /// Legacy `homeRowOrder` is builtin types only. Plugin JS already filters
+  /// this way; sliders live in `homeSections`.
+  static List<String> homeRowOrderNames(List<HomeSectionConfig> configs) =>
+      configs
+          .where(
+            (c) =>
+                c.enabled &&
+                c.isBuiltin &&
+                c.type != HomeSectionType.none,
+          )
+          .map((c) => c.type.serializedName)
+          .toList();
 
   static List<HomeSectionConfig> defaults() => const [
     HomeSectionConfig(
@@ -395,7 +482,18 @@ class HomeSectionConfig {
   ];
 
   static bool isSupportedJson(Map<String, dynamic> json) {
-    if (json['kind'] != HomeSectionKind.pluginDynamic.serializedName) return true;
+    final kind = json['kind'] as String?;
+    if (kind == HomeSectionKind.seerrSlider.serializedName) return true;
+    if (kind == HomeSectionKind.pluginDynamic.serializedName &&
+        json['pluginSource'] == 'seerr') {
+      return true;
+    }
+    final typeName = json['type'] as String?;
+    if (typeName == seerrSliderSerializedType ||
+        _legacySeerrSliderTypeNames.containsKey(typeName)) {
+      return true;
+    }
+    if (kind != HomeSectionKind.pluginDynamic.serializedName) return true;
     final source = json['pluginSource'] as String?;
     return HomeSectionPluginSource.values.any((s) => s.serializedName == source);
   }
@@ -408,9 +506,7 @@ class HomeSectionConfig {
       for (final e in list) {
         if (e is Map<String, dynamic> && isSupportedJson(e)) {
           final cfg = HomeSectionConfig.fromJson(e);
-          if (cfg.isBuiltin && cfg.type == HomeSectionType.none) {
-            continue;
-          }
+          if (!cfg.isPersistable) continue;
           parsed.add(cfg);
         }
       }
@@ -443,4 +539,47 @@ class HomeSectionConfig {
 
   static String toJsonString(List<HomeSectionConfig> configs) =>
       jsonEncode(configs.map((c) => c.toJson()).toList());
+
+  static int? _sliderTypeFromJson(Map<String, dynamic> json) {
+    final raw = json['sliderType'];
+    if (raw is num) return raw.toInt();
+    if (raw is String) {
+      final parsed = int.tryParse(raw);
+      if (parsed != null) return parsed;
+    }
+    return _legacySeerrSliderTypeNames[json['type'] as String?];
+  }
 }
+
+/// Serialized names from the short-lived per-slider HomeSectionType values.
+const _legacySeerrSliderTypeNames = {
+  'seerr_tmdb_movie_keyword': 13,
+  'seerr_tmdb_movie_genre': 14,
+  'seerr_tmdb_tv_keyword': 15,
+  'seerr_tmdb_tv_genre': 16,
+  'seerr_tmdb_search': 17,
+  'seerr_tmdb_studio': 18,
+  'seerr_tmdb_network': 19,
+  'seerr_tmdb_movie_streaming': 20,
+  'seerr_tmdb_tv_streaming': 21,
+  'seerr_trakt_recommendations': 22,
+  'seerr_trakt_watchlist': 23,
+  'seerr_trakt_list': 24,
+  'seerr_trakt_history': 25,
+  'seerr_anilist_trending': 26,
+  'seerr_anilist_season': 27,
+  'seerr_anilist_watching': 28,
+  'seerr_anilist_planning': 29,
+  'seerr_anilist_completed': 30,
+  'seerr_anilist_list': 31,
+  'seerr_anilist_popular': 32,
+  'seerr_anilist_top': 33,
+  'seerr_anilist_next_season': 34,
+  'seerr_mdblist_list': 35,
+  'seerr_simkl_trending': 36,
+  'seerr_simkl_plan_to_watch': 37,
+  'seerr_simkl_watching': 44,
+  'seerr_simkl_on_hold': 45,
+  'seerr_simkl_completed': 46,
+  'seerr_simkl_dropped': 47,
+};

--- a/lib/preference/home_section_config.dart
+++ b/lib/preference/home_section_config.dart
@@ -247,12 +247,12 @@ class HomeSectionConfig {
 
   bool get isBuiltin => kind == HomeSectionKind.builtin;
   bool get isPluginDynamic => kind == HomeSectionKind.pluginDynamic;
-  bool get isSeerrCustomSlider => kind == HomeSectionKind.seerrSlider;
+  bool get isSeerrSlider => kind == HomeSectionKind.seerrSlider;
 
-  /// False for slider rows with no id, and for the seerrSlider sentinel saved
-  /// as a builtin (legacy `homeRowOrder` pollution).
+  /// False for slider rows with no id, and for builtin [HomeSectionType.none]
+  /// leftovers from legacy `homeRowOrder` pollution.
   bool get isPersistable {
-    if (isSeerrCustomSlider) {
+    if (isSeerrSlider) {
       return sliderId != null && sliderId!.isNotEmpty;
     }
     if (isBuiltin && type == HomeSectionType.none) {

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -2557,13 +2557,16 @@ class UserPreferences extends ChangeNotifier {
         .toList();
   }
 
-  /// Ordered list of all enabled section configs (builtin + plugin dynamic).
-  /// Built-in `none` entries are filtered out.
+  /// Ordered list of all enabled section configs (builtin + plugin dynamic +
+  /// Seerr custom sliders). Built-in `none` entries are filtered out.
   List<HomeSectionConfig> get activeHomeSectionConfigs {
     final enabled = homeSectionsConfig.where((c) => c.enabled).toList()
       ..sort((a, b) => a.order.compareTo(b.order));
     return enabled
-        .where((c) => c.isPluginDynamic || c.type != HomeSectionType.none)
+        .where((c) =>
+            c.isPluginDynamic ||
+            c.isSeerrCustomSlider ||
+            c.type != HomeSectionType.none)
         .toList();
   }
 

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -2558,14 +2558,14 @@ class UserPreferences extends ChangeNotifier {
   }
 
   /// Ordered list of all enabled section configs (builtin + plugin dynamic +
-  /// Seerr custom sliders). Built-in `none` entries are filtered out.
+  /// Seerr sliders). Built-in `none` entries are filtered out.
   List<HomeSectionConfig> get activeHomeSectionConfigs {
     final enabled = homeSectionsConfig.where((c) => c.enabled).toList()
       ..sort((a, b) => a.order.compareTo(b.order));
     return enabled
         .where((c) =>
             c.isPluginDynamic ||
-            c.isSeerrCustomSlider ||
+            c.isSeerrSlider ||
             c.type != HomeSectionType.none)
         .toList();
   }

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3893,7 +3893,7 @@ class _ContentRowsState extends State<_ContentRows>
   String _localizedRowTitle(HomeRow row, AppLocalizations l10n) {
     final config = widget.prefs.homeSectionsConfig
         .firstWhereOrNull((c) => c.stableId == row.id);
-    if (config != null && config.isSeerrCustomSlider) {
+    if (config != null && config.isSeerrSlider) {
       return localizeSeerrSliderConfigTitle(config, l10n);
     }
     final merge = widget.prefs.get(UserPreferences.mergeContinueWatchingNextUp);

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -3891,6 +3891,11 @@ class _ContentRowsState extends State<_ContentRows>
   }
 
   String _localizedRowTitle(HomeRow row, AppLocalizations l10n) {
+    final config = widget.prefs.homeSectionsConfig
+        .firstWhereOrNull((c) => c.stableId == row.id);
+    if (config != null && config.isSeerrCustomSlider) {
+      return localizeSeerrSliderConfigTitle(config, l10n);
+    }
     final merge = widget.prefs.get(UserPreferences.mergeContinueWatchingNextUp);
     return localizeHomeRowTitle(
       row: row,
@@ -3903,7 +3908,11 @@ class _ContentRowsState extends State<_ContentRows>
     if (row.id == 'merged_calendar' || row.id == 'radarr_calendar' || row.id == 'sonarr_calendar') {
       return 'Radarr and Sonarr Calendars';
     }
-    if (row.id.startsWith('seerr_')) return l10n.seerrDiscoveryRows;
+    if (row.rowType == HomeRowType.seerr ||
+        row.id.startsWith('seerr_') ||
+        row.id.startsWith('seerrSlider:')) {
+      return l10n.seerrDiscoveryRows;
+    }
     if (row.id.startsWith('tmdb_')) return 'TMDB Lists';
     if (row.id.startsWith('imdb_')) return 'IMDb List';
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -31,6 +31,7 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../data/services/seerr/seerr_slider_catalog.dart';
 import '../../../data/services/seerr/seerr_slider_home_sections.dart';
+import '../../util/home_row_title_localizer.dart';
 import '../../../data/utils/bounded_concurrency.dart';
 import '../../../util/platform_detection.dart';
 import '../../../util/server_url.dart';
@@ -2312,7 +2313,11 @@ class HomeViewModel extends ChangeNotifier {
       return [
         _seerrRow(
           cfg.stableId,
-          cfg.pluginDisplayText ?? catalog.title,
+          localizeSeerrSliderTitle(
+            catalog.type,
+            currentAppLocalizations(),
+            serverTitle: cfg.pluginDisplayText ?? catalog.title,
+          ),
           items,
           totalCount: page.totalPages > 1 ? items.length + 1 : items.length,
         ),
@@ -2341,14 +2346,16 @@ class HomeViewModel extends ChangeNotifier {
     );
     final rawItems = page.results;
     _seerrRowPages[row.id] = nextPage;
-    final existingIds = row.items.map((item) => item.id).toSet();
+    final existingIds = row.items.map(_seerrCatalogItemIdentity).toSet();
     final items = [
       ...row.items,
       ..._seerrAggregatedItems(
         rawItems,
         hideAvailable: true,
         blockNsfw: seerrPrefs.blockNsfw,
-      ).where((item) => !existingIds.contains(item.id)),
+      ).where(
+        (item) => !existingIds.contains(_seerrCatalogItemIdentity(item)),
+      ),
     ];
     _rows = List.of(_rows);
     _rows[rowIndex] = row.copyWith(
@@ -2357,6 +2364,9 @@ class HomeViewModel extends ChangeNotifier {
     );
     notifyListeners();
   }
+
+  static String _seerrCatalogItemIdentity(AggregatedItem item) =>
+      '${item.seerrMediaType ?? item.type ?? ''}:${item.id}';
 
   Future<List<HomeRow>> _loadSeerrRow(
     SeerrRowType type,

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -29,6 +29,8 @@ import '../../../preference/user_preferences.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
+import '../../../data/services/seerr/seerr_slider_catalog.dart';
+import '../../../data/services/seerr/seerr_slider_home_sections.dart';
 import '../../../data/utils/bounded_concurrency.dart';
 import '../../../util/platform_detection.dart';
 import '../../../util/server_url.dart';
@@ -100,7 +102,9 @@ class HomeViewModel extends ChangeNotifier {
   /// address against a public domain never matches however it is spelled. With
   /// one server there is nowhere else the row could belong, so keep it anyway.
   bool _belongsToThisServer(HomeSectionConfig cfg) {
-    if (cfg.isBuiltin || cfg.pluginSource == HomeSectionPluginSource.custom) {
+    if (cfg.isBuiltin ||
+        cfg.pluginSource == HomeSectionPluginSource.custom ||
+        cfg.pluginSource == HomeSectionPluginSource.seerr) {
       return true;
     }
     if (!_multiServerEnabled) return true;
@@ -385,6 +389,12 @@ class HomeViewModel extends ChangeNotifier {
         }
       }
 
+      final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
+      final seerrPrefs = GetIt.instance<SeerrPreferences>();
+      if (showSeerrRows && seerrPrefs.enabled) {
+        await _syncSeerrCustomSliderHomeSections();
+      }
+
       final activeConfigs = _prefs.activeHomeSectionConfigs;
       final fallbackUsed = activeConfigs.isEmpty;
       final configs = fallbackUsed
@@ -417,8 +427,6 @@ class HomeViewModel extends ChangeNotifier {
         UserPreferences.displayPlaylistsRows,
       );
       final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
-      final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
-      final seerrPrefs = GetIt.instance<SeerrPreferences>();
       final showImdbRows = _isAnyImdbSectionEnabled();
       final showTmdbRows = _isAnyTmdbSectionEnabled();
       final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
@@ -453,6 +461,8 @@ class HomeViewModel extends ChangeNotifier {
                                 HomeSectionPluginSource.playlists))) &&
                 (showAudioRows || !_isAudioSectionType(c.type)) &&
                 (!_isSeerrSectionType(c.type) || (showSeerrRows && seerrPrefs.isSeerrHomeRowEnabled(c.type))) &&
+                (!c.isSeerrCustomSlider ||
+                    (showSeerrRows && seerrPrefs.enabled)) &&
                 (!_isImdbSectionType(c.type) || (showImdbRows && _isImdbSectionEnabled(c.type))) &&
                 (!_isTmdbSectionType(c.type) || (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
                 (c.type != HomeSectionType.radarrCalendar || _prefs.get(UserPreferences.enableRadarrCalendar)) &&
@@ -919,6 +929,11 @@ class HomeViewModel extends ChangeNotifier {
         await _loadMoreSeerrRow(rowIndex, seerrType);
         return;
       }
+      final sliderId = seerrCustomSliderIdFromStableId(row.id);
+      if (sliderId != null) {
+        await _loadMoreSeerrCatalogRow(rowIndex, sliderId);
+        return;
+      }
 
       // The aggregated multi-server rows take no offset, so they keep the
       // paging they already had.
@@ -959,6 +974,9 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<List<HomeRow>> _loadConfig(HomeSectionConfig cfg, {bool forceRefresh = false}) async {
+    if (cfg.isSeerrCustomSlider) {
+      return _loadSeerrCatalogRow(cfg);
+    }
     if (cfg.isPluginDynamic) {
       final section = cfg.pluginSection;
       if (section == null || section.isEmpty) return const [];
@@ -2244,6 +2262,101 @@ class HomeViewModel extends ChangeNotifier {
   /// Last page fetched per Seerr row. Seerr counts in pages where the rest of
   /// the home rows count in items, so this can't share `_rowOffsets`.
   final Map<String, int> _seerrRowPages = {};
+  Map<int, SeerrSliderCatalog> _seerrCustomCatalogs = {};
+
+  Future<void> _syncSeerrCustomSliderHomeSections() async {
+    _seerrCustomCatalogs = {};
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) return;
+      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      _seerrCustomCatalogs = {
+        for (final (slider, catalog) in resolved) slider.id: catalog,
+      };
+      final current = _prefs.homeSectionsConfig;
+      final merged = mergeSeerrCustomSliderHomeSections(current, resolved);
+      if (HomeSectionConfig.toJsonString(merged) ==
+          HomeSectionConfig.toJsonString(current)) {
+        return;
+      }
+      await _prefs.setHomeSectionsConfig(merged);
+    } catch (e) {
+      debugPrint('[SeerrHomeRow] Failed to sync custom sliders: $e');
+    }
+  }
+
+  Future<List<HomeRow>> _loadSeerrCatalogRow(HomeSectionConfig cfg) async {
+    final sliderId = int.tryParse(cfg.pluginAdditionalData ?? '');
+    final catalog = sliderId == null ? null : _seerrCustomCatalogs[sliderId];
+    if (sliderId == null || catalog == null) return const [];
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      final seerrPrefs = GetIt.instance<SeerrPreferences>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) return const [];
+
+      final page = await repo.getCatalog(
+        catalog.path,
+        query: catalog.query,
+        page: 1,
+        mediaTypeHint: catalog.mediaTypeHint,
+      );
+      final rawItems = page.results;
+      final items = _seerrAggregatedItems(
+        rawItems,
+        hideAvailable: true,
+        blockNsfw: seerrPrefs.blockNsfw,
+      );
+      _seerrRowPages[cfg.stableId] = 1;
+      return [
+        _seerrRow(
+          cfg.stableId,
+          cfg.pluginDisplayText ?? catalog.title,
+          items,
+          totalCount: page.totalPages > 1 ? items.length + 1 : items.length,
+        ),
+      ];
+    } catch (e) {
+      debugPrint('[SeerrHomeRow] Failed to load custom slider $sliderId: $e');
+      return const [];
+    }
+  }
+
+  Future<void> _loadMoreSeerrCatalogRow(int rowIndex, int sliderId) async {
+    final catalog = _seerrCustomCatalogs[sliderId];
+    if (catalog == null) return;
+    final row = _rows[rowIndex];
+    final repo = await GetIt.instance.getAsync<SeerrRepository>();
+    final seerrPrefs = GetIt.instance<SeerrPreferences>();
+    await repo.ensureInitialized();
+    if (!repo.isAvailable) return;
+
+    final nextPage = (_seerrRowPages[row.id] ?? 1) + 1;
+    final page = await repo.getCatalog(
+      catalog.path,
+      query: catalog.query,
+      page: nextPage,
+      mediaTypeHint: catalog.mediaTypeHint,
+    );
+    final rawItems = page.results;
+    _seerrRowPages[row.id] = nextPage;
+    final existingIds = row.items.map((item) => item.id).toSet();
+    final items = [
+      ...row.items,
+      ..._seerrAggregatedItems(
+        rawItems,
+        hideAvailable: true,
+        blockNsfw: seerrPrefs.blockNsfw,
+      ).where((item) => !existingIds.contains(item.id)),
+    ];
+    _rows = List.of(_rows);
+    _rows[rowIndex] = row.copyWith(
+      items: items,
+      totalCount: nextPage >= page.totalPages ? items.length : items.length + 1,
+    );
+    notifyListeners();
+  }
 
   Future<List<HomeRow>> _loadSeerrRow(
     SeerrRowType type,
@@ -2366,7 +2479,13 @@ class HomeViewModel extends ChangeNotifier {
         }
       }
 
-      final items = _seerrAggregatedItems(rawItems, type, blockNsfw);
+      final items = _seerrAggregatedItems(
+        rawItems,
+        hideAvailable: type != SeerrRowType.recentlyAdded &&
+            type != SeerrRowType.recentRequests &&
+            type != SeerrRowType.yourWatchlist,
+        blockNsfw: blockNsfw,
+      );
       _seerrRowPages[rowId] = 1;
 
       // Paging keys off `hasMore`, so a row with further pages has to claim a
@@ -2440,8 +2559,10 @@ class HomeViewModel extends ChangeNotifier {
       ...row.items,
       ..._seerrAggregatedItems(
         rawItems,
-        type,
-        seerrPrefs.blockNsfw,
+        hideAvailable: type != SeerrRowType.recentlyAdded &&
+            type != SeerrRowType.recentRequests &&
+            type != SeerrRowType.yourWatchlist,
+        blockNsfw: seerrPrefs.blockNsfw,
       ).where((item) => !existingIds.contains(item.id)),
     ];
 
@@ -2497,20 +2618,13 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   List<AggregatedItem> _seerrAggregatedItems(
-    List<SeerrDiscoverItem> rawItems,
-    SeerrRowType type,
-    bool blockNsfw,
-  ) {
-    // The request, watchlist and recently added rows are meant to show media the
-    // user already has, so only the discovery rows hide what is available.
-    final hidesAvailable =
-        type != SeerrRowType.recentlyAdded &&
-        type != SeerrRowType.recentRequests &&
-        type != SeerrRowType.yourWatchlist;
-
+    List<SeerrDiscoverItem> rawItems, {
+    required bool hideAvailable,
+    required bool blockNsfw,
+  }) {
     return rawItems
         .where((item) {
-          if (hidesAvailable && (item.isAvailable || item.isBlacklisted)) {
+          if (hideAvailable && (item.isAvailable || item.isBlacklisted)) {
             return false;
           }
           if (blockNsfw) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -105,7 +105,7 @@ class HomeViewModel extends ChangeNotifier {
   bool _belongsToThisServer(HomeSectionConfig cfg) {
     if (cfg.isBuiltin ||
         cfg.pluginSource == HomeSectionPluginSource.custom ||
-        cfg.pluginSource == HomeSectionPluginSource.seerr) {
+        cfg.isSeerrCustomSlider) {
       return true;
     }
     if (!_multiServerEnabled) return true;
@@ -180,8 +180,7 @@ class HomeViewModel extends ChangeNotifier {
       HomeSectionType.playlists ||
       HomeSectionType.audioPlaylists ||
       HomeSectionType.radarrCalendar ||
-      HomeSectionType.sonarrCalendar =>
-        false,
+      HomeSectionType.sonarrCalendar => false,
       final t when _isSeerrSectionType(t) || _isTmdbSectionType(t) => false,
       _ => true,
     };
@@ -315,14 +314,21 @@ class HomeViewModel extends ChangeNotifier {
 
   static int _getSinceYouWatchedIndex(HomeSectionType type) {
     switch (type) {
-      case HomeSectionType.sinceYouWatched1: return 1;
-      case HomeSectionType.sinceYouWatched2: return 2;
-      case HomeSectionType.sinceYouWatched3: return 3;
-      case HomeSectionType.sinceYouWatched4: return 4;
-      case HomeSectionType.sinceYouWatched5: return 5;
-      default: return 0;
+      case HomeSectionType.sinceYouWatched1:
+        return 1;
+      case HomeSectionType.sinceYouWatched2:
+        return 2;
+      case HomeSectionType.sinceYouWatched3:
+        return 3;
+      case HomeSectionType.sinceYouWatched4:
+        return 4;
+      case HomeSectionType.sinceYouWatched5:
+        return 5;
+      default:
+        return 0;
     }
   }
+
   ImageApi imageApiForServer(String serverId) {
     if (!_multiServerEnabled) return _dataSource.imageApi;
     return _multiServerRepo.getImageApiForServer(serverId);
@@ -364,14 +370,16 @@ class HomeViewModel extends ChangeNotifier {
     required bool couldReachServer,
   }) => canReachServer && !couldReachServer;
 
-  Future<void> load({bool preserveExisting = false, bool forceRefresh = false}) async {
+  Future<void> load({
+    bool preserveExisting = false,
+    bool forceRefresh = false,
+  }) async {
     _checkAndTriggerDailyExternalRowsRefresh();
     if (_isLoading) {
       _reloadRequestedWhileLoading = true;
       _pendingReloadPreserveExisting =
           _pendingReloadPreserveExisting && preserveExisting;
-      _pendingReloadForceRefresh =
-          _pendingReloadForceRefresh || forceRefresh;
+      _pendingReloadForceRefresh = _pendingReloadForceRefresh || forceRefresh;
       return;
     }
     _isLoading = true;
@@ -393,7 +401,7 @@ class HomeViewModel extends ChangeNotifier {
       final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
       final seerrPrefs = GetIt.instance<SeerrPreferences>();
       if (showSeerrRows && seerrPrefs.enabled) {
-        await _syncSeerrCustomSliderHomeSections();
+        await _cacheSeerrCustomSliderCatalogs();
       }
 
       final activeConfigs = _prefs.activeHomeSectionConfigs;
@@ -430,8 +438,12 @@ class HomeViewModel extends ChangeNotifier {
       final showAudioRows = _prefs.get(UserPreferences.displayAudioRows);
       final showImdbRows = _isAnyImdbSectionEnabled();
       final showTmdbRows = _isAnyTmdbSectionEnabled();
-      final showSinceYouWatched = _prefs.get(UserPreferences.displaySinceYouWatchedRows);
-      final sinceYouWatchedNum = _prefs.get(UserPreferences.sinceYouWatchedNumRows).value;
+      final showSinceYouWatched = _prefs.get(
+        UserPreferences.displaySinceYouWatchedRows,
+      );
+      final sinceYouWatchedNum = _prefs
+          .get(UserPreferences.sinceYouWatchedNumRows)
+          .value;
       final showRewatch = _prefs.get(UserPreferences.displayRewatchRow);
       final showStudiosRows = _prefs.get(UserPreferences.displayStudiosRows);
 
@@ -461,14 +473,23 @@ class HomeViewModel extends ChangeNotifier {
                             c.pluginSource ==
                                 HomeSectionPluginSource.playlists))) &&
                 (showAudioRows || !_isAudioSectionType(c.type)) &&
-                (!_isSeerrSectionType(c.type) || (showSeerrRows && seerrPrefs.isSeerrHomeRowEnabled(c.type))) &&
+                (!_isSeerrSectionType(c.type) ||
+                    (showSeerrRows &&
+                        seerrPrefs.isSeerrHomeRowEnabled(c.type))) &&
                 (!c.isSeerrCustomSlider ||
                     (showSeerrRows && seerrPrefs.enabled)) &&
-                (!_isImdbSectionType(c.type) || (showImdbRows && _isImdbSectionEnabled(c.type))) &&
-                (!_isTmdbSectionType(c.type) || (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
-                (c.type != HomeSectionType.radarrCalendar || _prefs.get(UserPreferences.enableRadarrCalendar)) &&
-                (c.type != HomeSectionType.sonarrCalendar || _prefs.get(UserPreferences.enableSonarrCalendar)) &&
-                (!_isSinceYouWatchedSectionType(c.type) || (showSinceYouWatched && _getSinceYouWatchedIndex(c.type) <= sinceYouWatchedNum)) &&
+                (!_isImdbSectionType(c.type) ||
+                    (showImdbRows && _isImdbSectionEnabled(c.type))) &&
+                (!_isTmdbSectionType(c.type) ||
+                    (showTmdbRows && _isTmdbSectionEnabled(c.type))) &&
+                (c.type != HomeSectionType.radarrCalendar ||
+                    _prefs.get(UserPreferences.enableRadarrCalendar)) &&
+                (c.type != HomeSectionType.sonarrCalendar ||
+                    _prefs.get(UserPreferences.enableSonarrCalendar)) &&
+                (!_isSinceYouWatchedSectionType(c.type) ||
+                    (showSinceYouWatched &&
+                        _getSinceYouWatchedIndex(c.type) <=
+                            sinceYouWatchedNum)) &&
                 (c.type != HomeSectionType.rewatch || showRewatch),
           )
           .toList(growable: false);
@@ -566,15 +587,15 @@ class HomeViewModel extends ChangeNotifier {
           sectionRows = const <HomeRow>[];
         }
         final currentConfigs = _prefs.activeHomeSectionConfigs;
-        final isStillActive = currentConfigs.any((c) => c.stableId == cfg.stableId);
+        final isStillActive = currentConfigs.any(
+          (c) => c.stableId == cfg.stableId,
+        );
         if (!isStillActive) return;
         // Cleanup runs even when the load failed, so the section's loading
         // placeholder is cleared instead of spinning forever.
         final loadedRows = sectionRows
             .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
-            .where(
-              (r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv,
-            )
+            .where((r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv)
             .toList();
         final placeholder = _placeholderForConfig(cfg);
         final loadedIds = loadedRows.map((r) => r.id).toSet();
@@ -648,7 +669,10 @@ class HomeViewModel extends ChangeNotifier {
         _reloadRequestedWhileLoading = false;
         _pendingReloadPreserveExisting = true;
         _pendingReloadForceRefresh = false;
-        await load(preserveExisting: nextPreserveExisting, forceRefresh: nextForceRefresh);
+        await load(
+          preserveExisting: nextPreserveExisting,
+          forceRefresh: nextForceRefresh,
+        );
       }
     }
   }
@@ -693,7 +717,7 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   bool _rowBelongsToConfig(HomeRow row, HomeSectionConfig cfg) {
-    if (cfg.isPluginDynamic) {
+    if (cfg.isPluginDynamic || cfg.isSeerrCustomSlider) {
       return row.id == cfg.stableId;
     }
 
@@ -829,7 +853,8 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.sinceYouWatched4:
       case HomeSectionType.sinceYouWatched5:
         final idx = _getSinceYouWatchedIndex(cfg.type);
-        return row.rowType == HomeRowType.latestMedia && row.id == 'sinceYouWatched$idx';
+        return row.rowType == HomeRowType.latestMedia &&
+            row.id == 'sinceYouWatched$idx';
       case HomeSectionType.rewatch:
         return row.rowType == HomeRowType.latestMedia && row.id == 'rewatch';
       case HomeSectionType.resumeBook:
@@ -974,7 +999,10 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
-  Future<List<HomeRow>> _loadConfig(HomeSectionConfig cfg, {bool forceRefresh = false}) async {
+  Future<List<HomeRow>> _loadConfig(
+    HomeSectionConfig cfg, {
+    bool forceRefresh = false,
+  }) async {
     if (cfg.isSeerrCustomSlider) {
       return _loadSeerrCatalogRow(cfg);
     }
@@ -996,6 +1024,14 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   HomeRow? _placeholderForConfig(HomeSectionConfig cfg) {
+    if (cfg.isSeerrCustomSlider) {
+      return HomeRow(
+        id: cfg.stableId,
+        title: localizeSeerrSliderConfigTitle(cfg, currentAppLocalizations()),
+        rowType: HomeRowType.seerr,
+        isLoading: true,
+      );
+    }
     if (cfg.isPluginDynamic) {
       final section = cfg.pluginSection;
       if (section == null || section.isEmpty) return null;
@@ -1154,7 +1190,10 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
-  Future<List<HomeRow>> _loadSection(HomeSectionType section, {bool forceRefresh = false}) async {
+  Future<List<HomeRow>> _loadSection(
+    HomeSectionType section, {
+    bool forceRefresh = false,
+  }) async {
     final l10n = currentAppLocalizations();
     final favoritesSortBy = _prefs
         .get(UserPreferences.favoritesRowSortBy)
@@ -1329,8 +1368,12 @@ class HomeViewModel extends ChangeNotifier {
                 ),
         ];
       case HomeSectionType.studios:
-        final studiosSortBy = _prefs.get(UserPreferences.studiosRowSortBy).apiValue;
-        final studiosSortOrder = _prefs.get(UserPreferences.studiosRowSortOrder).apiValue;
+        final studiosSortBy = _prefs
+            .get(UserPreferences.studiosRowSortBy)
+            .apiValue;
+        final studiosSortOrder = _prefs
+            .get(UserPreferences.studiosRowSortOrder)
+            .apiValue;
         final selectedIds = _prefs.get(UserPreferences.studiosRowSelectedIds);
         return [
           _multiServerEnabled
@@ -1517,31 +1560,83 @@ class HomeViewModel extends ChangeNotifier {
           'imdb_top_english_movies',
         );
       case HomeSectionType.tmdbPopularMovies:
-        return _loadTmdbChartRow(HomeSectionType.tmdbPopularMovies, 'Popular Movies', 'tmdb_popular_movies');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbPopularMovies,
+          'Popular Movies',
+          'tmdb_popular_movies',
+        );
       case HomeSectionType.tmdbTopRatedMovies:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTopRatedMovies, 'Top Rated Movies', 'tmdb_top_rated_movies');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTopRatedMovies,
+          'Top Rated Movies',
+          'tmdb_top_rated_movies',
+        );
       case HomeSectionType.tmdbNowPlayingMovies:
-        return _loadTmdbChartRow(HomeSectionType.tmdbNowPlayingMovies, 'Now Playing Movies', 'tmdb_now_playing_movies');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbNowPlayingMovies,
+          'Now Playing Movies',
+          'tmdb_now_playing_movies',
+        );
       case HomeSectionType.tmdbUpcomingMovies:
-        return _loadTmdbChartRow(HomeSectionType.tmdbUpcomingMovies, 'Upcoming Movies', 'tmdb_upcoming_movies');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbUpcomingMovies,
+          'Upcoming Movies',
+          'tmdb_upcoming_movies',
+        );
       case HomeSectionType.tmdbPopularTv:
-        return _loadTmdbChartRow(HomeSectionType.tmdbPopularTv, 'Popular TV', 'tmdb_popular_tv');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbPopularTv,
+          'Popular TV',
+          'tmdb_popular_tv',
+        );
       case HomeSectionType.tmdbTopRatedTv:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTopRatedTv, 'Top Rated TV', 'tmdb_top_rated_tv');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTopRatedTv,
+          'Top Rated TV',
+          'tmdb_top_rated_tv',
+        );
       case HomeSectionType.tmdbAiringTodayTv:
-        return _loadTmdbChartRow(HomeSectionType.tmdbAiringTodayTv, 'Airing Today TV', 'tmdb_airing_today_tv');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbAiringTodayTv,
+          'Airing Today TV',
+          'tmdb_airing_today_tv',
+        );
       case HomeSectionType.tmdbOnTheAirTv:
-        return _loadTmdbChartRow(HomeSectionType.tmdbOnTheAirTv, 'On The Air TV', 'tmdb_on_the_air_tv');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbOnTheAirTv,
+          'On The Air TV',
+          'tmdb_on_the_air_tv',
+        );
       case HomeSectionType.tmdbTrendingMovieDaily:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingMovieDaily, 'Trending Movies (Daily)', 'tmdb_trending_movie_daily');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTrendingMovieDaily,
+          'Trending Movies (Daily)',
+          'tmdb_trending_movie_daily',
+        );
       case HomeSectionType.tmdbTrendingMovieWeekly:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingMovieWeekly, 'Trending Movies (Weekly)', 'tmdb_trending_movie_weekly');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTrendingMovieWeekly,
+          'Trending Movies (Weekly)',
+          'tmdb_trending_movie_weekly',
+        );
       case HomeSectionType.tmdbTrendingTvDaily:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingTvDaily, 'Trending TV (Daily)', 'tmdb_trending_tv_daily');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTrendingTvDaily,
+          'Trending TV (Daily)',
+          'tmdb_trending_tv_daily',
+        );
       case HomeSectionType.tmdbTrendingTvWeekly:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingTvWeekly, 'Trending TV (Weekly)', 'tmdb_trending_tv_weekly');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTrendingTvWeekly,
+          'Trending TV (Weekly)',
+          'tmdb_trending_tv_weekly',
+        );
       case HomeSectionType.tmdbTrendingAllWeekly:
-        return _loadTmdbChartRow(HomeSectionType.tmdbTrendingAllWeekly, 'Trending All (Weekly)', 'tmdb_trending_all_weekly');
+        return _loadTmdbChartRow(
+          HomeSectionType.tmdbTrendingAllWeekly,
+          'Trending All (Weekly)',
+          'tmdb_trending_all_weekly',
+        );
       case HomeSectionType.recentlyReleased:
         return _loadRecentlyReleasedRow();
       case HomeSectionType.sinceYouWatched1:
@@ -1550,7 +1645,10 @@ class HomeViewModel extends ChangeNotifier {
       case HomeSectionType.sinceYouWatched4:
       case HomeSectionType.sinceYouWatched5:
         final rowIndex = _getSinceYouWatchedIndex(section);
-        final row = await _dataSource.loadSinceYouWatchedRow(_serverId, rowIndex);
+        final row = await _dataSource.loadSinceYouWatchedRow(
+          _serverId,
+          rowIndex,
+        );
         return [row];
       case HomeSectionType.rewatch:
         final row = await _dataSource.loadRewatchRow(_serverId);
@@ -1639,8 +1737,9 @@ class HomeViewModel extends ChangeNotifier {
     final mergedRows = <HomeRow>[];
     for (final entry in grouped.entries) {
       final collectionType = entry.key;
-      final loadedRows = (await Future.wait(entry.value.map(rowFor)))
-          .whereType<HomeRow>();
+      final loadedRows = (await Future.wait(
+        entry.value.map(rowFor),
+      )).whereType<HomeRow>();
 
       // The same title can sit in more than one library, so it is kept once.
       final seenIds = <String>{};
@@ -1816,49 +1915,49 @@ class HomeViewModel extends ChangeNotifier {
         return HomeRow(
           id: 'seerr_recent_requests',
           title: l10n.recentRequests,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrWatchlist:
         return HomeRow(
           id: 'seerr_watchlist',
           title: l10n.yourWatchlist,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrRecentlyAdded:
         return HomeRow(
           id: 'seerr_recently_added',
           title: l10n.recentlyAdded,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrPopularMovies:
         return HomeRow(
           id: 'seerr_popular_movies',
           title: l10n.popularMovies,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrUpcomingMovies:
         return HomeRow(
           id: 'seerr_upcoming_movies',
           title: l10n.upcomingMovies,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrPopularSeries:
         return HomeRow(
           id: 'seerr_popular_series',
           title: l10n.popularSeries,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrUpcomingSeries:
         return HomeRow(
           id: 'seerr_upcoming_series',
           title: l10n.upcomingSeries,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrShortcuts:
@@ -1867,35 +1966,35 @@ class HomeViewModel extends ChangeNotifier {
         return HomeRow(
           id: 'seerr_trending',
           title: l10n.trending,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrMovieGenres:
         return HomeRow(
           id: 'seerr_movie_genres',
           title: l10n.movieGenres,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrStudios:
         return HomeRow(
           id: 'seerr_studios',
           title: l10n.studios,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrSeriesGenres:
         return HomeRow(
           id: 'seerr_series_genres',
           title: l10n.seriesGenres,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.seerrNetworks:
         return HomeRow(
           id: 'seerr_networks',
           title: l10n.networks,
-          rowType: HomeRowType.pluginDynamic,
+          rowType: HomeRowType.seerr,
           isLoading: true,
         );
       case HomeSectionType.radarrCalendar:
@@ -2265,30 +2364,24 @@ class HomeViewModel extends ChangeNotifier {
   final Map<String, int> _seerrRowPages = {};
   Map<int, SeerrSliderCatalog> _seerrCustomCatalogs = {};
 
-  Future<void> _syncSeerrCustomSliderHomeSections() async {
-    _seerrCustomCatalogs = {};
+  Future<void> _cacheSeerrCustomSliderCatalogs() async {
     try {
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       await repo.ensureInitialized();
       if (!repo.isAvailable) return;
-      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      final resolved = resolveSeerrCustomSliders(
+        await repo.getDiscoverSliders(),
+      );
       _seerrCustomCatalogs = {
         for (final (slider, catalog) in resolved) slider.id: catalog,
       };
-      final current = _prefs.homeSectionsConfig;
-      final merged = mergeSeerrCustomSliderHomeSections(current, resolved);
-      if (HomeSectionConfig.toJsonString(merged) ==
-          HomeSectionConfig.toJsonString(current)) {
-        return;
-      }
-      await _prefs.setHomeSectionsConfig(merged);
     } catch (e) {
-      debugPrint('[SeerrHomeRow] Failed to sync custom sliders: $e');
+      debugPrint('[SeerrHomeRow] Failed to load custom sliders: $e');
     }
   }
 
   Future<List<HomeRow>> _loadSeerrCatalogRow(HomeSectionConfig cfg) async {
-    final sliderId = int.tryParse(cfg.pluginAdditionalData ?? '');
+    final sliderId = cfg.seerrSliderId;
     final catalog = sliderId == null ? null : _seerrCustomCatalogs[sliderId];
     if (sliderId == null || catalog == null) return const [];
     try {
@@ -2316,7 +2409,7 @@ class HomeViewModel extends ChangeNotifier {
           localizeSeerrSliderTitle(
             catalog.type,
             currentAppLocalizations(),
-            serverTitle: cfg.pluginDisplayText ?? catalog.title,
+            serverTitle: catalog.title,
           ),
           items,
           totalCount: page.totalPages > 1 ? items.length + 1 : items.length,
@@ -2353,9 +2446,7 @@ class HomeViewModel extends ChangeNotifier {
         rawItems,
         hideAvailable: true,
         blockNsfw: seerrPrefs.blockNsfw,
-      ).where(
-        (item) => !existingIds.contains(_seerrCatalogItemIdentity(item)),
-      ),
+      ).where((item) => !existingIds.contains(_seerrCatalogItemIdentity(item))),
     ];
     _rows = List.of(_rows);
     _rows[rowIndex] = row.copyWith(
@@ -2491,7 +2582,8 @@ class HomeViewModel extends ChangeNotifier {
 
       final items = _seerrAggregatedItems(
         rawItems,
-        hideAvailable: type != SeerrRowType.recentlyAdded &&
+        hideAvailable:
+            type != SeerrRowType.recentlyAdded &&
             type != SeerrRowType.recentRequests &&
             type != SeerrRowType.yourWatchlist,
         blockNsfw: blockNsfw,
@@ -2569,7 +2661,8 @@ class HomeViewModel extends ChangeNotifier {
       ...row.items,
       ..._seerrAggregatedItems(
         rawItems,
-        hideAvailable: type != SeerrRowType.recentlyAdded &&
+        hideAvailable:
+            type != SeerrRowType.recentlyAdded &&
             type != SeerrRowType.recentRequests &&
             type != SeerrRowType.yourWatchlist,
         blockNsfw: seerrPrefs.blockNsfw,
@@ -2678,7 +2771,7 @@ class HomeViewModel extends ChangeNotifier {
     return HomeRow(
       id: rowId,
       title: title,
-      rowType: HomeRowType.pluginDynamic,
+      rowType: HomeRowType.seerr,
       items: items,
       totalCount: totalCount,
     );
@@ -2856,7 +2949,6 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
-
   Future<List<HomeRow>> _loadImdbRow(
     HomeSectionType sectionType,
     String title,
@@ -2869,10 +2961,7 @@ class HomeViewModel extends ChangeNotifier {
         pluginSection: rowId,
         pluginDisplayText: title,
         pluginSource: HomeSectionPluginSource.custom,
-        pluginAdditionalData: jsonEncode({
-          'source': 'imdb',
-          'type': rowId,
-        }),
+        pluginAdditionalData: jsonEncode({'source': 'imdb', 'type': rowId}),
       );
 
       var items = await customService.loadCustomRowFromCache(
@@ -2914,7 +3003,7 @@ class HomeViewModel extends ChangeNotifier {
           title: title,
           rowType: HomeRowType.pluginDynamic,
           items: aggregatedItems,
-        )
+        ),
       ];
     } catch (e) {
       debugPrint('[ImdbRow] Failed to load IMDb row $sectionType: $e');
@@ -2979,10 +3068,12 @@ class HomeViewModel extends ChangeNotifier {
           title: title,
           rowType: HomeRowType.pluginDynamic,
           items: aggregatedItems,
-        )
+        ),
       ];
     } catch (e) {
-      debugPrint('[TmdbChartRow] Failed to load TMDB chart row $sectionType: $e');
+      debugPrint(
+        '[TmdbChartRow] Failed to load TMDB chart row $sectionType: $e',
+      );
       return const [];
     }
   }
@@ -3017,7 +3108,9 @@ class HomeViewModel extends ChangeNotifier {
     return null;
   }
 
-  List<AggregatedItem> _filterAndFormatRadarrItems(List<AggregatedItem> rawItems) {
+  List<AggregatedItem> _filterAndFormatRadarrItems(
+    List<AggregatedItem> rawItems,
+  ) {
     final now = DateTime.now();
     final showCinema = _prefs.get(UserPreferences.radarrCalendarShowCinema);
     final showDigital = _prefs.get(UserPreferences.radarrCalendarShowDigital);
@@ -3031,18 +3124,30 @@ class HomeViewModel extends ChangeNotifier {
       final digitalReleaseStr = item.rawData['DigitalRelease'] as String?;
       final physicalReleaseStr = item.rawData['PhysicalRelease'] as String?;
 
-      final inCinemas = inCinemasStr != null ? DateTime.tryParse(inCinemasStr) : null;
-      final digitalRelease = digitalReleaseStr != null ? DateTime.tryParse(digitalReleaseStr) : null;
-      final physicalRelease = physicalReleaseStr != null ? DateTime.tryParse(physicalReleaseStr) : null;
+      final inCinemas = inCinemasStr != null
+          ? DateTime.tryParse(inCinemasStr)
+          : null;
+      final digitalRelease = digitalReleaseStr != null
+          ? DateTime.tryParse(digitalReleaseStr)
+          : null;
+      final physicalRelease = physicalReleaseStr != null
+          ? DateTime.tryParse(physicalReleaseStr)
+          : null;
 
       final enabledReleases = <DateTime, String>{};
-      if (showCinema && inCinemas != null && inCinemas.isAfter(now.subtract(const Duration(days: 1)))) {
+      if (showCinema &&
+          inCinemas != null &&
+          inCinemas.isAfter(now.subtract(const Duration(days: 1)))) {
         enabledReleases[inCinemas] = 'Cinema: ';
       }
-      if (showDigital && digitalRelease != null && digitalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+      if (showDigital &&
+          digitalRelease != null &&
+          digitalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
         enabledReleases[digitalRelease] = 'Digital: ';
       }
-      if (showPhysical && physicalRelease != null && physicalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
+      if (showPhysical &&
+          physicalRelease != null &&
+          physicalRelease.isAfter(now.subtract(const Duration(days: 1)))) {
         enabledReleases[physicalRelease] = 'Physical: ';
       }
 
@@ -3080,11 +3185,15 @@ class HomeViewModel extends ChangeNotifier {
 
   List<AggregatedItem> _formatSonarrItems(List<AggregatedItem> rawItems) {
     final showDate = _prefs.get(UserPreferences.sonarrCalendarShowDate);
-    final showEpisodeInfo = _prefs.get(UserPreferences.sonarrCalendarShowEpisodeInfo);
+    final showEpisodeInfo = _prefs.get(
+      UserPreferences.sonarrCalendarShowEpisodeInfo,
+    );
 
     return rawItems.map((item) {
       final airDateUtcStr = item.rawData['CalendarDate'] as String?;
-      final airDateUtc = airDateUtcStr != null ? DateTime.tryParse(airDateUtcStr) : null;
+      final airDateUtc = airDateUtcStr != null
+          ? DateTime.tryParse(airDateUtcStr)
+          : null;
       if (airDateUtc == null) return item;
 
       final sNum = item.rawData['SeasonNumber'] as String? ?? '0';
@@ -3112,7 +3221,9 @@ class HomeViewModel extends ChangeNotifier {
     }).toList();
   }
 
-  Future<List<HomeRow>> _loadRadarrCalendarRow({bool forceRefresh = false}) async {
+  Future<List<HomeRow>> _loadRadarrCalendarRow({
+    bool forceRefresh = false,
+  }) async {
     final merge = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
     if (merge) {
       return _loadMergedCalendarRow(forceRefresh: forceRefresh);
@@ -3121,7 +3232,8 @@ class HomeViewModel extends ChangeNotifier {
       final nowMs = DateTime.now().millisecondsSinceEpoch;
       final lastFetch = _prefs.get(UserPreferences.lastRadarrCalendarFetchTime);
       final cacheAge = nowMs - lastFetch;
-      final shouldFetch = forceRefresh || cacheAge > const Duration(days: 1).inMilliseconds;
+      final shouldFetch =
+          forceRefresh || cacheAge > const Duration(days: 1).inMilliseconds;
 
       List<AggregatedItem> items;
       if (shouldFetch) {
@@ -3141,7 +3253,10 @@ class HomeViewModel extends ChangeNotifier {
           final fetchedItems = await _fetchRadarrCalendarFromApi();
           if (fetchedItems != null) {
             await _saveRadarrCalendarToCache(fetchedItems);
-            await _prefs.set(UserPreferences.lastRadarrCalendarFetchTime, nowMs);
+            await _prefs.set(
+              UserPreferences.lastRadarrCalendarFetchTime,
+              nowMs,
+            );
             items = _filterAndFormatRadarrItems(fetchedItems);
           }
         }
@@ -3153,7 +3268,7 @@ class HomeViewModel extends ChangeNotifier {
           title: 'Upcoming Movies (Radarr)',
           rowType: HomeRowType.pluginDynamic,
           items: items,
-        )
+        ),
       ];
     } catch (e) {
       debugPrint('[RadarrCalendar] Failed to load: $e');
@@ -3161,10 +3276,14 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
-  Future<List<HomeRow>> _loadSonarrCalendarRow({bool forceRefresh = false}) async {
+  Future<List<HomeRow>> _loadSonarrCalendarRow({
+    bool forceRefresh = false,
+  }) async {
     final merge = _prefs.get(UserPreferences.mergeRadarrSonarrCalendars);
     if (merge) {
-      final hasRadarrConfig = _prefs.homeSectionsConfig.any((c) => c.enabled && c.type == HomeSectionType.radarrCalendar);
+      final hasRadarrConfig = _prefs.homeSectionsConfig.any(
+        (c) => c.enabled && c.type == HomeSectionType.radarrCalendar,
+      );
       if (hasRadarrConfig) {
         return const [];
       } else {
@@ -3175,7 +3294,8 @@ class HomeViewModel extends ChangeNotifier {
       final nowMs = DateTime.now().millisecondsSinceEpoch;
       final lastFetch = _prefs.get(UserPreferences.lastSonarrCalendarFetchTime);
       final cacheAge = nowMs - lastFetch;
-      final shouldFetch = forceRefresh || cacheAge > const Duration(days: 1).inMilliseconds;
+      final shouldFetch =
+          forceRefresh || cacheAge > const Duration(days: 1).inMilliseconds;
 
       List<AggregatedItem> items;
       if (shouldFetch) {
@@ -3195,7 +3315,10 @@ class HomeViewModel extends ChangeNotifier {
           final fetchedItems = await _fetchSonarrCalendarFromApi();
           if (fetchedItems != null) {
             await _saveSonarrCalendarToCache(fetchedItems);
-            await _prefs.set(UserPreferences.lastSonarrCalendarFetchTime, nowMs);
+            await _prefs.set(
+              UserPreferences.lastSonarrCalendarFetchTime,
+              nowMs,
+            );
             items = _formatSonarrItems(fetchedItems);
           }
         }
@@ -3207,7 +3330,7 @@ class HomeViewModel extends ChangeNotifier {
           title: 'Upcoming TV Shows (Sonarr)',
           rowType: HomeRowType.pluginDynamic,
           items: items,
-        )
+        ),
       ];
     } catch (e) {
       debugPrint('[SonarrCalendar] Failed to load: $e');
@@ -3229,9 +3352,13 @@ class HomeViewModel extends ChangeNotifier {
       if (await file.exists()) {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
-        final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
+        final items = list
+            .map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>))
+            .toList();
         if (_isStaleCalendarCache(items)) {
-          debugPrint('[RadarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
+          debugPrint(
+            '[RadarrCalendarCache] Old cache detected, invalidating to force fresh fetch',
+          );
           try {
             await file.delete();
           } catch (_) {}
@@ -3249,7 +3376,9 @@ class HomeViewModel extends ChangeNotifier {
     try {
       final dir = await getApplicationSupportDirectory();
       final file = File('${dir.path}/radarr_calendar_cache.json');
-      final content = jsonEncode(items.map((x) => _aggregatedItemToJson(x)).toList());
+      final content = jsonEncode(
+        items.map((x) => _aggregatedItemToJson(x)).toList(),
+      );
       await file.writeAsString(content, flush: true);
     } catch (e) {
       debugPrint('[RadarrCalendarCache] Failed to save: $e');
@@ -3263,9 +3392,13 @@ class HomeViewModel extends ChangeNotifier {
       if (await file.exists()) {
         final content = await file.readAsString();
         final list = jsonDecode(content) as List;
-        final items = list.map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>)).toList();
+        final items = list
+            .map((x) => _aggregatedItemFromJson(x as Map<String, dynamic>))
+            .toList();
         if (_isStaleCalendarCache(items)) {
-          debugPrint('[SonarrCalendarCache] Old cache detected, invalidating to force fresh fetch');
+          debugPrint(
+            '[SonarrCalendarCache] Old cache detected, invalidating to force fresh fetch',
+          );
           try {
             await file.delete();
           } catch (_) {}
@@ -3283,7 +3416,9 @@ class HomeViewModel extends ChangeNotifier {
     try {
       final dir = await getApplicationSupportDirectory();
       final file = File('${dir.path}/sonarr_calendar_cache.json');
-      final content = jsonEncode(items.map((x) => _aggregatedItemToJson(x)).toList());
+      final content = jsonEncode(
+        items.map((x) => _aggregatedItemToJson(x)).toList(),
+      );
       await file.writeAsString(content, flush: true);
     } catch (e) {
       debugPrint('[SonarrCalendarCache] Failed to save: $e');
@@ -3291,11 +3426,7 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Map<String, dynamic> _aggregatedItemToJson(AggregatedItem item) {
-    return {
-      'id': item.id,
-      'serverId': item.serverId,
-      'rawData': item.rawData,
-    };
+    return {'id': item.id, 'serverId': item.serverId, 'rawData': item.rawData};
   }
 
   AggregatedItem _aggregatedItemFromJson(Map<String, dynamic> json) {
@@ -3421,7 +3552,10 @@ class HomeViewModel extends ChangeNotifier {
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       final now = DateTime.now();
       final start = now.toIso8601String().substring(0, 10);
-      final end = now.add(const Duration(days: 90)).toIso8601String().substring(0, 10);
+      final end = now
+          .add(const Duration(days: 90))
+          .toIso8601String()
+          .substring(0, 10);
 
       // The plugin fetches the Sonarr calendar server side, so the API key stays on the server and
       // this still works when a remote client cant reach a LAN only Sonarr.
@@ -3438,7 +3572,9 @@ class HomeViewModel extends ChangeNotifier {
         final tvdbId = tvdbIdVal as int;
 
         final airDateUtcStr = res['airDateUtc'] as String?;
-        final airDateUtc = airDateUtcStr != null ? DateTime.tryParse(airDateUtcStr) : null;
+        final airDateUtc = airDateUtcStr != null
+            ? DateTime.tryParse(airDateUtcStr)
+            : null;
         if (airDateUtc == null) continue;
 
         final existing = groupedEpisodes[tvdbId];
@@ -3489,7 +3625,8 @@ class HomeViewModel extends ChangeNotifier {
             for (final img in images) {
               if (img is! Map) continue;
               final type = img['coverType'] as String?;
-              final remoteUrl = img['remoteUrl'] as String? ?? img['url'] as String?;
+              final remoteUrl =
+                  img['remoteUrl'] as String? ?? img['url'] as String?;
               // Only external image URLs are used. A local arr image would need the API key and
               // wouldnt be reachable from a remote client anyway.
               if (remoteUrl != null && remoteUrl.startsWith('http')) {
@@ -3564,7 +3701,7 @@ class HomeViewModel extends ChangeNotifier {
       'Sep.',
       'Oct.',
       'Nov.',
-      'Dec.'
+      'Dec.',
     ];
     final month = months[date.month - 1];
     final day = date.day;
@@ -3577,14 +3714,20 @@ class HomeViewModel extends ChangeNotifier {
     return '$month $day$suffix';
   }
 
-  Future<List<HomeRow>> _loadMergedCalendarRow({bool forceRefresh = false}) async {
+  Future<List<HomeRow>> _loadMergedCalendarRow({
+    bool forceRefresh = false,
+  }) async {
     try {
       final nowMs = DateTime.now().millisecondsSinceEpoch;
 
       // 1. Load Radarr items
-      final lastRadarrFetch = _prefs.get(UserPreferences.lastRadarrCalendarFetchTime);
+      final lastRadarrFetch = _prefs.get(
+        UserPreferences.lastRadarrCalendarFetchTime,
+      );
       final radarrCacheAge = nowMs - lastRadarrFetch;
-      final shouldFetchRadarr = forceRefresh || radarrCacheAge > const Duration(days: 1).inMilliseconds;
+      final shouldFetchRadarr =
+          forceRefresh ||
+          radarrCacheAge > const Duration(days: 1).inMilliseconds;
 
       List<AggregatedItem> radarrItems;
       if (shouldFetchRadarr) {
@@ -3603,15 +3746,22 @@ class HomeViewModel extends ChangeNotifier {
           if (fetched != null) {
             radarrItems = fetched;
             await _saveRadarrCalendarToCache(radarrItems);
-            await _prefs.set(UserPreferences.lastRadarrCalendarFetchTime, nowMs);
+            await _prefs.set(
+              UserPreferences.lastRadarrCalendarFetchTime,
+              nowMs,
+            );
           }
         }
       }
 
       // 2. Load Sonarr items
-      final lastSonarrFetch = _prefs.get(UserPreferences.lastSonarrCalendarFetchTime);
+      final lastSonarrFetch = _prefs.get(
+        UserPreferences.lastSonarrCalendarFetchTime,
+      );
       final sonarrCacheAge = nowMs - lastSonarrFetch;
-      final shouldFetchSonarr = forceRefresh || sonarrCacheAge > const Duration(days: 1).inMilliseconds;
+      final shouldFetchSonarr =
+          forceRefresh ||
+          sonarrCacheAge > const Duration(days: 1).inMilliseconds;
 
       List<AggregatedItem> sonarrItems;
       if (shouldFetchSonarr) {
@@ -3630,7 +3780,10 @@ class HomeViewModel extends ChangeNotifier {
           if (fetched != null) {
             sonarrItems = fetched;
             await _saveSonarrCalendarToCache(sonarrItems);
-            await _prefs.set(UserPreferences.lastSonarrCalendarFetchTime, nowMs);
+            await _prefs.set(
+              UserPreferences.lastSonarrCalendarFetchTime,
+              nowMs,
+            );
           }
         }
       }
@@ -3651,7 +3804,7 @@ class HomeViewModel extends ChangeNotifier {
           title: 'Upcoming Releases',
           rowType: HomeRowType.pluginDynamic,
           items: mergedItems,
-        )
+        ),
       ];
     } catch (e) {
       debugPrint('[MergedCalendar] Failed to load merged calendar: $e');
@@ -3660,10 +3813,13 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   Future<void> _checkAndTriggerDailyExternalRowsRefresh() async {
-    final lastRefreshMs = _prefs.get(UserPreferences.lastExternalRowsRefreshTime);
+    final lastRefreshMs = _prefs.get(
+      UserPreferences.lastExternalRowsRefreshTime,
+    );
     final now = DateTime.now();
     final lastRefreshDate = DateTime.fromMillisecondsSinceEpoch(lastRefreshMs);
-    final isDifferentDay = lastRefreshMs == 0 ||
+    final isDifferentDay =
+        lastRefreshMs == 0 ||
         now.year != lastRefreshDate.year ||
         now.month != lastRefreshDate.month ||
         now.day != lastRefreshDate.day ||
@@ -3671,9 +3827,14 @@ class HomeViewModel extends ChangeNotifier {
 
     if (!isDifferentDay) return;
 
-    debugPrint('[DailyRefresh] Day changed or first run. Triggering background cache refresh of enabled lists...');
+    debugPrint(
+      '[DailyRefresh] Day changed or first run. Triggering background cache refresh of enabled lists...',
+    );
 
-    await _prefs.set(UserPreferences.lastExternalRowsRefreshTime, now.millisecondsSinceEpoch);
+    await _prefs.set(
+      UserPreferences.lastExternalRowsRefreshTime,
+      now.millisecondsSinceEpoch,
+    );
 
     unawaited(() async {
       try {
@@ -3687,12 +3848,15 @@ class HomeViewModel extends ChangeNotifier {
         final customService = GetIt.instance<CustomExternalListsService>();
         final configs = _prefs.homeSectionsConfig;
         for (final config in configs) {
-          if (config.pluginSource == HomeSectionPluginSource.custom && config.enabled) {
+          if (config.pluginSource == HomeSectionPluginSource.custom &&
+              config.enabled) {
             futures.add(() async {
               try {
                 await customService.fetchCustomRow(config, forceRefresh: true);
               } catch (e) {
-                debugPrint('[DailyRefresh] Failed to refresh custom row ${config.pluginSection}: $e');
+                debugPrint(
+                  '[DailyRefresh] Failed to refresh custom row ${config.pluginSection}: $e',
+                );
               }
             }());
           }
@@ -3700,7 +3864,9 @@ class HomeViewModel extends ChangeNotifier {
 
         if (futures.isNotEmpty) {
           await Future.wait(futures);
-          debugPrint('[DailyRefresh] Background cache refresh complete. Reloading HomeViewModel rows...');
+          debugPrint(
+            '[DailyRefresh] Background cache refresh complete. Reloading HomeViewModel rows...',
+          );
           await load(preserveExisting: true);
         }
       } catch (e) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -105,7 +105,7 @@ class HomeViewModel extends ChangeNotifier {
   bool _belongsToThisServer(HomeSectionConfig cfg) {
     if (cfg.isBuiltin ||
         cfg.pluginSource == HomeSectionPluginSource.custom ||
-        cfg.isSeerrCustomSlider) {
+        cfg.isSeerrSlider) {
       return true;
     }
     if (!_multiServerEnabled) return true;
@@ -401,7 +401,7 @@ class HomeViewModel extends ChangeNotifier {
       final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
       final seerrPrefs = GetIt.instance<SeerrPreferences>();
       if (showSeerrRows && seerrPrefs.enabled) {
-        await _cacheSeerrCustomSliderCatalogs();
+        await _cacheSeerrSliderCatalogs();
       }
 
       final activeConfigs = _prefs.activeHomeSectionConfigs;
@@ -476,7 +476,7 @@ class HomeViewModel extends ChangeNotifier {
                 (!_isSeerrSectionType(c.type) ||
                     (showSeerrRows &&
                         seerrPrefs.isSeerrHomeRowEnabled(c.type))) &&
-                (!c.isSeerrCustomSlider ||
+                (!c.isSeerrSlider ||
                     (showSeerrRows && seerrPrefs.enabled)) &&
                 (!_isImdbSectionType(c.type) ||
                     (showImdbRows && _isImdbSectionEnabled(c.type))) &&
@@ -717,7 +717,7 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   bool _rowBelongsToConfig(HomeRow row, HomeSectionConfig cfg) {
-    if (cfg.isPluginDynamic || cfg.isSeerrCustomSlider) {
+    if (cfg.isPluginDynamic || cfg.isSeerrSlider) {
       return row.id == cfg.stableId;
     }
 
@@ -955,7 +955,7 @@ class HomeViewModel extends ChangeNotifier {
         await _loadMoreSeerrRow(rowIndex, seerrType);
         return;
       }
-      final sliderId = seerrCustomSliderIdFromStableId(row.id);
+      final sliderId = seerrSliderIdFromStableId(row.id);
       if (sliderId != null) {
         await _loadMoreSeerrCatalogRow(rowIndex, sliderId);
         return;
@@ -1003,7 +1003,7 @@ class HomeViewModel extends ChangeNotifier {
     HomeSectionConfig cfg, {
     bool forceRefresh = false,
   }) async {
-    if (cfg.isSeerrCustomSlider) {
+    if (cfg.isSeerrSlider) {
       return _loadSeerrCatalogRow(cfg);
     }
     if (cfg.isPluginDynamic) {
@@ -1024,7 +1024,7 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   HomeRow? _placeholderForConfig(HomeSectionConfig cfg) {
-    if (cfg.isSeerrCustomSlider) {
+    if (cfg.isSeerrSlider) {
       return HomeRow(
         id: cfg.stableId,
         title: localizeSeerrSliderConfigTitle(cfg, currentAppLocalizations()),
@@ -2362,28 +2362,31 @@ class HomeViewModel extends ChangeNotifier {
   /// Last page fetched per Seerr row. Seerr counts in pages where the rest of
   /// the home rows count in items, so this can't share `_rowOffsets`.
   final Map<String, int> _seerrRowPages = {};
-  Map<int, SeerrSliderCatalog> _seerrCustomCatalogs = {};
+  Map<int, SeerrSliderCatalog> _seerrSliderCatalogs = {};
+  SeerrSliderFetchGate _seerrSliderFetchGate = const SeerrSliderFetchGate();
 
-  Future<void> _cacheSeerrCustomSliderCatalogs() async {
+  Future<void> _cacheSeerrSliderCatalogs() async {
     try {
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       await repo.ensureInitialized();
       if (!repo.isAvailable) return;
-      final resolved = resolveSeerrCustomSliders(
+      _seerrSliderFetchGate = await repo.loadSliderFetchGate();
+      final resolved = resolveSeerrSliders(
         await repo.getDiscoverSliders(),
       );
-      _seerrCustomCatalogs = {
+      _seerrSliderCatalogs = {
         for (final (slider, catalog) in resolved) slider.id: catalog,
       };
     } catch (e) {
-      debugPrint('[SeerrHomeRow] Failed to load custom sliders: $e');
+      debugPrint('[SeerrHomeRow] Failed to load sliders: $e');
     }
   }
 
   Future<List<HomeRow>> _loadSeerrCatalogRow(HomeSectionConfig cfg) async {
     final sliderId = cfg.seerrSliderId;
-    final catalog = sliderId == null ? null : _seerrCustomCatalogs[sliderId];
+    final catalog = sliderId == null ? null : _seerrSliderCatalogs[sliderId];
     if (sliderId == null || catalog == null) return const [];
+    if (!_seerrSliderFetchGate.canFetch(catalog.type)) return const [];
     try {
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       final seerrPrefs = GetIt.instance<SeerrPreferences>();
@@ -2416,14 +2419,15 @@ class HomeViewModel extends ChangeNotifier {
         ),
       ];
     } catch (e) {
-      debugPrint('[SeerrHomeRow] Failed to load custom slider $sliderId: $e');
+      debugPrint('[SeerrHomeRow] Failed to load slider $sliderId: $e');
       return const [];
     }
   }
 
   Future<void> _loadMoreSeerrCatalogRow(int rowIndex, int sliderId) async {
-    final catalog = _seerrCustomCatalogs[sliderId];
+    final catalog = _seerrSliderCatalogs[sliderId];
     if (catalog == null) return;
+    if (!_seerrSliderFetchGate.canFetch(catalog.type)) return;
     final row = _rows[rowIndex];
     final repo = await GetIt.instance.getAsync<SeerrRepository>();
     final seerrPrefs = GetIt.instance<SeerrPreferences>();

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -292,8 +292,8 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     });
   }
 
-  void _onItemTap(SeerrDiscoverItem item) {
-    final mediaType = item.mediaType ?? 'movie';
+  void _onItemTap(SeerrDiscoverItem item, {String? mediaTypeHint}) {
+    final mediaType = item.mediaType ?? mediaTypeHint ?? 'movie';
     context.push(
       Destinations.seerrMedia(item.id.toString(), mediaType: mediaType),
     );
@@ -510,7 +510,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   }
 
   Widget _buildRowContainer({
-    required SeerrRowType type,
+    required SeerrDiscoverRow row,
     required double rowHeight,
     required bool isLoading,
     required bool hasItems,
@@ -518,7 +518,9 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     required Widget child,
   }) {
     final l10n = AppLocalizations.of(context);
-    final title = localizeSeerrRowTitle(type, l10n);
+    final title = row.isCustomSlider
+        ? (row.title ?? '')
+        : localizeSeerrRowTitle(row.type!, l10n);
     final desktopScale = GetIt.instance<UserPreferences>()
         .get(UserPreferences.desktopUiScale)
         .scaleFactor;
@@ -598,7 +600,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
       child: LockedFocusRow<SeerrDiscoverItem>(
         key: focusKey,
         items: row.items,
-        hubKey: 'seerr_discover_media_${rowIndex}_${row.type.name}',
+        hubKey: row.focusHubKey,
         controller: _getRowScroll(rowIndex),
         itemExtent: 130,
         itemSpacing: 12 * desktopScale,
@@ -642,7 +644,10 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
             cardFocusExpansion: cardExpansion,
             suppressFocusGlow: suppressFocusGlow,
             externalIsFocused: isFocused,
-            onTap: () => _onItemTap(item),
+            onTap: () => _onItemTap(
+              item,
+              mediaTypeHint: row.catalog?.mediaTypeHint,
+            ),
             onHoverStart: () => _onItemSelected(item),
           );
         },
@@ -650,7 +655,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      type: row.type,
+      row: row,
       rowHeight: 260,
       isLoading: row.isLoading && row.items.isEmpty,
       hasItems: row.items.isNotEmpty,
@@ -680,7 +685,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrShortcut>(
       key: focusKey,
       items: shortcuts,
-      hubKey: 'seerr_discover_shortcuts_$rowIndex',
+      hubKey: row.focusHubKey,
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -721,7 +726,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      type: row.type,
+      row: row,
       rowHeight: 100 * desktopScale,
       isLoading: false,
       hasItems: true,
@@ -755,7 +760,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrGenre>(
       key: focusKey,
       items: row.genres,
-      hubKey: 'seerr_discover_genres_${rowIndex}_${row.type.name}',
+      hubKey: row.focusHubKey,
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -817,7 +822,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      type: row.type,
+      row: row,
       rowHeight: 90,
       isLoading: row.isLoading && row.genres.isEmpty,
       hasItems: row.genres.isNotEmpty,
@@ -841,7 +846,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrNetwork>(
       key: focusKey,
       items: row.networks,
-      hubKey: 'seerr_discover_networks_${rowIndex}_${row.type.name}',
+      hubKey: row.focusHubKey,
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -902,7 +907,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      type: row.type,
+      row: row,
       rowHeight: 90,
       isLoading: row.isLoading && row.networks.isEmpty,
       hasItems: row.networks.isNotEmpty,
@@ -926,7 +931,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     final child = LockedFocusRow<SeerrStudio>(
       key: focusKey,
       items: row.studios,
-      hubKey: 'seerr_discover_studios_${rowIndex}_${row.type.name}',
+      hubKey: row.focusHubKey,
       controller: _getRowScroll(rowIndex),
       itemExtent: 180,
       itemSpacing: 12 * desktopScale,
@@ -987,7 +992,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
 
     return _buildRowContainer(
-      type: row.type,
+      row: row,
       rowHeight: 90,
       isLoading: row.isLoading && row.studios.isEmpty,
       hasItems: row.studios.isNotEmpty,

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -519,7 +519,11 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
   }) {
     final l10n = AppLocalizations.of(context);
     final title = row.isCustomSlider
-        ? (row.title ?? '')
+        ? localizeSeerrSliderTitle(
+            row.slider!.type,
+            l10n,
+            serverTitle: row.slider?.title,
+          )
         : localizeSeerrRowTitle(row.type!, l10n);
     final desktopScale = GetIt.instance<UserPreferences>()
         .get(UserPreferences.desktopUiScale)

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -518,7 +518,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     required Widget child,
   }) {
     final l10n = AppLocalizations.of(context);
-    final title = row.isCustomSlider
+    final title = row.isSeerrSlider
         ? localizeSeerrSliderTitle(
             row.slider!.type,
             l10n,

--- a/lib/ui/screens/settings/home_rows_image_type_screen.dart
+++ b/lib/ui/screens/settings/home_rows_image_type_screen.dart
@@ -162,7 +162,7 @@ class _HomeRowsImageTypeScreenState extends State<HomeRowsImageTypeScreen> {
                   c.type != HomeSectionType.mediaBar &&
                   c.type != HomeSectionType.resumeAudio &&
                   c.type != HomeSectionType.libraryButtons &&
-                  !c.isSeerrCustomSlider,
+                  !c.isSeerrSlider,
             )
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));

--- a/lib/ui/screens/settings/home_rows_image_type_screen.dart
+++ b/lib/ui/screens/settings/home_rows_image_type_screen.dart
@@ -161,7 +161,8 @@ class _HomeRowsImageTypeScreenState extends State<HomeRowsImageTypeScreen> {
                   c.type != HomeSectionType.none &&
                   c.type != HomeSectionType.mediaBar &&
                   c.type != HomeSectionType.resumeAudio &&
-                  c.type != HomeSectionType.libraryButtons,
+                  c.type != HomeSectionType.libraryButtons &&
+                  !c.isSeerrCustomSlider,
             )
             .toList()
           ..sort((a, b) => a.order.compareTo(b.order));

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -476,6 +476,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       if (section.pluginSource == HomeSectionPluginSource.playlists) {
         return 5;
       }
+      if (section.pluginSource == HomeSectionPluginSource.seerr) {
+        return 6;
+      }
       return 7;
     }
     // is builtin
@@ -641,6 +644,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
     final showGenresRows = _prefs.get(UserPreferences.displayGenresRows);
     final showPlaylistsRows = _prefs.get(UserPreferences.displayPlaylistsRows);
     final showSeerrRows = GetIt.instance<PluginSyncService>().seerrAvailable;
+    final seerrEnabled = GetIt.instance<SeerrPreferences>().enabled;
     final showImdbRows = _isAnyImdbSectionEnabled();
     final showTmdbRows = _isAnyTmdbSectionEnabled();
 
@@ -662,11 +666,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
             (section.isPluginDynamic &&
                 section.pluginSource == HomeSectionPluginSource.playlists));
     final hiddenBySeerr =
-        _isSeerrSectionType(section.type) &&
-        (!showSeerrRows ||
-            !GetIt.instance<SeerrPreferences>().isSeerrHomeRowEnabled(
-              section.type,
-            ));
+        (_isSeerrSectionType(section.type) &&
+            (!showSeerrRows ||
+                !GetIt.instance<SeerrPreferences>().isSeerrHomeRowEnabled(
+                  section.type,
+                ))) ||
+        (section.isSeerrCustomSlider && (!showSeerrRows || !seerrEnabled));
     final hiddenByImdb =
         _isImdbSectionType(section.type) &&
         (!showImdbRows || !_isImdbRowEnabled(section.type));
@@ -2724,6 +2729,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       HomeSectionPluginSource.collections => 'Collections row',
       HomeSectionPluginSource.genres => 'Genres row',
       HomeSectionPluginSource.playlists => 'Playlists row',
+      HomeSectionPluginSource.seerr => 'Seerr custom slider',
       HomeSectionPluginSource.custom => (() {
         Map<String, dynamic> rowConfig = {};
         try {

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -483,7 +483,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       }
       return 7;
     }
-    if (section.isSeerrCustomSlider) {
+    if (section.isSeerrSlider) {
       return 6;
     }
     // is builtin
@@ -676,7 +676,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
                 !GetIt.instance<SeerrPreferences>().isSeerrHomeRowEnabled(
                   section.type,
                 ))) ||
-        (section.isSeerrCustomSlider && (!showSeerrRows || !seerrEnabled));
+        (section.isSeerrSlider && (!showSeerrRows || !seerrEnabled));
     final hiddenByImdb =
         _isImdbSectionType(section.type) &&
         (!showImdbRows || !_isImdbRowEnabled(section.type));
@@ -917,12 +917,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       await repo.ensureInitialized();
       if (!repo.isAvailable) return false;
-      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      final resolved = resolveSeerrSliders(await repo.getDiscoverSliders());
       final current = [
         ?_mediaBarConfig,
         ..._sections,
       ];
-      final merged = mergeSeerrCustomSliderHomeSections(current, resolved);
+      final merged = mergeSeerrSliderHomeSections(current, resolved);
       if (HomeSectionConfig.toJsonString(merged) ==
           HomeSectionConfig.toJsonString(current)) {
         return false;
@@ -1643,7 +1643,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
   }
 
   String _labelFor(HomeSectionConfig cfg, AppLocalizations l10n) {
-    if (cfg.isSeerrCustomSlider) {
+    if (cfg.isSeerrSlider) {
       return localizeSeerrSliderConfigTitle(cfg, l10n);
     }
     if (cfg.isPluginDynamic) {
@@ -2725,7 +2725,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
                 ],
               ],
             ),
-            subtitle: section.isSeerrCustomSlider
+            subtitle: section.isSeerrSlider
                 ? const Text('Seerr Discovery Rows')
                 : (section.isPluginDynamic
                 ? Text(_pluginSubtitle(section))

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -11,7 +11,10 @@ import 'package:server_core/server_core.dart';
 
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/utils/playlist_utils.dart';
+import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/plugin_sync_service.dart';
+import '../../../data/services/seerr/seerr_slider_catalog.dart';
+import '../../../data/services/seerr/seerr_slider_home_sections.dart';
 import '../../../preference/home_section_config.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
@@ -20,6 +23,7 @@ import '../../../preference/seerr_row_config.dart';
 import '../../../util/extensions.dart';
 import '../../../util/focus/scroll_utils.dart';
 import '../../../util/platform_detection.dart';
+import '../../util/home_row_title_localizer.dart';
 import '../../navigation/route_lifecycle_observer.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
@@ -451,7 +455,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
   }
 
   bool _isSeerrSectionType(HomeSectionType type) {
-    return type == HomeSectionType.seerrRecentRequests ||
+    return type == HomeSectionType.seerrShortcuts ||
+        type == HomeSectionType.seerrRecentRequests ||
         type == HomeSectionType.seerrWatchlist ||
         type == HomeSectionType.seerrRecentlyAdded ||
         type == HomeSectionType.seerrPopularMovies ||
@@ -476,10 +481,10 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       if (section.pluginSource == HomeSectionPluginSource.playlists) {
         return 5;
       }
-      if (section.pluginSource == HomeSectionPluginSource.seerr) {
-        return 6;
-      }
       return 7;
+    }
+    if (section.isSeerrCustomSlider) {
+      return 6;
     }
     // is builtin
     if (section.type == HomeSectionType.collections) {
@@ -814,7 +819,8 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
     var changed = false;
 
     for (final type in HomeSectionType.values) {
-      if (type == HomeSectionType.none || type == HomeSectionType.mediaBar) {
+      if (type == HomeSectionType.none ||
+          type == HomeSectionType.mediaBar) {
         continue;
       }
       if (existingTypes.contains(type)) continue;
@@ -843,11 +849,12 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       final collectionsFuture = _fetchCollectionsForHomeSections();
       final genresFuture = _fetchGenresForHomeSections();
       final playlistsFuture = _fetchPlaylistsForHomeSections();
+      final seerrChanged = await _mergeSeerrSliderSections();
       final discoveredCollections = await collectionsFuture;
       final discoveredGenres = await genresFuture;
       final discoveredPlaylists = await playlistsFuture;
       if (!mounted) return;
-      var changed = false;
+      var changed = seerrChanged;
       setState(() {
         final mergedPluginSections = _mergeDiscoveredPluginSections();
         final mergedCollectionSections = _mergeCollectionSections(
@@ -901,6 +908,37 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
 
   bool _mergeDiscoveredPluginSections() {
     return false;
+  }
+
+  Future<bool> _mergeSeerrSliderSections() async {
+    try {
+      if (!GetIt.instance<SeerrPreferences>().enabled) return false;
+      if (!GetIt.instance<PluginSyncService>().seerrAvailable) return false;
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) return false;
+      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      final current = [
+        ?_mediaBarConfig,
+        ..._sections,
+      ];
+      final merged = mergeSeerrCustomSliderHomeSections(current, resolved);
+      if (HomeSectionConfig.toJsonString(merged) ==
+          HomeSectionConfig.toJsonString(current)) {
+        return false;
+      }
+      _mediaBarConfig = merged
+          .where((s) => s.type == HomeSectionType.mediaBar)
+          .firstOrNull;
+      _sections = merged
+          .where((s) => s.type != HomeSectionType.mediaBar)
+          .toList()
+        ..sort((a, b) => a.order.compareTo(b.order));
+      return true;
+    } catch (e) {
+      debugPrint('[HomeSections] Failed to merge Seerr sliders: $e');
+      return false;
+    }
   }
 
   Future<List<_DiscoveredCollectionRow>>
@@ -1605,6 +1643,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
   }
 
   String _labelFor(HomeSectionConfig cfg, AppLocalizations l10n) {
+    if (cfg.isSeerrCustomSlider) {
+      return localizeSeerrSliderConfigTitle(cfg, l10n);
+    }
     if (cfg.isPluginDynamic) {
       return cfg.pluginDisplayText?.isNotEmpty == true
           ? cfg.pluginDisplayText!
@@ -2684,7 +2725,9 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
                 ],
               ],
             ),
-            subtitle: section.isPluginDynamic
+            subtitle: section.isSeerrCustomSlider
+                ? const Text('Seerr Discovery Rows')
+                : (section.isPluginDynamic
                 ? Text(_pluginSubtitle(section))
                 : (_isAudioSectionType(section.type)
                       ? const Text('Audio row')
@@ -2694,7 +2737,7 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
                                   ? const Text('IMDb List')
                                   : (_isTmdbSectionType(section.type)
                                         ? const Text('TMDB Lists')
-                                        : null)))),
+                                        : null))))),
             trailing: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -2729,7 +2772,6 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
       HomeSectionPluginSource.collections => 'Collections row',
       HomeSectionPluginSource.genres => 'Genres row',
       HomeSectionPluginSource.playlists => 'Playlists row',
-      HomeSectionPluginSource.seerr => 'Seerr custom slider',
       HomeSectionPluginSource.custom => (() {
         Map<String, dynamic> rowConfig = {};
         try {

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1313,12 +1313,16 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
                   }).toList(),
                 ),
                 if (_customSliders.isNotEmpty) ...[
-                  const _SectionHeader('Seerr Custom Sliders'),
+                  const _SectionHeader('Seerr Discover Sliders'),
                   adaptiveListSection(
                     children: [
                       for (final (slider, catalog) in _customSliders)
                         _SeerrRowSwitchTile(
-                          title: catalog.title,
+                          title: localizeSeerrSliderTitle(
+                            slider.type,
+                            l10n,
+                            serverTitle: catalog.title,
+                          ),
                           value: _isCustomHomeEnabled(slider.id),
                           onChanged: (enabled) =>
                               _toggleCustomHome(slider.id, enabled),

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1172,6 +1172,7 @@ class _SeerrListsScreen extends StatefulWidget {
 
 class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   late List<SeerrRowConfig> _rows;
+  List<(SeerrDiscoverSlider, SeerrSliderCatalog)> _customSliders = [];
   final _syncService = GetIt.instance<PluginSyncService>();
   final _seerrPrefs = GetIt.instance<SeerrPreferences>();
   final _scope = FocusScopeNode(debugLabel: 'SeerrListsScope');
@@ -1181,6 +1182,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   void initState() {
     super.initState();
     _rows = List.of(_seerrPrefs.homeRowsConfig);
+    _loadCustomSliders();
   }
 
   @override
@@ -1230,6 +1232,51 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     if (mounted) setState(() {});
   }
 
+  Future<void> _loadCustomSliders() async {
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      if (!repo.isAvailable) return;
+      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      final prefs = GetIt.instance<UserPreferences>();
+      final merged = mergeSeerrCustomSliderHomeSections(
+        prefs.homeSectionsConfig,
+        resolved,
+      );
+      if (HomeSectionConfig.toJsonString(merged) !=
+          HomeSectionConfig.toJsonString(prefs.homeSectionsConfig)) {
+        await prefs.setHomeSectionsConfig(merged);
+        _pushPersonalizationSync();
+      }
+      if (!mounted) return;
+      setState(() => _customSliders = resolved);
+    } catch (e) {
+      debugPrint('[SeerrLists] Failed to load custom sliders: $e');
+    }
+  }
+
+  bool _isCustomHomeEnabled(int sliderId) {
+    return GetIt.instance<UserPreferences>().homeSectionsConfig.any(
+      (c) =>
+          c.isSeerrCustomSlider &&
+          c.pluginAdditionalData == '$sliderId' &&
+          c.enabled,
+    );
+  }
+
+  Future<void> _toggleCustomHome(int sliderId, bool enabled) async {
+    final prefs = GetIt.instance<UserPreferences>();
+    final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
+    final idx = configs.indexWhere(
+      (c) => c.isSeerrCustomSlider && c.pluginAdditionalData == '$sliderId',
+    );
+    if (idx < 0) return;
+    configs[idx] = configs[idx].copyWith(enabled: enabled);
+    await prefs.setHomeSectionsConfig(configs);
+    _pushPersonalizationSync();
+    if (mounted) setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -1265,6 +1312,20 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
                     );
                   }).toList(),
                 ),
+                if (_customSliders.isNotEmpty) ...[
+                  const _SectionHeader('Seerr Custom Sliders'),
+                  adaptiveListSection(
+                    children: [
+                      for (final (slider, catalog) in _customSliders)
+                        _SeerrRowSwitchTile(
+                          title: catalog.title,
+                          value: _isCustomHomeEnabled(slider.id),
+                          onChanged: (enabled) =>
+                              _toggleCustomHome(slider.id, enabled),
+                        ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ),
@@ -2580,4 +2641,3 @@ class _SettingsTextFieldState extends State<_SettingsTextField> {
     }
   }
 }
-

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1257,10 +1257,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
 
   bool _isCustomHomeEnabled(int sliderId) {
     return GetIt.instance<UserPreferences>().homeSectionsConfig.any(
-      (c) =>
-          c.isSeerrCustomSlider &&
-          c.pluginAdditionalData == '$sliderId' &&
-          c.enabled,
+      (c) => c.isSeerrCustomSlider && c.seerrSliderId == sliderId && c.enabled,
     );
   }
 
@@ -1268,7 +1265,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     final prefs = GetIt.instance<UserPreferences>();
     final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
     final idx = configs.indexWhere(
-      (c) => c.isSeerrCustomSlider && c.pluginAdditionalData == '$sliderId',
+      (c) => c.isSeerrCustomSlider && c.seerrSliderId == sliderId,
     );
     if (idx < 0) return;
     configs[idx] = configs[idx].copyWith(enabled: enabled);

--- a/lib/ui/screens/settings/panel/external_lists_screen.dart
+++ b/lib/ui/screens/settings/panel/external_lists_screen.dart
@@ -1182,7 +1182,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
   void initState() {
     super.initState();
     _rows = List.of(_seerrPrefs.homeRowsConfig);
-    _loadCustomSliders();
+    _loadSeerrSliders();
   }
 
   @override
@@ -1232,14 +1232,14 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     if (mounted) setState(() {});
   }
 
-  Future<void> _loadCustomSliders() async {
+  Future<void> _loadSeerrSliders() async {
     try {
       final repo = await GetIt.instance.getAsync<SeerrRepository>();
       await repo.ensureInitialized();
       if (!repo.isAvailable) return;
-      final resolved = resolveSeerrCustomSliders(await repo.getDiscoverSliders());
+      final resolved = resolveSeerrSliders(await repo.getDiscoverSliders());
       final prefs = GetIt.instance<UserPreferences>();
-      final merged = mergeSeerrCustomSliderHomeSections(
+      final merged = mergeSeerrSliderHomeSections(
         prefs.homeSectionsConfig,
         resolved,
       );
@@ -1251,13 +1251,13 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
       if (!mounted) return;
       setState(() => _customSliders = resolved);
     } catch (e) {
-      debugPrint('[SeerrLists] Failed to load custom sliders: $e');
+      debugPrint('[SeerrLists] Failed to load Seerr sliders: $e');
     }
   }
 
   bool _isCustomHomeEnabled(int sliderId) {
     return GetIt.instance<UserPreferences>().homeSectionsConfig.any(
-      (c) => c.isSeerrCustomSlider && c.seerrSliderId == sliderId && c.enabled,
+      (c) => c.isSeerrSlider && c.seerrSliderId == sliderId && c.enabled,
     );
   }
 
@@ -1265,7 +1265,7 @@ class _SeerrListsScreenState extends State<_SeerrListsScreen> {
     final prefs = GetIt.instance<UserPreferences>();
     final configs = List<HomeSectionConfig>.from(prefs.homeSectionsConfig);
     final idx = configs.indexWhere(
-      (c) => c.isSeerrCustomSlider && c.seerrSliderId == sliderId,
+      (c) => c.isSeerrSlider && c.seerrSliderId == sliderId,
     );
     if (idx < 0) return;
     configs[idx] = configs[idx].copyWith(enabled: enabled);

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -21,6 +21,8 @@ import '../../../data/services/custom_external_lists_service.dart';
 import '../../../data/models/media_segment.dart';
 import '../../../data/utils/media_segment_actions.dart';
 import '../../../data/repositories/seerr_repository.dart';
+import '../../../data/services/seerr/seerr_slider_catalog.dart';
+import '../../../data/services/seerr/seerr_slider_home_sections.dart';
 import '../../../di/providers.dart';
 import '../../../util/idiom/app_ui_idiom.dart';
 import '../../../util/insecure_certificates.dart';

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -16,13 +16,13 @@ import 'package:server_core/server_core.dart' hide ImageType;
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../data/services/auto_download_service.dart';
+import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/plugin_sync_service.dart';
 import '../../../data/services/custom_external_lists_service.dart';
-import '../../../data/models/media_segment.dart';
-import '../../../data/utils/media_segment_actions.dart';
-import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_slider_catalog.dart';
 import '../../../data/services/seerr/seerr_slider_home_sections.dart';
+import '../../../data/models/media_segment.dart';
+import '../../../data/utils/media_segment_actions.dart';
 import '../../../di/providers.dart';
 import '../../../util/idiom/app_ui_idiom.dart';
 import '../../../util/insecure_certificates.dart';

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -1,4 +1,5 @@
 import '../../data/models/home_row.dart';
+import '../../data/services/seerr/seerr_slider_catalog.dart';
 import '../../l10n/app_localizations.dart';
 import '../../preference/preference_constants.dart';
 
@@ -20,6 +21,40 @@ String localizeSeerrRowTitle(SeerrRowType type, AppLocalizations l10n) =>
       SeerrRowType.upcomingSeries => l10n.upcomingSeries,
       SeerrRowType.networks => l10n.networks,
     };
+
+/// Admin-named custom sliders keep [serverTitle]. Built-in Foreseerr rows
+/// use the translation catalog.
+String localizeSeerrSliderTitle(
+  int type,
+  AppLocalizations l10n, {
+  String? serverTitle,
+}) {
+  final server = serverTitle?.trim() ?? '';
+  if (server.isNotEmpty && seerrSliderUsesServerTitle(type)) return server;
+  return switch (type) {
+    SeerrSliderType.traktRecommendations => l10n.seerrTraktRecommendations,
+    SeerrSliderType.traktWatchlist => l10n.seerrTraktWatchlist,
+    SeerrSliderType.traktHistory => l10n.seerrTraktHistory,
+    SeerrSliderType.traktList => l10n.seerrTraktList,
+    SeerrSliderType.anilistTrending => l10n.seerrAnilistTrending,
+    SeerrSliderType.anilistSeason => l10n.seerrAnilistThisSeason,
+    SeerrSliderType.anilistWatching => l10n.seerrAnilistWatching,
+    SeerrSliderType.anilistPlanning => l10n.seerrAnilistPlanning,
+    SeerrSliderType.anilistCompleted => l10n.seerrAnilistCompleted,
+    SeerrSliderType.anilistList => l10n.seerrAnilistList,
+    SeerrSliderType.anilistPopular => l10n.seerrAnilistPopular,
+    SeerrSliderType.anilistTop => l10n.seerrAnilistTop100,
+    SeerrSliderType.anilistNextSeason => l10n.seerrAnilistNextSeason,
+    SeerrSliderType.mdblistList => l10n.seerrMdblistList,
+    SeerrSliderType.simklTrending => l10n.seerrSimklTrending,
+    SeerrSliderType.simklPlanToWatch => l10n.seerrSimklPlanToWatch,
+    SeerrSliderType.simklWatching => l10n.seerrSimklWatching,
+    SeerrSliderType.simklOnHold => l10n.seerrSimklOnHold,
+    SeerrSliderType.simklCompleted => l10n.seerrSimklCompleted,
+    SeerrSliderType.simklDropped => l10n.seerrSimklDropped,
+    _ => server.isNotEmpty ? server : seerrSliderFallbackTitle(type),
+  };
+}
 
 String localizeHomeRowTitle({
   required HomeRow row,

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -1,6 +1,7 @@
 import '../../data/models/home_row.dart';
 import '../../data/services/seerr/seerr_slider_catalog.dart';
 import '../../l10n/app_localizations.dart';
+import '../../preference/home_section_config.dart';
 import '../../preference/preference_constants.dart';
 
 /// The Seerr page builds its rows from the type alone, so it localizes the
@@ -55,6 +56,15 @@ String localizeSeerrSliderTitle(
     _ => server.isNotEmpty ? server : seerrSliderFallbackTitle(type),
   };
 }
+
+String localizeSeerrSliderConfigTitle(
+  HomeSectionConfig config,
+  AppLocalizations l10n,
+) => localizeSeerrSliderTitle(
+  config.sliderType ?? 0,
+  l10n,
+  serverTitle: config.pluginDisplayText,
+);
 
 String localizeHomeRowTitle({
   required HomeRow row,

--- a/test/data/services/seerr_catalog_item_test.dart
+++ b/test/data/services/seerr_catalog_item_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_catalog_item.dart';
+
+void main() {
+  group('seerrCatalogTmdbId', () {
+    test('stock TMDB discover uses id when mapping fields are absent', () {
+      expect(seerrCatalogTmdbId({'id': 550, 'title': 'Fight Club'}), 550);
+    });
+
+    test('mapped list tile uses tmdbId, not the list id', () {
+      expect(
+        seerrCatalogTmdbId({
+          'id': 999001,
+          'tmdbId': 550,
+          'mappingState': {'state': 'mapped'},
+        }),
+        550,
+      );
+    });
+
+    test('accepts numeric ids encoded as strings', () {
+      expect(seerrCatalogTmdbId({'tmdbId': '550'}), 550);
+      expect(seerrCatalogTmdbId({'id': '551'}), 551);
+    });
+
+    test('unmapped list tile is not a TMDB id, even when id is set', () {
+      expect(
+        seerrCatalogTmdbId({
+          'id': 999001,
+          'title': 'Some anime',
+          'mappingState': {'state': 'unmapped'},
+        }),
+        isNull,
+      );
+    });
+
+    test('ambiguous and pending tiles are not TMDB ids', () {
+      expect(
+        seerrCatalogTmdbId({
+          'id': 1,
+          'tmdbId': 550,
+          'mappingState': {'state': 'ambiguous'},
+        }),
+        isNull,
+      );
+      expect(
+        seerrCatalogTmdbId({
+          'id': 1,
+          'mappingState': {'state': 'pending'},
+        }),
+        isNull,
+      );
+    });
+
+    test('tmdbId of 0 is not usable', () {
+      expect(seerrCatalogTmdbId({'id': 12, 'tmdbId': 0}), isNull);
+    });
+
+    test('mapped state without tmdbId does not fall back to a provider id', () {
+      expect(
+        seerrCatalogTmdbId({
+          'id': 999001,
+          'mappingState': {'state': 'mapped'},
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('normalizeSeerrCatalogItem', () {
+    test('keeps a stock TMDB result', () {
+      final item = normalizeSeerrCatalogItem({
+        'id': 550,
+        'title': 'Fight Club',
+        'posterPath': '/poster.jpg',
+      });
+      expect(item?['id'], 550);
+      expect(item?['posterPath'], '/poster.jpg');
+    });
+
+    test('rewrites id to tmdbId for a mapped list tile', () {
+      final item = normalizeSeerrCatalogItem({
+        'id': 999001,
+        'tmdbId': 550,
+        'title': 'Fight Club',
+        'mappingState': {'state': 'mapped'},
+      });
+      expect(item?['id'], 550);
+    });
+
+    test('drops an unmapped list tile instead of opening /movie/{traktId}', () {
+      expect(
+        normalizeSeerrCatalogItem({
+          'id': 999001,
+          'title': 'Unmapped',
+          'mappingState': {'state': 'unmapped'},
+          'source': 'trakt',
+        }),
+        isNull,
+      );
+    });
+
+    test('drops people', () {
+      expect(
+        normalizeSeerrCatalogItem({'id': 1, 'mediaType': 'person'}),
+        isNull,
+      );
+    });
+
+    test('fills mediaType from the catalog hint', () {
+      final item = normalizeSeerrCatalogItem({
+        'id': 550,
+        'title': 'Fight Club',
+      }, mediaTypeHint: 'movie');
+      expect(item?['mediaType'], 'movie');
+    });
+  });
+}

--- a/test/data/services/seerr_query_encoding_test.dart
+++ b/test/data/services/seerr_query_encoding_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_http_client.dart';
+
+void main() {
+  group('encodeSeerrQueryComponent', () {
+    test('encodes spaces as %20, not plus', () {
+      expect(encodeSeerrQueryComponent('star wars'), 'star%20wars');
+    });
+
+    test('encodes apostrophes and other search punctuation', () {
+      expect(
+        encodeSeerrQueryComponent("Ocean's Eleven!"),
+        'Ocean%27s%20Eleven%21',
+      );
+    });
+  });
+
+  group('seerrEncodedQueryString', () {
+    test('builds a TMDB search slider query without plus-encoded spaces', () {
+      expect(
+        seerrEncodedQueryString({'query': 'star wars', 'page': '1'}),
+        'query=star%20wars&page=1',
+      );
+    });
+  });
+}

--- a/test/data/services/seerr_slider_catalog_test.dart
+++ b/test/data/services/seerr_slider_catalog_test.dart
@@ -1,0 +1,249 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_slider_catalog.dart';
+
+SeerrDiscoverSlider _slider({
+  int id = 1,
+  required int type,
+  String? title = 'Custom Row',
+  String? data = '123',
+  bool enabled = true,
+  bool isBuiltIn = false,
+  int order = 0,
+}) => SeerrDiscoverSlider(
+  id: id,
+  type: type,
+  title: title,
+  data: data,
+  enabled: enabled,
+  isBuiltIn: isBuiltIn,
+  order: order,
+);
+
+void main() {
+  group('resolveSeerrSliderCatalog', () {
+    test('maps TMDB movie keyword', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbMovieKeyword, data: '123,456'),
+      );
+      expect(catalog?.path, 'discover/movies');
+      expect(catalog?.query, {'keywords': '123,456'});
+      expect(catalog?.title, 'Custom Row');
+      expect(catalog?.mediaTypeHint, 'movie');
+    });
+
+    test('maps TMDB tv keyword', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbTvKeyword),
+      );
+      expect(catalog?.path, 'discover/tv');
+      expect(catalog?.query, {'keywords': '123'});
+      expect(catalog?.mediaTypeHint, 'tv');
+    });
+
+    test('maps TMDB movie genre', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbMovieGenre, data: '28'),
+      );
+      expect(catalog?.path, 'discover/movies');
+      expect(catalog?.query, {'genre': '28'});
+      expect(catalog?.mediaTypeHint, 'movie');
+    });
+
+    test('maps TMDB tv genre', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbTvGenre, data: '18'),
+      );
+      expect(catalog?.path, 'discover/tv');
+      expect(catalog?.query, {'genre': '18'});
+      expect(catalog?.mediaTypeHint, 'tv');
+    });
+
+    test('maps TMDB search', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbSearch, data: 'star wars'),
+      );
+      expect(catalog?.path, 'search');
+      expect(catalog?.query, {'query': 'star wars'});
+      expect(catalog?.mediaTypeHint, isNull);
+    });
+
+    test('maps TMDB studio', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbStudio, data: '420'),
+      );
+      expect(catalog?.path, 'discover/movies/studio/420');
+      expect(catalog?.query, isEmpty);
+      expect(catalog?.mediaTypeHint, 'movie');
+    });
+
+    test('maps TMDB network', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbNetwork, data: '213'),
+      );
+      expect(catalog?.path, 'discover/tv/network/213');
+      expect(catalog?.query, isEmpty);
+      expect(catalog?.mediaTypeHint, 'tv');
+    });
+
+    test('maps TMDB movie streaming from region,provider', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbMovieStreaming, data: 'US,8'),
+      );
+      expect(catalog?.path, 'discover/movies');
+      expect(catalog?.query, {'watchRegion': 'US', 'watchProviders': '8'});
+      expect(catalog?.mediaTypeHint, 'movie');
+    });
+
+    test('maps TMDB tv streaming from region,provider', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.tmdbTvStreaming, data: 'GB,9'),
+      );
+      expect(catalog?.path, 'discover/tv');
+      expect(catalog?.query, {'watchRegion': 'GB', 'watchProviders': '9'});
+      expect(catalog?.mediaTypeHint, 'tv');
+    });
+
+    test('skips streaming data that is not region,provider', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: SeerrSliderType.tmdbMovieStreaming, data: 'US'),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips unknown types', () {
+      expect(resolveSeerrSliderCatalog(_slider(type: 99)), isNull);
+    });
+
+    test('skips sliders without a usable id', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(id: 0, type: SeerrSliderType.tmdbMovieKeyword),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips built-in sliders', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: SeerrSliderType.tmdbMovieKeyword, isBuiltIn: true),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips disabled sliders', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: SeerrSliderType.tmdbMovieKeyword, enabled: false),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips missing data', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: SeerrSliderType.tmdbMovieKeyword, data: ''),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips missing title', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: SeerrSliderType.tmdbMovieKeyword, title: '  '),
+        ),
+        isNull,
+      );
+    });
+  });
+
+  test('resolveSeerrCustomSliders keeps server order and drops skips', () {
+    final resolved = resolveSeerrCustomSliders([
+      _slider(
+        id: 2,
+        type: SeerrSliderType.tmdbTvGenre,
+        order: 5,
+        title: 'Drama',
+      ),
+      _slider(id: 1, type: 4, order: 1, title: 'Trending', isBuiltIn: true),
+      _slider(
+        id: 3,
+        type: SeerrSliderType.tmdbMovieKeyword,
+        order: 2,
+        title: 'Christmas',
+      ),
+    ]);
+    expect(resolved.map((e) => e.$1.id), [3, 2]);
+    expect(resolved.map((e) => e.$2.title), ['Christmas', 'Drama']);
+  });
+
+  group('SeerrDiscoverSlider.fromJson', () {
+    test('reads the fields settings/discover actually sends', () {
+      final slider = SeerrDiscoverSlider.fromJson({
+        'id': 12,
+        'type': 13,
+        'order': 4,
+        'isBuiltIn': false,
+        'enabled': true,
+        'title': 'Christmas',
+        'data': '123,456',
+      });
+      expect(slider.id, 12);
+      expect(slider.type, SeerrSliderType.tmdbMovieKeyword);
+      expect(slider.order, 4);
+      expect(slider.isBuiltIn, isFalse);
+      expect(slider.enabled, isTrue);
+      expect(slider.title, 'Christmas');
+      expect(slider.data, '123,456');
+    });
+
+    test('treats a missing enabled flag as on, matching Seerr defaults', () {
+      final slider = SeerrDiscoverSlider.fromJson({
+        'id': 1,
+        'type': 13,
+        'title': 'X',
+        'data': '1',
+      });
+      expect(slider.enabled, isTrue);
+      expect(slider.isBuiltIn, isFalse);
+    });
+
+    test('does not treat a built-in trending row as custom', () {
+      final slider = SeerrDiscoverSlider.fromJson({
+        'id': 1,
+        'type': 4,
+        'isBuiltIn': true,
+        'enabled': true,
+      });
+      expect(resolveSeerrSliderCatalog(slider), isNull);
+    });
+  });
+
+  group('seerrDiscoverFocusHubKey', () {
+    test('keys a builtin by type name, not list index', () {
+      expect(
+        seerrDiscoverFocusHubKey(typeName: 'trending'),
+        'seerr_discover_trending',
+      );
+    });
+
+    test('keys a custom row by slider id', () {
+      expect(
+        seerrDiscoverFocusHubKey(sliderId: 42, typeName: 'trending'),
+        'seerr_discover_slider_42',
+      );
+    });
+
+    test('does not collide two custom rows', () {
+      expect(
+        seerrDiscoverFocusHubKey(sliderId: 1),
+        isNot(seerrDiscoverFocusHubKey(sliderId: 2)),
+      );
+    });
+  });
+}

--- a/test/data/services/seerr_slider_catalog_test.dart
+++ b/test/data/services/seerr_slider_catalog_test.dart
@@ -9,6 +9,7 @@ SeerrDiscoverSlider _slider({
   bool enabled = true,
   bool isBuiltIn = false,
   int order = 0,
+  String? sort,
 }) => SeerrDiscoverSlider(
   id: id,
   type: type,
@@ -17,6 +18,7 @@ SeerrDiscoverSlider _slider({
   enabled: enabled,
   isBuiltIn: isBuiltIn,
   order: order,
+  sort: sort,
 );
 
 void main() {
@@ -112,6 +114,90 @@ void main() {
       );
     });
 
+    test('maps trakt list', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(
+          type: SeerrSliderType.traktList,
+          data: 'https://trakt.tv/users/foo/lists/bar',
+        ),
+      );
+      expect(catalog?.path, 'discover/trakt/list');
+      expect(catalog?.query, {'url': 'https://trakt.tv/users/foo/lists/bar'});
+    });
+
+    test('maps anilist list', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(type: SeerrSliderType.anilistList, data: 'Watching'),
+      );
+      expect(catalog?.path, 'discover/anilist/list');
+      expect(catalog?.query, {'name': 'Watching'});
+    });
+
+    test('maps mdblist list', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(
+          type: SeerrSliderType.mdblistList,
+          data: 'https://mdblist.com/lists/foo/bar',
+        ),
+      );
+      expect(catalog?.path, 'discover/mdblist/list');
+      expect(catalog?.query, {'url': 'https://mdblist.com/lists/foo/bar'});
+    });
+
+    test('maps built-in trakt recommendations with no data', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(
+          type: SeerrSliderType.traktRecommendations,
+          title: null,
+          data: '',
+          isBuiltIn: true,
+        ),
+      );
+      expect(catalog?.path, 'discover/trakt/recommendations');
+      expect(catalog?.query, isEmpty);
+      expect(catalog?.title, 'Trakt Recommendations');
+      expect(catalog?.type, SeerrSliderType.traktRecommendations);
+    });
+
+    test('maps built-in anilist watching and simkl library status', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(
+            type: SeerrSliderType.anilistWatching,
+            title: null,
+            data: '',
+            isBuiltIn: true,
+          ),
+        )?.path,
+        'discover/anilist/watching',
+      );
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(
+            type: SeerrSliderType.simklPlanToWatch,
+            title: null,
+            data: '',
+            isBuiltIn: true,
+          ),
+        )?.query,
+        {'status': 'plantowatch'},
+      );
+    });
+
+    test('passes sort through when set', () {
+      final catalog = resolveSeerrSliderCatalog(
+        _slider(
+          type: SeerrSliderType.traktList,
+          data: 'https://trakt.tv/users/foo/lists/bar',
+          sort: 'rank',
+        ),
+      );
+      expect(catalog?.query, {
+        'url': 'https://trakt.tv/users/foo/lists/bar',
+        'sort': 'rank',
+      });
+    });
+
     test('skips unknown types', () {
       expect(resolveSeerrSliderCatalog(_slider(type: 99)), isNull);
     });
@@ -125,10 +211,19 @@ void main() {
       );
     });
 
-    test('skips built-in sliders', () {
+    test('skips stock built-in trending that Moonfin already renders locally', () {
       expect(
         resolveSeerrSliderCatalog(
-          _slider(type: SeerrSliderType.tmdbMovieKeyword, isBuiltIn: true),
+          _slider(type: 4, title: 'Trending', data: '', isBuiltIn: true),
+        ),
+        isNull,
+      );
+    });
+
+    test('skips retired simkl premiere types', () {
+      expect(
+        resolveSeerrSliderCatalog(
+          _slider(type: 38, title: null, data: '', isBuiltIn: true),
         ),
         isNull,
       );
@@ -177,9 +272,21 @@ void main() {
         order: 2,
         title: 'Christmas',
       ),
+      _slider(
+        id: 4,
+        type: SeerrSliderType.traktRecommendations,
+        order: 3,
+        title: null,
+        data: '',
+        isBuiltIn: true,
+      ),
     ]);
-    expect(resolved.map((e) => e.$1.id), [3, 2]);
-    expect(resolved.map((e) => e.$2.title), ['Christmas', 'Drama']);
+    expect(resolved.map((e) => e.$1.id), [3, 4, 2]);
+    expect(resolved.map((e) => e.$2.title), [
+      'Christmas',
+      'Trakt Recommendations',
+      'Drama',
+    ]);
   });
 
   group('SeerrDiscoverSlider.fromJson', () {
@@ -192,6 +299,7 @@ void main() {
         'enabled': true,
         'title': 'Christmas',
         'data': '123,456',
+        'sort': 'rank',
       });
       expect(slider.id, 12);
       expect(slider.type, SeerrSliderType.tmdbMovieKeyword);
@@ -200,6 +308,7 @@ void main() {
       expect(slider.enabled, isTrue);
       expect(slider.title, 'Christmas');
       expect(slider.data, '123,456');
+      expect(slider.sort, 'rank');
     });
 
     test('treats a missing enabled flag as on, matching Seerr defaults', () {
@@ -211,6 +320,7 @@ void main() {
       });
       expect(slider.enabled, isTrue);
       expect(slider.isBuiltIn, isFalse);
+      expect(slider.sort, isNull);
     });
 
     test('does not treat a built-in trending row as custom', () {

--- a/test/data/services/seerr_slider_catalog_test.dart
+++ b/test/data/services/seerr_slider_catalog_test.dart
@@ -282,6 +282,11 @@ void main() {
       ),
     ]);
     expect(resolved.map((e) => e.$1.id), [3, 4, 2]);
+    expect(resolved.map((e) => e.$2.type), [
+      SeerrSliderType.tmdbMovieKeyword,
+      SeerrSliderType.traktRecommendations,
+      SeerrSliderType.tmdbTvGenre,
+    ]);
     expect(resolved.map((e) => e.$2.title), [
       'Christmas',
       'Trakt Recommendations',
@@ -353,6 +358,17 @@ void main() {
       expect(
         seerrDiscoverFocusHubKey(sliderId: 1),
         isNot(seerrDiscoverFocusHubKey(sliderId: 2)),
+      );
+    });
+  });
+
+  group('seerrSliderUsesServerTitle', () {
+    test('is true for admin-named list and TMDB sliders', () {
+      expect(seerrSliderUsesServerTitle(SeerrSliderType.traktList), isTrue);
+      expect(seerrSliderUsesServerTitle(SeerrSliderType.tmdbSearch), isTrue);
+      expect(
+        seerrSliderUsesServerTitle(SeerrSliderType.traktRecommendations),
+        isFalse,
       );
     });
   });

--- a/test/data/services/seerr_slider_catalog_test.dart
+++ b/test/data/services/seerr_slider_catalog_test.dart
@@ -257,8 +257,8 @@ void main() {
     });
   });
 
-  test('resolveSeerrCustomSliders keeps server order and drops skips', () {
-    final resolved = resolveSeerrCustomSliders([
+  test('resolveSeerrSliders keeps server order and drops skips', () {
+    final resolved = resolveSeerrSliders([
       _slider(
         id: 2,
         type: SeerrSliderType.tmdbTvGenre,
@@ -370,6 +370,71 @@ void main() {
         seerrSliderUsesServerTitle(SeerrSliderType.traktRecommendations),
         isFalse,
       );
+    });
+  });
+
+  group('SeerrSliderFetchGate', () {
+    test('allows TMDB sliders regardless of provider flags', () {
+      const gate = SeerrSliderFetchGate(
+        traktConfigured: false,
+        anilistConfigured: false,
+        simklConfigured: false,
+        mdblistConfigured: false,
+      );
+      expect(gate.canFetch(SeerrSliderType.tmdbMovieKeyword), isTrue);
+    });
+
+    test('skips Trakt recs when Trakt is not configured', () {
+      const gate = SeerrSliderFetchGate(traktConfigured: false);
+      expect(gate.canFetch(SeerrSliderType.traktRecommendations), isFalse);
+      expect(gate.canFetch(SeerrSliderType.traktList), isFalse);
+    });
+
+    test('skips Trakt recs when the account is not linked', () {
+      const gate = SeerrSliderFetchGate(
+        traktConfigured: true,
+        traktLinked: false,
+      );
+      expect(gate.canFetch(SeerrSliderType.traktRecommendations), isFalse);
+      expect(gate.canFetch(SeerrSliderType.traktList), isTrue);
+    });
+
+    test('allows Trakt recs when configured and linked', () {
+      const gate = SeerrSliderFetchGate(
+        traktConfigured: true,
+        traktLinked: true,
+      );
+      expect(gate.canFetch(SeerrSliderType.traktRecommendations), isTrue);
+    });
+
+    test('tries the fetch when Jellyseerr omits Foreseer flags', () {
+      final gate = SeerrSliderFetchGate.fromPublicSettings(const {});
+      expect(gate.canFetch(SeerrSliderType.traktRecommendations), isTrue);
+      expect(gate.canFetch(SeerrSliderType.anilistWatching), isTrue);
+      expect(gate.canFetch(SeerrSliderType.simklWatching), isTrue);
+    });
+
+    test('skips Simkl library rows until linked, not trending', () {
+      const gate = SeerrSliderFetchGate(
+        simklConfigured: true,
+        simklLinked: false,
+      );
+      expect(gate.canFetch(SeerrSliderType.simklWatching), isFalse);
+      expect(gate.canFetch(SeerrSliderType.simklTrending), isTrue);
+    });
+
+    test('skips AniList user lists until linked', () {
+      const gate = SeerrSliderFetchGate(
+        anilistConfigured: true,
+        anilistLinked: false,
+      );
+      expect(gate.canFetch(SeerrSliderType.anilistWatching), isFalse);
+      expect(gate.canFetch(SeerrSliderType.anilistTrending), isTrue);
+    });
+
+    test('skips Mdblist when the server says it is off', () {
+      const gate = SeerrSliderFetchGate(mdblistConfigured: false);
+      expect(gate.canFetch(SeerrSliderType.mdblistList), isFalse);
     });
   });
 }

--- a/test/data/services/seerr_slider_home_sections_test.dart
+++ b/test/data/services/seerr_slider_home_sections_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/services/seerr/seerr_slider_catalog.dart';
+import 'package:moonfin/data/services/seerr/seerr_slider_home_sections.dart';
+import 'package:moonfin/preference/home_section_config.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+
+SeerrDiscoverSlider _slider({int id = 1, String title = 'Trending Anime'}) =>
+    SeerrDiscoverSlider(
+      id: id,
+      type: SeerrSliderType.tmdbSearch,
+      title: title,
+      data: 'anime',
+    );
+
+void main() {
+  group('mergeSeerrCustomSliderHomeSections', () {
+    test('appends missing sliders disabled at the end', () {
+      final current = [
+        const HomeSectionConfig(
+          type: HomeSectionType.resume,
+          enabled: true,
+          order: 0,
+        ),
+      ];
+      final catalog = resolveSeerrSliderCatalog(_slider())!;
+      final merged = mergeSeerrCustomSliderHomeSections(current, [
+        (_slider(), catalog),
+      ]);
+
+      expect(merged, hasLength(2));
+      expect(merged.first.type, HomeSectionType.resume);
+      expect(merged.last.isSeerrCustomSlider, isTrue);
+      expect(merged.last.enabled, isFalse);
+      expect(merged.last.pluginDisplayText, 'Trending Anime');
+      expect(merged.last.pluginAdditionalData, '1');
+      expect(merged.last.order, 1);
+    });
+
+    test('keeps enable and order, refreshes the title', () {
+      final existing = HomeSectionConfig.pluginDynamic(
+        serverId: SeerrHomeSliderSection.serverId,
+        pluginSection: SeerrHomeSliderSection.pluginSection,
+        pluginAdditionalData: '1',
+        pluginDisplayText: 'Old title',
+        pluginSource: HomeSectionPluginSource.seerr,
+        enabled: true,
+        order: 4,
+      );
+      final catalog = resolveSeerrSliderCatalog(_slider(title: 'New title'))!;
+      final merged = mergeSeerrCustomSliderHomeSections(
+        [existing],
+        [(_slider(title: 'New title'), catalog)],
+      );
+
+      expect(merged, hasLength(1));
+      expect(merged.single.enabled, isTrue);
+      expect(merged.single.order, 4);
+      expect(merged.single.pluginDisplayText, 'New title');
+    });
+
+    test('drops sliders the server no longer returns', () {
+      final stale = HomeSectionConfig.pluginDynamic(
+        serverId: SeerrHomeSliderSection.serverId,
+        pluginSection: SeerrHomeSliderSection.pluginSection,
+        pluginAdditionalData: '99',
+        pluginDisplayText: 'Gone',
+        pluginSource: HomeSectionPluginSource.seerr,
+      );
+      final merged = mergeSeerrCustomSliderHomeSections([stale], const []);
+      expect(merged, isEmpty);
+    });
+
+    test('collapses duplicate saved entries for the same slider', () {
+      final first = HomeSectionConfig.pluginDynamic(
+        serverId: SeerrHomeSliderSection.serverId,
+        pluginSection: SeerrHomeSliderSection.pluginSection,
+        pluginAdditionalData: '1',
+        pluginDisplayText: 'Trending Anime',
+        pluginSource: HomeSectionPluginSource.seerr,
+        enabled: true,
+        order: 2,
+      );
+      final duplicate = first.copyWith(order: 8);
+      final catalog = resolveSeerrSliderCatalog(_slider())!;
+
+      final merged = mergeSeerrCustomSliderHomeSections(
+        [first, duplicate],
+        [(_slider(), catalog)],
+      );
+
+      expect(merged, [first]);
+    });
+  });
+
+  group('seerrCustomSliderIdFromStableId', () {
+    test('reads the slider id off the home row id', () {
+      final config = HomeSectionConfig.pluginDynamic(
+        serverId: SeerrHomeSliderSection.serverId,
+        pluginSection: SeerrHomeSliderSection.pluginSection,
+        pluginAdditionalData: '42',
+        pluginSource: HomeSectionPluginSource.seerr,
+      );
+      expect(seerrCustomSliderIdFromStableId(config.stableId), 42);
+    });
+
+    test('ignores builtin seerr rows', () {
+      expect(seerrCustomSliderIdFromStableId('seerr_trending'), isNull);
+    });
+  });
+}

--- a/test/data/services/seerr_slider_home_sections_test.dart
+++ b/test/data/services/seerr_slider_home_sections_test.dart
@@ -13,7 +13,7 @@ SeerrDiscoverSlider _slider({int id = 1, String title = 'Trending Anime'}) =>
     );
 
 void main() {
-  group('mergeSeerrCustomSliderHomeSections', () {
+  group('mergeSeerrSliderHomeSections', () {
     test('appends missing sliders disabled at the end', () {
       final current = [
         const HomeSectionConfig(
@@ -23,13 +23,13 @@ void main() {
         ),
       ];
       final catalog = resolveSeerrSliderCatalog(_slider())!;
-      final merged = mergeSeerrCustomSliderHomeSections(current, [
+      final merged = mergeSeerrSliderHomeSections(current, [
         (_slider(), catalog),
       ]);
 
       expect(merged, hasLength(2));
       expect(merged.first.type, HomeSectionType.resume);
-      expect(merged.last.isSeerrCustomSlider, isTrue);
+      expect(merged.last.isSeerrSlider, isTrue);
       expect(merged.last.enabled, isFalse);
       expect(merged.last.type, HomeSectionType.none);
       expect(merged.last.sliderId, '1');
@@ -46,7 +46,7 @@ void main() {
         order: 4,
       );
       final catalog = resolveSeerrSliderCatalog(_slider(title: 'New title'))!;
-      final merged = mergeSeerrCustomSliderHomeSections(
+      final merged = mergeSeerrSliderHomeSections(
         [existing],
         [(_slider(title: 'New title'), catalog)],
       );
@@ -65,7 +65,7 @@ void main() {
         sliderId: '99',
         sliderType: SeerrSliderType.tmdbSearch,
       );
-      final merged = mergeSeerrCustomSliderHomeSections([stale], const []);
+      final merged = mergeSeerrSliderHomeSections([stale], const []);
       expect(merged, isEmpty);
     });
 
@@ -80,7 +80,7 @@ void main() {
       final duplicate = first.copyWith(order: 8);
       final catalog = resolveSeerrSliderCatalog(_slider())!;
 
-      final merged = mergeSeerrCustomSliderHomeSections(
+      final merged = mergeSeerrSliderHomeSections(
         [first, duplicate],
         [(_slider(), catalog)],
       );
@@ -89,24 +89,24 @@ void main() {
     });
   });
 
-  group('seerrCustomSliderIdFromStableId', () {
+  group('seerrSliderIdFromStableId', () {
     test('reads the slider id off the home row id', () {
       final config = HomeSectionConfig.seerrSlider(
         sliderId: '42',
         sliderType: SeerrSliderType.tmdbSearch,
       );
-      expect(seerrCustomSliderIdFromStableId(config.stableId), 42);
+      expect(seerrSliderIdFromStableId(config.stableId), 42);
     });
 
     test('reads the legacy pluginDynamic seerr row id', () {
       expect(
-        seerrCustomSliderIdFromStableId('pluginDynamic:seerr:seerr:slider:42'),
+        seerrSliderIdFromStableId('pluginDynamic:seerr:seerr:slider:42'),
         42,
       );
     });
 
     test('ignores builtin seerr rows', () {
-      expect(seerrCustomSliderIdFromStableId('seerr_trending'), isNull);
+      expect(seerrSliderIdFromStableId('seerr_trending'), isNull);
     });
   });
 
@@ -206,7 +206,7 @@ void main() {
         '[{"type":"resume","enabled":true,"order":0},'
         '{"type":"seerr_slider","enabled":true,"order":1}]',
       );
-      expect(restored.where((c) => c.isSeerrCustomSlider), isEmpty);
+      expect(restored.where((c) => c.isSeerrSlider), isEmpty);
       expect(
         restored.any((c) => c.type == HomeSectionType.resume && c.enabled),
         isTrue,
@@ -215,7 +215,7 @@ void main() {
       final noId = HomeSectionConfig.fromJsonString(
         '[{"kind":"seerrSlider","type":"seerr_slider","enabled":true,"order":0}]',
       );
-      expect(noId.where((c) => c.isSeerrCustomSlider), isEmpty);
+      expect(noId.where((c) => c.isSeerrSlider), isEmpty);
 
       final kept = HomeSectionConfig.fromJsonString(
         HomeSectionConfig.toJsonString([
@@ -228,7 +228,7 @@ void main() {
         ]),
       );
       expect(
-        kept.where((c) => c.isSeerrCustomSlider && c.sliderId == '47'),
+        kept.where((c) => c.isSeerrSlider && c.sliderId == '47'),
         hasLength(1),
       );
     });

--- a/test/data/services/seerr_slider_home_sections_test.dart
+++ b/test/data/services/seerr_slider_home_sections_test.dart
@@ -31,18 +31,17 @@ void main() {
       expect(merged.first.type, HomeSectionType.resume);
       expect(merged.last.isSeerrCustomSlider, isTrue);
       expect(merged.last.enabled, isFalse);
+      expect(merged.last.type, HomeSectionType.none);
+      expect(merged.last.sliderId, '1');
+      expect(merged.last.sliderType, SeerrSliderType.tmdbSearch);
       expect(merged.last.pluginDisplayText, 'Trending Anime');
-      expect(merged.last.pluginAdditionalData, '1');
       expect(merged.last.order, 1);
     });
 
-    test('keeps enable and order, refreshes the title', () {
-      final existing = HomeSectionConfig.pluginDynamic(
-        serverId: SeerrHomeSliderSection.serverId,
-        pluginSection: SeerrHomeSliderSection.pluginSection,
-        pluginAdditionalData: '1',
-        pluginDisplayText: 'Old title',
-        pluginSource: HomeSectionPluginSource.seerr,
+    test('keeps enable and order, refreshes type and title', () {
+      final existing = HomeSectionConfig.seerrSlider(
+        sliderId: '1',
+        sliderType: SeerrSliderType.tmdbSearch,
         enabled: true,
         order: 4,
       );
@@ -55,28 +54,26 @@ void main() {
       expect(merged, hasLength(1));
       expect(merged.single.enabled, isTrue);
       expect(merged.single.order, 4);
+      expect(merged.single.type, HomeSectionType.none);
+      expect(merged.single.sliderType, SeerrSliderType.tmdbSearch);
       expect(merged.single.pluginDisplayText, 'New title');
+      expect(merged.single.sliderId, '1');
     });
 
     test('drops sliders the server no longer returns', () {
-      final stale = HomeSectionConfig.pluginDynamic(
-        serverId: SeerrHomeSliderSection.serverId,
-        pluginSection: SeerrHomeSliderSection.pluginSection,
-        pluginAdditionalData: '99',
-        pluginDisplayText: 'Gone',
-        pluginSource: HomeSectionPluginSource.seerr,
+      final stale = HomeSectionConfig.seerrSlider(
+        sliderId: '99',
+        sliderType: SeerrSliderType.tmdbSearch,
       );
       final merged = mergeSeerrCustomSliderHomeSections([stale], const []);
       expect(merged, isEmpty);
     });
 
     test('collapses duplicate saved entries for the same slider', () {
-      final first = HomeSectionConfig.pluginDynamic(
-        serverId: SeerrHomeSliderSection.serverId,
-        pluginSection: SeerrHomeSliderSection.pluginSection,
-        pluginAdditionalData: '1',
+      final first = HomeSectionConfig.seerrSlider(
+        sliderId: '1',
+        sliderType: SeerrSliderType.tmdbSearch,
         pluginDisplayText: 'Trending Anime',
-        pluginSource: HomeSectionPluginSource.seerr,
         enabled: true,
         order: 2,
       );
@@ -94,17 +91,146 @@ void main() {
 
   group('seerrCustomSliderIdFromStableId', () {
     test('reads the slider id off the home row id', () {
-      final config = HomeSectionConfig.pluginDynamic(
-        serverId: SeerrHomeSliderSection.serverId,
-        pluginSection: SeerrHomeSliderSection.pluginSection,
-        pluginAdditionalData: '42',
-        pluginSource: HomeSectionPluginSource.seerr,
+      final config = HomeSectionConfig.seerrSlider(
+        sliderId: '42',
+        sliderType: SeerrSliderType.tmdbSearch,
       );
       expect(seerrCustomSliderIdFromStableId(config.stableId), 42);
     });
 
+    test('reads the legacy pluginDynamic seerr row id', () {
+      expect(
+        seerrCustomSliderIdFromStableId('pluginDynamic:seerr:seerr:slider:42'),
+        42,
+      );
+    });
+
     test('ignores builtin seerr rows', () {
       expect(seerrCustomSliderIdFromStableId('seerr_trending'), isNull);
+    });
+  });
+
+  group('HomeSectionConfig seerrSlider json', () {
+    test('round-trips kind, sliderId, sliderType, and display text', () {
+      final config = HomeSectionConfig.seerrSlider(
+        sliderId: '47',
+        sliderType: SeerrSliderType.simklDropped,
+        pluginDisplayText: 'Dropped',
+        enabled: false,
+        order: 12,
+      );
+      final json = config.toJson();
+      expect(json['kind'], 'seerrSlider');
+      expect(json['type'], 'seerr_slider');
+      expect(json['sliderId'], '47');
+      expect(json['sliderType'], 47);
+      expect(json['pluginDisplayText'], 'Dropped');
+
+      final restored = HomeSectionConfig.fromJson(json);
+      expect(restored.kind, HomeSectionKind.seerrSlider);
+      expect(restored.type, HomeSectionType.none);
+      expect(restored.sliderId, '47');
+      expect(restored.sliderType, 47);
+      expect(restored.pluginDisplayText, 'Dropped');
+      expect(restored.enabled, isFalse);
+      expect(restored.order, 12);
+    });
+
+    test('migrates pluginSource seerr pluginDynamic rows', () {
+      final restored = HomeSectionConfig.fromJson({
+        'kind': 'pluginDynamic',
+        'type': 'none',
+        'enabled': true,
+        'order': 3,
+        'pluginSource': 'seerr',
+        'pluginSection': 'slider',
+        'pluginAdditionalData': '22',
+        'pluginDisplayText': 'Trakt Recommendations',
+      });
+      expect(restored.kind, HomeSectionKind.seerrSlider);
+      expect(restored.type, HomeSectionType.none);
+      expect(restored.sliderId, '22');
+      expect(restored.pluginDisplayText, 'Trakt Recommendations');
+    });
+
+    test('migrates legacy per-slider type names to sliderType', () {
+      final restored = HomeSectionConfig.fromJson({
+        'kind': 'seerrSlider',
+        'type': 'seerr_trakt_list',
+        'enabled': true,
+        'order': 2,
+        'sliderId': '9',
+        'pluginDisplayText': 'My List',
+      });
+      expect(restored.kind, HomeSectionKind.seerrSlider);
+      expect(restored.type, HomeSectionType.none);
+      expect(restored.sliderId, '9');
+      expect(restored.sliderType, SeerrSliderType.traktList);
+      expect(restored.pluginDisplayText, 'My List');
+    });
+  });
+
+  group('HomeSectionConfig homeRowOrderNames', () {
+    test('encodes enabled builtins only', () {
+      final configs = [
+        const HomeSectionConfig(
+          type: HomeSectionType.resume,
+          enabled: true,
+          order: 0,
+        ),
+        HomeSectionConfig.seerrSlider(
+          sliderId: '47',
+          sliderType: SeerrSliderType.simklDropped,
+          enabled: true,
+          order: 1,
+        ),
+        HomeSectionConfig.pluginDynamic(
+          serverId: 's',
+          pluginSection: 'collection',
+          pluginAdditionalData: '1',
+          pluginDisplayText: 'Box',
+        ),
+        const HomeSectionConfig(
+          type: HomeSectionType.nextUp,
+          enabled: false,
+          order: 3,
+        ),
+      ];
+      expect(HomeSectionConfig.homeRowOrderNames(configs), ['resume']);
+    });
+  });
+
+  group('HomeSectionConfig fromJsonString orphans', () {
+    test('drops sliderId-less seerrSlider rows', () {
+      final restored = HomeSectionConfig.fromJsonString(
+        '[{"type":"resume","enabled":true,"order":0},'
+        '{"type":"seerr_slider","enabled":true,"order":1}]',
+      );
+      expect(restored.where((c) => c.isSeerrCustomSlider), isEmpty);
+      expect(
+        restored.any((c) => c.type == HomeSectionType.resume && c.enabled),
+        isTrue,
+      );
+
+      final noId = HomeSectionConfig.fromJsonString(
+        '[{"kind":"seerrSlider","type":"seerr_slider","enabled":true,"order":0}]',
+      );
+      expect(noId.where((c) => c.isSeerrCustomSlider), isEmpty);
+
+      final kept = HomeSectionConfig.fromJsonString(
+        HomeSectionConfig.toJsonString([
+          HomeSectionConfig.seerrSlider(
+            sliderId: '47',
+            sliderType: SeerrSliderType.simklDropped,
+            enabled: true,
+            order: 0,
+          ),
+        ]),
+      );
+      expect(
+        kept.where((c) => c.isSeerrCustomSlider && c.sliderId == '47'),
+        hasLength(1),
+      );
     });
   });
 }


### PR DESCRIPTION
# Pull Request

## Summary

Moonfin's current Seerr integration uses its own fixed discovery rows and does not read the custom sliders configured by a Seerr administrator. This PR adds support for those server-defined sliders in Moonfin's Discover screen and as optional Home sections.

The first commit implements the stock Seerr feature: TMDB keyword, genre, search, studio, network, and streaming-provider custom sliders. The second commit is intentionally separate and explicitly adds compatibility with [Foreseerr](https://github.com/selmant/foreseerr): administrator-defined Trakt, AniList, and MDBList lists, plus enabled built-in Trakt / AniList / Simkl rows.

## Maintainer Context and Disclosure

I maintain Foreseerr, a personal fork of Seerr that adds Trakt, AniList, Simkl, and MDBList discovery and media workflows. My practical motivation for this contribution is to use those discovery sources from a good TV client. I had considered building another TV application, and have also maintained a separate desktop companion, but Moonfin already provides the client experience I was looking for. Contributing the missing integration here is much more useful than duplicating another application, and may remove my need to continue those separate client efforts.

I want to be completely clear about the boundary in this PR:

- Custom TMDB slider types 13–21 and `GET /settings/discover` are stock Seerr functionality.
- Trakt / AniList / MDBList list types (24, 31, 35) and Foreseerr's built-in Trakt, AniList, and Simkl rows do not exist in stock Seerr.
- The Foreseerr support is not intended to be presented as upstream Seerr behavior or slipped into Moonfin implicitly. It is isolated in its own commit so it can be reviewed, changed, or omitted independently.
- Foreseerr currently continues Seerr's `DiscoverSliderType` enum from 22. This client skips unknown types, so a later upstream Seerr type in that range would be ignored here rather than mixed with Trakt/AniList. If that numbering is a concern, I can migrate Foreseerr's extra types to a reserved band (starting at 1001) in a Foreseerr patch release and update this mapping to match.

I used AI tooling to assist with implementation and review. I personally reviewed every changed file and the final diff, verified the API routes against the relevant Seerr and Foreseerr sources, and ran the tests and analysis documented below. I am happy to answer questions, revise the approach, or help maintain this integration if the Moonfin maintainers have concerns.

## Related Issues

- None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Read enabled custom sliders from `GET /settings/discover`, preserve server ordering, and map stock Seerr slider types 13–21 to their documented search/discover routes.
- Append those sliders after Moonfin's built-in Discover rows and expose them as disabled-by-default Home sections whose enabled state and order persist with the existing Home layout settings.
- Add explicitly scoped Foreseerr compatibility in a separate commit: admin Trakt / AniList / MDBList lists, enabled built-in Trakt recommendations/watchlist/history, AniList browse and user lists, and Simkl trending/library rows.
- Rewrite list-tile ids to TMDB when mapped; omit unmapped, ambiguous, and pending tiles so they cannot open `/movie/{traktId}`.
- Localize built-in Foreseerr row titles from English `app_en.arb` keys. Admin-chosen list titles are kept as-is.
- Skip Moonfin-local stock builtins (types 1–12), retired Simkl Best/Premieres types, disabled, malformed, unknown, empty, or failed sliders without disturbing the existing local rows.
- Stock Seerr never returns the Foreseerr-only types, so it never receives those endpoints.

## API Compatibility

- Stock Seerr's OpenAPI documents `/settings/discover`, `/search`, and the movie/TV discover routes and query parameters used here.
- Moonfin uses Moonbase's existing catch-all `/Moonfin/Seerr/Api/{path}` proxy; no generated OpenAPI client, plugin route, or API schema change is required.
- Stock Seerr does not define or return Foreseerr list or built-in provider types, so a stock server never receives a request for a Foreseerr-only endpoint.
- Foreseerr currently continues Seerr's `DiscoverSliderType` enum from 22. This client skips unknown types, so if upstream Seerr later adds a type in that range it would be ignored here rather than colliding at runtime. If that numbering is a concern, I can migrate Foreseerr's extra types to a reserved band (starting at 1001) in a Foreseerr patch release and update this mapping to match.

## Commit Structure

1. `feat(seerr): add custom slider rows` — stock Seerr types 13–21, API access, Discover/Home integration, settings, and tests.
2. `feat(foreseerr): support list sliders and built-in Trakt, AniList, and Simkl rows` — Foreseerr-only types, payload normalization, English title keys, and tests.

## Platform

- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [x] Linux
- [x] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed on Linux desktop
- [ ] Not tested (explain why):

### Automated Checks

- Focused Seerr/Foreseerr catalog tests passed.
- `dart analyze` on the changed feature and test files: no issues found.
- Manually tested in the Linux desktop client.

### Test Steps

1. Configure stock Seerr custom TMDB keyword, genre, search, studio, network, and streaming-provider sliders and confirm they appear after Moonfin's built-in Discover rows.
2. Enable selected custom sliders under Home section settings, reorder them, restart Moonfin, and confirm their state and order persist.
3. With Foreseerr, enable Trakt / AniList / Simkl built-in rows and admin list sliders. Confirm mapped items open the correct TMDB detail and show posters from `posterPath`.
4. Confirm unmapped external items, unknown slider types, and retired Simkl premiere types are omitted without failing the rest of Discover or Home.

## Screenshots (if applicable)
<img width="3440" height="1440" alt="screenshot-2026-09-04_22-05-07" src="https://github.com/user-attachments/assets/69dcf89c-b1b6-4308-bdbf-c6f4309140ff" />

<!-- Add Discover, Home, and Home settings screenshots here. -->

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
