### PR TITLE
fix(details) - Small adjustment to Collections Next Up Pane

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -4102,18 +4102,19 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  item.name,
-                  style: (_landscape
-                          ? textTheme.displaySmall
-                          : textTheme.headlineMedium)
-                      ?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
+                Flexible(
+                  child: Text(
+                    item.name,
+                    style: (_landscape
+                            ? textTheme.displaySmall
+                            : textTheme.headlineMedium)
+                        ?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
+                  ),
                 ),
                 if (item.mediaSources.length > 1) ...[
                   const SizedBox(width: 16),
-                  () {
-                    final versionName = selectedSource?['Name'] as String? ?? 'Default';
-                    return Container(
+                  Flexible(
+                    child: Container(
                       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                       decoration: BoxDecoration(
                         color: AppColorScheme.accent.withValues(alpha: 0.15),
@@ -4124,14 +4125,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                         ),
                       ),
                       child: Text(
-                        versionName,
+                        selectedSource?['Name'] as String? ?? 'Default',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                         style: textTheme.bodySmall?.copyWith(
                           color: AppColorScheme.accent,
                           fontWeight: FontWeight.bold,
                         ),
                       ),
-                    );
-                  }(),
+                    ),
+                  ),
                 ],
               ],
             ),
@@ -4906,15 +4909,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                   crossAxisAlignment: CrossAxisAlignment.center,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Text(
-                      item.name,
-                      style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
+                    Flexible(
+                      child: Text(
+                        item.name,
+                        style: textTheme.displaySmall?.copyWith(fontWeight: FontWeight.w700, color: _titleColor),
+                      ),
                     ),
                     if (item.mediaSources.length > 1) ...[
                       const SizedBox(width: 16),
-                      () {
-                        final versionName = selectedSource?['Name'] as String? ?? 'Default';
-                        return Container(
+                      Flexible(
+                        child: Container(
                           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                           decoration: BoxDecoration(
                             color: AppColorScheme.accent.withValues(alpha: 0.15),
@@ -4925,14 +4929,16 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                             ),
                           ),
                           child: Text(
-                            versionName,
+                            selectedSource?['Name'] as String? ?? 'Default',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                             style: textTheme.bodySmall?.copyWith(
                               color: AppColorScheme.accent,
                               fontWeight: FontWeight.bold,
                             ),
                           ),
-                        );
-                      }(),
+                        ),
+                      ),
                     ],
                   ],
                 ),

--- a/lib/ui/screens/detail/modern/modern_landscape_layout.dart
+++ b/lib/ui/screens/detail/modern/modern_landscape_layout.dart
@@ -87,7 +87,7 @@ class ModernLandscapeLayout extends StatelessWidget {
                       if (upNext != null)
                         Expanded(
                           child: Align(
-                            alignment: Alignment.topCenter,
+                            alignment: isBoxSet ? Alignment.topRight : Alignment.topCenter,
                             child: Padding(
                               padding: EdgeInsets.only(
                                 top: isBoxSet


### PR DESCRIPTION
# Pull Request

## Summary
When the Next Up pane was adjusted in #1370 , it had an unexpected consequence for certain Collections pages -- specifically Collections that a) have no logo image, and b) have very long titles (which Jellyfin's automatic Collection generation is kind of notorious for). This PR restores top-right alignment for Collections (BoxSets) in Modern Details landscape view to prevent the Up Next portrait poster from overlapping with collection titles, and wraps text titles in Flexible to ensure long names soft-wrap cleanly instead of overflowing their container.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1370 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **modern_landscape_layout.dart**:
  - Restored `alignment: isBoxSet ? Alignment.topRight : Alignment.topCenter` for the Up Next card container in landscape view. Collections (`isBoxSet: true`) now position the 200 px portrait poster card at the top-right corner, preserving wide hero space and preventing overlap with title headers. TV series and seasons continue to use `Alignment.topCenter` for centered landscape episode thumbnails.
- **modern_detail_content.dart**:
  - Wrapped `item.name` in `Flexible` in both `aboveHeroWidget` and `_buildHero` fallback so long titles wrap within the hero column boundaries rather than overflowing horizontally across the screen.
  - Wrapped the media source version chip in `Flexible` with single-line truncation to match the logo row implementation.

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a Collection (BoxSet) details screen in Modern Details landscape layout.
2. Verify that the Next Up poster card aligns to the top-right corner without overlapping the collection title or overview text.
3. Verify that long titles wrap within the hero column without horizontal overflow.
4. Navigate to a TV series with Next Up episodes and verify that landscape episode cards remain centered in the right container area as intended.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Too Long Title (with Overlap)
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-06_10-40-19" src="https://github.com/user-attachments/assets/b16bf497-4e38-48aa-bdc3-82ae18cad1a7" />

### Post-PR - Collection with Logo and Next-Up:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-06_11-26-32" src="https://github.com/user-attachments/assets/4799c78c-bcd1-40d4-bca6-7912ff3e0840" />

### Post-PR - Collection with Long Title and Next-Up:
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-06_11-26-56" src="https://github.com/user-attachments/assets/cc4b9b6c-f7c1-48e2-808c-cb3ffd3f27ba" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
