### PR TITLE
bugfix-navigation - The one about Navigation Drift (refactor)

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -67,12 +67,19 @@ const _kChevronScrollStep = 480.0;
 const _kSongRowHeight = 56.0;
 
 /// One line of the grid, across whichever axis it scrolls.
-typedef _GridGeometry = ({
+typedef GridGeometry = ({
   int perLine,
   double lineExtent,
   double lineSpacing,
   double leadingPad,
 });
+
+/// Leading edge of the line holding [index], in the scroll view's own
+/// coordinates.
+double gridLineStart(GridGeometry geometry, int index) =>
+    geometry.leadingPad +
+    (index ~/ geometry.perLine) *
+        (geometry.lineExtent + geometry.lineSpacing);
 
 bool _isCompact(BuildContext context) =>
     !PlatformDetection.isTV &&
@@ -251,34 +258,23 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     _vm.loadMore();
   }
 
-  /// Geometry from the last grid layout, so a letter jump lands on the line the
-  /// grid really drew instead of one worked out from a second copy of the sums.
-  _GridGeometry? _gridGeometry;
+  /// Geometry from the last grid layout, so a letter jump and a focus scroll
+  /// both land on the line the grid really drew instead of one worked out from
+  /// a second copy of the sums.
+  GridGeometry? _gridGeometry;
 
-  void _scrollToGridRow({
-    required int index,
-    required int crossAxisCount,
-    required double cellHeight,
-    required double mainAxisSpacing,
-    double gridTopPadding = 8.0,
-  }) {
-    if (!mounted || !_scrollController.hasClients || _isJumpingToLetter) return;
+  void _scrollToGridRow(int index) {
+    if (!mounted || !_scrollController.hasClients) return;
     final geometry = _gridGeometry;
-    final effectivePerLine =
-        (geometry?.perLine ?? crossAxisCount).clamp(1, 100);
-    final effectiveLineExtent = geometry?.lineExtent ?? cellHeight;
-    final effectiveLineSpacing = geometry?.lineSpacing ?? mainAxisSpacing;
-    final effectiveLeadingPad = geometry?.leadingPad ?? gridTopPadding;
+    if (geometry == null) return;
 
-    final row = index ~/ effectivePerLine;
-    final rowTop =
-        effectiveLeadingPad + row * (effectiveLineExtent + effectiveLineSpacing);
-    final rowBottom = rowTop + effectiveLineExtent;
+    final rowTop = gridLineStart(geometry, index);
+    final rowBottom = rowTop + geometry.lineExtent;
     final position = _scrollController.position;
     final viewportH = position.viewportDimension;
     final current = position.pixels;
-    final topPad = effectiveLeadingPad;
-    final bottomPad = 52.0 + (effectiveLeadingPad - 8.0).clamp(0.0, 32.0);
+    final topPad = geometry.leadingPad;
+    const bottomPad = 52.0;
     double target = current;
     if (rowTop - topPad < current) {
       target = rowTop - topPad;
@@ -332,9 +328,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
       } else {
         final geometry = _gridGeometry;
         if (geometry == null) return;
-        final line = targetIndex ~/ geometry.perLine;
-        targetOffset = geometry.leadingPad +
-            line * (geometry.lineExtent + geometry.lineSpacing);
+        targetOffset = gridLineStart(geometry, targetIndex);
       }
 
       // Slivers report maxScrollExtent lazily as children are laid out, so a
@@ -1237,14 +1231,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                         sectionCount: categoryItems.length,
                         crossAxisCount: crossAxisCount,
                         cellWidth: cellWidth,
-                        childAspectRatio: childAspectRatio,
                         itemAspectRatio: itemAspectRatio,
                         focusColor: focusColor,
                         isNeon: isNeon,
                         watchedBehavior: watchedBehavior,
                         isMobile: isMobile,
-                        rowSpacing: rowSpacing,
-                        gridTopPadding: 8 + focusOverhang,
                       );
                     },
                     childCount: categoryItems.length,
@@ -1303,14 +1294,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     sectionCount: itemsToDisplay.length,
                     crossAxisCount: crossAxisCount,
                     cellWidth: cellWidth,
-                    childAspectRatio: childAspectRatio,
                     itemAspectRatio: itemAspectRatio,
                     focusColor: focusColor,
                     isNeon: isNeon,
                     watchedBehavior: watchedBehavior,
                     isMobile: isMobile,
-                    rowSpacing: rowSpacing,
-                    gridTopPadding: 8 + focusOverhang,
                   );
                 }, childCount: itemsToDisplay.length),
               ),
