### PR TITLE
[style]: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+	# Tell text editors what Moonfin's preferred coding styles are
+# https://EditorConfig.org
+
+# Unix-style newlines, with a newline ending every file, utf-8 charset
+# default to spaces not tabs, with 2 spaces for each indent
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+# Native platform sources indent with four
+[*.{kt,kts,java,swift,gradle,xml,cpp,cc,h}]
+indent_size = 4
+
+# Xcode owns the formatting of these
+[*.{pbxproj,plist,entitlements,xcscheme,xcconfig}]
+indent_style = tab
+
+# Vendored upstream code keeps its own line endings
+[packages/flutter_inappwebview_windows/**]
+end_of_line = crlf


### PR DESCRIPTION
# Pull Request

## Summary
Bundle a `.editorconfig` file, so that well-behaved code editors will automatically use Moonfin's preferred styles for tabs-vs-spaces and indent width.

(Because my own defaults are different and I have to keep remembering to manually change the settings and why put myself through that?)

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [x] Other (describe): developer experience

## Changes Made
A bundled `.editorconfig` file specifying:

- Unix-style line endings
- no final newlines at the end of files
- trim trailing whitespace from each line
- UTF-8 character set
- indent with spaces, not tabs
- indent width is 2 characters

## Platform
- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [ ] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open files in Neovim. Verify that indenting / unindenting, etc all match Moonfin's existing files, rather than my own personal formatting preferences

## Screenshots (if applicable)
N/A

## Checklist
- [ ] Code builds successfully
- [x] Code follows project style and conventions
- [ ] No unnecessary commented-out code
- [ ] No new warnings introduced