### PR TITLE
Upgrade pdfrx to 2.6.1

### DIFF
--- a/.github/workflows/build-tvos.yml
+++ b/.github/workflows/build-tvos.yml
@@ -12,7 +12,7 @@ on:
           - testflight
 
 env:
-  FLUTTER_TVOS_REF: 'v3.44.1-tvos.1.2.0'
+  FLUTTER_TVOS_REF: 'v3.47.2-tvos.1.10.0'
 
 jobs:
   build-tvos:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ permissions:
   actions: read
 
 env:
-  FLUTTER_VERSION: '3.44.1'
+  FLUTTER_VERSION: '3.47.2'
 
 jobs:
   # Android APK + AAB

--- a/.github/workflows/deploy-web-pages.yml
+++ b/.github/workflows/deploy-web-pages.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  FLUTTER_VERSION: '3.44.1'
+  FLUTTER_VERSION: '3.47.2'
 
 jobs:
   build:

--- a/.github/workflows/release-web-bundle.yml
+++ b/.github/workflows/release-web-bundle.yml
@@ -31,7 +31,7 @@ permissions:
   contents: write
 
 env:
-  FLUTTER_VERSION: '3.44.1'
+  FLUTTER_VERSION: '3.47.2'
 
 jobs:
   build-web-bundle:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Per-platform notes and the Tizen toolchain setup are on [Installation](https://g
 
 ## Building
 
-Flutter stable 3.41+ and Dart 3.11+ are the only prerequisites.
+Flutter stable 3.47+ and Dart 3.13+ are the only prerequisites.
 
 ```bash
 git clone https://github.com/Moonfin-Client/Moonfin-Core.git

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -384,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  cupertino_ui:
+    dependency: transitive
+    description:
+      name: cupertino_ui
+      sha256: e9dfe7fac704028f8928cbe4028a0be5e8a709498e8daf8247de99e99a32aef3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   custom_lint_core:
     dependency: transitive
     description:
@@ -1037,10 +1045,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -1171,10 +1179,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1183,6 +1191,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
+  material_ui:
+    dependency: transitive
+    description:
+      name: material_ui
+      sha256: "9c0156b0cf8b3f56d365c8ffe051a720be3cae9eec55119f01e01b986ffb7101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   media_kit:
     dependency: "direct main"
     description:
@@ -1228,10 +1244,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -1418,34 +1434,34 @@ packages:
     dependency: transitive
     description:
       name: pdfium_dart
-      sha256: b536c19a10f8c86c160274a54ca6f29bc4c88001324ddcda4cca316033f2dc96
+      sha256: ed25295fd2624bbf54b8e6bd3cd3d0fc644412d3d5e79ca2485cb36e65f20eb2
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.4"
+    version: "0.3.0"
   pdfium_flutter:
     dependency: transitive
     description:
       name: pdfium_flutter
-      sha256: "97ccb5cf207b66ba5549f09047e935376d967c6311ec3c5314405d1d04569fd2"
+      sha256: "2b1f27e30d29d0bb1d57a37c351b0cfa605cf5d2334aa565af370fa5b1eba8f4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.3.0"
   pdfrx:
     dependency: "direct main"
     description:
       name: pdfrx
-      sha256: "6b3571565fb412fb7d0a325a76154d0685bd0a0659c3f41ee007f408d48cfd46"
+      sha256: "5eed06c4318157ea6791666c2ea4b01a35adac554b0aac7ca6b6d0cd80ba8e15"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.6.1"
   pdfrx_engine:
     dependency: transitive
     description:
       name: pdfrx_engine
-      sha256: a201b11e13b6c729d731ddc96ce06394cce8503c39e4c7e9d2fa51b3e7b351a5
+      sha256: f7b80b9af7d72188cecc15b31a91558d216cb15f97980b24146fd0c36cd6d049
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.6.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -2072,10 +2088,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -2248,10 +2264,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   video_player:
     dependency: "direct main"
     description:
@@ -2477,5 +2493,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ moonfin:
   android_tv_build_number: 2000016
 
 environment:
-  sdk: ">=3.12.0 <4.0.0"
-  flutter: ">=3.44.0"
+  sdk: ">=3.13.0 <4.0.0"
+  flutter: ">=3.47.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -141,7 +141,7 @@ dependencies:
   webview_flutter_android: ^4.12.0
   webview_flutter_wkwebview: ^3.25.1
   youtube_player_iframe: ^6.0.0
-  pdfrx: ^2.2.24
+  pdfrx: ^2.6.1
   flutter_widget_from_html_core: ^0.16.1
   # Vendored fork of kindle_unpack 0.1.1 (MOBI/AZW/AZW3 -> EPUB), patched to
   # build against archive 4.x. See packages/kindle_unpack and the patch note.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,8 @@ moonfin:
   android_tv_build_number: 2000016
 
 environment:
-  sdk: ^3.11.0
+  sdk: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
# Pull Request

## Summary
Upgrades the `pdfrx` dependency from `2.4.3` to `2.6.1`. This update adjusts the SDK environment bounds (`Dart >= 3.13.0`, `Flutter >= 3.47.0`), bumps its underlying PDF rendering engine (`pdfrx_engine`, `pdfium_dart`, `pdfium_flutter`), and includes minor patch/transitive library adjustments.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [x] Build/CI change
- [x] Other (describe): Dependency & SDK constraint update

## Changes Made
- Bumping SDK constraints in `pubspec.yaml`:
  - `dart`: `>=3.12.0 <4.0.0` → `>=3.13.0 <4.0.0`
  - `flutter`: `>=3.44.0` → `>=3.47.0`
- Bumping core PDF library: `pdfrx` (`2.4.3` → `2.6.1`)
- Updating engine bindings: `pdfrx_engine` (`0.4.2` → `0.6.0`), `pdfium_dart` (`0.2.4` → `0.3.0`), `pdfium_flutter` (`0.2.1` → `0.3.0`)
- Addition of transitive UI dependencies: `cupertino_ui` (`1.0.2`), `material_ui` (`1.1.1`)
- Transitive library patch bumps: `intl` (`0.20.2` → `0.20.3`), `matcher` (`0.12.19` → `0.12.20`), `meta` (`1.18.0` → `1.19.0`), `vector_math` (`2.2.0` → `2.4.2`), `test_api` (`0.7.11` → `0.7.12`)

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Verify target environment is on Flutter `>=3.47.0` / Dart `>=3.13.0`.
2. Run `flutter pub get` and verify dependency graph resolves cleanly.
3. Build and launch the app; open PDF viewer views to verify document rendering and native binary bindings function without error.

### Test Steps
1. Viewed PDF E-book
2.
3.

## Screenshots (if applicable)
<img width="1522" height="891" alt="image" src="https://github.com/user-attachments/assets/11028e2a-1f6c-48a5-a572-a3f471af780c" />

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
