### PR TITLE
feat-ui - Add fancy MARQUEE scrolling for localization support

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -57,6 +57,7 @@ import '../../widgets/settings/settings_panel.dart';
 import '../../widgets/add_to_playlist_dialog.dart';
 import '../../widgets/logo_view.dart';
 import '../../widgets/media_card.dart';
+import '../../widgets/marquee_text.dart';
 import '../../widgets/seerr/seerr_cancel_request_dialog.dart';
 import '../../widgets/seerr/seerr_collection_banner.dart';
 import '../../widgets/seerr/seerr_image_urls.dart';
@@ -5867,24 +5868,24 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
   double _modernPlayFocusedWidth(String? label) {
     if (label == null) return _modernFocusedFloor;
     // Matching what _buildModernChild lays out around the label.
-    const iconWidth = 24.0;
-    const iconGap = 8.0;
-    const horizontalPadding = 36.0;
+    const iconWidth = 50.0; // height (54) - 4
+    const iconGap = 6.0;
+    const horizontalPadding = 22.0; // left (6) + right (16)
+    const borderWidth = 5.0; // showHighlight ? 2.5 * 2
     final painter = TextPainter(
       text: TextSpan(
         text: label,
-        // The second line of a two line label is a point smaller, so measuring
-        // both at the larger size can only leave room to spare.
         style: Theme.of(context).textTheme.bodyMedium?.copyWith(
           fontWeight: FontWeight.bold,
-          fontSize: 14,
+          fontSize: 13,
           height: 1.1,
         ),
       ),
       textDirection: Directionality.of(context),
       textScaler: MediaQuery.textScalerOf(context),
     )..layout();
-    final measured = painter.width + iconWidth + iconGap + horizontalPadding;
+    final measured =
+        painter.width + iconWidth + iconGap + horizontalPadding + borderWidth;
     painter.dispose();
     return measured.clamp(_modernPlayFocusedFloor, _modernFocusedFloor);
   }
@@ -10905,9 +10906,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     required Color labelColor,
   }) {
     final isExpanded = showHighlight;
-    final hasNewline = widget.label.contains('\n');
     final double height = widget.isPrimary
-        ? (isMobile ? (hasNewline ? 56.0 : 50.0) : (hasNewline ? 64.0 : 54.0))
+        ? (isMobile ? 50.0 : 54.0)
         : (isMobile ? 48.0 : 52.0);
 
     // Portrait spans the primary Play full width (circular secondary actions
@@ -10950,42 +10950,17 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               size: 24,
             ),
             const SizedBox(width: 8),
-            widget.label.contains('\n')
-                ? Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        widget.label.split('\n')[0],
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: fg,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 13,
-                              height: 1.1,
-                            ),
-                      ),
-                      Text(
-                        widget.label.split('\n')[1],
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: fg.withValues(alpha: 0.8),
-                              fontWeight: FontWeight.bold,
-                              fontSize: 12,
-                              height: 1.1,
-                            ),
-                      ),
-                    ],
-                  )
-                : Text(
-                    widget.label,
-                    maxLines: 1,
-                    softWrap: false,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: fg,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 14,
-                          height: 1.1,
-                        ),
+            Text(
+              widget.label,
+              maxLines: 1,
+              softWrap: false,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: fg,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                    height: 1.1,
                   ),
+            ),
           ],
         ),
       );
@@ -11052,6 +11027,12 @@ class _DetailActionButtonState extends State<_DetailActionButton>
 
     final double minWidth = height;
     final double maxWidth = isExpanded ? 200.0 : height;
+    final double maxLabelWidth = (maxWidth -
+            (isExpanded ? 22.0 : 0.0) -
+            (showHighlight ? 5.0 : 3.0) -
+            (height - 4) -
+            6.0)
+        .clamp(0.0, maxWidth);
 
     final containerColor = showHighlight
         ? AppColorScheme.buttonFocused
