### PR TITLE
handle more redaction patterns

### DIFF
--- a/lib/data/services/log_service.dart
+++ b/lib/data/services/log_service.dart
@@ -73,8 +73,26 @@ class LogService extends ChangeNotifier {
   static const int _maxEntries = 2000;
 
   static final _redactRegex = RegExp(
-    r'((?:https?|wss?)://)[A-Za-z0-9._~%\-:@\[\]]+',
+    r'''((?:https?|wss?)://)[^\s<>"',;()\]}]+''',
     caseSensitive: false,
+  );
+
+  static final _hostLookupRegex = RegExp(
+    r'''((?:Failed host lookup|Unable to resolve host):? ['"])[^'"]+''',
+    caseSensitive: false,
+  );
+
+  static final _genericErrorRedactRegex = RegExp(
+    r'''\b(host(?:name)?|address|ip)(\s*[:=]\s*)([^\s,;()<>"{}\[\]']+)''',
+    caseSensitive: false,
+  );
+
+  static final _ipv4Regex = RegExp(
+    r'\b(?:\d{1,3}\.){3}\d{1,3}\b',
+  );
+
+  static final _ipv6Regex = RegExp(
+    r'\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b',
   );
 
   final UserPreferences _prefs;
@@ -283,11 +301,36 @@ class LogService extends ChangeNotifier {
   };
 
   String _redact(String text) {
-    if (!text.contains('://')) {
-      return text;
+    var result = text;
+
+    if (result.contains('://')) {
+      result = result.replaceAllMapped(_redactRegex, (match) {
+        return '${match.group(1)}[REDACTED]';
+      });
     }
-    return text.replaceAllMapped(_redactRegex, (match) {
-      return '${match.group(1)}[REDACTED]';
-    });
+
+    final lower = result.toLowerCase();
+    if (lower.contains('host') || lower.contains('address') || lower.contains('ip')) {
+      result = result.replaceAllMapped(_genericErrorRedactRegex, (match) {
+        return '${match.group(1)}${match.group(2)}[REDACTED]';
+      });
+
+      if (lower.contains('host')) {
+        result = result.replaceAllMapped(_hostLookupRegex, (match) {
+          return "${match.group(1)}[REDACTED]";
+        });
+      }
+    }
+
+    // catch any ipv4's
+    if (result.contains('.')) {
+      result = result.replaceAll(_ipv4Regex, '[REDACTED]');
+    }
+    // catch any ipv6's
+    if (result.contains(':')) {
+      result = result.replaceAll(_ipv6Regex, '[REDACTED]');
+    }
+
+    return result;
   }
 }

--- a/lib/data/services/log_service.dart
+++ b/lib/data/services/log_service.dart
@@ -83,7 +83,8 @@ class LogService extends ChangeNotifier {
   );
 
   static final _genericErrorRedactRegex = RegExp(
-    r'''\b(host(?:name)?|address|ip)(\s*[:=]\s*)([^\s,;()<>"{}\[\]']+)''',
+    r'''\b(host(?:name)?|address|ip|server|url|uri|domain|origin)'''
+    r'''(\s*"?\s*[:=]\s*"?\s*)([^\s,;()<>"{}\[\]']*[.0-9][^\s,;()<>"{}\[\]']*)("?)''',
     caseSensitive: false,
   );
 
@@ -92,7 +93,10 @@ class LogService extends ChangeNotifier {
   );
 
   static final _ipv6Regex = RegExp(
-    r'\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b',
+    r'(?<![:.\w])(?:'
+    r'(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}'
+    r'|[A-Fa-f0-9:]*::[A-Fa-f0-9:]*'
+    r')(?![:.\w])',
   );
 
   final UserPreferences _prefs;
@@ -303,16 +307,17 @@ class LogService extends ChangeNotifier {
   String _redact(String text) {
     var result = text;
 
-    if (result.contains('://')) {
-      result = result.replaceAllMapped(_redactRegex, (match) {
-        return '${match.group(1)}[REDACTED]';
-      });
-    }
-
     final lower = result.toLowerCase();
-    if (lower.contains('host') || lower.contains('address') || lower.contains('ip')) {
+    if (lower.contains('host') ||
+        lower.contains('address') ||
+        lower.contains('ip') ||
+        lower.contains('server') ||
+        lower.contains('url') ||
+        lower.contains('uri') ||
+        lower.contains('domain') ||
+        lower.contains('origin')) {
       result = result.replaceAllMapped(_genericErrorRedactRegex, (match) {
-        return '${match.group(1)}${match.group(2)}[REDACTED]';
+        return '${match.group(1)}${match.group(2)}[REDACTED]${match.group(4)}';
       });
 
       if (lower.contains('host')) {
@@ -322,6 +327,12 @@ class LogService extends ChangeNotifier {
       }
     }
 
+    if (lower.contains('://')) {
+      result = result.replaceAllMapped(_redactRegex, (match) {
+        return '${match.group(1)}[REDACTED]';
+      });
+    }
+    
     // catch any ipv4's
     if (result.contains('.')) {
       result = result.replaceAll(_ipv4Regex, '[REDACTED]');

--- a/test/data/log_service_test.dart
+++ b/test/data/log_service_test.dart
@@ -38,29 +38,114 @@ void main() {
     expect(logs.entries.single.level, LogLevel.error);
   });
 
-  test('crash entries are redacted like everything else', () async {
-    final logs = await _service();
+  group('redaction logic', () {
+    late LogService logs;
 
-    logs.logCrash(
-      'Uncaught: bad response',
-      'DioException for https://myserver.example:8096/Items',
-    );
+    setUp(() async {
+      logs = await _service(loggingEnabled: true);
+    });
 
-    final text = logs.exportText();
-    expect(text, isNot(contains('myserver.example')));
-    expect(text, contains('https://[REDACTED]'));
-  });
-
-  test('exportText can be bounded to the newest entries', () async {
-    final logs = await _service(loggingEnabled: true);
-    for (var i = 0; i < 10; i++) {
-      logs.log(LogCategory.general, 'entry $i');
+    void assertRedacted(String input, String expectedSubstring) {
+      logs.clear();
+      logs.log(LogCategory.general, input);
+      final text = logs.entries.single.message;
+      expect(text, contains(expectedSubstring));
     }
 
-    final text = logs.exportText(maxEntries: 3);
-    expect(text, contains('entry 9'));
-    expect(text, contains('entry 7'));
-    expect(text, isNot(contains('entry 6')));
-    expect(text, contains('Entries: 3'));
+    test('redacts logCrash entries (message and error)', () async {
+      logs.clear();
+      logs.logCrash(
+        'Uncaught: bad response at https://myserver.example',
+        'DioException for https://myserver.example:8096/Items',
+      );
+
+      final entry = logs.entries.single;
+      expect(entry.message, contains('https://[REDACTED]'));
+      expect(entry.error, contains('https://[REDACTED]'));
+      expect(entry.message, isNot(contains('myserver.example')));
+      expect(entry.error, isNot(contains('myserver.example')));
+    });
+
+    test('redacts URLs and preserves delimiters', () {
+      assertRedacted(
+        'Connected to https://my-server.com, status 200',
+        'Connected to https://[REDACTED], status 200',
+      );
+      assertRedacted(
+        'URL is <https://example.com/path>',
+        'URL is <https://[REDACTED]>',
+      );
+    });
+
+    test('redacts Dart host lookup failures', () {
+      assertRedacted(
+        "SocketException: Failed host lookup: 'my.host.name' (OS Error: ...)",
+        "SocketException: Failed host lookup: '[REDACTED]'",
+      );
+    });
+
+    test('redacts Android native host lookup failures', () {
+      assertRedacted(
+        'Unable to resolve host "moonfin.io": No address associated',
+        'Unable to resolve host "[REDACTED]": No address associated',
+      );
+    });
+
+    test('redacts international domain names', () {
+      assertRedacted(
+        "Failed host lookup: 'münchen.de'",
+        "Failed host lookup: '[REDACTED]'",
+      );
+    });
+
+    test('redacts generic host and address labels', () {
+      assertRedacted('Connecting to host: moonfin.io', 'Connecting to host: [REDACTED]');
+      assertRedacted('Server address = 1.2.3.4', 'Server address = [REDACTED]');
+      assertRedacted('Client ip: 127.0.0.1', 'Client ip: [REDACTED]');
+    });
+
+    test('redacts standalone IPv4 and IPv6 addresses', () {
+      assertRedacted('Error connecting to 192.168.1.1', 'Error connecting to [REDACTED]');
+      assertRedacted(
+        'IPv6 failure at 2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+        'IPv6 failure at [REDACTED]',
+      );
+    });
+
+    test('does not redact version numbers or non-IP dots', () {
+      assertRedacted('App version 1.2.3', 'App version 1.2.3');
+      assertRedacted('Simple sentence.', 'Simple sentence.');
+    });
+  });
+
+  group('exportText', () {
+    test('produces a formatted report with headers', () async {
+      final logs = await _service(loggingEnabled: true);
+      logs.clear();
+      logs.log(LogCategory.general, 'routine event', level: LogLevel.info);
+      logs.logCrash('Uncaught: boom', 'stack trace');
+
+      final text = logs.exportText();
+      expect(text, contains('Moonfin diagnostic report'));
+      expect(text, contains('App: Moonfin 0.0.0'));
+      expect(text, contains('Device: Test Device (dev-1)'));
+      expect(text, contains('INFO  [general] routine event'));
+      expect(text, contains('ERROR [general] Uncaught: boom'));
+      expect(text, contains('└─ stack trace'));
+    });
+
+    test('can be bounded to the newest entries', () async {
+      final logs = await _service(loggingEnabled: true);
+      logs.clear();
+      for (var i = 0; i < 10; i++) {
+        logs.log(LogCategory.general, 'entry $i');
+      }
+
+      final text = logs.exportText(maxEntries: 3);
+      expect(text, contains('entry 9'));
+      expect(text, contains('entry 7'));
+      expect(text, isNot(contains('entry 6')));
+      expect(text, contains('Entries: 3'));
+    });
   });
 }

--- a/test/data/log_service_test.dart
+++ b/test/data/log_service_test.dart
@@ -104,16 +104,66 @@ void main() {
       assertRedacted('Client ip: 127.0.0.1', 'Client ip: [REDACTED]');
     });
 
+    test('redacts JSON-style keys and values with different spacing', () {
+      assertRedacted('"host":"moonfin.io"', '"host":"[REDACTED]"');
+      assertRedacted('"server": "1.2.3.4"', '"server": "[REDACTED]"');
+      assertRedacted('{"domain":"example.com"}', '{"domain":"[REDACTED]"}');
+    });
+
+    test('handles multiple field replacements and case sensitivity', () {
+      assertRedacted(
+        'SERVER: 1.1.1.1, ORIGIN: https://moonfin.io',
+        'SERVER: [REDACTED], ORIGIN: [REDACTED]',
+      );
+      assertRedacted(
+        'host: a.com and ip: 1.2.3.4',
+        'host: [REDACTED] and ip: [REDACTED]',
+      );
+    });
+
+    test('respects keyword boundaries to avoid false positives (e.g. ghost, stripping, addressable)', () {
+      // Each keyword from the regex embedded in another word followed by a separator
+      assertRedacted('ghost: value', 'ghost: value'); // host
+      assertRedacted('ghostname: value', 'ghostname: value'); // hostname
+      assertRedacted('addressable: true', 'addressable: true'); // address
+      assertRedacted('description: text', 'description: text'); // ip
+      assertRedacted('serverless: cloud', 'serverless: cloud'); // server
+      assertRedacted('surly: value', 'surly: value'); // url
+      assertRedacted('purify: water', 'purify: water'); // uri
+      assertRedacted('predominate: factor', 'predominate: factor'); // domain
+      assertRedacted('original: source', 'original: source'); // origin
+    });
+
+    test('redacts specific values after keywords but ignores friendly names and empty values', () {
+      // Redacts if it contains a dot or digit
+      assertRedacted('server: 1.2.3.4', 'server: [REDACTED]');
+      assertRedacted('domain=moonfin.io', 'domain=[REDACTED]');
+      assertRedacted('host: server7', 'host: [REDACTED]');
+
+      // Should NOT match because they don't contain a dot or digit (friendly names)
+      assertRedacted('server: Production', 'server: Production');
+      assertRedacted('domain=Development', 'domain=Development');
+
+      // Should NOT match because there is no value after the separator
+      assertRedacted('Connecting to host: ', 'Connecting to host: ');
+    });
+
     test('redacts standalone IPv4 and IPv6 addresses', () {
       assertRedacted('Error connecting to 192.168.1.1', 'Error connecting to [REDACTED]');
       assertRedacted(
         'IPv6 failure at 2001:0db8:85a3:0000:0000:8a2e:0370:7334',
         'IPv6 failure at [REDACTED]',
       );
+      assertRedacted('Compressed IPv6: fe80::1', 'Compressed IPv6: [REDACTED]');
+      assertRedacted('Loopback: ::1', 'Loopback: [REDACTED]');
+      assertRedacted('Common shorthand: 2001:db8::1', 'Common shorthand: [REDACTED]');
     });
 
-    test('does not redact version numbers or non-IP dots', () {
+    test('does not redact version numbers, UUIDs, or clock times', () {
       assertRedacted('App version 1.2.3', 'App version 1.2.3');
+      assertRedacted('Playback at 0:00:15.000000', 'Playback at 0:00:15.000000');
+      assertRedacted('UUID is 550e8400-e29b-41d4-a716-446655440000', 'UUID is 550e8400-e29b-41d4-a716-446655440000');
+      assertRedacted('Version with port v1.2.3:8080', 'Version with port v1.2.3:8080');
       assertRedacted('Simple sentence.', 'Simple sentence.');
     });
   });


### PR DESCRIPTION
# Pull Request

## Summary
Some error messages weren't being thoroughly checked for urls or ips.  This adds some more regex patterns and also allows international domain names instead of just latin script.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
-modified _redactRegex to use whitespace and other delimiter boundaries instead of allowed character sets so IDN's can work
-added _hostLookupRegex to check for dns lookup failure style error messages
-added _genericErrorRedactRegex to try to broadly match any host(name?)/address/ip[:=] value in an error string
-added _ipv4Regex and _ipv6Regex to match these address types in strings
-modified _redact to run through more regexes
-added a group for redaction tests, and added some scenarios
-added a group for exportText tests, and added a formatting test

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. send diagnostic report
2. verify no addresses are leaked
3. run log_service_test for potential scenarios

## Screenshots (if applicable)

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
