### PR TITLE
Feat: Downloads unwatched-only option, transfer speed/ETA, large queue performance

### DIFF
--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -236,6 +236,33 @@ class DownloadService extends ChangeNotifier {
   Timer? _rateRefreshTimer;
   static const _rateStaleAfter = Duration(seconds: 5);
 
+  Timer? _notifyTimer;
+  DateTime? _lastNotifiedAt;
+  bool _disposed = false;
+  static const _notifyInterval = Duration(milliseconds: 80);
+
+  /// Coalesces listener notifications into at most one per
+  /// [_notifyInterval]. Queueing a whole series fires one update per episode
+  /// in a single synchronous loop and every running transfer ticks several
+  /// times a second; rebuilding the downloads panel for each of those made
+  /// the app unusable with a few hundred queued items.
+  @override
+  void notifyListeners() {
+    if (_disposed || _notifyTimer != null) return;
+    final lastAt = _lastNotifiedAt;
+    final sinceLast = lastAt == null
+        ? _notifyInterval
+        : DateTime.now().difference(lastAt);
+    final delay = sinceLast >= _notifyInterval
+        ? Duration.zero
+        : _notifyInterval - sinceLast;
+    _notifyTimer = Timer(delay, () {
+      _notifyTimer = null;
+      _lastNotifiedAt = DateTime.now();
+      if (!_disposed) super.notifyListeners();
+    });
+  }
+
   bool _cancelAllRequested = false;
 
   final Queue<_QueuedDownload> _pendingDownloads = Queue<_QueuedDownload>();
@@ -3254,6 +3281,9 @@ class DownloadService extends ChangeNotifier {
     _prefs.removeListener(_onPreferencesChanged);
     _coordinator?.detach(statusHandler: _onTaskStatus);
     cancelAll();
+    _disposed = true;
+    _notifyTimer?.cancel();
+    _notifyTimer = null;
     _rateRefreshTimer?.cancel();
     _rateRefreshTimer = null;
     _downloadDio.close();

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -259,14 +259,13 @@ class DownloadService extends ChangeNotifier {
   bool _pluginEngineFor(
     DownloadQuality quality, {
     required bool destinationOnRemovableStorage,
-  }) =>
-      downloadUsesPluginEngine(
-        pluginEngineSupported: _pluginEngineSupported,
-        serverNeedsLegacyTls: _serverNeedsLegacyTls,
-        isAndroidTv: PlatformDetection.isAndroid && PlatformDetection.isTV,
-        qualityTranscoded: quality.isTranscoded,
-        destinationOnRemovableStorage: destinationOnRemovableStorage,
-      );
+  }) => downloadUsesPluginEngine(
+    pluginEngineSupported: _pluginEngineSupported,
+    serverNeedsLegacyTls: _serverNeedsLegacyTls,
+    isAndroidTv: PlatformDetection.isAndroid && PlatformDetection.isTV,
+    qualityTranscoded: quality.isTranscoded,
+    destinationOnRemovableStorage: destinationOnRemovableStorage,
+  );
 
   /// On iOS and Android the plugin posts its own download notifications for
   /// the downloads it runs. The desktop plugin engine and the legacy engine
@@ -2306,45 +2305,38 @@ class DownloadService extends ChangeNotifier {
     }
   }
 
-  Future<List<AggregatedItem>> _getAllEpisodesForSeries(String seriesId) async {
-    final seasonsData = await _client.itemsApi.getSeasons(seriesId);
-    final seasons = (seasonsData['Items'] as List?) ?? [];
-    final allEpisodes = <AggregatedItem>[];
-    for (final season in seasons) {
-      final seasonId = season['Id']?.toString() ?? '';
-      final episodesData = await _client.itemsApi.getEpisodes(
-        seriesId,
-        seasonId: seasonId,
-      );
-      final episodes = (episodesData['Items'] as List?) ?? [];
-      for (final raw in episodes) {
-        final ep = raw as Map<String, dynamic>;
-        allEpisodes.add(
-          AggregatedItem(
-            id: ep['Id']?.toString() ?? '',
-            serverId: _client.baseUrl,
-            rawData: ep,
-          ),
-        );
-      }
-    }
-    return allEpisodes;
-  }
+  /// Fields requested for batch fetches so the download sheet can estimate
+  /// sizes and filter on watched state before anything is queued.
+  static const _batchFetchFields =
+      'MediaStreams,MediaSources,RunTimeTicks,UserData';
 