@@ -11128,51 +11109,24 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               ),
               if (isExpanded && widget.label.isNotEmpty) ...[
                 const SizedBox(width: 6),
-                widget.label.contains('\n')
-                    ? Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            widget.label.split('\n')[0],
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                  color: effectiveLabelColor,
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 13,
-                                  height: 1.1,
-                                ),
-                          ),
-                          Text(
-                            widget.label.split('\n')[1],
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                  color: effectiveLabelColor.withValues(
-                                    alpha: 0.8,
-                                  ),
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 12,
-                                  height: 1.1,
-                                ),
-                          ),
-                        ],
-                      )
-                    : Text(
-                        widget.label,
-                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                              color: effectiveLabelColor,
-                              fontWeight: FontWeight.bold,
-                              fontSize: 13,
-                              height: 1.1,
-                            ),
-                        textAlign: TextAlign.center,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: maxLabelWidth),
+                  child: MarqueeText(
+                    text: widget.label,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: effectiveLabelColor,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 13,
+                          height: 1.1,
+                        ) ??
+                        TextStyle(
+                          color: effectiveLabelColor,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 13,
+                          height: 1.1,
+                        ),
+                  ),
+                ),
               ],
             ],
           ),

--- a/lib/ui/widgets/marquee_text.dart
+++ b/lib/ui/widgets/marquee_text.dart
@@ -15,6 +15,8 @@ class MarqueeText extends StatefulWidget {
   final double millisPerPixel;
   final double gap;
   final int pauseDurationMs;
+  final bool showDotSeparator;
+  final double dotSize;
 
   const MarqueeText({
     super.key,
@@ -24,8 +26,10 @@ class MarqueeText extends StatefulWidget {
     this.minDurationMs = 2200,
     this.maxDurationMs = 12000,
     this.millisPerPixel = 50,
-    this.gap = 30.0,
+    this.gap = 16.0,
     this.pauseDurationMs = 1500,
+    this.showDotSeparator = true,
+    this.dotSize = 4.0,
   });
 
   @override
@@ -146,6 +150,33 @@ class _MarqueeTextState extends State<MarqueeText>
           return Text.rich(span, maxLines: 1, overflow: TextOverflow.ellipsis);
         }
 
+        final Widget separatorWidget;
+        if (widget.showDotSeparator) {
+          final pad =
+              ((widget.gap - widget.dotSize) / 2).clamp(0.0, widget.gap);
+          final dotColor =
+              widget.style.color?.withValues(alpha: 0.7) ?? Colors.white70;
+          separatorWidget = Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(width: pad),
+              Center(
+                child: Container(
+                  width: widget.dotSize,
+                  height: widget.dotSize,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: dotColor,
+                  ),
+                ),
+              ),
+              SizedBox(width: pad),
+            ],
+          );
+        } else {
+          separatorWidget = SizedBox(width: widget.gap);
+        }
+
         return SingleChildScrollView(
           controller: _controller,
           scrollDirection: Axis.horizontal,
@@ -153,7 +184,7 @@ class _MarqueeTextState extends State<MarqueeText>
           child: Row(
             children: [
               Text.rich(span, maxLines: 1),
-              SizedBox(width: widget.gap),
+              separatorWidget,
               Text.rich(span, maxLines: 1),
             ],
           ),

--- a/test/ui/screens/detail/action_button_marquee_test.dart
+++ b/test/ui/screens/detail/action_button_marquee_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/marquee_text.dart';
+
+void main() {
+  const maxLabelWidth = 119.0;
+  const textStyle = TextStyle(
+    fontSize: 13,
+    fontWeight: FontWeight.bold,
+    height: 1.1,
+  );
+
+  Widget buildTestWidget(
+    String text, {
+    TextStyle style = textStyle,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: maxLabelWidth),
+                child: MarqueeText(
+                  text: text,
+                  style: style,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('short button label stays static and does not scroll', (tester) async {
+    await tester.pumpWidget(buildTestWidget('Play'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Play'), findsOneWidget);
+    // SingleChildScrollView inside MarqueeText is only built when overflowing
+    expect(find.descendant(
+      of: find.byType(MarqueeText),
+      matching: find.byType(SingleChildScrollView),
+    ), findsNothing);
+  });
+
+  testWidgets('long button label triggers marquee scrolling within constrained bounds', (tester) async {
+    // "Informar d'una incidència" is 24 characters and overflows the 119px available width
+    await tester.pumpWidget(buildTestWidget("Informar d'una incidència"));
+    await tester.pump();
+
+    // MarqueeText builds the scrolling row with duplicated text for looping
+    expect(find.descendant(
+      of: find.byType(MarqueeText),
+      matching: find.byType(SingleChildScrollView),
+    ), findsOneWidget);
+
+    final marqueeSize = tester.getSize(find.byType(MarqueeText));
+    expect(marqueeSize.width, lessThanOrEqualTo(maxLabelWidth));
+
+    // Verify circular dot separator is rendered between repeated texts
+    expect(
+      find.descendant(
+        of: find.byType(MarqueeText),
+        matching: find.byWidgetPredicate((widget) =>
+            widget is Container &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration as BoxDecoration).shape == BoxShape.circle),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('typeface variations affect overflow detection', (tester) async {
+    // Under Ahem test font, each character is square (13px wide at fontSize 13).
+    // 'Resume' is 6 chars = ~78px normally (fits in 119px).
+    // With fontSize 24, 'Resume' is 6 chars * 24px = ~144px (overflows 119px).
+    const text = 'Resume';
+    const normalStyle = TextStyle(fontSize: 13);
+    const wideStyle = TextStyle(fontSize: 24);
+
+    await tester.pumpWidget(buildTestWidget(text, style: normalStyle));
+    await tester.pump();
+    final scrollsNormal = find.descendant(
+      of: find.byType(MarqueeText),
+      matching: find.byType(SingleChildScrollView),
+    ).evaluate().isNotEmpty;
+
+    await tester.pumpWidget(buildTestWidget(text, style: wideStyle));
+    await tester.pump();
+    final scrollsWide = find.descendant(
+      of: find.byType(MarqueeText),
+      matching: find.byType(SingleChildScrollView),
+    ).evaluate().isNotEmpty;
+
+    expect(scrollsNormal, isFalse);
+    expect(scrollsWide, isTrue);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds marquee text scrolling to modern detail action buttons when focused labels exceed the 200px button cap on TV and desktop platforms. While I was looking at it, I felt the current implementation (32px gap) felt "too wide", so tweaked MarqueeText to have a tighter 16px loop gap and a subtle, centered circular delimiter dot between text repetitions.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1384 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - Bound focused action button labels to available remaining width (maxLabelWidth) within the 200px cap and wrap them in MarqueeText when overflowing.
  - Remove dead multi-line (\n) handling to simplify button layout to single-line text across all actions (this was old code from when we tried for the Resume SXEX multi-line thing that was a failed experiment).
  - Align _modernPlayFocusedWidth layout constants (fontSize: 13, icon width 50.0, gap 6.0, padding 22.0, border 5.0) to accurately reflect theme font metrics and actual button dimensions for the single-row case.
- **marquee_text.dart**:
  - Add showDotSeparator (default true) and dotSize (default 4.0) parameters.
  - Update default gap from 30.0 to 16.0.
  - Symmetrically center a circular dot between original and repeating text during scroll cycles at 70% opacity while maintaining exact mathematical loop offsets (scrollDistance = textWidth + gap).
- **action_button_marquee_test.dart**:
  - Add widget unit tests verifying that short labels remain static, long labels trigger constrained marquee scrolling, circular delimiter dot renders during scroll, and typeface metrics correctly drive overflow detection.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Run on TV or desktop client with UI scaling enabled.
2. Navigate to an item detail screen in a locale with longer button strings (e.g., Catalan "Informar d'una incidència" on Report Issue).
3. Focus the action button and observe smooth horizontal marquee scrolling within the 200px cap, separated by a centered dot and 16px gap on loop.
4. Verify short buttons (e.g., "Play", "Trailer") remain static and centered without scrolling.
5. Verify flutter test and flutter analyze pass with 0 errors.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Before
<img width="2880" height="2160" alt="IMG_4789" src="https://github.com/user-attachments/assets/0c147165-61c7-4d2c-b80a-9727c52765d9" />

### After
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-04_15-18-15" src="https://github.com/user-attachments/assets/0f3cd34d-bfeb-4f09-a756-4ca92790cd0a" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