@@ -1360,7 +1348,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required int sectionCount,
     required int crossAxisCount,
     required double cellWidth,
-    required double childAspectRatio,
     required double itemAspectRatio,
     required Color focusColor,
     required bool isNeon,
@@ -1368,8 +1355,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required bool isMobile,
     VoidCallback? onCardFocused,
     bool paginateOnEdge = true,
-    double? rowSpacing,
-    double? gridTopPadding,
   }) {
     // Section headers throw off the uniform row maths in _scrollToGridRow, so a
     // grouped card asks the viewport to reveal it and needs its own context.
@@ -1401,16 +1386,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 _onItemFocused(item);
                 if (onCardFocused != null) {
                   onCardFocused();
-                } else if (_isJumpingToLetter) {
-                  return;
                 } else if (revealContext == null) {
-                  _scrollToGridRow(
-                    index: positionInSection,
-                    crossAxisCount: crossAxisCount,
-                    cellHeight: cellWidth / childAspectRatio,
-                    mainAxisSpacing: rowSpacing ?? 8.0,
-                    gridTopPadding: gridTopPadding ?? 8.0,
-                  );
+                  _scrollToGridRow(positionInSection);
                 } else if (revealContext.mounted) {
                   unawaited(
                     Scrollable.ensureVisible(
@@ -1529,7 +1506,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             items: catItems,
             focusIndexOffset: focusOffsets[idx],
             cardWidth: cardWidth,
-            rowCardHeight: rowCardHeight,
             rowContainerHeight: rowContainerHeight,
             gridPadding: gridPadding,
             focusColor: focusColor,
@@ -3414,7 +3390,6 @@ class _GroupedCategoryRow extends StatefulWidget {
   /// a distinct index or two rows end up sharing a node.
   final int focusIndexOffset;
   final double cardWidth;
-  final double rowCardHeight;
   final double rowContainerHeight;
   final double gridPadding;
   final Color focusColor;
@@ -3428,7 +3403,6 @@ class _GroupedCategoryRow extends StatefulWidget {
     required int sectionCount,
     required int crossAxisCount,
     required double cellWidth,
-    required double childAspectRatio,
     required double itemAspectRatio,
     required Color focusColor,
     required bool isNeon,
@@ -3444,7 +3418,6 @@ class _GroupedCategoryRow extends StatefulWidget {
     required this.items,
     required this.focusIndexOffset,
     required this.cardWidth,
-    required this.rowCardHeight,
     required this.rowContainerHeight,
     required this.gridPadding,
     required this.focusColor,
@@ -3532,7 +3505,6 @@ class _GroupedCategoryRowState extends State<_GroupedCategoryRow> {
                     sectionCount: widget.items.length,
                     crossAxisCount: widget.items.length,
                     cellWidth: widget.cardWidth,
-                    childAspectRatio: widget.cardWidth / widget.rowCardHeight,
                     itemAspectRatio: itemAspectRatio,
                     focusColor: widget.focusColor,
                     isNeon: widget.isNeon,

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -262,15 +262,23 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required double mainAxisSpacing,
     double gridTopPadding = 8.0,
   }) {
-    if (!mounted || !_scrollController.hasClients) return;
-    final row = index ~/ crossAxisCount;
-    final rowTop = gridTopPadding + row * (cellHeight + mainAxisSpacing);
-    final rowBottom = rowTop + cellHeight;
+    if (!mounted || !_scrollController.hasClients || _isJumpingToLetter) return;
+    final geometry = _gridGeometry;
+    final effectivePerLine =
+        (geometry?.perLine ?? crossAxisCount).clamp(1, 100);
+    final effectiveLineExtent = geometry?.lineExtent ?? cellHeight;
+    final effectiveLineSpacing = geometry?.lineSpacing ?? mainAxisSpacing;
+    final effectiveLeadingPad = geometry?.leadingPad ?? gridTopPadding;
+
+    final row = index ~/ effectivePerLine;
+    final rowTop =
+        effectiveLeadingPad + row * (effectiveLineExtent + effectiveLineSpacing);
+    final rowBottom = rowTop + effectiveLineExtent;
     final position = _scrollController.position;
     final viewportH = position.viewportDimension;
     final current = position.pixels;
-    const topPad = 8.0;
-    const bottomPad = 52.0;
+    final topPad = effectiveLeadingPad;
+    final bottomPad = 52.0 + (effectiveLeadingPad - 8.0).clamp(0.0, 32.0);
     double target = current;
     if (rowTop - topPad < current) {
       target = rowTop - topPad;
@@ -1235,6 +1243,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                         isNeon: isNeon,
                         watchedBehavior: watchedBehavior,
                         isMobile: isMobile,
+                        rowSpacing: rowSpacing,
+                        gridTopPadding: 8 + focusOverhang,
                       );
                     },
                     childCount: categoryItems.length,
@@ -1299,6 +1309,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                     isNeon: isNeon,
                     watchedBehavior: watchedBehavior,
                     isMobile: isMobile,
+                    rowSpacing: rowSpacing,
+                    gridTopPadding: 8 + focusOverhang,
                   );
                 }, childCount: itemsToDisplay.length),
               ),
@@ -1356,6 +1368,8 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
     required bool isMobile,
     VoidCallback? onCardFocused,
     bool paginateOnEdge = true,
+    double? rowSpacing,
+    double? gridTopPadding,
   }) {
     // Section headers throw off the uniform row maths in _scrollToGridRow, so a
     // grouped card asks the viewport to reveal it and needs its own context.
@@ -1387,12 +1401,15 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
                 _onItemFocused(item);
                 if (onCardFocused != null) {
                   onCardFocused();
+                } else if (_isJumpingToLetter) {
+                  return;
                 } else if (revealContext == null) {
                   _scrollToGridRow(
                     index: positionInSection,
                     crossAxisCount: crossAxisCount,
                     cellHeight: cellWidth / childAspectRatio,
-                    mainAxisSpacing: 8.0,
+                    mainAxisSpacing: rowSpacing ?? 8.0,
+                    gridTopPadding: gridTopPadding ?? 8.0,
                   );
                 } else if (revealContext.mounted) {
                   unawaited(

--- a/test/ui/library_browse_grid_focus_test.dart
+++ b/test/ui/library_browse_grid_focus_test.dart
@@ -1,119 +1,182 @@
 import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/browse/library_browse_screen.dart';
 import 'package:moonfin/ui/widgets/media_card.dart';
 
+/// The vertical browse grid widens its row pitch and its leading pad to leave
+/// a focused card room to grow, and the scroll controller has to land on the
+/// lines the sliver really drew. These build the same sliver the screen builds
+/// and measure where the cards render, so a start that stops matching the
+/// layout fails here instead of walking the focused card off a TV screen.
 void main() {
-  group('Library Browse Grid Focus & Scroll Geometry (Issue #1356)', () {
-    test('tvOS focus overhang and row spacing parity across 200 rows', () {
-      // tvOS: focusScale is 1.12
-      const double tvosFocusScale = 1.12;
-      const double cellHeight = 282.0;
-      const int crossAxisCount = 5;
+  const viewport = Size(1920, 1080);
+  const gridPadding = 48.0;
+  const crossSpacing = 12.0;
 
-      // focusGap(cellHeight, minimum: 0.0) on tvOS
-      final focusOverhang =
-          math.max(0.0, cellHeight * (tvosFocusScale - 1.0) / 2.0);
-      final rowSpacing = math.max(8.0, focusOverhang);
-      final gridTopPadding = 8.0 + focusOverhang;
+  /// Lays out the grid the way _buildVerticalGrid does for a card of
+  /// [cellHeight] under [focusScale], then checks every row in [rows] renders
+  /// where gridLineStart says it will.
+  Future<void> expectNoDrift(
+    WidgetTester tester, {
+    required double focusScale,
+    required double cellHeight,
+    required int crossAxisCount,
+    required List<int> rows,
+  }) async {
+    tester.view.physicalSize = viewport;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
 
-      // Layout geometry used by SliverGridDelegate and _gridGeometry
-      final geometry = (
-        perLine: crossAxisCount,
-        lineExtent: cellHeight,
-        lineSpacing: rowSpacing,
-        leadingPad: gridTopPadding,
+    final overhang = math.max(0.0, cellHeight * (focusScale - 1) / 2);
+    final GridGeometry geometry = (
+      perLine: crossAxisCount,
+      lineExtent: cellHeight,
+      lineSpacing: math.max(8.0, overhang),
+      leadingPad: 8.0 + overhang,
+    );
+    final cellWidth =
+        (viewport.width -
+            gridPadding * 2 -
+            (crossAxisCount - 1) * crossSpacing) /
+        crossAxisCount;
+
+    // Enough lines past the deepest one under test for it to sit at the top of
+    // a full viewport, so no jump is clamped short of where it was aimed.
+    final pitch = geometry.lineExtent + geometry.lineSpacing;
+    final lineCount =
+        rows.reduce(math.max) + 2 + (viewport.height / pitch).ceil();
+
+    final controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: [
+            SliverPadding(
+              padding: EdgeInsets.fromLTRB(
+                gridPadding,
+                geometry.leadingPad,
+                gridPadding,
+                16,
+              ),
+              sliver: SliverGrid(
+                gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: geometry.perLine,
+                  mainAxisSpacing: geometry.lineSpacing,
+                  crossAxisSpacing: crossSpacing,
+                  childAspectRatio: cellWidth / geometry.lineExtent,
+                ),
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) =>
+                      SizedBox.expand(key: ValueKey<int>(index)),
+                  childCount: lineCount * crossAxisCount,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    for (final row in rows) {
+      final card = find.byKey(ValueKey<int>(row * crossAxisCount));
+      final start = gridLineStart(geometry, row * crossAxisCount);
+      controller.jumpTo(start);
+      await tester.pump();
+
+      expect(
+        controller.offset,
+        closeTo(start, 0.01),
+        reason:
+            'row $row has to be reachable or the checks below prove nothing',
       );
 
-      // Verify that using _gridGeometry matches the layout's exact row position
-      for (final row in [0, 1, 10, 30, 50, 100, 200]) {
-        final sliverRowTop =
-            gridTopPadding + row * (cellHeight + rowSpacing);
-
-        // Effective calculation in _scrollToGridRow with _gridGeometry
-        final effectiveLeadingPad = geometry.leadingPad;
-        final effectiveLineExtent = geometry.lineExtent;
-        final effectiveLineSpacing = geometry.lineSpacing;
-        final computedRowTop = effectiveLeadingPad +
-            row * (effectiveLineExtent + effectiveLineSpacing);
-
-        expect(
-          computedRowTop,
-          equals(sliverRowTop),
-          reason: 'Row $row position must match sliver layout without drift',
-        );
-
-        // Demonstrate the previous bug: hardcoded mainAxisSpacing: 8.0
-        final legacyRowTop = 8.0 + row * (cellHeight + 8.0);
-        final discrepancy = sliverRowTop - legacyRowTop;
-
-        if (row == 30) {
-          // At row 30 on tvOS, legacy formula was ~274px off!
-          expect(discrepancy, greaterThan(250.0));
-        } else if (row == 100) {
-          // At row 100 on tvOS, legacy formula was ~900px off (completely off-screen)
-          expect(discrepancy, greaterThan(850.0));
-        }
-      }
-    });
-
-    test('Desktop and Android TV Large card / Banner drift prevention', () {
-      // Android TV / Desktop: focusScale is 1.05
-      const double standardFocusScale = 1.05;
-      const double largeCellHeight = 360.0;
-      const int crossAxisCount = 6;
-
-      final focusOverhang =
-          math.max(0.0, largeCellHeight * (standardFocusScale - 1.0) / 2.0);
-      // For 360px card, overhang is 360 * 0.025 = 9.0px
-      expect(focusOverhang, closeTo(9.0, 0.001));
-
-      final rowSpacing = math.max(8.0, focusOverhang);
-      expect(rowSpacing, closeTo(9.0, 0.001));
-
-      final gridTopPadding = 8.0 + focusOverhang;
-      expect(gridTopPadding, closeTo(17.0, 0.001));
-
-      final geometry = (
-        perLine: crossAxisCount,
-        lineExtent: largeCellHeight,
-        lineSpacing: rowSpacing,
-        leadingPad: gridTopPadding,
+      final cardTop = tester.getTopLeft(card).dy;
+      expect(
+        cardTop,
+        closeTo(0.0, 0.01),
+        reason:
+            'row $row rendered ${cardTop}px from where gridLineStart put it',
       );
+      // A pitch that only comes out right because the extent and the spacing
+      // cancel each other would still leave the row's bottom edge wrong.
+      expect(tester.getSize(card).height, closeTo(geometry.lineExtent, 0.01));
+    }
+  }
 
-      for (final row in [0, 10, 50, 100]) {
-        final sliverRowTop =
-            gridTopPadding + row * (largeCellHeight + rowSpacing);
-
-        final computedRowTop = geometry.leadingPad +
-            row * (geometry.lineExtent + geometry.lineSpacing);
-
-        expect(
-          computedRowTop,
-          closeTo(sliverRowTop, 0.001),
-          reason: 'Large cards on Desktop/Android must match sliver layout',
-        );
-
-        // In legacy code, hardcoded 8.0 caused progressive drift on large cards
-        final legacyRowTop = 8.0 + row * (largeCellHeight + 8.0);
-        final discrepancy = sliverRowTop - legacyRowTop;
-        if (row == 100) {
-          // 1px per row + 9px top pad = 109px drift
-          expect(discrepancy, closeTo(109.0, 0.001));
-        }
-      }
+  group('grid line starts match the sliver the browse screen builds', () {
+    testWidgets('tvOS focus scale, standard poster', (tester) async {
+      await expectNoDrift(
+        tester,
+        focusScale: 1.12,
+        cellHeight: 282.0,
+        crossAxisCount: 5,
+        rows: const [0, 1, 10, 30, 100, 200],
+      );
     });
 
-    test('topPad respects focus overhang to prevent clipping top border glow', () {
-      const double tvosFocusScale = 1.12;
-      const double cellHeight = 282.0;
-      final focusOverhang =
-          math.max(0.0, cellHeight * (tvosFocusScale - 1.0) / 2.0);
-      final leadingPad = 8.0 + focusOverhang;
-
-      // In updated _scrollToGridRow:
-      final topPad = leadingPad;
-      expect(topPad, greaterThan(8.0));
-      expect(topPad, equals(8.0 + focusOverhang));
+    testWidgets('desktop and Android TV focus scale, standard poster', (
+      tester,
+    ) async {
+      await expectNoDrift(
+        tester,
+        focusScale: 1.05,
+        cellHeight: 282.0,
+        crossAxisCount: 6,
+        rows: const [0, 1, 10, 50, 200],
+      );
     });
+
+    testWidgets('desktop and Android TV focus scale, large poster', (
+      tester,
+    ) async {
+      await expectNoDrift(
+        tester,
+        focusScale: 1.05,
+        cellHeight: 360.0,
+        crossAxisCount: 6,
+        rows: const [0, 10, 100, 200],
+      );
+    });
+
+    testWidgets('banner layout, few wide cells per line', (tester) async {
+      await expectNoDrift(
+        tester,
+        focusScale: 1.12,
+        cellHeight: 180.0,
+        crossAxisCount: 2,
+        rows: const [0, 5, 60, 200],
+      );
+    });
+
+    testWidgets('the focus scale this build was compiled for', (tester) async {
+      await expectNoDrift(
+        tester,
+        focusScale: MediaCard.focusScale,
+        cellHeight: 282.0,
+        crossAxisCount: 5,
+        rows: const [0, 1, 40, 150],
+      );
+    });
+  });
+
+  test('gridLineStart holds a line together and steps a whole pitch', () {
+    const GridGeometry geometry = (
+      perLine: 5,
+      lineExtent: 282.0,
+      lineSpacing: 16.92,
+      leadingPad: 24.92,
+    );
+    const pitch = 282.0 + 16.92;
+
+    expect(gridLineStart(geometry, 0), closeTo(24.92, 0.001));
+    expect(gridLineStart(geometry, 4), closeTo(24.92, 0.001));
+    expect(gridLineStart(geometry, 5), closeTo(24.92 + pitch, 0.001));
+    expect(gridLineStart(geometry, 500), closeTo(24.92 + 100 * pitch, 0.001));
   });
 }

--- a/test/ui/library_browse_grid_focus_test.dart
+++ b/test/ui/library_browse_grid_focus_test.dart
@@ -1,0 +1,119 @@
+import 'dart:math' as math;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/media_card.dart';
+
+void main() {
+  group('Library Browse Grid Focus & Scroll Geometry (Issue #1356)', () {
+    test('tvOS focus overhang and row spacing parity across 200 rows', () {
+      // tvOS: focusScale is 1.12
+      const double tvosFocusScale = 1.12;
+      const double cellHeight = 282.0;
+      const int crossAxisCount = 5;
+
+      // focusGap(cellHeight, minimum: 0.0) on tvOS
+      final focusOverhang =
+          math.max(0.0, cellHeight * (tvosFocusScale - 1.0) / 2.0);
+      final rowSpacing = math.max(8.0, focusOverhang);
+      final gridTopPadding = 8.0 + focusOverhang;
+
+      // Layout geometry used by SliverGridDelegate and _gridGeometry
+      final geometry = (
+        perLine: crossAxisCount,
+        lineExtent: cellHeight,
+        lineSpacing: rowSpacing,
+        leadingPad: gridTopPadding,
+      );
+
+      // Verify that using _gridGeometry matches the layout's exact row position
+      for (final row in [0, 1, 10, 30, 50, 100, 200]) {
+        final sliverRowTop =
+            gridTopPadding + row * (cellHeight + rowSpacing);
+
+        // Effective calculation in _scrollToGridRow with _gridGeometry
+        final effectiveLeadingPad = geometry.leadingPad;
+        final effectiveLineExtent = geometry.lineExtent;
+        final effectiveLineSpacing = geometry.lineSpacing;
+        final computedRowTop = effectiveLeadingPad +
+            row * (effectiveLineExtent + effectiveLineSpacing);
+
+        expect(
+          computedRowTop,
+          equals(sliverRowTop),
+          reason: 'Row $row position must match sliver layout without drift',
+        );
+
+        // Demonstrate the previous bug: hardcoded mainAxisSpacing: 8.0
+        final legacyRowTop = 8.0 + row * (cellHeight + 8.0);
+        final discrepancy = sliverRowTop - legacyRowTop;
+
+        if (row == 30) {
+          // At row 30 on tvOS, legacy formula was ~274px off!
+          expect(discrepancy, greaterThan(250.0));
+        } else if (row == 100) {
+          // At row 100 on tvOS, legacy formula was ~900px off (completely off-screen)
+          expect(discrepancy, greaterThan(850.0));
+        }
+      }
+    });
+
+    test('Desktop and Android TV Large card / Banner drift prevention', () {
+      // Android TV / Desktop: focusScale is 1.05
+      const double standardFocusScale = 1.05;
+      const double largeCellHeight = 360.0;
+      const int crossAxisCount = 6;
+
+      final focusOverhang =
+          math.max(0.0, largeCellHeight * (standardFocusScale - 1.0) / 2.0);
+      // For 360px card, overhang is 360 * 0.025 = 9.0px
+      expect(focusOverhang, closeTo(9.0, 0.001));
+
+      final rowSpacing = math.max(8.0, focusOverhang);
+      expect(rowSpacing, closeTo(9.0, 0.001));
+
+      final gridTopPadding = 8.0 + focusOverhang;
+      expect(gridTopPadding, closeTo(17.0, 0.001));
+
+      final geometry = (
+        perLine: crossAxisCount,
+        lineExtent: largeCellHeight,
+        lineSpacing: rowSpacing,
+        leadingPad: gridTopPadding,
+      );
+
+      for (final row in [0, 10, 50, 100]) {
+        final sliverRowTop =
+            gridTopPadding + row * (largeCellHeight + rowSpacing);
+
+        final computedRowTop = geometry.leadingPad +
+            row * (geometry.lineExtent + geometry.lineSpacing);
+
+        expect(
+          computedRowTop,
+          closeTo(sliverRowTop, 0.001),
+          reason: 'Large cards on Desktop/Android must match sliver layout',
+        );
+
+        // In legacy code, hardcoded 8.0 caused progressive drift on large cards
+        final legacyRowTop = 8.0 + row * (largeCellHeight + 8.0);
+        final discrepancy = sliverRowTop - legacyRowTop;
+        if (row == 100) {
+          // 1px per row + 9px top pad = 109px drift
+          expect(discrepancy, closeTo(109.0, 0.001));
+        }
+      }
+    });
+
+    test('topPad respects focus overhang to prevent clipping top border glow', () {
+      const double tvosFocusScale = 1.12;
+      const double cellHeight = 282.0;
+      final focusOverhang =
+          math.max(0.0, cellHeight * (tvosFocusScale - 1.0) / 2.0);
+      final leadingPad = 8.0 + focusOverhang;
+
+      // In updated _scrollToGridRow:
+      final topPad = leadingPad;
+      expect(topPad, greaterThan(8.0));
+      expect(topPad, equals(8.0 + focusOverhang));
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
This is a pretty big swing but I think it is worth it. Prompted by issue #1356, I looked into what was responsible for the drift and found that, while the problem is magnified on tvOS (details below), it also impacts Desktop (with keyboard/remote navigation) and AndroidTV. The goal of this PR is to prevent focus indicator drift during vertical scrolling and viewport yank-back during alphabet letter jumps in the library browse grid. Since this is a pretty impactful PR, here are additional details about the root of the issue and why it should be addressed.

### Background & Problem
When navigating vertical library grids, focused cards scale up to indicate selection (`MediaCard.focusScale`). To prevent focused cards from visually clipping neighboring elements or top screen bounds, the vertical sliver layout reserves spacing dynamically in **library_browse_screen.dart**:
- `focusOverhang = isMobile ? 0.0 : MediaCard.focusGap(cellHeight, minimum: 0.0)`
- `rowSpacing = math.max(8.0, focusOverhang)`
- `gridTopPadding = 8.0 + focusOverhang`

On tvOS, Apple TV guidelines specify a larger focus expansion (`focusScale = 1.12`), producing a `~16.92px` overhang for standard poster cards (`cellHeight ≈ 282px`). On Android TV and Desktop, `focusScale = 1.05`. For standard cards on those platforms, `focusOverhang` is `7.05px` (clamped to `8.0px`), but for "Large" poster preferences or "Banner" views (`cellHeight > 320px`), `focusOverhang` exceeds `8.0px` (e.g., `9.0px` at `360px`).

However, the programmatic focus scrolling method **_scrollToGridRow** was not using these dynamic values. At its invocation in **_buildGridCard**, `mainAxisSpacing` was hardcoded to `8.0`, and `gridTopPadding` defaulted to `8.0`.  This created a progressive mathematical divergence between where the sliver grid actually positioned cards on screen and where **_scrollToGridRow** thought cards were located:

- **On tvOS**: An `~8.92px` error accumulated per row. At row 30, the calculated offset was ~267px too high; at row 100, it was ~892px too high. As the user navigated downward, **_scrollToGridRow** falsely determined that the card was above the top viewport boundary and scrolled in reverse (upward), driving the focused card off the bottom of the screen.
- **On Android TV & Desktop**: Although standard posters coincidentally matched the hardcoded `8.0px`, viewing Large cards or Banner layouts suffered progressive drift (e.g. 109px drift over 100 rows). In addition, an ~7px top-padding offset error was present on all non-mobile platforms.
- **During Alphabet Letter Jumps**: When jumping to a distant letter (e.g. 'M'), **_jumpToLetter** correctly computed the scroll destination using **_gridGeometry** and settled the viewport. However, 150ms later, the target card was focused, triggering **onFocus** and calling **_scrollToGridRow** with the faulty `8.0px` formula. This immediately yanked the viewport backward, throwing the freshly selected letter target off screen.

### Architectural Solution
To ensure long-term stability across all platforms (tvOS, Android TV, Desktop) and display configurations (Standard, Large, Banner), this PR refactors **_scrollToGridRow** to treat the active layout geometry (**_gridGeometry**) as the single source of truth:
1. **Unified Geometry Source**: **_scrollToGridRow** now derives `perLine`, `lineExtent`, `lineSpacing`, and `leadingPad` directly from **_gridGeometry**. The scroll controller and `SliverGridDelegateWithFixedCrossAxisCount` now share identical mathematical coordinates without maintaining duplicated formulas.
2. **Dynamic Fallbacks**: **_buildGridCard** now accepts and forwards dynamic `rowSpacing` and `gridTopPadding` (`8 + focusOverhang`) so that any fallback calculations also mirror the rendered layout.
3. **Alphabet Jump Mutual Exclusion**: **_scrollToGridRow** and card **onFocus** now guard against execution while **_isJumpingToLetter** is active, preventing competing scroll animations when landing on letter targets.
4. **Top Edge Clearance**: Adjusted viewport `topPad` in **_scrollToGridRow** to `effectiveLeadingPad`, ensuring the top-row card glow and 12% tvOS focus expansion are never clipped by the upper screen edge.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1356 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Refactored **_scrollToGridRow** in **library_browse_screen.dart** to consume **_gridGeometry** as the single source of truth for grid line calculations.
- Forwarded dynamic `rowSpacing` and `gridTopPadding` from **_buildVerticalGrid** through **_buildGridCard** to replace legacy hardcoded `8.0px` values.
- Guarded **_scrollToGridRow** and card **onFocus** against firing while **_isJumpingToLetter** is true, preventing viewport yankback after letter navigation.
- Updated top viewport boundary padding (`topPad`) to `effectiveLeadingPad` to preserve focus glow clearance at the top of the grid.
- Added **library_browse_grid_focus_test.dart** covering row coordinate parity across 200 rows under tvOS (1.12 scale), Android TV, and Desktop (1.05 scale and Large card layouts).

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a media library containing >150 items on tvOS, Android TV, or Desktop (with keyboard/remote navigation).
2. Continuously scroll downward with D-pad/arrow keys through 100+ items; confirm the focused poster stays steadily centered within the safe-zone and does not drift off-screen.
3. In Display Settings, switch poster size to "Large" and verify zero drift across 100+ rows.
4. Navigate to the alphabet jump bar and select a distant letter (e.g. 'M'); confirm the viewport smoothly lands on the target letter and focuses the first item without being yanked backward.
5. Run automated unit tests: `flutter test test/ui/library_browse_grid_focus_test.dart` and `flutter test test/focus/`.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

Focus indicactor remains on screen and movement is smooth (except for when I hit loading transitions):

https://github.com/user-attachments/assets/b12e5172-3539-4550-afd2-c68208e5529d

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