-  Future<void> downloadSeries(
+  /// The episodes of [seriesId], or of one of its seasons when [seasonId] is
+  /// given, with runtime, media sources and user data populated so sizes and
+  /// watched state are known before anything is queued.
+  Future<List<AggregatedItem>> fetchEpisodes(
     String seriesId, {
-    DownloadQuality quality = DownloadQuality.original,
+    String? seasonId,
   }) async {
-    final episodes = await _getAllEpisodesForSeries(seriesId);
-    await downloadItems(episodes, quality: quality);
+    final data = await _client.itemsApi.getEpisodes(
+      seriesId,
+      seasonId: seasonId,
+      fields: _batchFetchFields,
+    );
+    return _toItems(data['Items'] as List?);
   }
 
-  Future<void> downloadBoxSet(
-    String boxSetId, {
-    DownloadQuality quality = DownloadQuality.original,
-  }) async {
-    final playableItems = await _getAllPlayableItemsForBoxSet(boxSetId);
-    await downloadItems(playableItems, quality: quality);
+  List<AggregatedItem> _toItems(List? rawItems) {
+    if (rawItems == null) return const [];
+    final serverId = _client.baseUrl;
+    return [
+      for (final raw in rawItems.whereType<Map>())
+        if (raw['Id']?.toString() case final id? when id.isNotEmpty)
+          AggregatedItem(
+            id: id,
+            serverId: serverId,
+            rawData: raw.cast<String, dynamic>(),
+          ),
+    ];
   }
 
   Future<void> downloadAlbum(
@@ -2373,37 +2365,16 @@ class DownloadService extends ChangeNotifier {
     await downloadItems(tracks, quality: quality);
   }
 
-  Future<List<AggregatedItem>> _getAllPlayableItemsForBoxSet(
-    String boxSetId,
-  ) async {
-    try {
-      final data = await _client.itemsApi.getItems(
-        parentId: boxSetId,
-        recursive: true,
-        includeItemTypes: const ['Episode', 'Movie', 'Video', 'Audio'],
-        fields: 'MediaStreams,MediaSources,RunTimeTicks,Trickplay',
-      );
-      final rawItems = data['Items'] as List?;
-      if (rawItems == null) return const [];
-      final serverId = _client.baseUrl;
-      return rawItems
-          .whereType<Map>()
-          .map((raw) => raw.cast<String, dynamic>())
-          .where((raw) {
-            final id = raw['Id']?.toString();
-            return id != null && id.isNotEmpty;
-          })
-          .map(
-            (raw) => AggregatedItem(
-              id: raw['Id']?.toString() ?? '',
-              serverId: serverId,
-              rawData: raw,
-            ),
-          )
-          .toList();
-    } catch (_) {
-      return const [];
-    }
+  /// Every playable leaf item inside the collection [boxSetId], with runtime,
+  /// media sources and user data populated.
+  Future<List<AggregatedItem>> fetchBoxSetPlayableItems(String boxSetId) async {
+    final data = await _client.itemsApi.getItems(
+      parentId: boxSetId,
+      recursive: true,
+      includeItemTypes: const ['Episode', 'Movie', 'Video', 'Audio'],
+      fields: '$_batchFetchFields,Trickplay',
+    );
+    return _toItems(data['Items'] as List?);
   }
 
   Future<bool> deleteDownloadedItems(List<AggregatedItem> items) async {

--- a/lib/data/services/download_service.dart
+++ b/lib/data/services/download_service.dart
@@ -44,9 +44,17 @@ class DownloadProgress {
   /// progress replaces it, so UIs can show (and cancel) the waiting item.
   final bool isQueued;
 
-  /// Seconds the server expects its transcode to still need, read from the
-  /// plugin while a transcoded download runs. Null when nothing answers.
+  /// Seconds the download is expected to still need. For transcoded
+  /// downloads this is the server's own transcode estimate; for original
+  /// files it is derived from the recent transfer rate. Null when unknown.
   final int? etaSeconds;
+
+  /// Expected size of the file in bytes, or 0 when the server did not say.
+  final int totalBytes;
+
+  /// Recent transfer rate for original-quality downloads. Null for
+  /// transcoded streams and until enough samples exist.
+  final int? bytesPerSecond;
 
   const DownloadProgress({
     required this.itemId,
@@ -58,15 +66,48 @@ class DownloadProgress {
     this.quality = DownloadQuality.original,
     this.isQueued = false,
     this.etaSeconds,
+    this.totalBytes = 0,
+    this.bytesPerSecond,
   });
 
   bool get isTranscoded => quality.isTranscoded;
+
+  /// Copy with some fields replaced. [clearRate] drops the transfer rate and
+  /// remaining time, which a plain null argument cannot express.
+  DownloadProgress copyWith({
+    double? progress,
+    int? etaSeconds,
+    bool clearRate = false,
+  }) => DownloadProgress(
+    itemId: itemId,
+    fileName: fileName,
+    progress: progress ?? this.progress,
+    bytesReceived: bytesReceived,
+    isComplete: isComplete,
+    error: error,
+    quality: quality,
+    isQueued: isQueued,
+    etaSeconds: clearRate ? null : (etaSeconds ?? this.etaSeconds),
+    totalBytes: totalBytes,
+    bytesPerSecond: clearRate ? null : bytesPerSecond,
+  );
 
   /// True while the transfer has effectively finished but the file is still
   /// being moved to its final location and validated. Progress is clamped to
   /// 0.99 during this window, so without this the UI looks stuck at 99%.
   bool get isFinalizing => !isComplete && error == null && progress >= 0.99;
 }
+
+/// Byte progress of a transfer. The native engine also reports its own rate
+/// and remaining time; the legacy engine leaves them null and the service
+/// derives them from the byte samples instead.
+typedef _ProgressCallback =
+    void Function(
+      int received,
+      int total, {
+      int? bytesPerSecond,
+      int? etaSeconds,
+    });
 
 /// Per-attempt state for a media download running on the native
 /// background_downloader engine. Keyed by itemId in
@@ -77,7 +118,7 @@ class _MediaDownloadContext {
   final String displayName;
   final DownloadQuality quality;
   final String savePath;
-  final void Function(int received, int total) onReceiveProgress;
+  final _ProgressCallback onReceiveProgress;
   final Completer<Response> completer = Completer<Response>();
   String currentTaskId = '';
 
@@ -179,7 +220,10 @@ class DownloadService extends ChangeNotifier {
   final Map<String, DateTime> _downloadStartTimes = {};
   final Map<String, double> _lastPersistedProgress = {};
   final Map<String, double> _lastNotifiedProgress = {};
-  final Map<String, double> _lastCallbackProgress = {};
+
+  /// Progress and time of the last published update per item, for the
+  /// per-item throttle in [_transferProgress].
+  final Map<String, ({double progress, DateTime at})> _lastPublished = {};
 
   // The server side view of a running transcoded download, polled from the
   // plugin. Progress replaces the indeterminate bar and the ETA feeds the
@@ -187,6 +231,11 @@ class DownloadService extends ChangeNotifier {
   final Map<String, Timer> _transcodeStatusTimers = {};
   final Map<String, double> _serverTranscodeProgress = {};
   final Map<String, int> _transcodeEtaSeconds = {};
+  final Map<String, TransferRateTracker> _transferRates = {};
+
+  Timer? _rateRefreshTimer;
+  static const _rateStaleAfter = Duration(seconds: 5);
+
   bool _cancelAllRequested = false;
 
   final Queue<_QueuedDownload> _pendingDownloads = Queue<_QueuedDownload>();
@@ -618,6 +667,95 @@ class DownloadService extends ChangeNotifier {
     }
   }
 
+  /// Byte-progress bookkeeping shared by fresh and adopted transfers: the
+  /// per-item throttle and the transfer rate of original files. Returns null
+  /// when this update should be dropped.
+  ///
+  /// The native engine reports its own rate and remaining time; when it does
+  /// they win over the byte-sample estimate, which exists for the legacy
+  /// engine. Samples are still recorded so a stalled transfer can be told
+  /// apart from one that is merely quiet.
+  DownloadProgress? _transferProgress({
+    required String itemId,
+    required String fileName,
+    required DownloadQuality quality,
+    required double progress,
+    required int received,
+    required int total,
+    int? reportedBytesPerSecond,
+    int? reportedEtaSeconds,
+  }) {
+    final now = DateTime.now();
+    final tracksRate = !quality.isTranscoded && total > 0;
+    if (tracksRate) {
+      _transferRates
+          .putIfAbsent(itemId, TransferRateTracker.new)
+          .add(received, now);
+      _rateRefreshTimer ??= Timer.periodic(
+        const Duration(seconds: 2),
+        (_) => _expireStaleRates(),
+      );
+    }
+    // Publish when the bar moves a visible amount or every couple of
+    // seconds, whichever comes first; large files gain less than 1% between
+    // rate refreshes and the remaining-time row must still keep moving.
+    final last = _lastPublished[itemId];
+    if (progress >= 0 &&
+        progress < 0.99 &&
+        last != null &&
+        progress - last.progress < 0.01 &&
+        now.difference(last.at) < const Duration(seconds: 2)) {
+      return null;
+    }
+    _lastPublished[itemId] = (progress: progress, at: now);
+
+    var bytesPerSecond = reportedBytesPerSecond;
+    var etaSeconds = _transcodeEtaSeconds[itemId] ?? reportedEtaSeconds;
+    if (tracksRate) {
+      final tracker = _transferRates[itemId]!;
+      bytesPerSecond ??= tracker.bytesPerSecond;
+      etaSeconds ??= tracker.etaSeconds(received, total);
+    }
+    return DownloadProgress(
+      itemId: itemId,
+      fileName: fileName,
+      progress: progress,
+      bytesReceived: received,
+      quality: quality,
+      etaSeconds: etaSeconds,
+      // Dio reports -1 when the server sent no Content-Length.
+      totalBytes: total > 0 ? total : 0,
+      bytesPerSecond: bytesPerSecond,
+    );
+  }
+
+  /// Clears the rate and remaining time of transfers that stopped receiving
+  /// bytes, so a stalled connection does not keep showing its last speed.
+  /// Progress callbacks only fire when data arrives, so this runs on a timer.
+  void _expireStaleRates() {
+    if (_transferRates.isEmpty) {
+      _rateRefreshTimer?.cancel();
+      _rateRefreshTimer = null;
+      return;
+    }
+    final now = DateTime.now();
+    var changed = false;
+    for (final MapEntry(key: itemId, value: tracker)
+        in _transferRates.entries) {
+      final current = _activeDownloads[itemId];
+      final lastSample = tracker.lastSampleAt;
+      if (current == null ||
+          current.bytesPerSecond == null ||
+          lastSample == null ||
+          now.difference(lastSample) < _rateStaleAfter) {
+        continue;
+      }
+      _activeDownloads[itemId] = current.copyWith(clearRate: true);
+      changed = true;
+    }
+    if (changed) notifyListeners();
+  }
+
   double _calculateProgress({
     required int received,
     required int total,
@@ -899,7 +1037,7 @@ class DownloadService extends ChangeNotifier {
     required String savePath,
     required Map<String, String> headers,
     required CancelToken cancelToken,
-    required void Function(int, int) onReceiveProgress,
+    required _ProgressCallback onReceiveProgress,
   }) async {
     await _coordinator!.ensureInitialized();
     final ctx = _MediaDownloadContext(
@@ -1030,7 +1168,16 @@ class DownloadService extends ChangeNotifier {
     if (progress < 0 || progress > 1) return;
     final expected = update.expectedFileSize;
     if (expected > 0) {
-      ctx.onReceiveProgress((progress * expected).round(), expected);
+      ctx.onReceiveProgress(
+        (progress * expected).round(),
+        expected,
+        bytesPerSecond: update.hasNetworkSpeed
+            ? (update.networkSpeed * 1000 * 1000).round()
+            : null,
+        etaSeconds: update.hasTimeRemaining
+            ? update.timeRemaining.inSeconds
+            : null,
+      );
     }
   }
 
@@ -1284,12 +1431,8 @@ class DownloadService extends ChangeNotifier {
     if (current == null || current.isComplete || current.error != null) {
       return;
     }
-    _activeDownloads[itemId] = DownloadProgress(
-      itemId: itemId,
-      fileName: current.fileName,
-      progress: _serverTranscodeProgress[itemId] ?? current.progress,
-      bytesReceived: current.bytesReceived,
-      quality: current.quality,
+    _activeDownloads[itemId] = current.copyWith(
+      progress: _serverTranscodeProgress[itemId],
       etaSeconds: _transcodeEtaSeconds[itemId],
     );
     notifyListeners();
@@ -1931,7 +2074,12 @@ class DownloadService extends ChangeNotifier {
         });
       }
 
-      void onReceiveProgress(int received, int total) {
+      void onReceiveProgress(
+        int received,
+        int total, {
+        int? bytesPerSecond,
+        int? etaSeconds,
+      }) {
         var rawProgress = _calculateProgress(
           received: received,
           total: total,
@@ -1943,21 +2091,19 @@ class DownloadService extends ChangeNotifier {
         if (rawProgress < 0) {
           rawProgress = _serverTranscodeProgress[item.id] ?? rawProgress;
         }
-        final progress = rawProgress >= 1.0 ? 0.99 : rawProgress;
-        if (progress >= 0 && progress < 0.99) {
-          final lastCb = _lastCallbackProgress[item.id] ?? -1.0;
-          if ((progress - lastCb) < 0.01) return;
-        }
-        _lastCallbackProgress[item.id] = progress;
-
-        _activeDownloads[item.id] = DownloadProgress(
+        final update = _transferProgress(
           itemId: item.id,
           fileName: fileName,
-          progress: progress,
-          bytesReceived: received,
           quality: quality,
-          etaSeconds: _transcodeEtaSeconds[item.id],
+          progress: rawProgress >= 1.0 ? 0.99 : rawProgress,
+          received: received,
+          total: total,
+          reportedBytesPerSecond: bytesPerSecond,
+          reportedEtaSeconds: etaSeconds,
         );
+        if (update == null) return;
+        final progress = update.progress;
+        _activeDownloads[item.id] = update;
         if (_shouldPersistProgress(item.id, progress)) {
           unawaited(
             _offlineRepo.updateDownloadStatus(
@@ -2223,7 +2369,8 @@ class DownloadService extends ChangeNotifier {
       _cancelTokens.remove(item.id);
       _lastPersistedProgress.remove(item.id);
       _lastNotifiedProgress.remove(item.id);
-      _lastCallbackProgress.remove(item.id);
+      _lastPublished.remove(item.id);
+      _transferRates.remove(item.id);
       _transcodeStatusTimers.remove(item.id)?.cancel();
       _serverTranscodeProgress.remove(item.id);
       _transcodeEtaSeconds.remove(item.id);
@@ -2983,21 +3130,26 @@ class DownloadService extends ChangeNotifier {
       displayName: row.name,
       quality: quality,
       savePath: savePath,
-      onReceiveProgress: (received, total) {
+      onReceiveProgress: (received, total, {bytesPerSecond, etaSeconds}) {
         final rawProgress = _calculateProgress(
           received: received,
           total: total,
           estimatedSize: 0,
           quality: quality,
         );
-        final progress = rawProgress >= 1.0 ? 0.99 : rawProgress;
-        _activeDownloads[itemId] = DownloadProgress(
+        final update = _transferProgress(
           itemId: itemId,
           fileName: fileName,
-          progress: progress,
-          bytesReceived: received,
           quality: quality,
+          progress: rawProgress >= 1.0 ? 0.99 : rawProgress,
+          received: received,
+          total: total,
+          reportedBytesPerSecond: bytesPerSecond,
+          reportedEtaSeconds: etaSeconds,
         );
+        if (update == null) return;
+        final progress = update.progress;
+        _activeDownloads[itemId] = update;
         if (_shouldPersistProgress(itemId, progress)) {
           unawaited(
             _offlineRepo.updateDownloadStatus(
@@ -3102,6 +3254,8 @@ class DownloadService extends ChangeNotifier {
     _prefs.removeListener(_onPreferencesChanged);
     _coordinator?.detach(statusHandler: _onTaskStatus);
     cancelAll();
+    _rateRefreshTimer?.cancel();
+    _rateRefreshTimer = null;
     _downloadDio.close();
     _errorController.close();
     super.dispose();

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1816,6 +1816,27 @@
       }
     }
   },
+  "downloadBytesOfTotal": "{received} of {total}",
+  "@downloadBytesOfTotal": {
+    "description": "Transfer status of a running download, e.g. '1.2 GB of 4.6 GB'",
+    "placeholders": {
+      "received": {
+        "type": "String"
+      },
+      "total": {
+        "type": "String"
+      }
+    }
+  },
+  "downloadSpeed": "{speed}/s",
+  "@downloadSpeed": {
+    "description": "Transfer rate of a running download, e.g. '25.3 MB/s'",
+    "placeholders": {
+      "speed": {
+        "type": "String"
+      }
+    }
+  },
   "downloadSizeTotal": "{size} total",
   "@downloadSizeTotal": {
     "description": "Exact total file size of a batch of original files, e.g. '12.4 GB total'",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1779,6 +1779,61 @@
   "@noEpisodesLoaded": {
     "description": "Message when no episodes are available for download"
   },
+  "downloadScopeTitle": "What to download",
+  "@downloadScopeTitle": {
+    "description": "Title of the sheet asking whether to download all or only unwatched items"
+  },
+  "downloadAllEpisodes": "All episodes",
+  "@downloadAllEpisodes": {
+    "description": "Download scope option: every episode of a series or season"
+  },
+  "downloadUnwatchedEpisodes": "All unwatched episodes",
+  "@downloadUnwatchedEpisodes": {
+    "description": "Download scope option: only episodes not yet marked as watched"
+  },
+  "downloadAllMovies": "All movies",
+  "@downloadAllMovies": {
+    "description": "Download scope option: every movie in a collection"
+  },
+  "downloadUnwatchedMovies": "All unwatched movies",
+  "@downloadUnwatchedMovies": {
+    "description": "Download scope option: only collection movies not yet marked as watched"
+  },
+  "downloadScopeLoading": "Loading items...",
+  "@downloadScopeLoading": {
+    "description": "Subtitle shown in the download scope sheet while the item list is being fetched"
+  },
+  "downloadScopeLoadFailed": "Could not load items to download",
+  "@downloadScopeLoadFailed": {
+    "description": "Snackbar shown when the item list for a batch download could not be fetched"
+  },
+  "downloadEstimateTotal": "~{size} total",
+  "@downloadEstimateTotal": {
+    "description": "Estimated total download size for a batch, e.g. '~1.2 GB total'",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "downloadSizeTotal": "{size} total",
+  "@downloadSizeTotal": {
+    "description": "Exact total file size of a batch of original files, e.g. '12.4 GB total'",
+    "placeholders": {
+      "size": {
+        "type": "String"
+      }
+    }
+  },
+  "downloadEstimateUnknownCount": "{count} unknown",
+  "@downloadEstimateUnknownCount": {
+    "description": "Appended to a batch size estimate when some items had no runtime to estimate from",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "downloadingItem": "Downloading {name} ({quality})...",
   "@downloadingItem": {
     "description": "Snackbar message when downloading an item",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1543,6 +1543,15 @@
     "description": "Status label shown while a finished download is being moved to its final location and validated"
   },
   "queuedDownload": "Queued",
+  "queuedMoreCount": "{count, plural, =1{1 more queued} other{{count} more queued}}",
+  "@queuedMoreCount": {
+    "description": "Row under the active downloads list standing in for queued items not shown individually",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "@queuedDownload": {
     "description": "Status label for a download waiting in the queue for a free download slot"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2602,6 +2602,18 @@ abstract class AppLocalizations {
   /// **'~{size} total'**
   String downloadEstimateTotal(String size);
 
+  /// Transfer status of a running download, e.g. '1.2 GB of 4.6 GB'
+  ///
+  /// In en, this message translates to:
+  /// **'{received} of {total}'**
+  String downloadBytesOfTotal(String received, String total);
+
+  /// Transfer rate of a running download, e.g. '25.3 MB/s'
+  ///
+  /// In en, this message translates to:
+  /// **'{speed}/s'**
+  String downloadSpeed(String speed);
+
   /// Exact total file size of a batch of original files, e.g. '12.4 GB total'
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2278,6 +2278,12 @@ abstract class AppLocalizations {
   /// **'Queued'**
   String get queuedDownload;
 
+  /// Row under the active downloads list standing in for queued items not shown individually
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 more queued} other{{count} more queued}}'**
+  String queuedMoreCount(int count);
+
   /// Action button label to download all items
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2554,6 +2554,66 @@ abstract class AppLocalizations {
   /// **'No episodes loaded'**
   String get noEpisodesLoaded;
 
+  /// Title of the sheet asking whether to download all or only unwatched items
+  ///
+  /// In en, this message translates to:
+  /// **'What to download'**
+  String get downloadScopeTitle;
+
+  /// Download scope option: every episode of a series or season
+  ///
+  /// In en, this message translates to:
+  /// **'All episodes'**
+  String get downloadAllEpisodes;
+
+  /// Download scope option: only episodes not yet marked as watched
+  ///
+  /// In en, this message translates to:
+  /// **'All unwatched episodes'**
+  String get downloadUnwatchedEpisodes;
+
+  /// Download scope option: every movie in a collection
+  ///
+  /// In en, this message translates to:
+  /// **'All movies'**
+  String get downloadAllMovies;
+
+  /// Download scope option: only collection movies not yet marked as watched
+  ///
+  /// In en, this message translates to:
+  /// **'All unwatched movies'**
+  String get downloadUnwatchedMovies;
+
+  /// Subtitle shown in the download scope sheet while the item list is being fetched
+  ///
+  /// In en, this message translates to:
+  /// **'Loading items...'**
+  String get downloadScopeLoading;
+
+  /// Snackbar shown when the item list for a batch download could not be fetched
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load items to download'**
+  String get downloadScopeLoadFailed;
+
+  /// Estimated total download size for a batch, e.g. '~1.2 GB total'
+  ///
+  /// In en, this message translates to:
+  /// **'~{size} total'**
+  String downloadEstimateTotal(String size);
+
+  /// Exact total file size of a batch of original files, e.g. '12.4 GB total'
+  ///
+  /// In en, this message translates to:
+  /// **'{size} total'**
+  String downloadSizeTotal(String size);
+
+  /// Appended to a batch size estimate when some items had no runtime to estimate from
+  ///
+  /// In en, this message translates to:
+  /// **'{count} unknown'**
+  String downloadEstimateUnknownCount(int count);
+
   /// Snackbar message when downloading an item
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsAf extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Laai Alles af';
 
   @override

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1366,6 +1366,16 @@ class AppLocalizationsAf extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -1340,6 +1340,42 @@ class AppLocalizationsAf extends AppLocalizations {
   String get noEpisodesLoaded => 'Geen episodes gelaai nie';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Laai tans $name af ($quality)...';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsAr extends AppLocalizations {
   String get noEpisodesLoaded => 'لم يتم تحميل أي حلقات';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'جارٍ التنزيل $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1180,6 +1180,17 @@ class AppLocalizationsAr extends AppLocalizations {
   String get queuedDownload => 'في الانتظار';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'تحميل الكل';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsAr extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1179,6 +1179,17 @@ class AppLocalizationsBe extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Спампаваць усе';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1339,6 +1339,42 @@ class AppLocalizationsBe extends AppLocalizations {
   String get noEpisodesLoaded => 'Няма загружаных серый';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Спампоўка $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -1365,6 +1365,16 @@ class AppLocalizationsBe extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1172,6 +1172,17 @@ class AppLocalizationsBg extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Изтегли всички';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1361,6 +1361,16 @@ class AppLocalizationsBg extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -1335,6 +1335,42 @@ class AppLocalizationsBg extends AppLocalizations {
   String get noEpisodesLoaded => 'Няма заредени епизоди';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Изтегля се $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsBn extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'সব ডাউনলোড করুন';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1329,6 +1329,42 @@ class AppLocalizationsBn extends AppLocalizations {
   String get noEpisodesLoaded => 'কোনো পর্ব লোড করা হয়নি';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'ডাউনলোড হচ্ছে $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -1355,6 +1355,16 @@ class AppLocalizationsBn extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1181,6 +1181,17 @@ class AppLocalizationsCa extends AppLocalizations {
   String get queuedDownload => 'En cua';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Descarrega-ho tot';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1343,6 +1343,42 @@ class AppLocalizationsCa extends AppLocalizations {
   String get noEpisodesLoaded => 'No s\'ha carregat cap capítol';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'S\'està baixant $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -1369,6 +1369,16 @@ class AppLocalizationsCa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsCs extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsCs extends AppLocalizations {
   String get noEpisodesLoaded => 'Nebyly načteny žádné epizody';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Stahování $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -1182,6 +1182,17 @@ class AppLocalizationsCs extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Stáhnout vše';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1369,6 +1369,16 @@ class AppLocalizationsCy extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1181,6 +1181,17 @@ class AppLocalizationsCy extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Lawrlwythwch Pawb';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -1343,6 +1343,42 @@ class AppLocalizationsCy extends AppLocalizations {
   String get noEpisodesLoaded => 'Dim penodau wedi\'u llwytho';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Wrthi\'n lawrlwytho $name ($quality)…';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1172,6 +1172,17 @@ class AppLocalizationsDa extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Download alle';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1332,6 +1332,42 @@ class AppLocalizationsDa extends AppLocalizations {
   String get noEpisodesLoaded => 'Ingen episoder indlæst';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Downloader $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -1358,6 +1358,16 @@ class AppLocalizationsDa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1412,6 +1412,42 @@ class AppLocalizationsDe extends AppLocalizations {
   String get noEpisodesLoaded => 'Keine Episoden geladen';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name (Qualität: $quality) wird heruntergeladen...';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1438,6 +1438,16 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1243,6 +1243,17 @@ class AppLocalizationsDe extends AppLocalizations {
   String get queuedDownload => 'Warteschlange';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Alle herunterladen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1348,6 +1348,42 @@ class AppLocalizationsEl extends AppLocalizations {
   String get noEpisodesLoaded => 'Δεν φορτώθηκαν επεισόδια';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Λήψη $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1374,6 +1374,16 @@ class AppLocalizationsEl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -1182,6 +1182,17 @@ class AppLocalizationsEl extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Λήψη όλων';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1328,6 +1328,42 @@ class AppLocalizationsEn extends AppLocalizations {
   String get noEpisodesLoaded => 'No episodes loaded';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Downloading $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsEn extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Download All';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1354,6 +1354,16 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1173,6 +1173,17 @@ class AppLocalizationsEo extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Elŝutu Ĉion';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsEo extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsEo extends AppLocalizations {
   String get noEpisodesLoaded => 'Neniuj epizodoj ŝarĝitaj';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Elŝutante $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1342,6 +1342,42 @@ class AppLocalizationsEs extends AppLocalizations {
   String get noEpisodesLoaded => 'No hay episodios cargados';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Descargando $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1368,6 +1368,16 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsEs extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Descargar todo';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1338,6 +1338,42 @@ class AppLocalizationsEt extends AppLocalizations {
   String get noEpisodesLoaded => 'Ühtegi episoodi pole laaditud';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ($quality) allalaadimine...';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1364,6 +1364,16 @@ class AppLocalizationsEt extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -1176,6 +1176,17 @@ class AppLocalizationsEt extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Laadige kõik alla';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1328,6 +1328,42 @@ class AppLocalizationsFa extends AppLocalizations {
   String get noEpisodesLoaded => 'هیچ قسمتی بارگذاری نشده است';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'در حال دانلود $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1354,6 +1354,16 @@ class AppLocalizationsFa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsFa extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'دانلود همه';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1177,6 +1177,17 @@ class AppLocalizationsFi extends AppLocalizations {
   String get queuedDownload => 'Jonossa';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Lataa kaikki';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1364,6 +1364,16 @@ class AppLocalizationsFi extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -1338,6 +1338,42 @@ class AppLocalizationsFi extends AppLocalizations {
   String get noEpisodesLoaded => 'Ei ladattuja jaksoja';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Ladataan $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsFr extends AppLocalizations {
   String get noEpisodesLoaded => 'Aucun épisode chargé';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Téléchargement de $name ($quality)…';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1181,6 +1181,17 @@ class AppLocalizationsFr extends AppLocalizations {
   String get queuedDownload => 'En file d\'attente';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Tout télécharger';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1181,6 +1181,17 @@ class AppLocalizationsGl extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Descargar Todo';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1372,6 +1372,16 @@ class AppLocalizationsGl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -1346,6 +1346,42 @@ class AppLocalizationsGl extends AppLocalizations {
   String get noEpisodesLoaded => 'Non se cargaron episodios';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Descargando $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1323,6 +1323,42 @@ class AppLocalizationsHe extends AppLocalizations {
   String get noEpisodesLoaded => 'לא נטענו פרקים';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'מוריד את $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1349,6 +1349,16 @@ class AppLocalizationsHe extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1165,6 +1165,17 @@ class AppLocalizationsHe extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'הורד הכל';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1358,6 +1358,16 @@ class AppLocalizationsHi extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1332,6 +1332,42 @@ class AppLocalizationsHi extends AppLocalizations {
   String get noEpisodesLoaded => 'कोई एपिसोड लोड नहीं किया गया';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name डाउनलोड हो रहा है ($quality)...';
   }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1172,6 +1172,17 @@ class AppLocalizationsHi extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'सभी डाउनलोड करें';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1429,6 +1429,16 @@ class AppLocalizationsHr extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1240,6 +1240,17 @@ class AppLocalizationsHr extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Preuzmi sve';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -1403,6 +1403,42 @@ class AppLocalizationsHr extends AppLocalizations {
   String get noEpisodesLoaded => 'Nema učitanih epizoda';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Preuzimanje: $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1365,6 +1365,16 @@ class AppLocalizationsHu extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1339,6 +1339,42 @@ class AppLocalizationsHu extends AppLocalizations {
   String get noEpisodesLoaded => 'Nincsenek betöltve epizódok';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name letöltése ($quality)...';
   }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsHu extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Az összes letöltése';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1363,6 +1363,16 @@ class AppLocalizationsId extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1177,6 +1177,17 @@ class AppLocalizationsId extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Unduh Semua';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1337,6 +1337,42 @@ class AppLocalizationsId extends AppLocalizations {
   String get noEpisodesLoaded => 'Tidak ada episode yang dimuat';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Mengunduh $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1337,6 +1337,42 @@ class AppLocalizationsIt extends AppLocalizations {
   String get noEpisodesLoaded => 'Nessun episodio caricato';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Download di $name ($quality) in corso…';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1363,6 +1363,16 @@ class AppLocalizationsIt extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsIt extends AppLocalizations {
   String get queuedDownload => 'In coda';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Scarica Tutto';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1144,6 +1144,17 @@ class AppLocalizationsJa extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'すべてダウンロード';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1301,6 +1301,42 @@ class AppLocalizationsJa extends AppLocalizations {
   String get noEpisodesLoaded => 'エピソードがロードされていません';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ($quality) をダウンロードしています...';
   }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1327,6 +1327,16 @@ class AppLocalizationsJa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1360,6 +1360,16 @@ class AppLocalizationsKk extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1334,6 +1334,42 @@ class AppLocalizationsKk extends AppLocalizations {
   String get noEpisodesLoaded => 'Жүктелген эпизодтар жоқ';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name жүктелуде ($quality)...';
   }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -1174,6 +1174,17 @@ class AppLocalizationsKk extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Барлығын жүктеп алыңыз';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1335,6 +1335,42 @@ class AppLocalizationsKn extends AppLocalizations {
   String get noEpisodesLoaded => 'ಯಾವುದೇ ಸಂಚಿಕೆಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಿಲ್ಲ';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ ($quality)...';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1361,6 +1361,16 @@ class AppLocalizationsKn extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -1176,6 +1176,17 @@ class AppLocalizationsKn extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'ಎಲ್ಲವನ್ನೂ ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1146,6 +1146,17 @@ class AppLocalizationsKo extends AppLocalizations {
   String get queuedDownload => '대기 중';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => '모두 다운로드';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1329,6 +1329,16 @@ class AppLocalizationsKo extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -1303,6 +1303,42 @@ class AppLocalizationsKo extends AppLocalizations {
   String get noEpisodesLoaded => '로드된 에피소드가 없습니다.';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name 다운로드 중($quality)...';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1362,6 +1362,16 @@ class AppLocalizationsLt extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1177,6 +1177,17 @@ class AppLocalizationsLt extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Atsisiųsti viską';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -1336,6 +1336,42 @@ class AppLocalizationsLt extends AppLocalizations {
   String get noEpisodesLoaded => 'Neįkelta jokių serijų';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Atsisiunčiama $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsLv extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Lejupielādēt visu';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1342,6 +1342,42 @@ class AppLocalizationsLv extends AppLocalizations {
   String get noEpisodesLoaded => 'Nav ielādēta neviena sērija';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Notiek lejupielāde $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -1368,6 +1368,16 @@ class AppLocalizationsLv extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1176,6 +1176,17 @@ class AppLocalizationsMk extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Преземете ги сите';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1365,6 +1365,16 @@ class AppLocalizationsMk extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -1339,6 +1339,42 @@ class AppLocalizationsMk extends AppLocalizations {
   String get noEpisodesLoaded => 'Нема вчитани епизоди';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Се презема $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsMl extends AppLocalizations {
   String get noEpisodesLoaded => 'എപ്പിസോഡുകളൊന്നും ലോഡ് ചെയ്തിട്ടില്ല';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ഡൗൺലോഡ് ചെയ്യുന്നു ($quality)...';
   }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsMl extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'എല്ലാം ഡൗൺലോഡ് ചെയ്യുക';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsMl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1174,6 +1174,17 @@ class AppLocalizationsMn extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Бүгдийг татаж авах';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsMn extends AppLocalizations {
   String get noEpisodesLoaded => 'Ямар ч анги ачаалагдсангүй';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ($quality) татаж байна...';
   }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsMn extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1174,6 +1174,17 @@ class AppLocalizationsNb extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Last ned alle';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsNb extends AppLocalizations {
   String get noEpisodesLoaded => 'Ingen episoder er lastet inn';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Laster ned $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsNb extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1176,6 +1176,17 @@ class AppLocalizationsNl extends AppLocalizations {
   String get queuedDownload => 'In de wachtrij';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Alles downloaden';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1364,6 +1364,16 @@ class AppLocalizationsNl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -1338,6 +1338,42 @@ class AppLocalizationsNl extends AppLocalizations {
   String get noEpisodesLoaded => 'Er zijn geen afleveringen geladen';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name downloaden ($quality)...';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsPa extends AppLocalizations {
   String get noEpisodesLoaded => 'ਕੋਈ ਐਪੀਸੋਡ ਲੋਡ ਨਹੀਂ ਕੀਤੇ ਗਏ';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ ($quality)...';
   }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1174,6 +1174,17 @@ class AppLocalizationsPa extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'ਸਾਰੇ ਡਾਊਨਲੋਡ ਕਰੋ';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsPa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1249,6 +1249,17 @@ class AppLocalizationsPl extends AppLocalizations {
   String get queuedDownload => 'W kolejce';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Pobierz wszystko';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1442,6 +1442,16 @@ class AppLocalizationsPl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -1416,6 +1416,42 @@ class AppLocalizationsPl extends AppLocalizations {
   String get noEpisodesLoaded => 'Brak odcinków do pobrania';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Pobieranie „$name” ($quality)...';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1176,6 +1176,17 @@ class AppLocalizationsPt extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Baixar Tudo';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1363,6 +1363,16 @@ class AppLocalizationsPt extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1337,6 +1337,42 @@ class AppLocalizationsPt extends AppLocalizations {
   String get noEpisodesLoaded => 'Nenhum episódio carregado';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Baixando $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1366,6 +1366,16 @@ class AppLocalizationsRo extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1340,6 +1340,42 @@ class AppLocalizationsRo extends AppLocalizations {
   String get noEpisodesLoaded => 'Niciun episod încărcat';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Se descarcă $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsRo extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Descărcați toate';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1182,6 +1182,17 @@ class AppLocalizationsRu extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Скачать все';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1343,6 +1343,42 @@ class AppLocalizationsRu extends AppLocalizations {
   String get noEpisodesLoaded => 'Серии не загружены';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Скачивание $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1369,6 +1369,16 @@ class AppLocalizationsRu extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1354,6 +1354,16 @@ class AppLocalizationsSi extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1169,6 +1169,17 @@ class AppLocalizationsSi extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'සියල්ල බාගත කරන්න';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -1328,6 +1328,42 @@ class AppLocalizationsSi extends AppLocalizations {
   String get noEpisodesLoaded => 'කථාංග කිසිවක් පූරණය කර නැත';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name බාගත කරමින් ($quality)...';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1345,6 +1345,42 @@ class AppLocalizationsSk extends AppLocalizations {
   String get noEpisodesLoaded => 'Neboli načítané žiadne epizódy';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Sťahuje sa $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1371,6 +1371,16 @@ class AppLocalizationsSk extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -1184,6 +1184,17 @@ class AppLocalizationsSk extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Stiahnuť všetko';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1182,6 +1182,17 @@ class AppLocalizationsSl extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Prenesi vse';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1370,6 +1370,16 @@ class AppLocalizationsSl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -1344,6 +1344,42 @@ class AppLocalizationsSl extends AppLocalizations {
   String get noEpisodesLoaded => 'Ni naloženih epizod';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Prenašanje $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1180,6 +1180,17 @@ class AppLocalizationsSq extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Shkarkoni të gjitha';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsSq extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsSq extends AppLocalizations {
   String get noEpisodesLoaded => 'Nuk është ngarkuar asnjë episode';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Po shkarkohet $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1402,6 +1402,42 @@ class AppLocalizationsSr extends AppLocalizations {
   String get noEpisodesLoaded => 'Нема учитаних епизода';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Преузимање: $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1238,6 +1238,17 @@ class AppLocalizationsSr extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Преузми све';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -1428,6 +1428,16 @@ class AppLocalizationsSr extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsSv extends AppLocalizations {
   String get noEpisodesLoaded => 'Inga avsnitt laddade';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Laddar ner $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1173,6 +1173,17 @@ class AppLocalizationsSv extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Ladda ner alla';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsSv extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1369,6 +1369,16 @@ class AppLocalizationsSw extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1343,6 +1343,42 @@ class AppLocalizationsSw extends AppLocalizations {
   String get noEpisodesLoaded => 'Hakuna vipindi vilivyopakiwa';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Inapakua $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -1181,6 +1181,17 @@ class AppLocalizationsSw extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Pakua Zote';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1179,6 +1179,17 @@ class AppLocalizationsTa extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'அனைத்தையும் பதிவிறக்கவும்';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1340,6 +1340,42 @@ class AppLocalizationsTa extends AppLocalizations {
   String get noEpisodesLoaded => 'எபிசோடுகள் ஏற்றப்படவில்லை';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name பதிவிறக்குகிறது ($quality)...';
   }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -1366,6 +1366,16 @@ class AppLocalizationsTa extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1177,6 +1177,17 @@ class AppLocalizationsTe extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'అన్నీ డౌన్‌లోడ్ చేయండి';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1363,6 +1363,16 @@ class AppLocalizationsTe extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -1337,6 +1337,42 @@ class AppLocalizationsTe extends AppLocalizations {
   String get noEpisodesLoaded => 'ఎపిసోడ్‌లు ఏవీ లోడ్ చేయబడలేదు';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name డౌన్‌లోడ్ అవుతోంది ($quality)...';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1351,6 +1351,16 @@ class AppLocalizationsTh extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1325,6 +1325,42 @@ class AppLocalizationsTh extends AppLocalizations {
   String get noEpisodesLoaded => 'ไม่มีตอนโหลด';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'กำลังดาวน์โหลด $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -1167,6 +1167,17 @@ class AppLocalizationsTh extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'ดาวน์โหลดทั้งหมด';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1342,6 +1342,42 @@ class AppLocalizationsTl extends AppLocalizations {
   String get noEpisodesLoaded => 'Walang na-load na mga episode';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Dina-download ang $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1368,6 +1368,16 @@ class AppLocalizationsTl extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsTl extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'I-download Lahat';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1173,6 +1173,17 @@ class AppLocalizationsTr extends AppLocalizations {
   String get queuedDownload => 'Sırada';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Tümünü İndir';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1360,6 +1360,16 @@ class AppLocalizationsTr extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -1334,6 +1334,42 @@ class AppLocalizationsTr extends AppLocalizations {
   String get noEpisodesLoaded => 'Hiçbir bölüm yüklenmedi';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name indiriliyor ($quality)…';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1172,6 +1172,17 @@ class AppLocalizationsUg extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'ھەممىنى چۈشۈرۈڭ';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1333,6 +1333,42 @@ class AppLocalizationsUg extends AppLocalizations {
   String get noEpisodesLoaded => 'ھېچقانداق بۆلەك يۈكلەنمىدى';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '$name چۈشۈرۈلۈۋاتىدۇ ($quality)...';
   }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -1359,6 +1359,16 @@ class AppLocalizationsUg extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1179,6 +1179,17 @@ class AppLocalizationsUk extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Завантажити все';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1341,6 +1341,42 @@ class AppLocalizationsUk extends AppLocalizations {
   String get noEpisodesLoaded => 'Немає завантажених епізодів';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Завантаження $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1367,6 +1367,16 @@ class AppLocalizationsUk extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1363,6 +1363,16 @@ class AppLocalizationsVi extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1337,6 +1337,42 @@ class AppLocalizationsVi extends AppLocalizations {
   String get noEpisodesLoaded => 'Không có tập nào được tải';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return 'Đang tải xuống $name ($quality)...';
   }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1178,6 +1178,17 @@ class AppLocalizationsVi extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => 'Tải xuống tất cả';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1137,6 +1137,17 @@ class AppLocalizationsYue extends AppLocalizations {
   String get queuedDownload => 'Queued';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => '下載全部';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1320,6 +1320,16 @@ class AppLocalizationsYue extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -1294,6 +1294,42 @@ class AppLocalizationsYue extends AppLocalizations {
   String get noEpisodesLoaded => '沒有載入劇集';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '下載緊 $name（$quality）...';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1291,6 +1291,42 @@ class AppLocalizationsZh extends AppLocalizations {
   String get noEpisodesLoaded => '未加载剧集';
 
   @override
+  String get downloadScopeTitle => 'What to download';
+
+  @override
+  String get downloadAllEpisodes => 'All episodes';
+
+  @override
+  String get downloadUnwatchedEpisodes => 'All unwatched episodes';
+
+  @override
+  String get downloadAllMovies => 'All movies';
+
+  @override
+  String get downloadUnwatchedMovies => 'All unwatched movies';
+
+  @override
+  String get downloadScopeLoading => 'Loading items...';
+
+  @override
+  String get downloadScopeLoadFailed => 'Could not load items to download';
+
+  @override
+  String downloadEstimateTotal(String size) {
+    return '~$size total';
+  }
+
+  @override
+  String downloadSizeTotal(String size) {
+    return '$size total';
+  }
+
+  @override
+  String downloadEstimateUnknownCount(int count) {
+    return '$count unknown';
+  }
+
+  @override
   String downloadingItem(String name, String quality) {
     return '正在下载 $name（$quality）...';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1317,6 +1317,16 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String downloadBytesOfTotal(String received, String total) {
+    return '$received of $total';
+  }
+
+  @override
+  String downloadSpeed(String speed) {
+    return '$speed/s';
+  }
+
+  @override
   String downloadSizeTotal(String size) {
     return '$size total';
   }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1134,6 +1134,17 @@ class AppLocalizationsZh extends AppLocalizations {
   String get queuedDownload => '已排队';
 
   @override
+  String queuedMoreCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count more queued',
+      one: '1 more queued',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get downloadAll => '全部下载';
 
   @override

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -573,12 +573,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       manager: manager,
       destination: Destinations.videoPlayer,
       startPlayback: (launchSession) async {
-        final forceTranscode =
-            await shouldForceTranscodeForDolbyVisionQueue(
-              context,
-              [item],
-              mediaSourceId: mediaSourceId,
-            );
+        final forceTranscode = await shouldForceTranscodeForDolbyVisionQueue(
+          context,
+          [item],
+          mediaSourceId: mediaSourceId,
+        );
         if (!context.mounted) return false;
         return _runWithDolbyVisionStartupFallbackPrompt(
           context,
@@ -1834,8 +1833,12 @@ class _DetailContentState extends State<_DetailContent> {
         .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
         .toList();
     final hasFeatures = presentCategories.isNotEmpty;
-    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
-    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
+    final firstFeatureNode = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.first)
+        : null;
+    final lastFeatureNode = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.last)
+        : null;
 
     final hasCast = viewModel.actors.isNotEmpty;
     final hasCollection = viewModel.parentCollectionItems.isNotEmpty;
@@ -1988,12 +1991,12 @@ class _DetailContentState extends State<_DetailContent> {
     final seerr = viewModel.seerr;
     if (!viewModel.isSeerrOnly || seerr == null) return null;
     return (seasonNumber) => showSeerrRequestDialog(
-          context: context,
-          vm: seerr,
-          is4k: false,
-          qualityToggle: true,
-          season: seasonNumber > 0 ? seasonNumber : null,
-        );
+      context: context,
+      vm: seerr,
+      is4k: false,
+      qualityToggle: true,
+      season: seasonNumber > 0 ? seasonNumber : null,
+    );
   }
 
   /// The focusable pieces of the Seerr block, in the order they appear, so each
@@ -2026,8 +2029,9 @@ class _DetailContentState extends State<_DetailContent> {
       color: AppColorScheme.onSurface,
       fontWeight: FontWeight.w700,
     );
-    final seerrLabel =
-        GetIt.instance<SeerrPreferences>().labelOrDefault(l10n.seerr);
+    final seerrLabel = GetIt.instance<SeerrPreferences>().labelOrDefault(
+      l10n.seerr,
+    );
     final collection = state.movie?.collection;
     final chain = _seerrSectionChain();
     final chipsNode = _sectionFocusNode('detailSeerrChips');
@@ -2123,7 +2127,9 @@ class _DetailContentState extends State<_DetailContent> {
         .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
         .toList();
     final hasFeatures = presentCategories.isNotEmpty;
-    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
+    final firstFeatureNode = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.first)
+        : null;
 
     final hasNextUp = viewModel.nextUp != null;
     final seriesNextUpFocusNode = hasNextUp ? _seriesNextUpFocusNode : null;
@@ -2325,7 +2331,8 @@ class _DetailContentState extends State<_DetailContent> {
       ),
       ..._buildSeerrSections(
         context,
-        upTarget: similarFocusNode ??
+        upTarget:
+            similarFocusNode ??
             castFocusNode ??
             seasonsFocusNode ??
             metadataFocusNode ??
@@ -2387,8 +2394,12 @@ class _DetailContentState extends State<_DetailContent> {
         .where((cat) => groupedFeatures[cat]?.isNotEmpty == true)
         .toList();
     final hasFeatures = presentCategories.isNotEmpty;
-    final firstFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.first) : null;
-    final lastFeatureNode = hasFeatures ? _featureFocusNodeFor(presentCategories.last) : null;
+    final firstFeatureNode = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.first)
+        : null;
+    final lastFeatureNode = hasFeatures
+        ? _featureFocusNodeFor(presentCategories.last)
+        : null;
 
     final hasSeasonEpisodes = viewModel.episodes.isNotEmpty;
     final hasCast = viewModel.actors.isNotEmpty;
@@ -2610,12 +2621,11 @@ class _DetailContentState extends State<_DetailContent> {
       manager: manager,
       destination: Destinations.videoPlayer,
       startPlayback: (launchSession) async {
-        final forceTranscode =
-            await shouldForceTranscodeForDolbyVisionQueue(
-              context,
-              [item],
-              mediaSourceId: mediaSourceId,
-            );
+        final forceTranscode = await shouldForceTranscodeForDolbyVisionQueue(
+          context,
+          [item],
+          mediaSourceId: mediaSourceId,
+        );
         if (!context.mounted) return false;
         return _runWithDolbyVisionStartupFallbackPrompt(
           context,
@@ -2711,10 +2721,7 @@ class _DetailContentState extends State<_DetailContent> {
             imageApi: viewModel.imageApi,
             prefs: prefs,
             onItemLongPress: _showItemContextMenu,
-            scrollController: _trackSectionScrollController(
-              focusNode,
-              ctrl,
-            ),
+            scrollController: _trackSectionScrollController(focusNode, ctrl),
             firstItemFocusNode: focusNode,
             onItemKeyEvent: _buildVerticalRowHandler(
               sourceFocusNode: focusNode,
@@ -3451,10 +3458,8 @@ class _DetailContentState extends State<_DetailContent> {
                 startPlayback: (launchSession) async {
                   await runPlaybackStart(
                     launchSession,
-                    () => manager.playItems(
-                      viewModel.tracks,
-                      startIndex: index,
-                    ),
+                    () =>
+                        manager.playItems(viewModel.tracks, startIndex: index),
                   );
                   return true;
                 },
@@ -4404,7 +4409,11 @@ String? _resolveSeriesLandscapeThumbnailUrl(
       thumbId.isNotEmpty &&
       thumbTag != null &&
       thumbTag.isNotEmpty) {
-    return imageApi.getThumbImageUrl(thumbId, maxWidth: maxWidth, tag: thumbTag);
+    return imageApi.getThumbImageUrl(
+      thumbId,
+      maxWidth: maxWidth,
+      tag: thumbTag,
+    );
   }
 
   final seriesId = item.seriesId ?? item.parentPrimaryImageItemId;
@@ -4446,7 +4455,8 @@ class _EpisodeThumbnail extends StatelessWidget {
         ? _resolveSeriesLandscapeThumbnailUrl(item, imageApi, maxWidth: maxW)
         : null;
 
-    final imageUrl = seriesThumbUrl ??
+    final imageUrl =
+        seriesThumbUrl ??
         (item.primaryImageTag != null
             ? imageApi.getPrimaryImageUrl(
                 item.id,
@@ -6339,9 +6349,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final subtitleStreams = mediaStreams
         .where((s) => s['Type'] == 'Subtitle')
         .toList();
-    final audioStreams = _streamsForTrackSelectors(item, selectedSource)
-        .where((s) => s['Type'] == 'Audio')
-        .toList();
+    final audioStreams = _streamsForTrackSelectors(
+      item,
+      selectedSource,
+    ).where((s) => s['Type'] == 'Audio').toList();
 
     final canShowDownloadActions =
         _isDownloadable(item.type) && userCanDownload();
@@ -6494,8 +6505,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           // A series keeps the button even when nothing was counted for it,
           // since a trailer in a season folder belongs to that season and
           // isn't counted against the series it came from.
-          : (item.type == 'Series' ||
-                    hasTrailer(item, viewModel.features)) &&
+          : (item.type == 'Series' || hasTrailer(item, viewModel.features)) &&
                 shows(DetailButton.trailer))
         DetailButton.trailer: _DetailActionButton(
           label: l10n.trailer,
@@ -6538,11 +6548,12 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         DetailButton.personalRating: _DetailActionButton(
           label: _personalRatingActionLabel(l10n, item),
           icon: switch (_personalRatingStyle()) {
-            PersonalRatingStyle.thumbs => _displayRatingLikes(item) == true
-                ? Icons.thumb_up
-                : _displayRatingLikes(item) == false
-                ? Icons.thumb_down
-                : Icons.thumb_up_outlined,
+            PersonalRatingStyle.thumbs =>
+              _displayRatingLikes(item) == true
+                  ? Icons.thumb_up
+                  : _displayRatingLikes(item) == false
+                  ? Icons.thumb_down
+                  : Icons.thumb_up_outlined,
             PersonalRatingStyle.stars => Icons.star_outline,
             PersonalRatingStyle.numeric => Icons.numbers,
           },
@@ -6570,8 +6581,13 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           ),
         ),
       if (canShowDownloadActions && shows(DetailButton.download))
-        DetailButton.download: _DownloadButton(item: item, viewModel: viewModel),
-      if (canShowDownloadActions && shows(DetailButton.deleteFiles) && _availableOffline)
+        DetailButton.download: _DownloadButton(
+          item: item,
+          viewModel: viewModel,
+        ),
+      if (canShowDownloadActions &&
+          shows(DetailButton.deleteFiles) &&
+          _availableOffline)
         DetailButton.deleteFiles: _DeleteDownloadButton(item: item),
       if (item.type == 'Episode' &&
           item.seriesId != null &&
@@ -6705,8 +6721,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       primaryAction = requestSlot(false) ?? requestSlot(true) ?? cancelSlot();
       byButton.removeWhere(
         (button, _) =>
-            !button.availableInSeerrOnly ||
-            button == DetailButton.seerrRequest,
+            !button.availableInSeerrOnly || button == DetailButton.seerrRequest,
       );
     } else {
       primaryAction = playButton;
@@ -6718,10 +6733,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         DetailButton.values,
         (button) => button.id,
         prefs,
-      )) ...[
-        ?byButton[button],
-        ?cancelByButton[button],
-      ],
+      )) ...[?byButton[button], ?cancelByButton[button]],
     ];
 
     if (isNeon) {
@@ -7285,7 +7297,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                             horizontal: 16,
                           ),
                           decoration: BoxDecoration(
-                            color: hasFocus ? Colors.white12 : Colors.transparent,
+                            color: hasFocus
+                                ? Colors.white12
+                                : Colors.transparent,
                             borderRadius: AppRadius.circular(8),
                           ),
                           child: Row(
@@ -7427,7 +7441,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                             horizontal: 16,
                           ),
                           decoration: BoxDecoration(
-                            color: hasFocus ? Colors.white12 : Colors.transparent,
+                            color: hasFocus
+                                ? Colors.white12
+                                : Colors.transparent,
                             borderRadius: AppRadius.circular(8),
                           ),
                           child: Row(
@@ -7502,7 +7518,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     final manager = GetIt.instance<PlaybackManager>();
     return computeEffectiveAudioIndex(
       audioStreams: audioStreams,
-      preferredAudioLanguage: manager.lastExplicitAudioLanguage ??
+      preferredAudioLanguage:
+          manager.lastExplicitAudioLanguage ??
           prefs.get(UserPreferences.defaultAudioLanguage),
       fallbackAudioLanguage: prefs.get(UserPreferences.fallbackAudioLanguage),
       preferDefaultAudioTrack: prefs.get(
@@ -7788,7 +7805,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       case 'AlbumArtist':
         if (viewModel.tracks.isNotEmpty) return viewModel.tracks.length > 1;
         if (viewModel.albums.isNotEmpty) return true;
-        final childCount = item.rawData['ChildCount'] ?? item.rawData['SongCount'];
+        final childCount =
+            item.rawData['ChildCount'] ?? item.rawData['SongCount'];
         if (childCount is num) return childCount > 1;
         return true;
       case 'MusicAlbum':
@@ -8264,7 +8282,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           e.playbackPosition! > Duration.zero,
     );
     if (resumeIndex >= 0) {
-      return (resumeIndex, items[resumeIndex].playbackPosition ?? Duration.zero);
+      return (
+        resumeIndex,
+        items[resumeIndex].playbackPosition ?? Duration.zero,
+      );
     }
 
     final nextUnwatchedIndex = items.indexWhere((e) => !e.isPlayed);
@@ -8436,10 +8457,18 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 ]);
             final directAllowed = !dvForceTranscode && !forceTranscode;
 
-            final epMediaStreams = _mediaStreamsForCurrentSelection(selectedEpisode);
-            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
-            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
-            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epMediaStreams = _mediaStreamsForCurrentSelection(
+              selectedEpisode,
+            );
+            final epAudioStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Audio')
+                .toList();
+            final epSubtitleStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Subtitle')
+                .toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(
+              epAudioStreams,
+            );
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
@@ -8498,10 +8527,18 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 ]);
             final directAllowed = !dvForceTranscode && !forceTranscode;
 
-            final epMediaStreams = _mediaStreamsForCurrentSelection(selectedEpisode);
-            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
-            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
-            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epMediaStreams = _mediaStreamsForCurrentSelection(
+              selectedEpisode,
+            );
+            final epAudioStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Audio')
+                .toList();
+            final epSubtitleStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Subtitle')
+                .toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(
+              epAudioStreams,
+            );
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
@@ -8645,9 +8682,15 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             final directAllowed = !dvForceTranscode && !forceTranscode;
 
             final epMediaStreams = _mediaStreamsForCurrentSelection(targetItem);
-            final epAudioStreams = epMediaStreams.where((s) => s['Type'] == 'Audio').toList();
-            final epSubtitleStreams = epMediaStreams.where((s) => s['Type'] == 'Subtitle').toList();
-            final epAudioStreamIndex = _effectiveAudioStreamIndex(epAudioStreams);
+            final epAudioStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Audio')
+                .toList();
+            final epSubtitleStreams = epMediaStreams
+                .where((s) => s['Type'] == 'Subtitle')
+                .toList();
+            final epAudioStreamIndex = _effectiveAudioStreamIndex(
+              epAudioStreams,
+            );
             final epSubtitleStreamIndex = _effectiveSubtitleStreamIndex(
               epSubtitleStreams,
               epAudioStreams,
@@ -8704,7 +8747,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 parentId: item.id,
                 includeItemTypes: const ['Audio'],
                 sortBy: 'ParentIndexNumber,IndexNumber,SortName',
-                fields: 'PrimaryImageAspectRatio,BasicSyncInfo,UserData,RunTimeTicks',
+                fields:
+                    'PrimaryImageAspectRatio,BasicSyncInfo,UserData,RunTimeTicks',
               );
               tracks = _mapRawItemsForServer(data['Items'], item.serverId);
             }
@@ -8734,10 +8778,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
             // beginning, matching standard music player behavior.
             await runPlaybackStart(
               launchSession,
-              () => manager.playItems(
-                tracks,
-                startIndex: albumStartIndex,
-              ),
+              () => manager.playItems(tracks, startIndex: albumStartIndex),
             );
             break;
 
@@ -8762,7 +8803,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
 
             // Start at the first unwatched item, or resume the one left partway
             // through, instead of always restarting from the top.
-            final (startIndex, startPosition) = _resolveQueueResumeStart(tracks);
+            final (startIndex, startPosition) = _resolveQueueResumeStart(
+              tracks,
+            );
 
             // Playlists can contain video, so honor the Dolby Vision
             // force-transcode check before allowing direct play/stream.
@@ -8856,8 +8899,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
                 final targetSibling = siblings[startIndex];
                 final startPos = resume
                     ? (targetSibling.playbackPosition ??
-                        item.playbackPosition ??
-                        Duration.zero)
+                          item.playbackPosition ??
+                          Duration.zero)
                     : Duration.zero;
                 await runPlaybackStart(
                   launchSession,
@@ -8928,9 +8971,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     AggregatedItem item,
   ) async {
     final manager = GetIt.instance<PlaybackManager>();
-    Future<
-      ({List<AggregatedItem> queue, bool isAudio, bool forceTranscode})?
-    >
+    Future<({List<AggregatedItem> queue, bool isAudio, bool forceTranscode})?>
     prepareQueue(PlaybackLaunchSession? session) async {
       // With a player route already up, the session is the lifecycle: the
       // rotation the player forces on a phone unmounts this context while
@@ -8966,19 +9007,18 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       PlaybackLaunchSession? launchSession,
       ({List<AggregatedItem> queue, bool isAudio, bool forceTranscode})
       prepared,
-    ) =>
-        _runWithDolbyVisionStartupFallbackPrompt(
-          context,
-          manager,
-          () => runPlaybackStart(
-            launchSession,
-            () => manager.playItems(
-              prepared.queue,
-              enableDirectPlay: !prepared.forceTranscode,
-              enableDirectStream: !prepared.forceTranscode,
-            ),
-          ),
-        );
+    ) => _runWithDolbyVisionStartupFallbackPrompt(
+      context,
+      manager,
+      () => runPlaybackStart(
+        launchSession,
+        () => manager.playItems(
+          prepared.queue,
+          enableDirectPlay: !prepared.forceTranscode,
+          enableDirectStream: !prepared.forceTranscode,
+        ),
+      ),
+    );
 
     final canOpenVideoBeforeQueueWork = switch (item.type) {
       'Series' || 'Season' || 'BoxSet' => true,
@@ -9005,8 +9045,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       destination: prepared.isAudio
           ? Destinations.audioPlayer
           : Destinations.videoPlayer,
-      startPlayback: (launchSession) =>
-          startPlayback(launchSession, prepared),
+      startPlayback: (launchSession) => startPlayback(launchSession, prepared),
     );
   }
 
@@ -9073,9 +9112,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     List<AggregatedItem> features,
   ) {
     final candidates = features
-        .where(
-          (feature) => isTrailerFeature(feature) && feature.id.isNotEmpty,
-        )
+        .where((feature) => isTrailerFeature(feature) && feature.id.isNotEmpty)
         .toList(growable: false);
     return _preferredLocalTrailer(candidates);
   }
@@ -9180,11 +9217,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         context,
         destination: Destinations.videoPlayer,
         startPlayback: (launchSession) async {
-          final forceTranscode =
-              await shouldForceTranscodeForDolbyVisionQueue(
-                context,
-                [localTrailer!],
-              );
+          final forceTranscode = await shouldForceTranscodeForDolbyVisionQueue(
+            context,
+            [localTrailer!],
+          );
           if (!context.mounted) return false;
           return _runWithDolbyVisionStartupFallbackPrompt(
             context,
@@ -9324,7 +9360,8 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       results = await withProgressSnackBar(
         messenger,
         AppLocalizations.of(context).searchingSubtitles,
-        () => client.itemsApi.searchRemoteSubtitles(item.id, language: language),
+        () =>
+            client.itemsApi.searchRemoteSubtitles(item.id, language: language),
       );
     } catch (error) {
       if (!context.mounted) {
@@ -9797,7 +9834,9 @@ Future<_DolbyVisionPlayDecision?> _showDolbyVisionFallbackDecisionDialog(
   );
 }
 
-Future<bool> _anyItemHasCompletedDownload(Iterable<AggregatedItem> items) async {
+Future<bool> _anyItemHasCompletedDownload(
+  Iterable<AggregatedItem> items,
+) async {
   final repo = GetIt.instance<OfflineRepository>();
   for (final item in items) {
     final row = await repo.getItem(item.id);
@@ -10105,9 +10144,18 @@ class _DownloadButtonState extends State<_DownloadButton> {
   String _originalQualitySubtitle(
     AggregatedItem item, {
     required bool isMulti,
+    List<AggregatedItem> batchItems = const [],
   }) {
+    final l10n = AppLocalizations.of(context);
     if (isMulti) {
-      return AppLocalizations.of(context).originalFilesNoReencoding;
+      final sizeLabel = _batchSizeLabel(
+        batchItems,
+        sourceSizeBytes,
+        l10n.downloadSizeTotal,
+      );
+      return sizeLabel == null
+          ? l10n.originalFilesNoReencoding
+          : '$sizeLabel • ${l10n.originalFilesNoReencoding}';
     }
 
     final mediaSource = item.mediaSources.isNotEmpty
@@ -10134,7 +10182,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     }
 
     if (details.isEmpty) {
-      return AppLocalizations.of(context).originalFileNoReencoding;
+      return l10n.originalFileNoReencoding;
     }
 
     return details.join(' • ');
@@ -10145,72 +10193,54 @@ class _DownloadButtonState extends State<_DownloadButton> {
     DownloadQuality quality, {
     required bool supportsTranscoding,
     required bool isMulti,
-    String? multiEstimateSubtitle,
+    List<AggregatedItem> batchItems = const [],
   }) {
     if (!quality.isTranscoded || !supportsTranscoding) {
-      return _originalQualitySubtitle(item, isMulti: isMulti);
+      return _originalQualitySubtitle(
+        item,
+        isMulti: isMulti,
+        batchItems: batchItems,
+      );
     }
 
-    if (isMulti) {
-      if (multiEstimateSubtitle != null) {
-        return '$multiEstimateSubtitle • ${quality.encodingInfo}';
-      }
-      return '${quality.estimatedSizePerHour} • ${quality.encodingInfo}';
-    }
-
-    final estimateBytes = estimateTranscodedSizeBytes(item, quality);
-    if (estimateBytes != null) {
-      return '~${formatBytes(estimateBytes)} • ${quality.encodingInfo}';
-    }
-
-    return '${quality.estimatedSizePerHour} • ${quality.encodingInfo}';
+    final estimate = isMulti
+        ? _batchSizeLabel(
+            batchItems,
+            (batchItem) => estimateTranscodedSizeBytes(batchItem, quality),
+            AppLocalizations.of(context).downloadEstimateTotal,
+          )
+        : switch (estimateTranscodedSizeBytes(item, quality)) {
+            final bytes? => '~${formatBytes(bytes)}',
+            null => null,
+          };
+    return '${estimate ?? quality.estimatedSizePerHour} • ${quality.encodingInfo}';
   }
 
-  String? _multiTranscodedEstimateSubtitle(
-    List<AggregatedItem> episodes,
-    DownloadQuality quality,
+  /// Sums [bytesOf] over [items], skipping items whose size is unknown, and
+  /// formats the total with [label]. Notes how many items were skipped.
+  /// Null when no item had a size.
+  String? _batchSizeLabel(
+    List<AggregatedItem> items,
+    int? Function(AggregatedItem item) bytesOf,
+    String Function(String size) label,
   ) {
-    if (episodes.isEmpty) {
-      return null;
-    }
-
     var totalBytes = 0;
-    var estimatedCount = 0;
-    for (final episode in episodes) {
-      final estimate = estimateTranscodedSizeBytes(episode, quality);
-      if (estimate != null && estimate > 0) {
-        totalBytes += estimate;
-        estimatedCount++;
+    var knownCount = 0;
+    for (final item in items) {
+      final bytes = bytesOf(item);
+      if (bytes != null && bytes > 0) {
+        totalBytes += bytes;
+        knownCount++;
       }
     }
+    if (knownCount == 0) return null;
 
-    if (estimatedCount == 0) {
-      return null;
-    }
-
-    final totalLabel = '~${formatBytes(totalBytes)} total';
-    if (estimatedCount == episodes.length) {
-      return totalLabel;
-    }
-
-    return '$totalLabel (${episodes.length - estimatedCount} unknown)';
-  }
-
-  Map<DownloadQuality, String> _multiTranscodedEstimateSubtitles(
-    List<AggregatedItem> episodes,
-    List<DownloadQuality> qualities,
-  ) {
-    final subtitles = <DownloadQuality, String>{};
-    for (final quality in qualities) {
-      if (!quality.isTranscoded) {
-        continue;
-      }
-      final subtitle = _multiTranscodedEstimateSubtitle(episodes, quality);
-      if (subtitle != null) {
-        subtitles[quality] = subtitle;
-      }
-    }
-    return subtitles;
+    final sizeLabel = label(formatBytes(totalBytes));
+    if (knownCount == items.length) return sizeLabel;
+    final unknown = AppLocalizations.of(
+      context,
+    ).downloadEstimateUnknownCount(items.length - knownCount);
+    return '$sizeLabel ($unknown)';
   }
 
   @override
@@ -10247,10 +10277,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
       listenable: downloadService,
       builder: (context, _) {
         final item = widget.item;
-        final isMulti =
-            item.type == 'Season' ||
-            item.type == 'Series' ||
-            item.type == 'BoxSet';
+        final isMulti = _isBatchType(item.type);
         final progress = downloadService.activeDownloads[item.id];
         final downloadError = progress?.error;
         final isBatch = downloadService.isBatchDownloading;
@@ -10330,7 +10357,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
             icon: Icons.download_done,
             isActive: true,
             activeColor: const Color(0xFF4CAF50),
-            onPressed: () => _showQualityPicker(context, downloadService),
+            onPressed: () => _showDownloadOptions(context, downloadService),
           );
         }
 
@@ -10346,7 +10373,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
                   context,
                 ).showSnackBar(SnackBar(content: Text(downloadError)));
               }
-              _showQualityPicker(context, downloadService);
+              _showDownloadOptions(context, downloadService);
             },
           );
         }
@@ -10354,24 +10381,206 @@ class _DownloadButtonState extends State<_DownloadButton> {
         return wire(
           label: AppLocalizations.of(context).download,
           icon: Icons.download,
-          onPressed: () => _showQualityPicker(context, downloadService),
+          onPressed: () => _showDownloadOptions(context, downloadService),
         );
       },
     );
   }
 
-  void _showQualityPicker(BuildContext context, DownloadService service) {
+  static bool _isBatchType(String? type) =>
+      type == 'Season' || type == 'Series' || type == 'BoxSet';
+
+  Widget _sheetTitle(BuildContext sheetContext, String text) => Padding(
+    padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+    child: Text(
+      text,
+      style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
+        color: Colors.white,
+        fontWeight: FontWeight.bold,
+      ),
+    ),
+  );
+
+  /// Entry point for the download button. Series, seasons and collections
+  /// first ask whether to download everything or only unwatched items; single
+  /// items go straight to the quality picker.
+  void _showDownloadOptions(BuildContext context, DownloadService service) {
+    if (_isBatchType(widget.item.type)) {
+      _showScopePicker(context, service);
+    } else {
+      _showQualityPicker(context, service);
+    }
+  }
+
+  /// Asks whether to download all items or only unwatched ones, then opens
+  /// the quality picker for the chosen list. The list is resolved once here
+  /// so the counts, the size estimates and the queued downloads all agree.
+  Future<void> _showScopePicker(
+    BuildContext context,
+    DownloadService service,
+  ) async {
     final item = widget.item;
-    final isMulti =
-        item.type == 'Season' || item.type == 'Series' || item.type == 'BoxSet';
-    final supportsTranscoding = item.type == 'Movie' ||
+    final isCollection = item.type == 'BoxSet';
+    final seriesId = item.seriesId;
+
+    // Always fetched through the service: the detail view model loads only
+    // overview fields, and the Original row needs media sources for sizes.
+    final Future<List<AggregatedItem>> fetch = switch (item.type) {
+      'Season' =>
+        seriesId == null
+            ? Future.error(StateError('Season ${item.id} has no SeriesId'))
+            : service.fetchEpisodes(seriesId, seasonId: item.id),
+      'Series' => service.fetchEpisodes(item.id),
+      _ => service.fetchBoxSetPlayableItems(item.id),
+    };
+    // Failure becomes null: the sheet subscribes a frame later, so a fast
+    // failure would otherwise surface as an unhandled async error.
+    final Future<List<AggregatedItem>?> itemsFuture = fetch
+        .then<List<AggregatedItem>?>(
+          (items) => items,
+          onError: (Object error) {
+            debugPrint('Download scope fetch failed for ${item.id}: $error');
+            return null;
+          },
+        );
+
+    final chosen =
+        await showFocusRestoringModalBottomSheet<List<AggregatedItem>>(
+          context: context,
+          isScrollControlled: PlatformDetection.isTV,
+          backgroundColor: const Color(0xFF1E1E1E),
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+          ),
+          builder: (sheetContext) {
+            final l10n = AppLocalizations.of(sheetContext);
+            return SafeArea(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _sheetTitle(sheetContext, l10n.downloadScopeTitle),
+                  FutureBuilder<List<AggregatedItem>?>(
+                    future: itemsFuture,
+                    builder: (_, snapshot) {
+                      final loading =
+                          snapshot.connectionState != ConnectionState.done;
+                      final allItems =
+                          snapshot.data ?? const <AggregatedItem>[];
+                      if (!loading && allItems.isEmpty) {
+                        return Padding(
+                          padding: const EdgeInsets.fromLTRB(20, 8, 20, 16),
+                          child: Text(
+                            snapshot.data == null
+                                ? l10n.downloadScopeLoadFailed
+                                : isCollection
+                                ? l10n.noItems
+                                : l10n.noEpisodesLoaded,
+                            style: TextStyle(
+                              color: PlatformDetection.isTV
+                                  ? null
+                                  : Colors.white70,
+                            ),
+                          ),
+                        );
+                      }
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _scopeRow(
+                            sheetContext,
+                            autofocus: true,
+                            icon: Icons.download,
+                            label: isCollection
+                                ? l10n.downloadAllMovies
+                                : l10n.downloadAllEpisodes,
+                            items: allItems,
+                            loading: loading,
+                          ),
+                          _scopeRow(
+                            sheetContext,
+                            autofocus: false,
+                            icon: Icons.visibility_off_outlined,
+                            label: isCollection
+                                ? l10n.downloadUnwatchedMovies
+                                : l10n.downloadUnwatchedEpisodes,
+                            items: allItems.where((i) => !i.isPlayed).toList(),
+                            loading: loading,
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  const SizedBox(height: 8),
+                ],
+              ),
+            );
+          },
+        );
+    // Opened only after the scope sheet is gone, so the quality picker
+    // restores focus to the Download button rather than to a disposed row.
+    if (chosen == null || !mounted) return;
+    _showQualityPicker(this.context, service, items: chosen);
+  }
+
+  Widget _scopeRow(
+    BuildContext sheetContext, {
+    required bool autofocus,
+    required IconData icon,
+    required String label,
+    required List<AggregatedItem> items,
+    required bool loading,
+  }) {
+    final l10n = AppLocalizations.of(sheetContext);
+    final isTV = PlatformDetection.isTV;
+    final enabled = loading || items.isNotEmpty;
+    final subtitle = loading
+        ? l10n.downloadScopeLoading
+        : widget.item.type == 'BoxSet'
+        ? l10n.itemCountLabel(items.length)
+        : l10n.episodeCount(items.length);
+    return DpadListTile(
+      autofocus: autofocus,
+      enabled: enabled,
+      leading: AdaptiveIcon(icon, color: isTV ? null : Colors.white70),
+      title: Text(
+        label,
+        style: isTV
+            ? null
+            : TextStyle(color: enabled ? Colors.white : Colors.white38),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: isTV
+            ? null
+            : TextStyle(color: Colors.white.withValues(alpha: 0.5)),
+      ),
+      // Always tappable so the row can take focus on TV while loading; the
+      // guard keeps a press during the fetch from selecting an empty list.
+      onTap: () {
+        if (loading) return;
+        Navigator.pop(sheetContext, items);
+      },
+    );
+  }
+
+  /// Shows the quality picker. For series, seasons and collections [items] is
+  /// the list resolved by the scope picker and drives both the size estimate
+  /// and what gets queued.
+  void _showQualityPicker(
+    BuildContext context,
+    DownloadService service, {
+    List<AggregatedItem>? items,
+  }) {
+    final item = widget.item;
+    final isMulti = _isBatchType(item.type);
+    final supportsTranscoding =
+        item.type == 'Movie' ||
         item.type == 'Episode' ||
         item.type == 'MusicVideo' ||
         item.type == 'Video' ||
         isMulti;
-    final estimationItems = item.type == 'BoxSet'
-        ? widget.viewModel.collectionItems
-        : widget.viewModel.episodes;
+    final batchItems = items ?? const <AggregatedItem>[];
 
     if (!isMulti && !supportsTranscoding) {
       _startDownload(context, service, DownloadQuality.original);
@@ -10381,7 +10590,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     final sourceWidth = isMulti
         ? (() {
             int? maxWidth;
-            for (final episode in estimationItems) {
+            for (final episode in batchItems) {
               final width = episode.sourceVideoWidth;
               if (width == null) continue;
               maxWidth = maxWidth == null || width > maxWidth
@@ -10396,9 +10605,21 @@ class _DownloadButtonState extends State<_DownloadButton> {
       if (sourceWidth == null) return true;
       return q.maxWidth! <= sourceWidth;
     }).toList();
-    final multiEstimateSubtitles = isMulti
-        ? _multiTranscodedEstimateSubtitles(estimationItems, availableQualities)
-        : const <DownloadQuality, String>{};
+    // Computed once: summing a whole series' sizes on every sheet rebuild
+    // (each focus move on TV) is wasted work.
+    final subtitles = {
+      for (final quality in availableQualities)
+        quality: _qualitySubtitle(
+          item,
+          quality,
+          supportsTranscoding: supportsTranscoding,
+          isMulti: isMulti,
+          batchItems: batchItems,
+        ),
+    };
+    final title = isMulti
+        ? AppLocalizations.of(context).downloadAllQuality
+        : AppLocalizations.of(context).downloadQuality;
 
     if (PlatformDetection.isTV) {
       showFocusRestoringModalBottomSheet(
@@ -10417,18 +10638,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                  child: Text(
-                    isMulti
-                        ? AppLocalizations.of(sheetContext).downloadAllQuality
-                        : AppLocalizations.of(sheetContext).downloadQuality,
-                    style: Theme.of(sheetContext).textTheme.titleMedium?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
+                _sheetTitle(sheetContext, title),
                 Flexible(
                   child: ListView(
                     shrinkWrap: true,
@@ -10444,19 +10654,15 @@ class _DownloadButtonState extends State<_DownloadButton> {
                               : Icons.file_copy_outlined,
                         ),
                         title: Text(quality.label),
-                        subtitle: Text(
-                          _qualitySubtitle(
-                            item,
-                            quality,
-                            supportsTranscoding: supportsTranscoding,
-                            isMulti: isMulti,
-                            multiEstimateSubtitle:
-                                multiEstimateSubtitles[quality],
-                          ),
-                        ),
+                        subtitle: Text(subtitles[quality]!),
                         onTap: () {
                           Navigator.pop(sheetContext);
-                          _startDownload(context, service, quality);
+                          _startDownload(
+                            context,
+                            service,
+                            quality,
+                            items: items,
+                          );
                         },
                       );
                     }).toList(),
@@ -10481,18 +10687,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-              child: Text(
-                isMulti
-                    ? AppLocalizations.of(context).downloadAllQuality
-                    : AppLocalizations.of(context).downloadQuality,
-                style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
+            _sheetTitle(context, title),
             ...availableQualities.map(
               (quality) => ListTile(
                 leading: AdaptiveIcon(
@@ -10506,18 +10701,12 @@ class _DownloadButtonState extends State<_DownloadButton> {
                   style: const TextStyle(color: Colors.white),
                 ),
                 subtitle: Text(
-                  _qualitySubtitle(
-                    item,
-                    quality,
-                    supportsTranscoding: supportsTranscoding,
-                    isMulti: isMulti,
-                    multiEstimateSubtitle: multiEstimateSubtitles[quality],
-                  ),
+                  subtitles[quality]!,
                   style: TextStyle(color: Colors.white.withValues(alpha: 0.5)),
                 ),
                 onTap: () {
                   Navigator.pop(context);
-                  _startDownload(context, service, quality);
+                  _startDownload(context, service, quality, items: items);
                 },
               ),
             ),
@@ -10528,49 +10717,37 @@ class _DownloadButtonState extends State<_DownloadButton> {
     );
   }
 
+  /// Queues the download. [items] is the list chosen in the scope sheet for
+  /// series, seasons and collections; single items leave it null.
   void _startDownload(
     BuildContext context,
     DownloadService service,
-    DownloadQuality quality,
-  ) {
+    DownloadQuality quality, {
+    List<AggregatedItem>? items,
+  }) {
     final item = widget.item;
-    switch (item.type) {
-      case 'Movie':
-      case 'Episode':
-      case 'Audio':
-      case 'AudioBook':
-      case 'Book':
-      case 'MusicVideo':
-      case 'Video':
-        service.downloadItem(item, quality: quality);
-      case 'MusicAlbum':
+    final l10n = AppLocalizations.of(context);
+    final String message;
+    if (items != null) {
+      if (items.isEmpty) {
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(l10n.noEpisodesLoaded)));
+        return;
+      }
+      service.downloadItems(items, quality: quality);
+      message = l10n.downloadingTitle(item.name, items.length);
+    } else {
+      if (item.type == 'MusicAlbum') {
         service.downloadAlbum(item.id, quality: quality);
-      case 'Season':
-        final episodes = widget.viewModel.episodes;
-        if (episodes.isEmpty) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(AppLocalizations.of(context).noEpisodesLoaded),
-            ),
-          );
-          return;
-        }
-        service.downloadItems(episodes, quality: quality);
-      case 'Series':
-        service.downloadSeries(item.id, quality: quality);
-      case 'BoxSet':
-        service.downloadBoxSet(item.id, quality: quality);
+      } else {
+        service.downloadItem(item, quality: quality);
+      }
+      message = l10n.downloadingItem(item.name, quality.label);
     }
 
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          AppLocalizations.of(
-            context,
-          ).downloadingItem(item.name, quality.label),
-        ),
-        duration: const Duration(seconds: 2),
-      ),
+      SnackBar(content: Text(message), duration: const Duration(seconds: 2)),
     );
   }
 }
@@ -10729,26 +10906,31 @@ class _PersonalRatingActionIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (style) {
-      PersonalRatingStyle.thumbs => likes == null
-          ? Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(Icons.thumb_up_outlined, color: color, size: size * 0.5),
-                  SizedBox(width: size * 0.08),
-                  Icon(
-                    Icons.thumb_down_outlined,
-                    color: color,
-                    size: size * 0.5,
-                  ),
-                ],
+      PersonalRatingStyle.thumbs =>
+        likes == null
+            ? Center(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.thumb_up_outlined,
+                      color: color,
+                      size: size * 0.5,
+                    ),
+                    SizedBox(width: size * 0.08),
+                    Icon(
+                      Icons.thumb_down_outlined,
+                      color: color,
+                      size: size * 0.5,
+                    ),
+                  ],
+                ),
+              )
+            : Icon(
+                likes! ? Icons.thumb_up : Icons.thumb_down,
+                color: color,
+                size: size * 0.72,
               ),
-            )
-          : Icon(
-              likes! ? Icons.thumb_up : Icons.thumb_down,
-              color: color,
-              size: size * 0.72,
-            ),
       PersonalRatingStyle.stars => _StarFillIcon(
         fill: ((rating ?? 0).clamp(0, 10) / 10).toDouble(),
         size: size * 0.82,
@@ -10916,7 +11098,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
 
     // Portrait spans the primary Play full width (circular secondary actions
     // wrap beneath); landscape keeps it content-width, inline with them.
-    final fullWidth = widget.isPrimary &&
+    final fullWidth =
+        widget.isPrimary &&
         (context
                 .findAncestorWidgetOfExactType<DetailActionButtons>()
                 ?.fullWidthPrimary ??
@@ -10959,11 +11142,11 @@ class _DetailActionButtonState extends State<_DetailActionButton>
               maxLines: 1,
               softWrap: false,
               style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                    color: fg,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 14,
-                    height: 1.1,
-                  ),
+                color: fg,
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+                height: 1.1,
+              ),
             ),
           ],
         ),
@@ -11031,28 +11214,29 @@ class _DetailActionButtonState extends State<_DetailActionButton>
 
     final double minWidth = height;
     final double maxWidth = isExpanded ? 200.0 : height;
-    final double maxLabelWidth = (maxWidth -
-            (isExpanded ? 22.0 : 0.0) -
-            (showHighlight ? 5.0 : 3.0) -
-            (height - 4) -
-            6.0)
-        .clamp(0.0, maxWidth);
+    final double maxLabelWidth =
+        (maxWidth -
+                (isExpanded ? 22.0 : 0.0) -
+                (showHighlight ? 5.0 : 3.0) -
+                (height - 4) -
+                6.0)
+            .clamp(0.0, maxWidth);
 
     final containerColor = showHighlight
         ? AppColorScheme.buttonFocused
         : (widget.isPrimary
-            ? AppColorScheme.accent
-            : (widget.isActive
-                ? (widget.activeColor ?? AppColorScheme.accent).withValues(
-                    alpha: 0.18,
-                  )
-                : Colors.white.withValues(alpha: 0.06)));
+              ? AppColorScheme.accent
+              : (widget.isActive
+                    ? (widget.activeColor ?? AppColorScheme.accent).withValues(
+                        alpha: 0.18,
+                      )
+                    : Colors.white.withValues(alpha: 0.06)));
 
     final borderColor = showHighlight
         ? focusColor
         : (widget.isPrimary
-            ? Colors.transparent
-            : AppColorScheme.onSurface.withValues(alpha: 0.35));
+              ? Colors.transparent
+              : AppColorScheme.onSurface.withValues(alpha: 0.35));
 
     final iconWidget = widget.isPrimary
         ? AdaptiveIcon(
@@ -11060,24 +11244,24 @@ class _DetailActionButtonState extends State<_DetailActionButton>
             color: (widget.icon == Icons.favorite && widget.isActive)
                 ? const Color(0xFFE50914)
                 : (showHighlight
-                    ? AppColorScheme.onButtonFocused
-                    : AppColorScheme.onAccent),
+                      ? AppColorScheme.onButtonFocused
+                      : AppColorScheme.onAccent),
             size: 24,
           )
         : (widget.iconBuilder != null
-            ? widget.iconBuilder!(36, iconColor)
-            : AdaptiveIcon(
-                widget.icon!,
-                color: (widget.icon == Icons.favorite && widget.isActive)
-                    ? const Color(0xFFE50914)
-                    : iconColor,
-                size: 24,
-              ));
+              ? widget.iconBuilder!(36, iconColor)
+              : AdaptiveIcon(
+                  widget.icon!,
+                  color: (widget.icon == Icons.favorite && widget.isActive)
+                      ? const Color(0xFFE50914)
+                      : iconColor,
+                  size: 24,
+                ));
 
     final effectiveLabelColor = widget.isPrimary
         ? (showHighlight
-            ? AppColorScheme.onButtonFocused
-            : AppColorScheme.onAccent)
+              ? AppColorScheme.onButtonFocused
+              : AppColorScheme.onAccent)
         : labelColor;
 
     return AnimatedContainer(
@@ -11117,7 +11301,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                   constraints: BoxConstraints(maxWidth: maxLabelWidth),
                   child: MarqueeText(
                     text: widget.label,
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    style:
+                        Theme.of(context).textTheme.bodyMedium?.copyWith(
                           color: effectiveLabelColor,
                           fontWeight: FontWeight.bold,
                           fontSize: 13,
@@ -11221,7 +11406,8 @@ class _DetailActionButtonState extends State<_DetailActionButton>
     final iconColor = showHighlight
         ? AppColorScheme.onButtonFocused
         : (widget.isActive
-              ? (widget.activeColor ?? (isNeon ? neonAccent : AppColorScheme.onButtonNormal))
+              ? (widget.activeColor ??
+                    (isNeon ? neonAccent : AppColorScheme.onButtonNormal))
               : (isNeon ? neonAccent : AppColorScheme.onButtonNormal));
     final showLabelInside = modern && (widget.isPrimary || !isMobile);
     final labelColor = (showHighlight && showLabelInside)
@@ -11489,12 +11675,12 @@ class DetailCastRow extends StatelessWidget {
             onTap: personId == null
                 ? null
                 : () => context.push(
-                      // A person who only exists in Seerr has a TMDB id, which
-                      // the library wouldn't know what to do with.
-                      serverId == 'seerr'
-                          ? Destinations.seerrPerson(personId)
-                          : Destinations.item(personId, serverId: serverId),
-                    ),
+                    // A person who only exists in Seerr has a TMDB id, which
+                    // the library wouldn't know what to do with.
+                    serverId == 'seerr'
+                        ? Destinations.seerrPerson(personId)
+                        : Destinations.item(personId, serverId: serverId),
+                  ),
           );
         },
       ),
@@ -11615,7 +11801,9 @@ class _CastPersonCardState extends State<_CastPersonCard> with FocusStateMixin {
                   Text(
                     widget.name,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: isNeon ? AppColorScheme.accent : AppColorScheme.onSurface,
+                      color: isNeon
+                          ? AppColorScheme.accent
+                          : AppColorScheme.onSurface,
                       fontWeight: FontWeight.w600,
                       fontSize: widget.isMobile ? 11 : null,
                     ),
@@ -11676,7 +11864,8 @@ class DetailSimilarRow extends StatelessWidget {
     final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
     final isMobile = _isCompact(context);
     final desktopScale = _desktopUiScale(prefs: prefs);
-    final cardWidth = customCardWidth ?? (isMobile ? 120.0 : 150.0 * desktopScale);
+    final cardWidth =
+        customCardWidth ?? (isMobile ? 120.0 : 150.0 * desktopScale);
     final baseGap = isMobile ? 8.0 : 12 * desktopScale;
     final separatorWidth = cardExpansion && !isMobile
         ? MediaCard.focusGap(cardWidth, minimum: baseGap)
@@ -11704,9 +11893,9 @@ class DetailSimilarRow extends StatelessWidget {
                     tag: item.primaryImageTag,
                   )
                 : (item.rawData['PosterPath'] != null &&
-                        (item.rawData['PosterPath'] as String).isNotEmpty
-                    ? 'https://image.tmdb.org/t/p/w342${item.rawData['PosterPath']}'
-                    : null),
+                          (item.rawData['PosterPath'] as String).isNotEmpty
+                      ? 'https://image.tmdb.org/t/p/w342${item.rawData['PosterPath']}'
+                      : null),
             width: cardWidth,
             aspectRatio: ar,
             focusColor: isNeon
@@ -11728,7 +11917,8 @@ class DetailSimilarRow extends StatelessWidget {
                 : () => onItemLongPress!(item),
             onTap: () {
               if (item.serverId == 'seerr') {
-                final mediaType = item.seerrMediaType ??
+                final mediaType =
+                    item.seerrMediaType ??
                     (item.type == 'Series' ? 'tv' : 'movie');
                 context.push(
                   Destinations.seerrMedia(item.id, mediaType: mediaType),
@@ -11880,7 +12070,8 @@ class DetailChaptersRow extends StatelessWidget {
               ? (chapter['Name'] as String)
               : AppLocalizations.of(context).chapterNumber(index + 1);
           final imageTag = chapter['ImageTag'] as String?;
-          final chapterImageUrl = seriesThumbUrl ??
+          final chapterImageUrl =
+              seriesThumbUrl ??
               imageApi.getChapterImageUrl(
                 item.id,
                 index: index,
@@ -12739,7 +12930,8 @@ Widget? _seerrRequestButton(
       status.isNotEmpty && status != 'ended' && status != 'canceled';
   final quality = seerr.state.quality(is4k: is4k);
   // The same set the request sheet reads to decide which seasons it may offer.
-  final hasUnrequestedSeasons = seerr.state.isTv &&
+  final hasUnrequestedSeasons =
+      seerr.state.isTv &&
       seerrSeasonNumbersOf(
         seerr.state.tv?.seasons ?? const [],
         seerr.state.numberOfSeasons ?? 0,
@@ -12790,11 +12982,8 @@ Widget? _seerrCancelButton(
     isPrimary: isPrimary,
     focusNode: focusNode,
     autofocus: autofocus,
-    onPressed: () => showSeerrCancelRequestDialog(
-      context: context,
-      vm: seerr,
-      is4k: is4k,
-    ),
+    onPressed: () =>
+        showSeerrCancelRequestDialog(context: context, vm: seerr, is4k: is4k),
   );
 }
 
@@ -12886,8 +13075,8 @@ class DetailSeasonsRow extends StatelessWidget {
             onTap: onSeasonTap != null
                 ? () => onSeasonTap!(season.indexNumber ?? 0)
                 : () => context.push(
-                      Destinations.item(season.id, serverId: season.serverId),
-                    ),
+                    Destinations.item(season.id, serverId: season.serverId),
+                  ),
             onLongPress: onItemLongPress != null
                 ? () => onItemLongPress!(season)
                 : null,
@@ -13089,8 +13278,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
     final prefs = GetIt.instance<UserPreferences>();
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
     final maxH = widget.isMobile ? 250 : (250 * desktopScale).round();
-    final seriesThumbUrl =
-        prefs.get(UserPreferences.detailUseSeriesThumbnails)
+    final seriesThumbUrl = prefs.get(UserPreferences.detailUseSeriesThumbnails)
         ? _resolveSeriesLandscapeThumbnailUrl(
             ep,
             widget.imageApi,
@@ -13098,7 +13286,8 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
           )
         : null;
 
-    final epImageUrl = seriesThumbUrl ??
+    final epImageUrl =
+        seriesThumbUrl ??
         (ep.primaryImageTag != null
             ? widget.imageApi.getPrimaryImageUrl(
                 ep.id,
@@ -13135,9 +13324,7 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
           onSecondaryTap: _handleLongPress,
           child: Container(
             width: widget.isMobile ? 180.0 : 220.0 * desktopScale,
-            decoration: BoxDecoration(
-              borderRadius: AppRadius.circular(8),
-            ),
+            decoration: BoxDecoration(borderRadius: AppRadius.circular(8)),
             clipBehavior: Clip.antiAlias,
             child: Stack(
               fit: StackFit.passthrough,
@@ -13173,7 +13360,9 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                               ),
                             ),
                           if ((ep.playedPercentage ?? 0) > 0)
-                            _EpisodeProgressBar(percentage: ep.playedPercentage!),
+                            _EpisodeProgressBar(
+                              percentage: ep.playedPercentage!,
+                            ),
                           if (ep.isPlayed && (ep.playedPercentage ?? 0) == 0)
                             const Positioned(
                               top: 6,
@@ -13196,7 +13385,9 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                               'E$epNum',
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+                                    color: AppColorScheme.onSurface.withValues(
+                                      alpha: 0.85,
+                                    ),
                                     fontWeight: FontWeight.w600,
                                   ),
                             ),
@@ -13221,7 +13412,9 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                               runtimeText,
                               style: Theme.of(context).textTheme.labelSmall
                                   ?.copyWith(
-                                    color: AppColorScheme.onSurface.withValues(alpha: 0.8),
+                                    color: AppColorScheme.onSurface.withValues(
+                                      alpha: 0.8,
+                                    ),
                                   ),
                             ),
                           ],
@@ -13238,16 +13431,20 @@ class _EpisodeListCardState extends State<_EpisodeListCard>
                           borderRadius: AppRadius.circular(8),
                           border: showFocusBorder
                               ? Border.fromBorderSide(
-                                  ThemeRegistry.active.borders.focusBorder.copyWith(
-                                    color: isNeon ? AppColorScheme.accent : focusColor,
-                                    width: 1.5,
-                                  ),
+                                  ThemeRegistry.active.borders.focusBorder
+                                      .copyWith(
+                                        color: isNeon
+                                            ? AppColorScheme.accent
+                                            : focusColor,
+                                        width: 1.5,
+                                      ),
                                 )
                               : Border.fromBorderSide(
-                                  ThemeRegistry.active.borders.focusBorder.copyWith(
-                                    color: AppColorScheme.onSurface,
-                                    width: 2.5,
-                                  ),
+                                  ThemeRegistry.active.borders.focusBorder
+                                      .copyWith(
+                                        color: AppColorScheme.onSurface,
+                                        width: 2.5,
+                                      ),
                                 ),
                         ),
                       ),
@@ -13314,8 +13511,7 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
     final focusColor = Color(prefs.get(UserPreferences.focusColor).colorValue);
     final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
     final maxH = isMobile ? 240 : (240 * desktopScale).round();
-    final seriesThumbUrl =
-        prefs.get(UserPreferences.detailUseSeriesThumbnails)
+    final seriesThumbUrl = prefs.get(UserPreferences.detailUseSeriesThumbnails)
         ? _resolveSeriesLandscapeThumbnailUrl(
             episode,
             widget.imageApi,
@@ -13324,7 +13520,8 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
         : null;
 
     final epThumbTag = episode.primaryImageTag;
-    final epImageUrl = seriesThumbUrl ??
+    final epImageUrl =
+        seriesThumbUrl ??
         (epThumbTag != null
             ? widget.imageApi.getPrimaryImageUrl(
                 episode.id,
@@ -13379,7 +13576,8 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                               OfflineAwareImage(
                                 imageUrl: epImageUrl,
                                 fit: BoxFit.cover,
-                                errorWidget: (_, _, _) => const SizedBox.shrink(),
+                                errorWidget: (_, _, _) =>
+                                    const SizedBox.shrink(),
                               ),
                             if ((episode.playedPercentage ?? 0) > 0)
                               _EpisodeProgressBar(
@@ -13414,7 +13612,9 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                                     ?.copyWith(
                                       color: isNeon
                                           ? AppColorScheme.onSurface
-                                          : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                                          : AppColorScheme.onSurface.withValues(
+                                              alpha: 0.7,
+                                            ),
                                     ),
                                 maxLines: 3,
                                 overflow: TextOverflow.ellipsis,
@@ -13440,7 +13640,9 @@ class DetailNextUpCardState extends State<DetailNextUpCard>
                             borderRadius: AppRadius.circular(8),
                             border: Border.fromBorderSide(
                               ThemeRegistry.active.borders.focusBorder.copyWith(
-                                color: isNeon ? AppColorScheme.accent : focusColor,
+                                color: isNeon
+                                    ? AppColorScheme.accent
+                                    : focusColor,
                                 width: 1.5,
                               ),
                             ),
@@ -13545,8 +13747,7 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
     final cardExpansion = prefs.get(UserPreferences.cardFocusExpansion);
     final isMobile = _isCompact(context);
     final maxH = isMobile ? 220 : (220 * desktopScale).round();
-    final seriesThumbUrl =
-        prefs.get(UserPreferences.detailUseSeriesThumbnails)
+    final seriesThumbUrl = prefs.get(UserPreferences.detailUseSeriesThumbnails)
         ? _resolveSeriesLandscapeThumbnailUrl(
             episode,
             widget.imageApi,
@@ -13555,7 +13756,8 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
         : null;
 
     final epThumbTag = episode.primaryImageTag;
-    final epImageUrl = seriesThumbUrl ??
+    final epImageUrl =
+        seriesThumbUrl ??
         (epThumbTag != null
             ? widget.imageApi.getPrimaryImageUrl(
                 episode.id,
@@ -13678,7 +13880,8 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                   runtimeText,
                                   style: Theme.of(context).textTheme.bodySmall
                                       ?.copyWith(
-                                        color: AppColorScheme.onSurface.withValues(alpha: 0.8),
+                                        color: AppColorScheme.onSurface
+                                            .withValues(alpha: 0.8),
                                       ),
                                 ),
                               ],
@@ -13690,7 +13893,8 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                                       ?.copyWith(
                                         color: isNeon
                                             ? AppColorScheme.onSurface
-                                            : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                                            : AppColorScheme.onSurface
+                                                  .withValues(alpha: 0.7),
                                       ),
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
@@ -13711,20 +13915,23 @@ class DetailEpisodeCardState extends State<DetailEpisodeCard>
                             borderRadius: AppRadius.circular(8),
                             border: showFocusBorder
                                 ? Border.fromBorderSide(
-                                    ThemeRegistry.active.borders.focusBorder.copyWith(
-                                      color: isNeon ? AppColorScheme.accent : focusColor,
-                                      width: 1.5,
-                                    ),
+                                    ThemeRegistry.active.borders.focusBorder
+                                        .copyWith(
+                                          color: isNeon
+                                              ? AppColorScheme.accent
+                                              : focusColor,
+                                          width: 1.5,
+                                        ),
                                   )
                                 : Border.fromBorderSide(
-                                    ThemeRegistry.active.borders.focusBorder.copyWith(
-                                      color: isNeon
-                                          ? const Color(0xFF00FFFF)
-                                          : AppColorScheme.accent.withValues(
-                                              alpha: 0.7,
-                                            ),
-                                      width: 1.5,
-                                    ),
+                                    ThemeRegistry.active.borders.focusBorder
+                                        .copyWith(
+                                          color: isNeon
+                                              ? const Color(0xFF00FFFF)
+                                              : AppColorScheme.accent
+                                                    .withValues(alpha: 0.7),
+                                          width: 1.5,
+                                        ),
                                   ),
                           ),
                         ),
@@ -15368,7 +15575,9 @@ class _TrackTileState extends State<TrackTile> with FocusStateMixin {
                 ? widget.track.artists.join(', ')
                 : widget.track.albumArtist ?? '';
             if (widget.showAlbum) {
-              final albumText = widget.track.album ?? widget.track.rawData['Album'] as String?;
+              final albumText =
+                  widget.track.album ??
+                  widget.track.rawData['Album'] as String?;
               if (albumText != null && albumText.isNotEmpty) {
                 if (artistText.isNotEmpty) {
                   return '$albumText • $artistText';

--- a/lib/ui/screens/downloads/downloads_panel.dart
+++ b/lib/ui/screens/downloads/downloads_panel.dart
@@ -816,16 +816,19 @@ class _ActiveDownloadsSection extends StatelessWidget {
     return ListenableBuilder(
       listenable: service,
       builder: (context, _) {
-        final active = service.activeDownloads.values
-            .where((p) => !p.isComplete && p.error == null)
-            .toList();
-        // Keep transferring items above queued ones so the list reads as
-        // "running first, waiting behind".
-        active.sort((a, b) {
-          if (a.isQueued == b.isQueued) return 0;
-          return a.isQueued ? 1 : -1;
-        });
-        if (active.isEmpty) return const SizedBox.shrink();
+        // Running transfers first, then the queue in order. A series can
+        // queue hundreds of episodes; listing them all is noise and, in this
+        // non-lazy column, costly on every update, so only the head of the
+        // queue gets a tile and the rest is one summary row.
+        final running = <DownloadProgress>[];
+        final queued = <DownloadProgress>[];
+        for (final p in service.activeDownloads.values) {
+          if (p.isComplete || p.error != null) continue;
+          (p.isQueued ? queued : running).add(p);
+        }
+        if (running.isEmpty && queued.isEmpty) return const SizedBox.shrink();
+        final active = [...running, ...queued.take(_maxQueuedTiles)];
+        final hiddenQueued = queued.length - (active.length - running.length);
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -930,11 +933,24 @@ class _ActiveDownloadsSection extends StatelessWidget {
                     ? () => service.cancelDownload(active[index].itemId)
                     : null,
               ),
+            if (hiddenQueued > 0)
+              Padding(
+                padding: EdgeInsets.symmetric(
+                  horizontal: PlatformDetection.isTV ? 16 : 0,
+                  vertical: 8,
+                ),
+                child: Text(
+                  l10n.queuedMoreCount(hiddenQueued),
+                  style: statusStyle,
+                ),
+              ),
           ],
         );
       },
     );
   }
+
+  static const _maxQueuedTiles = 10;
 }
 
 class _TotalStorageHeader extends StatelessWidget {

--- a/lib/ui/screens/downloads/downloads_panel.dart
+++ b/lib/ui/screens/downloads/downloads_panel.dart
@@ -201,17 +201,12 @@ class _DownloadsPanelState extends ConsumerState<DownloadsPanel> {
         // and needs no button.
         leading: PlatformDetection.isTV
             ? null
-            : IconButton(
-                onPressed: _closePanel,
-                icon: const Icon(Icons.close),
-              ),
+            : IconButton(onPressed: _closePanel, icon: const Icon(Icons.close)),
         automaticallyImplyLeading: false,
         title: Text(l10n.savedMedia),
         actions: [
           const SyncIndicator(),
-          if (!PlatformDetection.isTV &&
-              _selectMode &&
-              _selected.isNotEmpty)
+          if (!PlatformDetection.isTV && _selectMode && _selected.isNotEmpty)
             IconButton(
               icon: Icon(Icons.delete, color: AppColorScheme.statusRequested),
               onPressed: _bulkDelete,
@@ -251,8 +246,7 @@ class _DownloadsPanelState extends ConsumerState<DownloadsPanel> {
           const SizedBox(height: 24),
           if (hasDownloadedItems)
             _buildItemsSection(
-              initialFocusNode:
-                  PlatformDetection.isTV && !hasActiveDownloads
+              initialFocusNode: PlatformDetection.isTV && !hasActiveDownloads
                   ? _initialContentFocusNode
                   : null,
             ),
@@ -471,9 +465,7 @@ class _DownloadsPanelState extends ConsumerState<DownloadsPanel> {
           if (expanded)
             Padding(
               padding: const EdgeInsets.only(left: 16),
-              child: Column(
-                children: group.items.map(_buildItemTile).toList(),
-              ),
+              child: Column(children: group.items.map(_buildItemTile).toList()),
             ),
         ],
       );
@@ -627,10 +619,7 @@ class _DownloadsPanelState extends ConsumerState<DownloadsPanel> {
     );
   }
 
-  Widget _buildStorageLimitSetting(
-    int currentLimitMb, {
-    FocusNode? focusNode,
-  }) {
+  Widget _buildStorageLimitSetting(int currentLimitMb, {FocusNode? focusNode}) {
     final l10n = AppLocalizations.of(context);
     if (PlatformDetection.isTV) {
       return DpadListTile(
@@ -684,10 +673,7 @@ class _DownloadsPanelState extends ConsumerState<DownloadsPanel> {
           onChanged: (value) {
             ref
                 .read(userPreferencesProvider)
-                .set(
-                  UserPreferences.downloadStorageLimitMb,
-                  value.round(),
-                );
+                .set(UserPreferences.downloadStorageLimitMb, value.round());
           },
         ),
       ],
@@ -793,6 +779,24 @@ class _ActiveDownloadsSection extends StatelessWidget {
   // Status texts must follow the tile's focus-inverted palette on TV: an
   // explicit onSurface color would vanish on the focused tile's light fill.
   // On other platforms the muted explicit color stays.
+  /// "1.2 GB of 4.6 GB • 25.3 MB/s • 2m 10s remaining" for a running
+  /// original-file transfer, omitting whatever is not known yet. Null when
+  /// nothing is, or while the item is queued or finalizing.
+  String? _transferStatusLine(AppLocalizations l10n, DownloadProgress p) {
+    if (p.isQueued || p.isFinalizing) return null;
+    final parts = <String>[
+      if (p.totalBytes > 0 && p.bytesReceived > 0)
+        l10n.downloadBytesOfTotal(
+          formatBytes(p.bytesReceived),
+          formatBytes(p.totalBytes),
+        ),
+      if (p.bytesPerSecond != null)
+        l10n.downloadSpeed(formatBytes(p.bytesPerSecond!)),
+      if (p.etaSeconds != null) l10n.timeRemaining(formatEta(p.etaSeconds!)),
+    ];
+    return parts.isEmpty ? null : parts.join(' • ');
+  }
+
   TextStyle? get _statusTextStyle => PlatformDetection.isTV
       ? null
       : TextStyle(
@@ -807,6 +811,7 @@ class _ActiveDownloadsSection extends StatelessWidget {
     }
     final service = GetIt.instance<DownloadService>();
     final l10n = AppLocalizations.of(context);
+    final statusStyle = _statusTextStyle;
 
     return ListenableBuilder(
       listenable: service,
@@ -872,8 +877,7 @@ class _ActiveDownloadsSection extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (active[index].isTranscoded &&
-                          !active[index].isQueued)
+                      if (active[index].isTranscoded && !active[index].isQueued)
                         Padding(
                           padding: const EdgeInsets.only(bottom: 4),
                           child: Text(
@@ -882,8 +886,14 @@ class _ActiveDownloadsSection extends StatelessWidget {
                                     formatEta(active[index].etaSeconds!),
                                   )
                                 : l10n.transcodingTimeRemainingUnavailable,
-                            style: _statusTextStyle,
+                            style: statusStyle,
                           ),
+                        )
+                      else if (_transferStatusLine(l10n, active[index])
+                          case final line?)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Text(line, style: statusStyle),
                         ),
                       _TileTrackedProgress(
                         value: active[index].isQueued
@@ -898,16 +908,13 @@ class _ActiveDownloadsSection extends StatelessWidget {
                           padding: const EdgeInsets.only(top: 4),
                           child: Text(
                             l10n.finalizingDownload,
-                            style: _statusTextStyle,
+                            style: statusStyle,
                           ),
                         ),
                       if (active[index].isQueued)
                         Padding(
                           padding: const EdgeInsets.only(top: 4),
-                          child: Text(
-                            l10n.queuedDownload,
-                            style: _statusTextStyle,
-                          ),
+                          child: Text(l10n.queuedDownload, style: statusStyle),
                         ),
                     ],
                   ),
@@ -916,9 +923,8 @@ class _ActiveDownloadsSection extends StatelessWidget {
                     ? const Icon(Icons.close)
                     : IconButton(
                         icon: const Icon(Icons.close),
-                        onPressed: () => service.cancelDownload(
-                          active[index].itemId,
-                        ),
+                        onPressed: () =>
+                            service.cancelDownload(active[index].itemId),
                       ),
                 onTap: PlatformDetection.isTV
                     ? () => service.cancelDownload(active[index].itemId)

--- a/lib/util/download_utils.dart
+++ b/lib/util/download_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:background_downloader/background_downloader.dart' as bgd;
 import 'package:get_it/get_it.dart';
 import 'package:path/path.dart' as p;
@@ -66,16 +68,16 @@ String formatEta(int seconds) {
 String formatBytes(int bytes) {
   if (bytes < 1024) return '$bytes B';
   if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-  if (bytes < 1024 * 1024 * 1024) return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
   return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
 }
 
 int sourceSizeBytes(AggregatedItem item) {
-  if (item.mediaSources.isEmpty) {
-    return 0;
-  }
-
-  return item.mediaSources.first['Size'] as int? ?? 0;
+  final sources = item.mediaSources;
+  if (sources.isEmpty) return 0;
+  return sources.first['Size'] as int? ?? 0;
 }
 
 Duration? runtimeForEstimate(AggregatedItem item) {
@@ -116,4 +118,58 @@ int estimateDownloadSizeBytes(AggregatedItem item, DownloadQuality quality) {
   }
 
   return estimateTranscodedSizeBytes(item, quality) ?? sourceSizeBytes(item);
+}
+
+/// Rolling transfer-rate estimate for one download. Feeds the remaining-time
+/// row for original-quality transfers, where the server has no ETA to offer.
+///
+/// Samples are kept for the last [window] so a stalled or bursty connection
+/// changes the estimate within seconds rather than being averaged away by the
+/// whole transfer so far.
+class TransferRateTracker {
+  TransferRateTracker({
+    this.window = const Duration(seconds: 15),
+    this.minSampleGap = const Duration(milliseconds: 500),
+  });
+
+  final Duration window;
+  final Duration minSampleGap;
+  final ListQueue<(DateTime, int)> _samples = ListQueue();
+
+  /// Records that [bytes] have been received in total as of [now].
+  void add(int bytes, DateTime now) {
+    if (_samples.isNotEmpty) {
+      final last = _samples.last;
+      if (now.difference(last.$1) < minSampleGap) return;
+      // A retry restarts the byte count; forget the old run.
+      if (bytes < last.$2) _samples.clear();
+    }
+    _samples.add((now, bytes));
+    while (_samples.length > 1 && now.difference(_samples.first.$1) > window) {
+      _samples.removeFirst();
+    }
+  }
+
+  /// When the most recent sample arrived, or null before the first one.
+  DateTime? get lastSampleAt => _samples.isEmpty ? null : _samples.last.$1;
+
+  /// Average rate over the retained window, or null until at least one
+  /// second of samples exists or while nothing is arriving.
+  int? get bytesPerSecond {
+    if (_samples.length < 2) return null;
+    final first = _samples.first;
+    final last = _samples.last;
+    final elapsedMs = last.$1.difference(first.$1).inMilliseconds;
+    if (elapsedMs < 1000) return null;
+    final rate = (last.$2 - first.$2) * 1000 / elapsedMs;
+    return rate > 0 ? rate.round() : null;
+  }
+
+  /// Seconds left to reach [total] at the current rate, or null when the
+  /// rate is unknown or the transfer is already complete.
+  int? etaSeconds(int received, int total) {
+    final rate = bytesPerSecond;
+    if (rate == null || total <= received) return null;
+    return ((total - received) / rate).ceil();
+  }
 }

--- a/test/offline/download_retry_state_test.dart
+++ b/test/offline/download_retry_state_test.dart
@@ -440,6 +440,28 @@ void main() {
     );
   });
 
+  test('queueing a large batch coalesces listener notifications', () async {
+    await prefs.set(UserPreferences.downloadWifiOnly, true);
+    final items = List.generate(
+      200,
+      (index) => AggregatedItem(
+        id: 'movie-$index',
+        serverId: 'http://127.0.0.1:1',
+        rawData: itemData,
+      ),
+    );
+    var notifications = 0;
+    service.addListener(() => notifications++);
+
+    await service.downloadItems(items);
+    await pumpEventQueue();
+
+    // One placeholder per item plus one failure per item used to mean 400
+    // rebuilds of the downloads panel; they now collapse to a handful.
+    expect(notifications, lessThan(10));
+    expect(service.activeDownloads.length, items.length);
+  });
+
   test('a batch with an escaping failure resets its state', () async {
     await prefs.set(UserPreferences.downloadWifiOnly, true);
     final items = List.generate(

--- a/test/offline/download_retry_state_test.dart
+++ b/test/offline/download_retry_state_test.dart
@@ -158,6 +158,48 @@ class _BlockingItemsApi implements ItemsApi {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+/// Answers the batch-fetch calls (seasons, episodes, collection children)
+/// and records the `fields` each request asked for.
+class _LibraryItemsApi implements ItemsApi {
+  _LibraryItemsApi({required this.episodesBySeason, required this.boxSetItems});
+
+  final Map<String, List<Map<String, dynamic>>> episodesBySeason;
+  final List<Map<String, dynamic>> boxSetItems;
+  final List<String?> episodeFields = [];
+  String? boxSetFields;
+
+  @override
+  Future<Map<String, dynamic>> getEpisodes(
+    String seriesId, {
+    String? seasonId,
+    String? fields,
+  }) async {
+    episodeFields.add(fields);
+    if (seasonId == null) {
+      return {'Items': episodesBySeason.values.expand((e) => e).toList()};
+    }
+    return {'Items': episodesBySeason[seasonId] ?? const []};
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    // getItems has dozens of named parameters; intercept it here instead of
+    // spelling out the full override.
+    if (invocation.memberName == #getItems) {
+      boxSetFields = invocation.namedArguments[#fields] as String?;
+      return Future<Map<String, dynamic>>.value({'Items': boxSetItems});
+    }
+    return super.noSuchMethod(invocation);
+  }
+}
+
+Map<String, dynamic> _playableItem(String id, {required bool played}) => {
+  'Id': id,
+  'Type': 'Episode',
+  'Name': 'Item $id',
+  'UserData': {'Played': played},
+};
+
 class _FakeClient implements MediaServerClient {
   _FakeClient(this._itemsApi);
 
@@ -377,9 +419,7 @@ void main() {
     await _waitFor(() => repo.upsertCalls == 1);
     itemsApi.releaseParked.complete();
 
-    await _waitFor(
-      () => service.activeDownloads['storage-b']?.error != null,
-    );
+    await _waitFor(() => service.activeDownloads['storage-b']?.error != null);
     expect(
       service.activeDownloads['storage-b']?.error,
       contains('Storage limit'),
@@ -422,6 +462,75 @@ void main() {
       expect(progress?.error, isNotNull);
       expect(progress?.isQueued, isFalse);
     }
+  });
+
+  group('unwatched-only batch downloads', () {
+    late _LibraryItemsApi api;
+    late DownloadService libraryService;
+
+    setUp(() {
+      api = _LibraryItemsApi(
+        episodesBySeason: {
+          'season-1': [
+            _playableItem('ep-1', played: true),
+            _playableItem('ep-2', played: false),
+          ],
+          'season-2': [
+            _playableItem('ep-3', played: false),
+            _playableItem('ep-4', played: true),
+          ],
+        },
+        boxSetItems: [
+          _playableItem('movie-a', played: true),
+          _playableItem('movie-b', played: false),
+        ],
+      );
+      libraryService = DownloadService(
+        _FakeClient(api),
+        DownloadNotificationService(),
+      );
+    });
+
+    tearDown(() => libraryService.dispose());
+
+    test('series fetch is one call and requests user data', () async {
+      final episodes = await libraryService.fetchEpisodes('series-1');
+
+      expect(episodes.map((e) => e.id), ['ep-1', 'ep-2', 'ep-3', 'ep-4']);
+      expect(api.episodeFields.single, contains('UserData'));
+      expect(api.episodeFields.single, contains('RunTimeTicks'));
+    });
+
+    test('season fetch requests media sources and user data', () async {
+      final episodes = await libraryService.fetchEpisodes(
+        'series-1',
+        seasonId: 'season-2',
+      );
+
+      expect(episodes.map((e) => e.id), ['ep-3', 'ep-4']);
+      expect(api.episodeFields.single, contains('MediaSources'));
+      expect(api.episodeFields.single, contains('UserData'));
+    });
+
+    test('collection fetch requests user data', () async {
+      final items = await libraryService.fetchBoxSetPlayableItems('boxset-1');
+
+      expect(items.map((e) => e.id), ['movie-a', 'movie-b']);
+      expect(api.boxSetFields, contains('UserData'));
+    });
+
+    test('downloadItems queues exactly the unwatched list', () async {
+      // wifiOnly makes every item fail fast in tests (no Connectivity
+      // platform), leaving one error entry per queued item.
+      await prefs.set(UserPreferences.downloadWifiOnly, true);
+      final episodes = await libraryService.fetchEpisodes('series-1');
+
+      await libraryService.downloadItems(
+        episodes.where((e) => !e.isPlayed).toList(),
+      );
+
+      expect(libraryService.activeDownloads.keys.toSet(), {'ep-2', 'ep-3'});
+    });
   });
 }
 

--- a/test/util/transfer_rate_tracker_test.dart
+++ b/test/util/transfer_rate_tracker_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/util/download_utils.dart';
+
+void main() {
+  final t0 = DateTime(2026, 1, 1, 12);
+
+  test('reports no rate until a second of samples exists', () {
+    final tracker = TransferRateTracker();
+    tracker.add(0, t0);
+    expect(tracker.bytesPerSecond, isNull);
+    tracker.add(500, t0.add(const Duration(milliseconds: 600)));
+    expect(tracker.bytesPerSecond, isNull);
+  });
+
+  test('derives rate and remaining time from the sample window', () {
+    final tracker = TransferRateTracker();
+    tracker.add(0, t0);
+    tracker.add(10 * 1024 * 1024, t0.add(const Duration(seconds: 2)));
+
+    expect(tracker.bytesPerSecond, 5 * 1024 * 1024);
+    expect(tracker.etaSeconds(10 * 1024 * 1024, 60 * 1024 * 1024), 10);
+  });
+
+  test('forgets samples older than the window', () {
+    final tracker = TransferRateTracker(window: const Duration(seconds: 4));
+    tracker.add(0, t0);
+    tracker.add(1000, t0.add(const Duration(seconds: 2)));
+    tracker.add(1000, t0.add(const Duration(seconds: 5)));
+    tracker.add(1000, t0.add(const Duration(seconds: 8)));
+
+    // Only the stalled samples remain, so no rate is reported.
+    expect(tracker.bytesPerSecond, isNull);
+    expect(tracker.etaSeconds(1000, 5000), isNull);
+  });
+
+  test('ignores samples closer together than the minimum gap', () {
+    final tracker = TransferRateTracker();
+    tracker.add(0, t0);
+    tracker.add(100, t0.add(const Duration(milliseconds: 100)));
+    tracker.add(2000, t0.add(const Duration(seconds: 2)));
+
+    expect(tracker.bytesPerSecond, 1000);
+  });
+
+  test('restarts after a retry resets the byte count', () {
+    final tracker = TransferRateTracker();
+    tracker.add(0, t0);
+    tracker.add(4000, t0.add(const Duration(seconds: 2)));
+    tracker.add(0, t0.add(const Duration(seconds: 4)));
+    expect(tracker.bytesPerSecond, isNull);
+    tracker.add(3000, t0.add(const Duration(seconds: 7)));
+    expect(tracker.bytesPerSecond, 1000);
+  });
+
+  test('has no remaining time once the transfer is complete', () {
+    final tracker = TransferRateTracker();
+    tracker.add(0, t0);
+    tracker.add(1000, t0.add(const Duration(seconds: 1)));
+    expect(tracker.etaSeconds(1000, 1000), isNull);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds an "unwatched only" choice when downloading a series, season or collection, shows transfer rate and remaining time for original-quality downloads, and keeps the downloads panel usable when hundreds of items are queued.

Downloading a whole series today queues every episode, watched or not. The download button on a Series, Season or BoxSet now opens a scope sheet first ("All episodes" / "All unwatched episodes", or "All movies" / "All unwatched movies" for collections), each row with a count, before the existing quality picker. The chosen list drives the size estimates and what gets queued, and the Original row now shows the summed file size. Single items skip the step.

While testing a 700-episode download two other problems surfaced and are fixed here: original-quality downloads had no remaining time at all (only transcoded ones did), and queueing hundreds of items made the whole app lag because every enqueue and every progress tick rebuilt one tile per queued item.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #235

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Download scope sheet** (`item_detail_screen.dart`): Series/Season/BoxSet open a "What to  Unwatched rows and counts; rows are disabled when empty; the sheet returns its choice and the quality picker opens afterwards so TV focus restoration lands back on the Download button. Fetch failures are captured and shown as "Could not load items". The "Downloaded" state of the button goes through the
same flow.
- **Quality picker**: subtitles are computed once per sheet instead of on every rebuild; the Original row for batches shows "12.4 GB total • Original files, no re-encoding" (with an "N unknown" note when some
items have no size); the batch estimate string is localized instead of hardcoded.
- **DownloadService fetch helpers**: `fetchEpisodes(seriesId, {seasonId})` and `fetchBoxSetPlayableItems` request `UserData` (for `isPlayed`) plus media sources and runtime; a series is one `getEpisodes` call
instead of one per season. `downloadSeries` / `downloadBoxSet`, which bypassed the scope choi
- **Transfer rate and remaining time** (`download_service.dart`, `download_utils.dart`, `downloads_panel.dart`): `DownloadProgress` gains `totalBytes`, `bytesPerSecond` and a `copyWith`. The native engine's own
speed/ETA are passed through; the legacy engine gets a 15-second rolling `TransferRateTracker of a stalled transfer after 5 s without data. Fresh and re-attached (post-relaunch) transfers share one progress helper. The panel shows "1.2 GB of 4.6 GB • 25.3 MB/s • 2m 10s remaining" under running original transfers.
- **Progress throttle**: the per-item 1% gate now also passes an update every 2 s so the remag on large files.
- **Large queues**: `DownloadService.notifyListeners` is coalesced to at most one per 80 ms; the downloads panel renders running transfers plus the first ten queued items and a "N more queued" row.
- **l10n**: new English keys for the scope sheet, size totals, transfer status and queued sumuse the existing `itemCountLabel`.
- **Tests**: batch fetch fields and unwatched filtering, notification coalescing with 200 queued items, and six unit tests for `TransferRateTracker`.

## Platform
- [ ] Android
- [x] iOS
- [ ] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Unit tests: `test/offline/download_retry_state_test.dart` and `test/util/transfer_rate_tracker_test.dart` (16 tests, all passing). `dart analyze` reports no new issues. Manually tested on macOS (Debug build) and
on an iPhone 17 Pro Max (Release build) against a Jellyfin server, including a 700-episode in a serie.

### Test Steps
1. Open a series with some watched episodes, press Download: the "What to download" sheet shows "All episodes" and "All unwatched episodes" with counts; pick the unwatched row, then a quality. The Original row shows a total size, and the Downloads panel lists only unplayed episodes.
2. Repeat on a season and on a collection ("All movies" / "All unwatched movies"). A fully watched series shows the unwatched row disabled. A single movie or episode opens the quality picker directly.
3. Start an original-quality download and open the Downloads panel: the line under the file re remaining". Drop the network briefly; the speed disappears within about five seconds and returns when data flows again.
4. Download a large series with "All episodes": the app stays responsive, the panel shows queued items and "N more queued".
5. On a series with one episode already downloaded, press the green "Downloaded" button: the scope sheet still opens.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced