### PR TITLE
Update DIO (Dependency) to Latest 5.11.1

### DIFF
--- a/lib/util/settings_save_retry.dart
+++ b/lib/util/settings_save_retry.dart
@@ -30,6 +30,7 @@ bool isTransientTransportFailure(Object error) {
     case DioExceptionType.connectionTimeout:
     case DioExceptionType.sendTimeout:
     case DioExceptionType.receiveTimeout:
+    case DioExceptionType.transformTimeout:
     case DioExceptionType.connectionError:
       return true;
     case DioExceptionType.badResponse:

--- a/lib/util/settings_save_retry.dart
+++ b/lib/util/settings_save_retry.dart
@@ -30,7 +30,6 @@ bool isTransientTransportFailure(Object error) {
     case DioExceptionType.connectionTimeout:
     case DioExceptionType.sendTimeout:
     case DioExceptionType.receiveTimeout:
-    case DioExceptionType.transformTimeout:
     case DioExceptionType.connectionError:
       return true;
     case DioExceptionType.badResponse:
@@ -39,6 +38,9 @@ bool isTransientTransportFailure(Object error) {
     case DioExceptionType.cancel:
     case DioExceptionType.badCertificate:
     case DioExceptionType.unknown:
+    // The response already arrived and decoding it ran long, so sending the
+    // write again only buys the same slow decode.
+    case DioExceptionType.transformTimeout:
       return false;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -451,10 +451,10 @@ packages:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: "852ec3b48cc431ac04fff978413c541502b67ffc3e26921e74e3d994694192c1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.11.1"
   dio_cookie_manager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   riverpod_annotation: ^2.6.1
 
   # Networking
-  dio: ^5.9.2
+  dio: ^5.11.1
   dio_cookie_manager: ^3.4.0
   background_downloader: ^9.5.6
   cookie_jar: ^4.0.9

--- a/test/util/settings_save_retry_test.dart
+++ b/test/util/settings_save_retry_test.dart
@@ -64,6 +64,13 @@ void main() {
       );
     });
 
+    test('a slow decode is local work, not a transport failure', () {
+      expect(
+        isTransientTransportFailure(_dio(DioExceptionType.transformTimeout)),
+        isFalse,
+      );
+    });
+
     test('a non-Dio error is an unknown, and unknowns are not retried', () {
       expect(isTransientTransportFailure(StateError('bug')), isFalse);
     });


### PR DESCRIPTION
# Pull Request

## Summary
Upgrades `dio` dependency to `v5.11.1` and handles the `DioExceptionType.transformTimeout` case in `isTransientTransportFailure` to maintain exhaustive enum matching and prevent build failures.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [x] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Upgraded `dio` dependency from `5.9.2` to `5.11.1` in `pubspec.yaml`.
- Handled `DioExceptionType.transformTimeout` in `lib/util/settings_save_retry.dart` within `isTransientTransportFailure()` to fix non-exhaustive `switch` compilation errors.
- Classified `transformTimeout` as a non-transient failure (`return false`), as payload parsing errors are local and non-retryable.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Ran `flutter pub get` with updated `dio` dependency.
2. Verified project builds successfully across desktop targets without compilation errors.
3. Confirmed network retry logic executes as expected on error states.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

*N/A — Backend / dependency change only.*

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced