### PR TITLE
bugfix-books: Fix Disappearing Books and Refine Queries

### DIFF
--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -252,6 +252,44 @@ class AggregatedItem {
 
   List<Map<String, dynamic>> get chapters => _toListOfMaps(rawData['Chapters']);
 
+  static const _comicExtensions = {'cbz', 'cbr', 'cb7', 'cbt'};
+
+  /// Whether this item is a comic / graphic novel (archive or server Comic type).
+  bool get isComic {
+    final t = (type ?? '').toLowerCase();
+    if (t == 'comic') return true;
+    final container = (rawData['Container'] as String? ?? '').toLowerCase();
+    if (_comicExtensions.contains(container)) return true;
+    for (final source in mediaSources) {
+      final sc = (source['Container'] as String? ?? '').toLowerCase();
+      if (_comicExtensions.contains(sc)) return true;
+      final path =
+          (source['Path'] as String? ?? source['Name'] as String? ?? '')
+              .toLowerCase();
+      final dot = path.lastIndexOf('.');
+      if (dot >= 0 && dot < path.length - 1) {
+        if (_comicExtensions.contains(path.substring(dot + 1))) return true;
+      }
+    }
+    for (final candidate in [
+      rawData['Path'],
+      rawData['FileName'],
+      rawData['FilePath'],
+      rawData['Name'],
+      name,
+    ]) {
+      if (candidate is String && candidate.isNotEmpty) {
+        final lower = candidate.toLowerCase();
+        final dot = lower.lastIndexOf('.');
+        if (dot >= 0 && dot < lower.length - 1) {
+          final ext = lower.substring(dot + 1).split('?').first;
+          if (_comicExtensions.contains(ext)) return true;
+        }
+      }
+    }
+    return false;
+  }
+
   /// Whether this item should use the audiobook player experience.
   ///
   /// Jellyfin marks audiobook collections with Type "AudioBook" and audiobook
@@ -261,6 +299,7 @@ class AggregatedItem {
   bool get isAudiobook {
     final t = (type ?? '').toLowerCase();
     if (t == 'audiobook') return true;
+    if (isComic) return false;
     final mediaType = (rawData['MediaType'] as String? ?? '').toLowerCase();
     // A books library holds readable books next to audio, so a Book that is
     // not audio stays a book whatever the collection says below.

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -43,13 +43,13 @@ class RowDataSource {
       'ParentIndexNumber,IndexNumber,Status,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
-      'ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio';
+      'ParentLogoItemId,ParentLogoImageTag,PrimaryImageTag,PrimaryImageAspectRatio,People,Artists';
   static const _fallbackFields =
       'DateCreated,Type,UserData,OfficialRating,RunTimeTicks,ProductionYear,SeriesName,'
       'ParentIndexNumber,IndexNumber,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,ParentThumbItemId,'
       'ParentThumbImageTag,SeriesId,SeriesPrimaryImageTag,'
-      'ParentLogoItemId,ParentLogoImageTag';
+      'ParentLogoItemId,ParentLogoImageTag,People,Artists';
   static const _minimalFields =
       'Type,UserData,RunTimeTicks,ProductionYear,ImageTags,BackdropImageTags,'
       'ParentBackdropItemId,ParentBackdropImageTags,SeriesId';
@@ -973,7 +973,7 @@ class RowDataSource {
     String sortBy = 'SortName',
     String sortOrder = 'Ascending',
   }) async {
-    final response = await _getItemsWithFallback(
+    var response = await _getItemsWithFallback(
       parentId: parentId,
       isFavorite: true,
       sortBy: sortBy,
@@ -982,6 +982,35 @@ class RowDataSource {
       limit: _defaultLimit,
       includeItemTypes: includeItemTypes,
     );
+    final favList = response['Items'] as List? ?? const [];
+    if (includeItemTypes != null &&
+        (includeItemTypes.contains('Book') ||
+            includeItemTypes.contains('AudioBook') ||
+            includeItemTypes.contains('Comic'))) {
+      final fallbackResponse = await _getItemsWithFallback(
+        parentId: parentId,
+        isFavorite: true,
+        excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+        sortBy: sortBy,
+        sortOrder: sortOrder,
+        recursive: true,
+        limit: _defaultLimit,
+      );
+      final rawItems = (fallbackResponse['Items'] as List? ?? const [])
+          .whereType<Map>()
+          .where((m) {
+            final t = m['Type']?.toString();
+            return t != null && includeItemTypes.contains(t);
+          })
+          .toList();
+      if (rawItems.length > favList.length) {
+        response = {
+          ...fallbackResponse,
+          'Items': rawItems,
+          'TotalRecordCount': rawItems.length,
+        };
+      }
+    }
     return _buildRow(
       id: 'favorites_$parentId',
       title: _l10n.favorites,
@@ -1017,7 +1046,7 @@ class RowDataSource {
     String serverId, {
     List<String>? includeItemTypes,
   }) async {
-    final response = await _getItemsWithFallback(
+    var response = await _getItemsWithFallback(
       parentId: parentId,
       sortBy: 'DatePlayed',
       sortOrder: 'Descending',
@@ -1026,6 +1055,35 @@ class RowDataSource {
       limit: _defaultLimit,
       includeItemTypes: includeItemTypes,
     );
+    final lastList = response['Items'] as List? ?? const [];
+    if (includeItemTypes != null &&
+        (includeItemTypes.contains('Book') ||
+            includeItemTypes.contains('AudioBook') ||
+            includeItemTypes.contains('Comic'))) {
+      final fallbackResponse = await _getItemsWithFallback(
+        parentId: parentId,
+        sortBy: 'DatePlayed',
+        sortOrder: 'Descending',
+        filters: ['IsPlayed'],
+        excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+        recursive: true,
+        limit: _defaultLimit,
+      );
+      final rawItems = (fallbackResponse['Items'] as List? ?? const [])
+          .whereType<Map>()
+          .where((m) {
+            final t = m['Type']?.toString();
+            return t != null && includeItemTypes.contains(t);
+          })
+          .toList();
+      if (rawItems.length > lastList.length) {
+        response = {
+          ...fallbackResponse,
+          'Items': rawItems,
+          'TotalRecordCount': rawItems.length,
+        };
+      }
+    }
     return _buildRow(
       id: 'lastPlayed_$parentId',
       title: _l10n.lastPlayed,
@@ -1045,7 +1103,7 @@ class RowDataSource {
   }) async {
     final isAlbumArtistBrowse =
         includeItemTypes.length == 1 && includeItemTypes.first == 'AlbumArtist';
-    final response = isAlbumArtistBrowse
+    var response = isAlbumArtistBrowse
         ? await _client.itemsApi.getAlbumArtists(
             parentId: parentId,
             userId: _client.userId,
@@ -1063,6 +1121,36 @@ class RowDataSource {
             recursive: true,
             limit: _defaultLimit,
           );
+
+    final itemsList = response['Items'] as List? ?? const [];
+    if (!isAlbumArtistBrowse &&
+        (includeItemTypes.contains('Book') ||
+            includeItemTypes.contains('AudioBook') ||
+            includeItemTypes.contains('Comic'))) {
+      final fallbackResponse = await _getItemsWithFallback(
+        parentId: parentId,
+        excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+        sortBy: sortBy,
+        sortOrder: sortOrder,
+        recursive: true,
+        limit: _defaultLimit,
+      );
+      final rawItems = (fallbackResponse['Items'] as List? ?? const [])
+          .whereType<Map>()
+          .where((m) {
+            final t = m['Type']?.toString();
+            return t != null && includeItemTypes.contains(t);
+          })
+          .toList();
+      if (rawItems.length > itemsList.length) {
+        response = {
+          ...fallbackResponse,
+          'Items': rawItems,
+          'TotalRecordCount': rawItems.length,
+        };
+      }
+    }
+
     return _buildRow(
       id: '${includeItemTypes.first.toLowerCase()}_$parentId',
       title: title,
@@ -1116,6 +1204,39 @@ class RowDataSource {
           serverId: serverId,
           rowType: HomeRowType.resume,
         );
+      } catch (_) {}
+    }
+    if (row.items.isEmpty) {
+      try {
+        final fallback2 = await _getItemsWithFallback(
+          parentId: parentId,
+          excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+          filters: ['IsResumable'],
+          sortBy: 'DatePlayed',
+          sortOrder: 'Descending',
+          recursive: true,
+          limit: _defaultLimit,
+        );
+        final rawItems = (fallback2['Items'] as List? ?? const [])
+            .whereType<Map>()
+            .where((m) {
+              final t = m['Type']?.toString();
+              return t != null && includeItemTypes.contains(t);
+            })
+            .toList();
+        if (rawItems.isNotEmpty) {
+          row = _buildRow(
+            id: 'bookResume_$parentId',
+            title: title,
+            response: {
+              ...fallback2,
+              'Items': rawItems,
+              'TotalRecordCount': rawItems.length,
+            },
+            serverId: serverId,
+            rowType: HomeRowType.resume,
+          );
+        }
       } catch (_) {}
     }
     return row;
@@ -3123,7 +3244,7 @@ class RowDataSource {
           includeItemTypes: const ['BoxSet'],
           recursive: true,
           limit: 50,
-          fields: '$_fields',
+          fields: _fields,
         );
         final collections = _parseItems(res, serverId);
         

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -983,10 +983,10 @@ class RowDataSource {
       includeItemTypes: includeItemTypes,
     );
     final favList = response['Items'] as List? ?? const [];
-    if (includeItemTypes != null &&
+    if (favList.isEmpty &&
+        includeItemTypes != null &&
         (includeItemTypes.contains('Book') ||
-            includeItemTypes.contains('AudioBook') ||
-            includeItemTypes.contains('Comic'))) {
+            includeItemTypes.contains('AudioBook'))) {
       final fallbackResponse = await _getItemsWithFallback(
         parentId: parentId,
         isFavorite: true,
@@ -1003,7 +1003,7 @@ class RowDataSource {
             return t != null && includeItemTypes.contains(t);
           })
           .toList();
-      if (rawItems.length > favList.length) {
+      if (rawItems.isNotEmpty) {
         response = {
           ...fallbackResponse,
           'Items': rawItems,
@@ -1056,10 +1056,10 @@ class RowDataSource {
       includeItemTypes: includeItemTypes,
     );
     final lastList = response['Items'] as List? ?? const [];
-    if (includeItemTypes != null &&
+    if (lastList.isEmpty &&
+        includeItemTypes != null &&
         (includeItemTypes.contains('Book') ||
-            includeItemTypes.contains('AudioBook') ||
-            includeItemTypes.contains('Comic'))) {
+            includeItemTypes.contains('AudioBook'))) {
       final fallbackResponse = await _getItemsWithFallback(
         parentId: parentId,
         sortBy: 'DatePlayed',
@@ -1076,7 +1076,7 @@ class RowDataSource {
             return t != null && includeItemTypes.contains(t);
           })
           .toList();
-      if (rawItems.length > lastList.length) {
+      if (rawItems.isNotEmpty) {
         response = {
           ...fallbackResponse,
           'Items': rawItems,
@@ -1123,10 +1123,10 @@ class RowDataSource {
           );
 
     final itemsList = response['Items'] as List? ?? const [];
-    if (!isAlbumArtistBrowse &&
+    if (itemsList.isEmpty &&
+        !isAlbumArtistBrowse &&
         (includeItemTypes.contains('Book') ||
-            includeItemTypes.contains('AudioBook') ||
-            includeItemTypes.contains('Comic'))) {
+            includeItemTypes.contains('AudioBook'))) {
       final fallbackResponse = await _getItemsWithFallback(
         parentId: parentId,
         excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
@@ -1142,7 +1142,7 @@ class RowDataSource {
             return t != null && includeItemTypes.contains(t);
           })
           .toList();
-      if (rawItems.length > itemsList.length) {
+      if (rawItems.isNotEmpty) {
         response = {
           ...fallbackResponse,
           'Items': rawItems,

--- a/lib/data/viewmodels/book_browse_view_model.dart
+++ b/lib/data/viewmodels/book_browse_view_model.dart
@@ -1,3 +1,6 @@
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:server_core/server_core.dart';
 
@@ -8,7 +11,7 @@ import '../services/row_data_source.dart';
 
 /// Which formats the library tab is currently showing. Only meaningful for
 /// mixed libraries; single-format libraries always behave like [all].
-enum BookScope { all, books, audiobooks }
+enum BookScope { all, books, audiobooks, comics }
 
 class BookBrowseViewModel extends ChangeNotifier {
   final RowDataSource _dataSource;
@@ -38,11 +41,27 @@ class BookBrowseViewModel extends ChangeNotifier {
   int get bookCount => _bookCount;
   int _audiobookCount = 0;
   int get audiobookCount => _audiobookCount;
+  int _comicCount = 0;
+  int get comicCount => _comicCount;
 
-  /// True when the library holds both regular books and audiobooks, which
-  /// enables the scope filter and the per-format rows.
-  bool get isMixedLibrary =>
-      !isAudiobookLibrary && _bookCount > 0 && _audiobookCount > 0;
+  /// True when the library holds 2 or more formats (books, audiobooks, comics),
+  /// which enables the scope filter and the per-format rows.
+  bool get isMixedLibrary {
+    if (isAudiobookLibrary) return false;
+    var count = 0;
+    if (_bookCount > 0) count++;
+    if (_audiobookCount > 0) count++;
+    if (_comicCount > 0) count++;
+    return count >= 2;
+  }
+
+  /// The active formats available in this library.
+  List<BookScope> get availableScopes => [
+    BookScope.all,
+    if (_bookCount > 0) BookScope.books,
+    if (_audiobookCount > 0) BookScope.audiobooks,
+    if (_comicCount > 0) BookScope.comics,
+  ];
 
   AggregatedItem? _featured;
   AggregatedItem? get featuredItem => _featured;
@@ -54,18 +73,31 @@ class BookBrowseViewModel extends ChangeNotifier {
   int _seriesCount = 0;
   int get seriesCount => _seriesCount;
   int _authorCount = 0;
-  int get authorCount => _authorCount;
+  int get authorCount {
+    final scoped = _scopedAuthorsRow();
+    if (scoped != null) {
+      return scoped.totalCount > 0 ? scoped.totalCount : scoped.items.length;
+    }
+    return _authorCount;
+  }
 
   // Source rows kept unfiltered so scope switches recompose without refetch.
   HomeRow? _resumeRow;
   HomeRow? _latestBooksRow;
   HomeRow? _latestAudiobooksRow;
+  HomeRow? _latestComicsRow;
   HomeRow? _lastPlayedRow;
   HomeRow? _authorsRow;
   HomeRow? _genresRow;
   HomeRow? _collectionsRow;
   HomeRow? _favoritesRow;
   HomeRow? _allRow;
+  HomeRow? _allBooksRow;
+  HomeRow? _allAudiobooksRow;
+  Set<String> _bookAuthorNames = const {};
+  Set<String> _bookAuthorIds = const {};
+  Set<String> _audioAuthorNames = const {};
+  Set<String> _audioAuthorIds = const {};
   List<AggregatedItem> _seriesSource = const [];
 
   String get _serverId => _client.baseUrl;
@@ -76,12 +108,13 @@ class BookBrowseViewModel extends ChangeNotifier {
     required RowDataSource dataSource,
     required MediaServerClient client,
     String? collectionType,
-  }) : _dataSource = dataSource,
-       _client = client,
-       _collectionType = collectionType;
+  }) : _dataSource = dataSource, // ignore: prefer_initializing_formals
+       _client = client, // ignore: prefer_initializing_formals
+       _collectionType = collectionType; // ignore: prefer_initializing_formals
 
   String get _latestBooksRowId => 'latestBooks_$libraryId';
   String get _latestAudiobooksRowId => 'latestAudiobooks_$libraryId';
+  String get _latestComicsRowId => 'latestComics_$libraryId';
   String get _lastPlayedRowId => 'lastPlayed_$libraryId';
   String get _favoritesRowId => 'favorites_$libraryId';
   String get _allRowId => 'allTitles_$libraryId';
@@ -90,9 +123,12 @@ class BookBrowseViewModel extends ChangeNotifier {
       isAudiobookLibrary ? const ['AudioBook', 'Audio'] : const ['AudioBook'];
 
   /// Types for whole-library queries. Books libraries include AudioBook so
-  /// audiobooks shelved in a books library are no longer invisible.
+  /// audiobooks shelved in a books library are visible. Note: Jellyfin treats
+  /// comics as Book types, so Comic is partitioned client-side.
   List<String> get combinedTypes =>
-      isAudiobookLibrary ? const ['AudioBook', 'Audio'] : const ['Book', 'AudioBook'];
+      isAudiobookLibrary
+          ? const ['AudioBook', 'Audio']
+          : const ['Book', 'AudioBook'];
 
   /// Types matching the active scope, for See-all navigation and genre routes.
   List<String> get scopedTypes {
@@ -100,26 +136,35 @@ class BookBrowseViewModel extends ChangeNotifier {
     return switch (_scope) {
       BookScope.books => const ['Book'],
       BookScope.audiobooks => _audiobookTypes,
+      BookScope.comics => const ['Book'],
       BookScope.all => combinedTypes,
     };
   }
 
-  /// Whether [item] is an audiobook (vs a regular book). Explicit server
-  /// types win; the heuristic only breaks ties for bare audio items.
+  /// Whether [item] is an audiobook (vs a regular book or comic). Explicit
+  /// server types win; the heuristic only breaks ties for bare audio items.
   bool isAudiobookItem(AggregatedItem item) {
+    if (item.isComic) return false;
     final type = item.type;
     if (type == 'AudioBook' || type == 'Audio') return true;
     if (type == 'Book') return false;
     return item.isAudiobook;
   }
 
+  bool isComicItem(AggregatedItem item) => item.isComic;
+
+  bool isBookItem(AggregatedItem item) => !isAudiobookItem(item) && !item.isComic;
+
   /// Item types the See-all grid should show for [row]. Lives here so the
   /// mapping sits next to where the row ids are minted.
   List<String> seeAllTypesFor(HomeRow row) {
-    if (row.id == _latestBooksRowId) return const ['Book'];
-    if (row.id == _latestAudiobooksRowId || row.id == _lastPlayedRowId) {
+    if (row.id == _latestBooksRowId || row.id.startsWith('allBooks_')) return const ['Book'];
+    if (row.id == _latestAudiobooksRowId ||
+        row.id == _lastPlayedRowId ||
+        row.id.startsWith('allAudiobooks_')) {
       return _audiobookTypes;
     }
+    if (row.id == _latestComicsRowId) return const ['Comic', 'Book'];
     return scopedTypes;
   }
 
@@ -134,8 +179,9 @@ class BookBrowseViewModel extends ChangeNotifier {
 
   bool _matchesScope(AggregatedItem item) => switch (_scope) {
     BookScope.all => true,
-    BookScope.books => !isAudiobookItem(item),
+    BookScope.books => isBookItem(item),
     BookScope.audiobooks => isAudiobookItem(item),
+    BookScope.comics => isComicItem(item),
   };
 
   /// Time left in an audiobook (or book with server progress); null without
@@ -193,6 +239,16 @@ class BookBrowseViewModel extends ChangeNotifier {
         sortBy: 'DateCreated',
         sortOrder: 'Descending',
       );
+      final latestComicsF = isAudiobookLibrary
+          ? null
+          : _dataSource.loadLibraryItemsByType(
+              libraryId,
+              _serverId,
+              title: l10n.latestComics,
+              includeItemTypes: const ['Book'],
+              sortBy: 'DateCreated',
+              sortOrder: 'Descending',
+            );
       final lastPlayedF = isAudiobookLibrary
           ? _dataSource.loadLibraryLastPlayed(
               libraryId,
@@ -212,6 +268,22 @@ class BookBrowseViewModel extends ChangeNotifier {
         parentId: libraryId,
       );
       final collectionsF = _loadBookCollections();
+      final allBooksF = isAudiobookLibrary
+          ? null
+          : _dataSource.loadLibraryItemsByType(
+              libraryId,
+              _serverId,
+              title: l10n.books,
+              includeItemTypes: const ['Book'],
+              sortBy: 'SortName',
+            );
+      final allAudiobooksF = _dataSource.loadLibraryItemsByType(
+        libraryId,
+        _serverId,
+        title: l10n.audiobooks,
+        includeItemTypes: _audiobookTypes,
+        sortBy: 'SortName',
+      );
       final allF = _dataSource.loadLibraryItemsByType(
         libraryId,
         _serverId,
@@ -229,11 +301,14 @@ class BookBrowseViewModel extends ChangeNotifier {
         resumeF,
         ?latestBooksF,
         latestAudiobooksF,
+        ?latestComicsF,
         ?lastPlayedF,
         authorsF,
         favoritesF,
         genresF,
         collectionsF,
+        ?allBooksF,
+        allAudiobooksF,
         allF,
         seriesSourceF,
         bookCountF,
@@ -241,27 +316,204 @@ class BookBrowseViewModel extends ChangeNotifier {
       ]);
 
       _resumeRow = await resumeF;
-      _latestBooksRow = latestBooksF == null
-          ? null
-          : (await latestBooksF).copyWith(id: _latestBooksRowId);
-      _latestAudiobooksRow = (await latestAudiobooksF).copyWith(
-        id: _latestAudiobooksRowId,
-      );
+      _allRow = (await allF).copyWith(id: _allRowId);
+      final allItems = _allRow?.items ?? const <AggregatedItem>[];
+
+      var latestBooks = await latestBooksF;
+      var allBooks = await allBooksF;
+      if (latestBooks != null) {
+        final filteredBooks = latestBooks.items.where(isBookItem).toList();
+        latestBooks = latestBooks.copyWith(items: filteredBooks);
+        _latestBooksRow = latestBooks.copyWith(id: _latestBooksRowId);
+      } else {
+        _latestBooksRow = null;
+      }
+
+      if (allBooks != null) {
+        final filteredBooks = allBooks.items.where(isBookItem).toList();
+        if (filteredBooks.isEmpty && (latestBooks?.items.isNotEmpty == true)) {
+          allBooks = allBooks.copyWith(items: latestBooks!.items);
+        } else {
+          allBooks = allBooks.copyWith(items: filteredBooks);
+        }
+        _allBooksRow = allBooks.copyWith(id: 'allBooks_$libraryId', title: l10n.books);
+      } else if (latestBooks != null && latestBooks.items.isNotEmpty) {
+        _allBooksRow = latestBooks.copyWith(id: 'allBooks_$libraryId', title: l10n.books);
+      } else {
+        _allBooksRow = null;
+      }
+
+      var latestAudio = await latestAudiobooksF;
+      var allAudio = await allAudiobooksF;
+      final filteredAudio = latestAudio.items.where(isAudiobookItem).toList();
+      latestAudio = latestAudio.copyWith(items: filteredAudio);
+      _latestAudiobooksRow = latestAudio.copyWith(id: _latestAudiobooksRowId);
+
+      final filteredAllAudio = allAudio.items.where(isAudiobookItem).toList();
+      if (filteredAllAudio.isEmpty && latestAudio.items.isNotEmpty) {
+        allAudio = allAudio.copyWith(items: latestAudio.items);
+      } else {
+        allAudio = allAudio.copyWith(items: filteredAllAudio);
+      }
+      _allAudiobooksRow = allAudio.copyWith(id: 'allAudiobooks_$libraryId', title: l10n.audiobooks);
+
+      final booksFromAll = _allBooksRow?.items ?? const <AggregatedItem>[];
+      final audioFromAll = _allAudiobooksRow?.items ?? const <AggregatedItem>[];
+      final comicsFromAll = allItems.where(isComicItem).toList();
+
+      final combinedAllItems = [
+        ...booksFromAll,
+        ...audioFromAll,
+      ]..sort((a, b) => (a.sortName ?? a.name).toLowerCase().compareTo((b.sortName ?? b.name).toLowerCase()));
+      if (combinedAllItems.isNotEmpty) {
+        _allRow = _allRow!.copyWith(
+          items: combinedAllItems,
+          totalCount: combinedAllItems.length,
+        );
+      }
+
+      if (!isAudiobookLibrary && comicsFromAll.isNotEmpty) {
+        var latestComics = await latestComicsF;
+        final filteredComics = (latestComics?.items ?? const <AggregatedItem>[])
+            .where(isComicItem)
+            .toList();
+        final finalComics =
+            filteredComics.isNotEmpty ? filteredComics : comicsFromAll;
+        if (finalComics.isNotEmpty) {
+          _latestComicsRow = HomeRow(
+            id: _latestComicsRowId,
+            title: l10n.latestComics,
+            items: finalComics,
+            rowType: HomeRowType.latestMedia,
+            totalCount: finalComics.length,
+          );
+        } else {
+          _latestComicsRow = null;
+        }
+      } else {
+        _latestComicsRow = null;
+      }
+
       _lastPlayedRow = lastPlayedF == null ? null : await lastPlayedF;
-      _authorsRow = await authorsF;
+
+      final bookAuthorNames = <String>{};
+      final bookAuthorIds = <String>{};
+      for (final book in booksFromAll) {
+        final people = book.rawData['People'] as List?;
+        if (people != null) {
+          for (final p in people) {
+            if (p is Map && (p['Type'] == 'Author' || p['Role'] == 'Author')) {
+              final name = p['Name'] as String?;
+              final id = p['Id'] as String?;
+              if (name != null) bookAuthorNames.add(name.toLowerCase());
+              if (id != null) bookAuthorIds.add(id);
+            }
+          }
+        }
+        final artist = book.rawData['AlbumArtist'] as String?;
+        if (artist != null) bookAuthorNames.add(artist.toLowerCase());
+        final artists = book.rawData['Artists'] as List?;
+        if (artists != null) {
+          for (final a in artists) {
+            if (a is String) bookAuthorNames.add(a.toLowerCase());
+          }
+        }
+      }
+
+      final audioAuthorNames = <String>{};
+      final audioAuthorIds = <String>{};
+      for (final audio in audioFromAll) {
+        final artistItems = audio.rawData['ArtistItems'] as List?;
+        if (artistItems != null) {
+          for (final a in artistItems) {
+            if (a is Map) {
+              final name = a['Name'] as String?;
+              final id = a['Id'] as String?;
+              if (name != null) audioAuthorNames.add(name.toLowerCase());
+              if (id != null) audioAuthorIds.add(id);
+            }
+          }
+        }
+        final artist = audio.rawData['AlbumArtist'] as String?;
+        if (artist != null) audioAuthorNames.add(artist.toLowerCase());
+        final artists = audio.rawData['Artists'] as List?;
+        if (artists != null) {
+          for (final a in artists) {
+            if (a is String) audioAuthorNames.add(a.toLowerCase());
+          }
+        }
+        final people = audio.rawData['People'] as List?;
+        if (people != null) {
+          for (final p in people) {
+            if (p is Map && (p['Type'] == 'Author' || p['Role'] == 'Author')) {
+              final name = p['Name'] as String?;
+              final id = p['Id'] as String?;
+              if (name != null) audioAuthorNames.add(name.toLowerCase());
+              if (id != null) audioAuthorIds.add(id);
+            }
+          }
+        }
+      }
+
+      _bookAuthorNames = bookAuthorNames;
+      _bookAuthorIds = bookAuthorIds;
+      _audioAuthorNames = audioAuthorNames;
+      _audioAuthorIds = audioAuthorIds;
+
+      var authors = await authorsF;
+      final existingAuthorNames =
+          authors.items.map((a) => a.name.toLowerCase()).toSet();
+      final extraAuthors = <AggregatedItem>[];
+      for (final item in [...booksFromAll, ...allItems]) {
+        final people = item.rawData['People'] as List?;
+        if (people == null) continue;
+        for (final p in people) {
+          if (p is Map && (p['Type'] == 'Author' || p['Role'] == 'Author')) {
+            final name = p['Name'] as String?;
+            final id = p['Id'] as String?;
+            if (name != null &&
+                name.isNotEmpty &&
+                !existingAuthorNames.contains(name.toLowerCase())) {
+              existingAuthorNames.add(name.toLowerCase());
+              final primaryTag = p['PrimaryImageTag'] as String?;
+              extraAuthors.add(AggregatedItem(
+                id: id ?? name,
+                serverId: _serverId,
+                rawData: {
+                  'Id': id ?? name,
+                  'Name': name,
+                  'Type': 'Person',
+                  if (primaryTag != null) 'ImageTags': {'Primary': primaryTag},
+                },
+              ));
+            }
+          }
+        }
+      }
+      if (extraAuthors.isNotEmpty) {
+        final combinedAuthors = [...authors.items, ...extraAuthors]
+          ..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+        authors = authors.copyWith(
+          items: combinedAuthors,
+          totalCount: combinedAuthors.length,
+        );
+      }
+      _authorsRow = authors;
       _favoritesRow = await favoritesF;
       _genresRow = await genresF;
       _collectionsRow = await collectionsF;
-      _allRow = (await allF).copyWith(id: _allRowId);
       _seriesSource = await seriesSourceF;
-      _bookCount = await bookCountF;
-      _audiobookCount = await audiobookCountF;
+
+      _bookCount = math.max(await bookCountF, booksFromAll.length);
+      _audiobookCount = math.max(await audiobookCountF, audioFromAll.length);
+      _comicCount = comicsFromAll.length;
 
       final resume = _resumeRow!;
       _featured = resume.items.isNotEmpty
           ? resume.items.first
           : (_latestBooksRow?.items.firstOrNull ??
-                _latestAudiobooksRow?.items.firstOrNull);
+                _latestAudiobooksRow?.items.firstOrNull ??
+                _latestComicsRow?.items.firstOrNull);
       final all = _allRow!;
       _titleCount = all.totalCount > 0 ? all.totalCount : all.items.length;
       _genreCount = _genresRow?.items.length ?? 0;
@@ -291,20 +543,26 @@ class BookBrowseViewModel extends ChangeNotifier {
   void _composeRows() {
     final seriesRow = _buildSeriesRow();
     _seriesCount = seriesRow?.items.length ?? 0;
-    final showBooks = _scope != BookScope.audiobooks;
-    final showAudiobooks = _scope != BookScope.books;
+    final showBooks = _scope == BookScope.all || _scope == BookScope.books;
+    final showAudiobooks =
+        _scope == BookScope.all || _scope == BookScope.audiobooks;
+    final showComics = _scope == BookScope.all || _scope == BookScope.comics;
 
     final composed = <HomeRow?>[
       _scopedRow(_resumeRow),
       if (showBooks && !isAudiobookLibrary) _latestBooksRow,
       if (showAudiobooks) _latestAudiobooksRow,
-      if (showAudiobooks) _lastPlayedRow,
-      seriesRow,
-      _authorsRow,
-      _genresRow,
-      _collectionsRow,
-      _scopedRow(_favoritesRow),
-      _scopedRow(_allRow),
+      if (showComics &&
+          !isAudiobookLibrary &&
+          (_latestComicsRow?.items.isNotEmpty == true))
+        _latestComicsRow,
+      if (_scope == BookScope.all && showAudiobooks) _lastPlayedRow,
+      if (_scope == BookScope.all) seriesRow,
+      _scopedAuthorsRow(),
+      if (_scope == BookScope.all) _genresRow,
+      if (_scope == BookScope.all) _collectionsRow,
+      if (_scope == BookScope.all) _scopedRow(_favoritesRow),
+      _scopedAllRow(),
     ];
     _rows = composed
         .whereType<HomeRow>()
@@ -312,9 +570,71 @@ class BookBrowseViewModel extends ChangeNotifier {
         .toList();
   }
 
+  HomeRow? _scopedAuthorsRow() {
+    final base = _authorsRow;
+    if (base == null || base.items.isEmpty) return null;
+    if (_scope == BookScope.all) return base;
+
+    final filtered = base.items.where((author) {
+      final name = author.name.toLowerCase();
+      final id = author.id;
+      return switch (_scope) {
+        BookScope.books =>
+          _bookAuthorNames.contains(name) || _bookAuthorIds.contains(id),
+        BookScope.audiobooks =>
+          _audioAuthorNames.contains(name) ||
+          _audioAuthorIds.contains(id) ||
+          (!_bookAuthorNames.contains(name) && !_bookAuthorIds.contains(id)),
+        BookScope.comics => false,
+        BookScope.all => true,
+      };
+    }).toList();
+
+    if (filtered.isEmpty) return null;
+    return base.copyWith(
+      items: filtered,
+      totalCount: filtered.length,
+    );
+  }
+
+  HomeRow? _scopedAllRow() {
+    final l10n = currentAppLocalizations();
+    switch (_scope) {
+      case BookScope.books:
+        return _allBooksRow?.copyWith(title: l10n.books);
+      case BookScope.audiobooks:
+        return _allAudiobooksRow?.copyWith(title: l10n.audiobooks);
+      case BookScope.comics:
+        if (_comicCount == 0) return null;
+        return _latestComicsRow?.copyWith(title: l10n.comics);
+      case BookScope.all:
+        return isMixedLibrary
+            ? _allRow?.copyWith(title: l10n.allTitles)
+            : _allRow;
+    }
+  }
+
   HomeRow? _scopedRow(HomeRow? row) {
-    if (row == null || _scope == BookScope.all) return row;
-    return row.copyWith(items: row.items.where(_matchesScope).toList());
+    if (row == null) return null;
+    final l10n = currentAppLocalizations();
+    final isAllTitles = row.id.startsWith('allTitles_');
+    if (_scope == BookScope.all) {
+      if (isAllTitles && isMixedLibrary) {
+        return row.copyWith(title: l10n.allTitles);
+      }
+      return row;
+    }
+    final scopedItems = row.items.where(_matchesScope).toList();
+    final dynamicTitle = switch (_scope) {
+      BookScope.audiobooks => l10n.audiobooks,
+      BookScope.comics => l10n.comics,
+      BookScope.books => l10n.books,
+      BookScope.all => row.title,
+    };
+    return row.copyWith(
+      title: isAllTitles ? dynamicTitle : row.title,
+      items: scopedItems,
+    );
   }
 
   Future<int> _countOf(List<String> types) async {
@@ -326,7 +646,20 @@ class BookBrowseViewModel extends ChangeNotifier {
         limit: 1,
         enableTotalRecordCount: true,
       );
-      return resp['TotalRecordCount'] as int? ?? 0;
+      final count = resp['TotalRecordCount'] as int? ?? 0;
+      final fallbackResp = await _client.itemsApi.getItems(
+        parentId: libraryId,
+        excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+        recursive: true,
+        limit: 500,
+      );
+      final items =
+          (fallbackResp['Items'] as List? ?? const []).whereType<Map>();
+      final fallbackCount = items.where((it) {
+        final t = it['Type']?.toString();
+        return t != null && types.contains(t);
+      }).length;
+      return math.max(count, fallbackCount);
     } catch (_) {
       return 0;
     }
@@ -334,7 +667,7 @@ class BookBrowseViewModel extends ChangeNotifier {
 
   Future<List<AggregatedItem>> _loadSeriesSource() async {
     try {
-      final resp = await _client.itemsApi.getItems(
+      var resp = await _client.itemsApi.getItems(
         parentId: libraryId,
         includeItemTypes: combinedTypes,
         recursive: true,
@@ -345,7 +678,22 @@ class BookBrowseViewModel extends ChangeNotifier {
         enableImageTypes: 'Primary',
         imageTypeLimit: 1,
       );
-      final items = (resp['Items'] as List? ?? const [])
+      var rawItems = resp['Items'] as List? ?? const [];
+      if (rawItems.isEmpty) {
+        resp = await _client.itemsApi.getItems(
+          parentId: libraryId,
+          excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
+          recursive: true,
+          limit: _seriesSourceLimit,
+          sortBy: 'SortName',
+          sortOrder: 'Ascending',
+          fields: 'SeriesName,ImageTags,UserData,RunTimeTicks,DateCreated',
+          enableImageTypes: 'Primary',
+          imageTypeLimit: 1,
+        );
+        rawItems = resp['Items'] as List? ?? const [];
+      }
+      final items = rawItems
           .whereType<Map>()
           .map(
             (raw) => AggregatedItem(
@@ -451,7 +799,14 @@ class BookBrowseViewModel extends ChangeNotifier {
       case 'MusicArtist':
         return '';
       default:
+        final people = item.rawData['People'] as List?;
+        final authorPerson = people?.whereType<Map>().firstWhereOrNull(
+              (p) => p['Type'] == 'Author' || p['Role'] == 'Author',
+            );
+        final authorFromPeople = authorPerson?['Name'] as String?;
+
         final author =
+            authorFromPeople ??
             (item.rawData['AlbumArtist'] as String?) ??
             item.seriesName ??
             (item.rawData['Artists'] as List?)?.cast<String>().firstOrNull ??

--- a/lib/data/viewmodels/book_browse_view_model.dart
+++ b/lib/data/viewmodels/book_browse_view_model.dart
@@ -94,6 +94,7 @@ class BookBrowseViewModel extends ChangeNotifier {
   HomeRow? _allRow;
   HomeRow? _allBooksRow;
   HomeRow? _allAudiobooksRow;
+  HomeRow? _allComicsRow;
   Set<String> _bookAuthorNames = const {};
   Set<String> _bookAuthorIds = const {};
   Set<String> _audioAuthorNames = const {};
@@ -115,6 +116,7 @@ class BookBrowseViewModel extends ChangeNotifier {
   String get _latestBooksRowId => 'latestBooks_$libraryId';
   String get _latestAudiobooksRowId => 'latestAudiobooks_$libraryId';
   String get _latestComicsRowId => 'latestComics_$libraryId';
+  String get _allComicsRowId => 'allComics_$libraryId';
   String get _lastPlayedRowId => 'lastPlayed_$libraryId';
   String get _favoritesRowId => 'favorites_$libraryId';
   String get _allRowId => 'allTitles_$libraryId';
@@ -164,7 +166,11 @@ class BookBrowseViewModel extends ChangeNotifier {
         row.id.startsWith('allAudiobooks_')) {
       return _audiobookTypes;
     }
-    if (row.id == _latestComicsRowId) return const ['Comic', 'Book'];
+    // Comic is not a type the server knows, so asking for it is rejected.
+    // Book is the type comics carry and the nearest the grid can request.
+    if (row.id == _latestComicsRowId || row.id == _allComicsRowId) {
+      return const ['Book'];
+    }
     return scopedTypes;
   }
 
@@ -176,6 +182,11 @@ class BookBrowseViewModel extends ChangeNotifier {
         row.id == _favoritesRowId ||
         row.id == _allRowId;
   }
+
+  static int _bySortName(AggregatedItem a, AggregatedItem b) =>
+      (a.sortName ?? a.name).toLowerCase().compareTo(
+        (b.sortName ?? b.name).toLowerCase(),
+      );
 
   bool _matchesScope(AggregatedItem item) => switch (_scope) {
     BookScope.all => true,
@@ -239,16 +250,6 @@ class BookBrowseViewModel extends ChangeNotifier {
         sortBy: 'DateCreated',
         sortOrder: 'Descending',
       );
-      final latestComicsF = isAudiobookLibrary
-          ? null
-          : _dataSource.loadLibraryItemsByType(
-              libraryId,
-              _serverId,
-              title: l10n.latestComics,
-              includeItemTypes: const ['Book'],
-              sortBy: 'DateCreated',
-              sortOrder: 'Descending',
-            );
       final lastPlayedF = isAudiobookLibrary
           ? _dataSource.loadLibraryLastPlayed(
               libraryId,
@@ -301,7 +302,6 @@ class BookBrowseViewModel extends ChangeNotifier {
         resumeF,
         ?latestBooksF,
         latestAudiobooksF,
-        ?latestComicsF,
         ?lastPlayedF,
         authorsF,
         favoritesF,
@@ -321,6 +321,11 @@ class BookBrowseViewModel extends ChangeNotifier {
 
       var latestBooks = await latestBooksF;
       var allBooks = await allBooksF;
+      // Comics are Book typed on the server, so the book responses already
+      // carry them and no separate request is needed to find them.
+      final comicsByRecency = (latestBooks?.items ?? const <AggregatedItem>[])
+          .where(isComicItem)
+          .toList();
       if (latestBooks != null) {
         final filteredBooks = latestBooks.items.where(isBookItem).toList();
         latestBooks = latestBooks.copyWith(items: filteredBooks);
@@ -361,37 +366,42 @@ class BookBrowseViewModel extends ChangeNotifier {
       final audioFromAll = _allAudiobooksRow?.items ?? const <AggregatedItem>[];
       final comicsFromAll = allItems.where(isComicItem).toList();
 
+      // Comics belong here too, and totalCount stays the server's because
+      // these items are one page of the library rather than all of it.
       final combinedAllItems = [
         ...booksFromAll,
         ...audioFromAll,
-      ]..sort((a, b) => (a.sortName ?? a.name).toLowerCase().compareTo((b.sortName ?? b.name).toLowerCase()));
+        ...comicsFromAll,
+      ]..sort(_bySortName);
       if (combinedAllItems.isNotEmpty) {
-        _allRow = _allRow!.copyWith(
-          items: combinedAllItems,
-          totalCount: combinedAllItems.length,
-        );
+        _allRow = _allRow!.copyWith(items: combinedAllItems);
       }
 
-      if (!isAudiobookLibrary && comicsFromAll.isNotEmpty) {
-        var latestComics = await latestComicsF;
-        final filteredComics = (latestComics?.items ?? const <AggregatedItem>[])
-            .where(isComicItem)
-            .toList();
-        final finalComics =
-            filteredComics.isNotEmpty ? filteredComics : comicsFromAll;
-        if (finalComics.isNotEmpty) {
-          _latestComicsRow = HomeRow(
-            id: _latestComicsRowId,
-            title: l10n.latestComics,
-            items: finalComics,
-            rowType: HomeRowType.latestMedia,
-            totalCount: finalComics.length,
-          );
-        } else {
-          _latestComicsRow = null;
-        }
-      } else {
+      final comicsById = <String, AggregatedItem>{
+        for (final comic in [...comicsByRecency, ...comicsFromAll])
+          comic.id: comic,
+      };
+      if (isAudiobookLibrary || comicsById.isEmpty) {
         _latestComicsRow = null;
+        _allComicsRow = null;
+      } else {
+        _latestComicsRow = HomeRow(
+          id: _latestComicsRowId,
+          title: l10n.latestComics,
+          items: comicsByRecency.isNotEmpty
+              ? comicsByRecency
+              : comicsById.values.toList(),
+          rowType: HomeRowType.latestMedia,
+          totalCount: comicsById.length,
+        );
+        final byName = comicsById.values.toList()..sort(_bySortName);
+        _allComicsRow = HomeRow(
+          id: _allComicsRowId,
+          title: l10n.comics,
+          items: byName,
+          rowType: HomeRowType.latestMedia,
+          totalCount: byName.length,
+        );
       }
 
       _lastPlayedRow = lastPlayedF == null ? null : await lastPlayedF;
@@ -504,9 +514,13 @@ class BookBrowseViewModel extends ChangeNotifier {
       _collectionsRow = await collectionsF;
       _seriesSource = await seriesSourceF;
 
-      _bookCount = math.max(await bookCountF, booksFromAll.length);
+      // The server counts comics as books, so a library holding nothing but
+      // comics would otherwise offer a Books tab with nothing behind it.
+      _bookCount = booksFromAll.isEmpty
+          ? 0
+          : math.max(await bookCountF, booksFromAll.length);
       _audiobookCount = math.max(await audiobookCountF, audioFromAll.length);
-      _comicCount = comicsFromAll.length;
+      _comicCount = comicsById.length;
 
       final resume = _resumeRow!;
       _featured = resume.items.isNotEmpty
@@ -520,6 +534,11 @@ class BookBrowseViewModel extends ChangeNotifier {
       _authorCount = (_authorsRow?.totalCount ?? 0) > 0
           ? _authorsRow!.totalCount
           : (_authorsRow?.items.length ?? 0);
+      // A refresh can drop the format the user was on, and leaving the scope
+      // there strands them on a tab the filter no longer offers.
+      if (!availableScopes.contains(_scope)) {
+        _scope = BookScope.all;
+      }
       _composeRows();
     } catch (_) {}
 
@@ -605,8 +624,9 @@ class BookBrowseViewModel extends ChangeNotifier {
       case BookScope.audiobooks:
         return _allAudiobooksRow?.copyWith(title: l10n.audiobooks);
       case BookScope.comics:
-        if (_comicCount == 0) return null;
-        return _latestComicsRow?.copyWith(title: l10n.comics);
+        // Its own row rather than the latest one retitled, which would put
+        // the same id on two shelves and collide their keys.
+        return _allComicsRow;
       case BookScope.all:
         return isMixedLibrary
             ? _allRow?.copyWith(title: l10n.allTitles)
@@ -616,25 +636,8 @@ class BookBrowseViewModel extends ChangeNotifier {
 
   HomeRow? _scopedRow(HomeRow? row) {
     if (row == null) return null;
-    final l10n = currentAppLocalizations();
-    final isAllTitles = row.id.startsWith('allTitles_');
-    if (_scope == BookScope.all) {
-      if (isAllTitles && isMixedLibrary) {
-        return row.copyWith(title: l10n.allTitles);
-      }
-      return row;
-    }
-    final scopedItems = row.items.where(_matchesScope).toList();
-    final dynamicTitle = switch (_scope) {
-      BookScope.audiobooks => l10n.audiobooks,
-      BookScope.comics => l10n.comics,
-      BookScope.books => l10n.books,
-      BookScope.all => row.title,
-    };
-    return row.copyWith(
-      title: isAllTitles ? dynamicTitle : row.title,
-      items: scopedItems,
-    );
+    if (_scope == BookScope.all) return row;
+    return row.copyWith(items: row.items.where(_matchesScope).toList());
   }
 
   Future<int> _countOf(List<String> types) async {
@@ -647,6 +650,9 @@ class BookBrowseViewModel extends ChangeNotifier {
         enableTotalRecordCount: true,
       );
       final count = resp['TotalRecordCount'] as int? ?? 0;
+      // The wide sweep only earns its size when the typed count came back
+      // empty, which is what this counts around.
+      if (count > 0) return count;
       final fallbackResp = await _client.itemsApi.getItems(
         parentId: libraryId,
         excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView'],
@@ -655,11 +661,10 @@ class BookBrowseViewModel extends ChangeNotifier {
       );
       final items =
           (fallbackResp['Items'] as List? ?? const []).whereType<Map>();
-      final fallbackCount = items.where((it) {
+      return items.where((it) {
         final t = it['Type']?.toString();
         return t != null && types.contains(t);
       }).length;
-      return math.max(count, fallbackCount);
     } catch (_) {
       return 0;
     }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1102,6 +1102,14 @@
   "@latestAudiobooks": {
     "description": "Row title for recently added audiobooks in the book library"
   },
+  "latestComics": "Latest Comics",
+  "@latestComics": {
+    "description": "Row title for recently added comics in the book library"
+  },
+  "comics": "Comics",
+  "@comics": {
+    "description": "Label for comic media format or section"
+  },
   "bookSeriesItemCount": "{count, plural, =1{1 book} other{{count} books}}",
   "@bookSeriesItemCount": {
     "description": "Subtitle for a book series shelf entry showing how many books it contains",
@@ -1118,6 +1126,18 @@
   "bookFormatAudiobook": "Audiobook",
   "@bookFormatAudiobook": {
     "description": "Semantic label for the audiobook format badge on library cards"
+  },
+  "bookFormatComic": "Comic",
+  "@bookFormatComic": {
+    "description": "Semantic label for the comic format badge on library cards"
+  },
+  "noBooksFound": "No Books Found",
+  "@noBooksFound": {
+    "description": "Title shown when a books library has no items"
+  },
+  "noBooksFoundDescription": "This library does not contain any books, audiobooks, or comics yet.",
+  "@noBooksFoundDescription": {
+    "description": "Description shown when a books library has no items"
   },
   "bookPercentRead": "{percent}% read",
   "@bookPercentRead": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1726,6 +1726,18 @@ abstract class AppLocalizations {
   /// **'Latest Audiobooks'**
   String get latestAudiobooks;
 
+  /// Row title for recently added comics in the book library
+  ///
+  /// In en, this message translates to:
+  /// **'Latest Comics'**
+  String get latestComics;
+
+  /// Label for comic media format or section
+  ///
+  /// In en, this message translates to:
+  /// **'Comics'**
+  String get comics;
+
   /// Subtitle for a book series shelf entry showing how many books it contains
   ///
   /// In en, this message translates to:
@@ -1743,6 +1755,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Audiobook'**
   String get bookFormatAudiobook;
+
+  /// Semantic label for the comic format badge on library cards
+  ///
+  /// In en, this message translates to:
+  /// **'Comic'**
+  String get bookFormatComic;
+
+  /// Placeholder when no books are found for an author
+  ///
+  /// In en, this message translates to:
+  /// **'No books found for this author.'**
+  String get noBooksFound;
+
+  /// Description shown when a books library has no items
+  ///
+  /// In en, this message translates to:
+  /// **'This library does not contain any books, audiobooks, or comics yet.'**
+  String get noBooksFoundDescription;
 
   /// Reading progress label on book cards
   ///
@@ -2043,12 +2073,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No biography available for this author.'**
   String get noBiographyAvailable;
-
-  /// Placeholder when no books are found for an author
-  ///
-  /// In en, this message translates to:
-  /// **'No books found for this author.'**
-  String get noBooksFound;
 
   /// Error message when author details fail to load
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -848,6 +848,12 @@ class AppLocalizationsAf extends AppLocalizations {
   String get latestAudiobooks => 'Nuutste oudioboeke';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Oudioboek';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Geen boeke vir hierdie skrywer gevind nie.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Geen biografie beskikbaar vir hierdie skrywer nie.';
-
-  @override
-  String get noBooksFound => 'Geen boeke vir hierdie skrywer gevind nie.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -840,6 +840,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get latestAudiobooks => 'أحدث الكتب الصوتية';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -859,6 +865,16 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'كتاب صوتي';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'لم يتم العثور على كتب لهذا المؤلف.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'لا توجد سيرة ذاتية متاحة لهذا المؤلف.';
-
-  @override
-  String get noBooksFound => 'لم يتم العثور على كتب لهذا المؤلف.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -845,6 +845,12 @@ class AppLocalizationsBe extends AppLocalizations {
   String get latestAudiobooks => 'Апошнія аўдыякнігі';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -862,6 +868,16 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аўдыякніга';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Кнігі гэтага аўтара не знойдзены.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Біяграфія гэтага аўтара адсутнічае.';
-
-  @override
-  String get noBooksFound => 'Кнігі гэтага аўтара не знойдзены.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -844,6 +844,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get latestAudiobooks => 'Последни аудиокниги';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -859,6 +865,16 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудиокнига';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Няма намерени книги за този автор.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1034,9 +1050,6 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Няма налична биография за този автор.';
-
-  @override
-  String get noBooksFound => 'Няма намерени книги за този автор.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -841,6 +841,12 @@ class AppLocalizationsBn extends AppLocalizations {
   String get latestAudiobooks => 'সর্বশেষ অডিওবুক';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -856,6 +862,16 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'অডিওবুক';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'এই লেখকের জন্য কোন বই পাওয়া যায়নি।';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1031,9 +1047,6 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'এই লেখকের জন্য কোন জীবনী উপলব্ধ নেই।';
-
-  @override
-  String get noBooksFound => 'এই লেখকের জন্য কোন বই পাওয়া যায়নি।';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -851,6 +851,12 @@ class AppLocalizationsCa extends AppLocalizations {
   String get latestAudiobooks => 'Audiollibres afegits recentment';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -866,6 +872,16 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiollibre';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'No s\'han trobat llibres per a aquest autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1043,9 +1059,6 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'No hi ha biografia disponible per a aquest autor.';
-
-  @override
-  String get noBooksFound => 'No s\'han trobat llibres per a aquest autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -847,6 +847,12 @@ class AppLocalizationsCs extends AppLocalizations {
   String get latestAudiobooks => 'Nejnovější audioknihy';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -864,6 +870,16 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiokniha';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Pro tohoto autora nebyly nalezeny žádné knihy.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,9 +1058,6 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Pro tohoto autora není k dispozici žádná biografie.';
-
-  @override
-  String get noBooksFound => 'Pro tohoto autora nebyly nalezeny žádné knihy.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -848,6 +848,12 @@ class AppLocalizationsCy extends AppLocalizations {
   String get latestAudiobooks => 'Llyfrau Sain Diweddaraf';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Llyfr sain';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Ni chafwyd hyd i lyfrau ar gyfer yr awdur hwn.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1043,9 +1059,6 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Nid oes bywgraffiad ar gael i\'r awdur hwn.';
-
-  @override
-  String get noBooksFound => 'Ni chafwyd hyd i lyfrau ar gyfer yr awdur hwn.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -843,6 +843,12 @@ class AppLocalizationsDa extends AppLocalizations {
   String get latestAudiobooks => 'Seneste lydbøger';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -858,6 +864,16 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Lydbog';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Ingen bøger fundet for denne forfatter.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1034,9 +1050,6 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Ingen biografi tilgængelig for denne forfatter.';
-
-  @override
-  String get noBooksFound => 'Ingen bøger fundet for denne forfatter.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -895,6 +895,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get latestAudiobooks => 'Neueste Hörbücher';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -910,6 +916,16 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Hörbuch';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Keine Bücher von diesem Autor gefunden.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1105,9 +1121,6 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Für diesen Autor ist keine Biografie verfügbar.';
-
-  @override
-  String get noBooksFound => 'Keine Bücher von diesem Autor gefunden.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -852,6 +852,12 @@ class AppLocalizationsEl extends AppLocalizations {
   String get latestAudiobooks => 'Πρόσφατα ηχητικά βιβλία';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -867,6 +873,16 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Ηχητικό βιβλίο';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Δεν βρέθηκαν βιβλία για αυτόν τον συγγραφέα.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1044,9 +1060,6 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Δεν υπάρχει διαθέσιμη βιογραφία για αυτόν τον συγγραφέα.';
-
-  @override
-  String get noBooksFound => 'Δεν βρέθηκαν βιβλία για αυτόν τον συγγραφέα.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -842,6 +842,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get latestAudiobooks => 'Latest Audiobooks';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -857,6 +863,16 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'No books found for this author.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1031,9 +1047,6 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'No biography available for this author.';
-
-  @override
-  String get noBooksFound => 'No books found for this author.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -12200,6 +12213,9 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get bookFormatAudiobook => 'Audiobook';
 
   @override
+  String get noBooksFound => 'No books found for this author.';
+
+  @override
   String bookPercentRead(int percent) {
     return '$percent% read';
   }
@@ -12372,9 +12388,6 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get noBiographyAvailable => 'No biography available for this author.';
-
-  @override
-  String get noBooksFound => 'No books found for this author.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -844,6 +844,12 @@ class AppLocalizationsEo extends AppLocalizations {
   String get latestAudiobooks => 'Plej novaj aŭdlibroj';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -859,6 +865,16 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Aŭdlibro';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Neniuj libroj trovitaj por ĉi tiu aŭtoro.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1035,9 +1051,6 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Neniu biografio disponebla por ĉi tiu aŭtoro.';
-
-  @override
-  String get noBooksFound => 'Neniuj libroj trovitaj por ĉi tiu aŭtoro.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -848,6 +848,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get latestAudiobooks => 'Últimos audiolibros';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiolibro';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'No se encontraron libros para este autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'No hay biografía disponible para este autor.';
-
-  @override
-  String get noBooksFound => 'No se encontraron libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -12233,6 +12246,9 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   String get books => 'Libros';
 
   @override
+  String get noBooksFound => 'No se encontraron libros para este autor.';
+
+  @override
   String get author => 'Autor';
 
   @override
@@ -12389,9 +12405,6 @@ class AppLocalizationsEs419 extends AppLocalizationsEs {
   @override
   String get noBiographyAvailable =>
       'No hay biografía disponible para este autor.';
-
-  @override
-  String get noBooksFound => 'No se encontraron libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -20129,6 +20142,9 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   String get books => 'Libros';
 
   @override
+  String get noBooksFound => 'No se encontraron libros para este autor.';
+
+  @override
   String get author => 'Autor';
 
   @override
@@ -20285,9 +20301,6 @@ class AppLocalizationsEsAr extends AppLocalizationsEs {
   @override
   String get noBiographyAvailable =>
       'No hay biografía disponible para este autor.';
-
-  @override
-  String get noBooksFound => 'No se encontraron libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -27909,6 +27922,9 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   String get books => 'Libros';
 
   @override
+  String get noBooksFound => 'No se encontraron libros para este autor.';
+
+  @override
   String get author => 'Autor';
 
   @override
@@ -28065,9 +28081,6 @@ class AppLocalizationsEsDo extends AppLocalizationsEs {
   @override
   String get noBiographyAvailable =>
       'No hay biografía disponible para este autor.';
-
-  @override
-  String get noBooksFound => 'No se encontraron libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -35742,6 +35755,9 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   String get books => 'Libros';
 
   @override
+  String get noBooksFound => 'No se encontraron libros para este autor.';
+
+  @override
   String get author => 'Autor';
 
   @override
@@ -35898,9 +35914,6 @@ class AppLocalizationsEsMx extends AppLocalizationsEs {
   @override
   String get noBiographyAvailable =>
       'No hay biografía disponible para este autor.';
-
-  @override
-  String get noBooksFound => 'No se encontraron libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -848,6 +848,12 @@ class AppLocalizationsEt extends AppLocalizations {
   String get latestAudiobooks => 'Uusimad audioraamatud';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audioraamat';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Selle autori jaoks ei leitud ühtegi raamatut.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Selle autori elulugu pole saadaval.';
-
-  @override
-  String get noBooksFound => 'Selle autori jaoks ei leitud ühtegi raamatut.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -840,6 +840,12 @@ class AppLocalizationsFa extends AppLocalizations {
   String get latestAudiobooks => 'جدیدترین کتاب‌های صوتی';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -855,6 +861,16 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'کتاب صوتی';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'هیچ کتابی برای این نویسنده یافت نشد.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1031,9 +1047,6 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'بیوگرافی برای این نویسنده موجود نیست.';
-
-  @override
-  String get noBooksFound => 'هیچ کتابی برای این نویسنده یافت نشد.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -848,6 +848,12 @@ class AppLocalizationsFi extends AppLocalizations {
   String get latestAudiobooks => 'Uusimmat äänikirjat';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Äänikirja';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Tälle kirjailijalle ei löytynyt kirjoja.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Tämän kirjoittajan elämäkertaa ei ole saatavilla.';
-
-  @override
-  String get noBooksFound => 'Tälle kirjailijalle ei löytynyt kirjoja.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -849,6 +849,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get latestAudiobooks => 'Livres audio récemment ajoutés';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -864,6 +870,16 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Livre audio';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Aucun livre trouvé pour cet auteur.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,9 +1058,6 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Aucune biographie disponible pour cet auteur.';
-
-  @override
-  String get noBooksFound => 'Aucun livre trouvé pour cet auteur.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -851,6 +851,12 @@ class AppLocalizationsGl extends AppLocalizations {
   String get latestAudiobooks => 'Últimos audiolibros';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -866,6 +872,16 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiolibro';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Non se atoparon libros para este autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1043,9 +1059,6 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Non hai biografía dispoñible para este autor.';
-
-  @override
-  String get noBooksFound => 'Non se atoparon libros para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -835,6 +835,12 @@ class AppLocalizationsHe extends AppLocalizations {
   String get latestAudiobooks => 'ספרי השמע האחרונים';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -851,6 +857,16 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ספר שמע';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'לא נמצאו ספרים עבור מחבר זה.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1027,9 +1043,6 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'אין ביוגרפיה זמינה עבור מחבר זה.';
-
-  @override
-  String get noBooksFound => 'לא נמצאו ספרים עבור מחבר זה.';
 
   @override
   String get unableToLoadAuthorDetails => 'לא ניתן לטעון את פרטי המחבר כרגע.';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -845,6 +845,12 @@ class AppLocalizationsHi extends AppLocalizations {
   String get latestAudiobooks => 'नवीनतम ऑडियोबुक';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -860,6 +866,16 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ऑडियोबुक';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'इस लेखक के लिए कोई पुस्तक नहीं मिली.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1035,9 +1051,6 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'इस लेखक की कोई जीवनी उपलब्ध नहीं है.';
-
-  @override
-  String get noBooksFound => 'इस लेखक के लिए कोई पुस्तक नहीं मिली.';
 
   @override
   String get unableToLoadAuthorDetails => 'अभी लेखक विवरण लोड करने में असमर्थ.';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -889,6 +889,12 @@ class AppLocalizationsHr extends AppLocalizations {
   String get latestAudiobooks => 'Najnovije audioknjige';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -905,6 +911,16 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audioknjiga';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nema pronađenih knjiga za ovog autora.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1101,9 +1117,6 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Nema dostupne biografije ovog autora.';
-
-  @override
-  String get noBooksFound => 'Nema pronađenih knjiga za ovog autora.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -850,6 +850,12 @@ class AppLocalizationsHu extends AppLocalizations {
   String get latestAudiobooks => 'Legújabb hangoskönyvek';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Hangoskönyv';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nem található könyv ehhez a szerzőhöz.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'A szerző életrajza nem érhető el.';
-
-  @override
-  String get noBooksFound => 'Nem található könyv ehhez a szerzőhöz.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -848,6 +848,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get latestAudiobooks => 'Audiobook Terbaru';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Tidak ada buku yang ditemukan untuk penulis ini.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Belum ada biografi yang tersedia untuk penulis ini.';
-
-  @override
-  String get noBooksFound => 'Tidak ada buku yang ditemukan untuk penulis ini.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -848,6 +848,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get latestAudiobooks => 'Ultimi Audiolibri';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiolibro';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nessun libro trovato per questo autore.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Nessuna biografia disponibile per questo autore.';
-
-  @override
-  String get noBooksFound => 'Nessun libro trovato per questo autore.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -820,6 +820,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get latestAudiobooks => '最新のオーディオブック';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -835,6 +841,16 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'オーディオブック';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'この著者の書籍は見つかりませんでした。';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1007,9 +1023,6 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'この著者の経歴はありません。';
-
-  @override
-  String get noBooksFound => 'この著者の書籍は見つかりませんでした。';
 
   @override
   String get unableToLoadAuthorDetails => '現在、著者の詳細を読み込むことができません。';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -846,6 +846,12 @@ class AppLocalizationsKk extends AppLocalizations {
   String get latestAudiobooks => 'Соңғы аудиокітаптар';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -861,6 +867,16 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудиокітап';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Бұл авторға арналған кітаптар табылмады.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1036,9 +1052,6 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Бұл автордың өмірбаяны жоқ.';
-
-  @override
-  String get noBooksFound => 'Бұл авторға арналған кітаптар табылмады.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -847,6 +847,12 @@ class AppLocalizationsKn extends AppLocalizations {
   String get latestAudiobooks => 'ಇತ್ತೀಚಿನ ಆಡಿಯೋಬುಕ್‌ಗಳು';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -862,6 +868,16 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ಆಡಿಯೋಬುಕ್';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'ಈ ಲೇಖಕರಿಗೆ ಯಾವುದೇ ಪುಸ್ತಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'ಈ ಲೇಖಕರಿಗೆ ಯಾವುದೇ ಜೀವನಚರಿತ್ರೆ ಲಭ್ಯವಿಲ್ಲ.';
-
-  @override
-  String get noBooksFound => 'ಈ ಲೇಖಕರಿಗೆ ಯಾವುದೇ ಪುಸ್ತಕಗಳು ಕಂಡುಬಂದಿಲ್ಲ.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -822,6 +822,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get latestAudiobooks => '최신 오디오북';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -837,6 +843,16 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => '오디오북';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => '이 저자에 대한 도서를 찾을 수 없습니다.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1009,9 +1025,6 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => '이 저자의 전기가 없습니다.';
-
-  @override
-  String get noBooksFound => '이 저자에 대한 도서를 찾을 수 없습니다.';
 
   @override
   String get unableToLoadAuthorDetails => '지금은 작성자 세부정보를 로드할 수 없습니다.';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -844,6 +844,12 @@ class AppLocalizationsLt extends AppLocalizations {
   String get latestAudiobooks => 'Naujausios garso knygos';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -861,6 +867,16 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Garso knyga';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nerasta šio autoriaus knygų.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1037,9 +1053,6 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Nėra šio autoriaus biografijos.';
-
-  @override
-  String get noBooksFound => 'Nerasta šio autoriaus knygų.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -847,6 +847,12 @@ class AppLocalizationsLv extends AppLocalizations {
   String get latestAudiobooks => 'Jaunākās audiogrāmatas';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiogrāmata';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Šim autoram nav atrasta neviena grāmata.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Šim autoram nav pieejama biogrāfija.';
-
-  @override
-  String get noBooksFound => 'Šim autoram nav atrasta neviena grāmata.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -847,6 +847,12 @@ class AppLocalizationsMk extends AppLocalizations {
   String get latestAudiobooks => 'Најнови аудиокниги';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -862,6 +868,16 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудиокнига';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Не се пронајдени книги за овој автор.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Нема достапна биографија за овој автор.';
-
-  @override
-  String get noBooksFound => 'Не се пронајдени книги за овој автор.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -850,6 +850,12 @@ class AppLocalizationsMl extends AppLocalizations {
   String get latestAudiobooks => 'ഏറ്റവും പുതിയ ഓഡിയോബുക്കുകൾ';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ഓഡിയോബുക്ക്';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'ഈ രചയിതാവിനായി പുസ്‌തകങ്ങളൊന്നും കണ്ടെത്തിയില്ല.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'ഈ രചയിതാവിന് ജീവചരിത്രമൊന്നും ലഭ്യമല്ല.';
-
-  @override
-  String get noBooksFound => 'ഈ രചയിതാവിനായി പുസ്‌തകങ്ങളൊന്നും കണ്ടെത്തിയില്ല.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -846,6 +846,12 @@ class AppLocalizationsMn extends AppLocalizations {
   String get latestAudiobooks => 'Шинэ аудио номууд';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -861,6 +867,16 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудио ном';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Энэ зохиолчийн ном олдсонгүй.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1036,9 +1052,6 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Энэ зохиолчийн намтар байхгүй.';
-
-  @override
-  String get noBooksFound => 'Энэ зохиолчийн ном олдсонгүй.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -844,6 +844,12 @@ class AppLocalizationsNb extends AppLocalizations {
   String get latestAudiobooks => 'Nyeste lydbøker';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -859,6 +865,16 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Lydbok';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Fant ingen bøker for denne forfatteren.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1036,9 +1052,6 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Ingen biografi tilgjengelig for denne forfatteren.';
-
-  @override
-  String get noBooksFound => 'Fant ingen bøker for denne forfatteren.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -847,6 +847,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get latestAudiobooks => 'Nieuwste luisterboeken';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -862,6 +868,16 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Luisterboek';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Er zijn geen boeken gevonden voor deze auteur.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Er is geen biografie beschikbaar van deze auteur.';
-
-  @override
-  String get noBooksFound => 'Er zijn geen boeken gevonden voor deze auteur.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -846,6 +846,12 @@ class AppLocalizationsPa extends AppLocalizations {
   String get latestAudiobooks => 'ਨਵੀਨਤਮ ਆਡੀਓਬੁੱਕਸ';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -861,6 +867,16 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ਆਡੀਓਬੁੱਕ';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'ਇਸ ਲੇਖਕ ਲਈ ਕੋਈ ਕਿਤਾਬ ਨਹੀਂ ਮਿਲੀ।';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1036,9 +1052,6 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'ਇਸ ਲੇਖਕ ਲਈ ਕੋਈ ਜੀਵਨੀ ਉਪਲਬਧ ਨਹੀਂ ਹੈ।';
-
-  @override
-  String get noBooksFound => 'ਇਸ ਲੇਖਕ ਲਈ ਕੋਈ ਕਿਤਾਬ ਨਹੀਂ ਮਿਲੀ।';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -892,6 +892,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get latestAudiobooks => 'Najnowsze audiobooki';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -909,6 +915,16 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nie znaleziono książek tego autora.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1109,9 +1125,6 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Brak biografii tego autora.';
-
-  @override
-  String get noBooksFound => 'Nie znaleziono książek tego autora.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -846,6 +846,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get latestAudiobooks => 'Audiolivros Recentes';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -861,6 +867,16 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiolivro';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nenhum livro encontrado para este autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1038,9 +1054,6 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Nenhuma biografia disponível para este autor.';
-
-  @override
-  String get noBooksFound => 'Nenhum livro encontrado para este autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -12300,6 +12313,9 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   String get bookFormatAudiobook => 'Audiolivro';
 
   @override
+  String get noBooksFound => 'Nenhum livro encontrado deste autor.';
+
+  @override
   String bookPercentRead(int percent) {
     return '$percent% lido';
   }
@@ -12475,9 +12491,6 @@ class AppLocalizationsPtBr extends AppLocalizationsPt {
   @override
   String get noBiographyAvailable =>
       'Nenhuma biografia disponível para este autor.';
-
-  @override
-  String get noBooksFound => 'Nenhum livro encontrado deste autor.';
 
   @override
   String get unableToLoadAuthorDetails =>
@@ -22382,6 +22395,9 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   String get bookFormatAudiobook => 'Audiolivro';
 
   @override
+  String get noBooksFound => 'Nenhum livro encontrado deste autor.';
+
+  @override
   String bookPercentRead(int percent) {
     return '$percent% lido';
   }
@@ -22557,9 +22573,6 @@ class AppLocalizationsPtPt extends AppLocalizationsPt {
   @override
   String get noBiographyAvailable =>
       'Nenhuma biografia disponível para este autor.';
-
-  @override
-  String get noBooksFound => 'Nenhum livro encontrado deste autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -846,6 +846,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get latestAudiobooks => 'Cele mai recente cărți audio';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -862,6 +868,16 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Carte audio';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nu s-au găsit cărți pentru acest autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Nicio biografie disponibilă pentru acest autor.';
-
-  @override
-  String get noBooksFound => 'Nu s-au găsit cărți pentru acest autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -848,6 +848,12 @@ class AppLocalizationsRu extends AppLocalizations {
   String get latestAudiobooks => 'Новые аудиокниги';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудиокнига';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Книг этого автора не найдено.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,9 +1058,6 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Биографии этого автора не существует.';
-
-  @override
-  String get noBooksFound => 'Книг этого автора не найдено.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -842,6 +842,12 @@ class AppLocalizationsSi extends AppLocalizations {
   String get latestAudiobooks => 'නවතම ශ්‍රව්‍ය පොත්';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -857,6 +863,16 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ශ්‍රව්‍ය පොත';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'මෙම කතුවරයා සඳහා පොත් කිසිවක් හමු නොවීය.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1032,9 +1048,6 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'මෙම කතුවරයා සඳහා චරිතාපදානයක් නොමැත.';
-
-  @override
-  String get noBooksFound => 'මෙම කතුවරයා සඳහා පොත් කිසිවක් හමු නොවීය.';
 
   @override
   String get unableToLoadAuthorDetails => 'දැන් කර්තෘ විස්තර පූරණය කළ නොහැක.';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -848,6 +848,12 @@ class AppLocalizationsSk extends AppLocalizations {
   String get latestAudiobooks => 'Najnovšie audioknihy';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiokniha';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Pre tohto autora sa nenašli žiadne knihy.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1044,9 +1060,6 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Pre tohto autora nie je k dispozícii žiadna biografia.';
-
-  @override
-  String get noBooksFound => 'Pre tohto autora sa nenašli žiadne knihy.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -849,6 +849,12 @@ class AppLocalizationsSl extends AppLocalizations {
   String get latestAudiobooks => 'Najnovejše zvočne knjige';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -866,6 +872,16 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Zvočna knjiga';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Za tega avtorja ni bilo najdenih knjig.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,9 +1058,6 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Za tega avtorja ni na voljo biografije.';
-
-  @override
-  String get noBooksFound => 'Za tega avtorja ni bilo najdenih knjig.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -851,6 +851,12 @@ class AppLocalizationsSq extends AppLocalizations {
   String get latestAudiobooks => 'Audiolibrat më të fundit';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -866,6 +872,16 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiolibër';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Nuk u gjetën libra për këtë autor.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,9 +1058,6 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Nuk ka biografi për këtë autor.';
-
-  @override
-  String get noBooksFound => 'Nuk u gjetën libra për këtë autor.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -886,6 +886,12 @@ class AppLocalizationsSr extends AppLocalizations {
   String get latestAudiobooks => 'Најновије аудио-књиге';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -902,6 +908,16 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудио-књига';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Нису пронађене књиге за овог аутора.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1099,9 +1115,6 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'За овог аутора није доступна биографија.';
-
-  @override
-  String get noBooksFound => 'Нису пронађене књиге за овог аутора.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -843,6 +843,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get latestAudiobooks => 'Senaste ljudböckerna';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -858,6 +864,16 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Ljudbok';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Inga böcker hittades för denna författare.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1035,9 +1051,6 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Ingen biografi tillgänglig för denna författare.';
-
-  @override
-  String get noBooksFound => 'Inga böcker hittades för denna författare.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -852,6 +852,12 @@ class AppLocalizationsSw extends AppLocalizations {
   String get latestAudiobooks => 'Vitabu vya Sauti vya Hivi Punde';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -867,6 +873,17 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Kitabu cha Sauti';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound =>
+      'Hakuna vitabu vilivyopatikana vya mwandishi huyu.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1042,10 +1059,6 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Hakuna wasifu unaopatikana kwa mwandishi huyu.';
-
-  @override
-  String get noBooksFound =>
-      'Hakuna vitabu vilivyopatikana vya mwandishi huyu.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -849,6 +849,12 @@ class AppLocalizationsTa extends AppLocalizations {
   String get latestAudiobooks => 'சமீபத்திய ஆடியோ புத்தகங்கள்';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -864,6 +870,17 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ஆடியோ புத்தகம்';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound =>
+      'இந்த ஆசிரியருக்கு புத்தகங்கள் எதுவும் கிடைக்கவில்லை.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,10 +1057,6 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'இந்த ஆசிரியரின் சுயசரிதை எதுவும் கிடைக்கவில்லை.';
-
-  @override
-  String get noBooksFound =>
-      'இந்த ஆசிரியருக்கு புத்தகங்கள் எதுவும் கிடைக்கவில்லை.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -848,6 +848,12 @@ class AppLocalizationsTe extends AppLocalizations {
   String get latestAudiobooks => 'సరికొత్త ఆడియోబుక్‌లు';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,16 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ఆడియోబుక్';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'ఈ రచయిత కోసం పుస్తకాలు ఏవీ కనుగొనబడలేదు.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'ఈ రచయితకు జీవిత చరిత్ర అందుబాటులో లేదు.';
-
-  @override
-  String get noBooksFound => 'ఈ రచయిత కోసం పుస్తకాలు ఏవీ కనుగొనబడలేదు.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -840,6 +840,12 @@ class AppLocalizationsTh extends AppLocalizations {
   String get latestAudiobooks => 'หนังสือเสียงล่าสุด';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -855,6 +861,16 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'หนังสือเสียง';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'ไม่พบหนังสือสำหรับผู้แต่งคนนี้';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1029,9 +1045,6 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'ไม่มีชีวประวัติของผู้เขียนคนนี้';
-
-  @override
-  String get noBooksFound => 'ไม่พบหนังสือสำหรับผู้แต่งคนนี้';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -848,6 +848,12 @@ class AppLocalizationsTl extends AppLocalizations {
   String get latestAudiobooks => 'Mga Pinakabagong Audiobook';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -863,6 +869,17 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Audiobook';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound =>
+      'Walang nakitang mga aklat para sa may-akda na ito.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,10 +1056,6 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get noBiographyAvailable =>
       'Walang available na talambuhay para sa may-akda na ito.';
-
-  @override
-  String get noBooksFound =>
-      'Walang nakitang mga aklat para sa may-akda na ito.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -845,6 +845,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get latestAudiobooks => 'Son Eklenen Sesli Kitaplar';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -860,6 +866,16 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Sesli Kitap';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Bu yazara ait kitap bulunamadı.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1035,9 +1051,6 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Bu yazara ait biyografi mevcut değil.';
-
-  @override
-  String get noBooksFound => 'Bu yazara ait kitap bulunamadı.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -845,6 +845,12 @@ class AppLocalizationsUg extends AppLocalizations {
   String get latestAudiobooks => 'ئەڭ يېڭى ئاۋازلىق كىتابلار';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -860,6 +866,16 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'ئاۋازلىق كىتاب';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'بۇ ئاپتور ئۈچۈن ھېچقانداق كىتاب تېپىلمىدى.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1034,9 +1050,6 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'بۇ ئاپتورنىڭ تەرجىمىھالى يوق.';
-
-  @override
-  String get noBooksFound => 'بۇ ئاپتور ئۈچۈن ھېچقانداق كىتاب تېپىلمىدى.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -847,6 +847,12 @@ class AppLocalizationsUk extends AppLocalizations {
   String get latestAudiobooks => 'Найновіші аудіокниги';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -864,6 +870,16 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Аудіокнига';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Книг цього автора не знайдено.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1039,9 +1055,6 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Немає доступної біографії цього автора.';
-
-  @override
-  String get noBooksFound => 'Книг цього автора не знайдено.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -850,6 +850,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get latestAudiobooks => 'Sách nói mới nhất';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -865,6 +871,16 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => 'Sách nói';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => 'Không tìm thấy sách nào cho tác giả này.';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1040,9 +1056,6 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => 'Không có tiểu sử có sẵn cho tác giả này.';
-
-  @override
-  String get noBooksFound => 'Không tìm thấy sách nào cho tác giả này.';
 
   @override
   String get unableToLoadAuthorDetails =>

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -813,6 +813,12 @@ class AppLocalizationsYue extends AppLocalizations {
   String get latestAudiobooks => '最新有聲書';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -828,6 +834,16 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => '有聲書';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => '沒有找到該作者的書籍。';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -1000,9 +1016,6 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => '沒有該作者的傳記。';
-
-  @override
-  String get noBooksFound => '沒有找到該作者的書籍。';
 
   @override
   String get unableToLoadAuthorDetails => '目前無法載入作者詳細資料。';
@@ -11617,6 +11630,9 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
   String get books => '图书';
 
   @override
+  String get noBooksFound => '没有找到该作者的书籍。';
+
+  @override
   String get author => '作者';
 
   @override
@@ -11768,9 +11784,6 @@ class AppLocalizationsYueCn extends AppLocalizationsYue {
 
   @override
   String get noBiographyAvailable => '没有该作者的传记。';
-
-  @override
-  String get noBooksFound => '没有找到该作者的书籍。';
 
   @override
   String get unableToLoadAuthorDetails => '目前无法加载作者详细信息。';
@@ -19066,6 +19079,9 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
   String get books => '圖書';
 
   @override
+  String get noBooksFound => '沒有找到該作者的書籍。';
+
+  @override
   String get author => '作者';
 
   @override
@@ -19217,9 +19233,6 @@ class AppLocalizationsYueHk extends AppLocalizationsYue {
 
   @override
   String get noBiographyAvailable => '沒有該作者的傳記。';
-
-  @override
-  String get noBooksFound => '沒有找到該作者的書籍。';
 
   @override
   String get unableToLoadAuthorDetails => '目前無法載入作者詳細資料。';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -810,6 +810,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get latestAudiobooks => '最新有声读物';
 
   @override
+  String get latestComics => 'Latest Comics';
+
+  @override
+  String get comics => 'Comics';
+
+  @override
   String bookSeriesItemCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -825,6 +831,16 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get bookFormatAudiobook => '有声读物';
+
+  @override
+  String get bookFormatComic => 'Comic';
+
+  @override
+  String get noBooksFound => '未找到该作者的图书。';
+
+  @override
+  String get noBooksFoundDescription =>
+      'This library does not contain any books, audiobooks, or comics yet.';
 
   @override
   String bookPercentRead(int percent) {
@@ -997,9 +1013,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get noBiographyAvailable => '此作者暂无传记。';
-
-  @override
-  String get noBooksFound => '未找到该作者的图书。';
 
   @override
   String get unableToLoadAuthorDetails => '目前无法加载作者详情。';
@@ -11717,6 +11730,9 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
   String get bookFormatAudiobook => '有聲書';
 
   @override
+  String get noBooksFound => '沒有找到該作者的書籍。';
+
+  @override
   String bookPercentRead(int percent) {
     return '已讀 $percent%';
   }
@@ -11887,9 +11903,6 @@ class AppLocalizationsZhHant extends AppLocalizationsZh {
 
   @override
   String get noBiographyAvailable => '沒有該作者的傳記。';
-
-  @override
-  String get noBooksFound => '沒有找到該作者的書籍。';
 
   @override
   String get unableToLoadAuthorDetails => '目前無法載入作者詳細資訊。';

--- a/lib/ui/screens/browse/book_browse_screen.dart
+++ b/lib/ui/screens/browse/book_browse_screen.dart
@@ -123,7 +123,7 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
       context.push(Destinations.folder(item.id, serverId: item.serverId));
       return;
     }
-    if (type == 'Book') {
+    if (type == 'Book' || item.isComic) {
       context.push(Destinations.book(item.id, serverId: item.serverId));
       return;
     }
@@ -185,8 +185,11 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
 
   List<BookStat> _stats(AppLocalizations l10n) => [
     if (_vm.isMixedLibrary) ...[
-      BookStat(label: l10n.books, count: _vm.bookCount),
-      BookStat(label: l10n.audiobooks, count: _vm.audiobookCount),
+      if (_vm.bookCount > 0) BookStat(label: l10n.books, count: _vm.bookCount),
+      if (_vm.audiobookCount > 0)
+        BookStat(label: l10n.audiobooks, count: _vm.audiobookCount),
+      if (_vm.comicCount > 0)
+        BookStat(label: l10n.comics, count: _vm.comicCount),
     ] else
       BookStat(
         label: _vm.isAudiobookLibrary ? l10n.audiobooks : l10n.books,
@@ -268,6 +271,7 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
               child: BookScopeFilter(
                 value: _vm.scope,
                 onChanged: _vm.setScope,
+                availableScopes: _vm.availableScopes,
                 focusNode: _scopeFocusNode,
                 onVerticalNavigation: (isUp) =>
                     _moveVertical(scopeIndex, isUp),
@@ -298,17 +302,56 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
           ),
         ),
       ),
-      if (_tab == 0)
-        ...[
+      if (_tab == 0) ...[
+        if (rows.isNotEmpty)
           for (var i = 0; i < rows.length; i++)
-            _buildShelf(rows[i], l10n, firstRowIndex + i),
-        ]
-      else
+            _buildShelf(rows[i], l10n, firstRowIndex + i)
+        else
+          _buildEmptyState(l10n),
+      ] else
         BookDiscoverTab(
           libraryId: widget.libraryId,
           isAudiobook: _vm.isAudiobookLibrary,
         ),
     ];
+  }
+
+  Widget _buildEmptyState(AppLocalizations l10n) {
+    final onSurface = AppColorScheme.onSurface;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 64),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.auto_stories_outlined,
+              size: 56,
+              color: onSurface.withValues(alpha: 0.35),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              l10n.noBooksFound,
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                color: onSurface.withValues(alpha: 0.85),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.noBooksFoundDescription,
+              style: TextStyle(
+                fontSize: 14,
+                color: onSurface.withValues(alpha: 0.5),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Widget _buildHero(
@@ -372,6 +415,7 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
       imageUrlFor: _vm.bookImageUrl,
       subtitleFor: _vm.bookSubtitle,
       isAudiobookFor: _vm.isAudiobookItem,
+      isComicFor: _vm.isComicItem,
       remainingFor: _vm.remainingFor,
     );
   }

--- a/lib/ui/util/home_row_title_localizer.dart
+++ b/lib/ui/util/home_row_title_localizer.dart
@@ -98,6 +98,9 @@ String localizeHomeRowTitle({
   if (row.id.startsWith('albumartist_')) return l10n.albumArtists;
   if (row.id.startsWith('musicartist_')) return l10n.artists;
   if (row.id.startsWith('musicalbum_')) return l10n.albums;
+  if (row.id.startsWith('latestBooks_')) return l10n.latestBooks;
+  if (row.id.startsWith('latestAudiobooks_')) return l10n.latestAudiobooks;
+  if (row.id.startsWith('latestComics_')) return l10n.latestComics;
 
   if (row.id.startsWith('latest_')) {
     return _localizeLatestRowTitle(row.title, l10n);

--- a/lib/ui/widgets/book/book_card.dart
+++ b/lib/ui/widgets/book/book_card.dart
@@ -12,6 +12,7 @@ import 'book_format_badge.dart';
 class BookCard extends StatelessWidget {
   final AggregatedItem item;
   final bool isAudiobook;
+  final bool isComic;
   final String? subtitle;
   final String? imageUrl;
   final double width;
@@ -31,6 +32,7 @@ class BookCard extends StatelessWidget {
     super.key,
     required this.item,
     required this.isAudiobook,
+    this.isComic = false,
     this.subtitle,
     this.imageUrl,
     this.width = 132,
@@ -75,7 +77,10 @@ class BookCard extends StatelessWidget {
           Positioned(
             top: 6,
             left: 6,
-            child: BookFormatBadge(isAudiobook: isAudiobook),
+            child: BookFormatBadge(
+              isAudiobook: isAudiobook,
+              isComic: isComic,
+            ),
           ),
         if (chipLabel != null)
           Positioned(

--- a/lib/ui/widgets/book/book_format_badge.dart
+++ b/lib/ui/widgets/book/book_format_badge.dart
@@ -3,18 +3,29 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../l10n/app_localizations.dart';
 
-/// Small glyph chip identifying a card as a book or an audiobook. Solid
-/// scrim colors (no glass) so rows of cards stay cheap on TV GPUs.
+/// Small glyph chip identifying a card as a book, an audiobook, or a comic.
+/// Solid scrim colors (no glass) so rows of cards stay cheap on TV GPUs.
 class BookFormatBadge extends StatelessWidget {
   final bool isAudiobook;
+  final bool isComic;
 
-  const BookFormatBadge({super.key, required this.isAudiobook});
+  const BookFormatBadge({
+    super.key,
+    this.isAudiobook = false,
+    this.isComic = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
+    final (label, icon) = isComic
+        ? (l10n.bookFormatComic, Icons.auto_stories_rounded)
+        : (isAudiobook
+            ? (l10n.bookFormatAudiobook, Icons.headphones_rounded)
+            : (l10n.bookFormatBook, Icons.menu_book_rounded));
+
     return Semantics(
-      label: isAudiobook ? l10n.bookFormatAudiobook : l10n.bookFormatBook,
+      label: label,
       child: DecoratedBox(
         decoration: BoxDecoration(
           color: AppColorScheme.scrim.withValues(alpha: 0.72),
@@ -23,7 +34,7 @@ class BookFormatBadge extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 3),
           child: Icon(
-            isAudiobook ? Icons.headphones_rounded : Icons.menu_book_rounded,
+            icon,
             size: 12,
             color: AppColorScheme.onBadge,
           ),

--- a/lib/ui/widgets/book/book_scope_filter.dart
+++ b/lib/ui/widgets/book/book_scope_filter.dart
@@ -18,6 +18,7 @@ import 'book_glass.dart';
 class BookScopeFilter extends StatefulWidget {
   final BookScope value;
   final ValueChanged<BookScope> onChanged;
+  final List<BookScope>? availableScopes;
   final FocusNode? focusNode;
 
   /// Up/down D-pad from the pill; return true when handled.
@@ -27,6 +28,7 @@ class BookScopeFilter extends StatefulWidget {
     super.key,
     required this.value,
     required this.onChanged,
+    this.availableScopes,
     this.focusNode,
     this.onVerticalNavigation,
   });
@@ -36,7 +38,7 @@ class BookScopeFilter extends StatefulWidget {
 }
 
 class _BookScopeFilterState extends State<BookScopeFilter> {
-  static const _scopes = BookScope.values;
+  List<BookScope> get _scopes => widget.availableScopes ?? BookScope.values;
 
   FocusNode? _ownedNode;
   FocusNode get _node =>
@@ -55,13 +57,16 @@ class _BookScopeFilterState extends State<BookScopeFilter> {
       return KeyEventResult.ignored;
     }
     final key = event.logicalKey;
-    final index = _scopes.indexOf(widget.value);
+    final scopes = _scopes;
+    final index = scopes.indexOf(widget.value);
     if (key.isLeftKey) {
-      if (index > 0) widget.onChanged(_scopes[index - 1]);
+      if (index > 0) widget.onChanged(scopes[index - 1]);
       return KeyEventResult.handled;
     }
     if (key.isRightKey) {
-      if (index < _scopes.length - 1) widget.onChanged(_scopes[index + 1]);
+      if (index >= 0 && index < scopes.length - 1) {
+        widget.onChanged(scopes[index + 1]);
+      }
       return KeyEventResult.handled;
     }
     if (event is KeyDownEvent && (key.isUpKey || key.isDownKey)) {
@@ -75,6 +80,7 @@ class _BookScopeFilterState extends State<BookScopeFilter> {
     BookScope.all => l10n.all,
     BookScope.books => l10n.books,
     BookScope.audiobooks => l10n.audiobooks,
+    BookScope.comics => l10n.comics,
   };
 
   @override
@@ -83,7 +89,9 @@ class _BookScopeFilterState extends State<BookScopeFilter> {
     final glass = bookGlassEligible;
     final onSurface = AppColorScheme.onSurface;
     final accent = AppColorScheme.accent;
-    final selectedIndex = _scopes.indexOf(widget.value);
+    final scopes = _scopes;
+    final selectedIndex = scopes.indexOf(widget.value);
+    final effectiveIndex = selectedIndex >= 0 ? selectedIndex : 0;
 
     final thumbColor = glass
         ? onSurface.withValues(alpha: 0.22)
@@ -96,13 +104,13 @@ class _BookScopeFilterState extends State<BookScopeFilter> {
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeOutCubic,
           alignment: Alignment(
-            _scopes.length == 1
+            scopes.length <= 1
                 ? 0
-                : -1 + selectedIndex * (2 / (_scopes.length - 1)),
+                : -1 + effectiveIndex * (2 / (scopes.length - 1)),
             0,
           ),
           child: FractionallySizedBox(
-            widthFactor: 1 / _scopes.length,
+            widthFactor: scopes.isEmpty ? 1 : 1 / scopes.length,
             heightFactor: 1,
             child: Container(
               decoration: BoxDecoration(
@@ -120,7 +128,7 @@ class _BookScopeFilterState extends State<BookScopeFilter> {
         ),
         Row(
           children: [
-            for (final scope in _scopes)
+            for (final scope in scopes)
               Expanded(
                 child: GestureDetector(
                   behavior: HitTestBehavior.opaque,

--- a/lib/ui/widgets/book/book_shelf_row.dart
+++ b/lib/ui/widgets/book/book_shelf_row.dart
@@ -44,6 +44,7 @@ class BookShelfRow extends StatelessWidget {
   final String? Function(AggregatedItem item) imageUrlFor;
   final String Function(AggregatedItem item)? subtitleFor;
   final bool Function(AggregatedItem item)? isAudiobookFor;
+  final bool Function(AggregatedItem item)? isComicFor;
   final Duration? Function(AggregatedItem item)? remainingFor;
 
   /// Show the book/headphones glyph on poster cards (mixed rows).
@@ -67,6 +68,7 @@ class BookShelfRow extends StatelessWidget {
     this.onSeeAll,
     this.subtitleFor,
     this.isAudiobookFor,
+    this.isComicFor,
     this.remainingFor,
     this.showFormatBadges = false,
     this.cardWidth = 132,
@@ -77,6 +79,7 @@ class BookShelfRow extends StatelessWidget {
   static const _labelBudget = 48.0;
 
   bool _isAudio(AggregatedItem item) => isAudiobookFor?.call(item) ?? false;
+  bool _isComic(AggregatedItem item) => isComicFor?.call(item) ?? item.isComic;
 
   double get _itemExtent =>
       variant == BookShelfVariant.chip ? _chipWidth : cardWidth;
@@ -171,6 +174,7 @@ class BookShelfRow extends StatelessWidget {
         );
       case BookShelfVariant.poster:
         final isAudio = _isAudio(item);
+        final isComic = _isComic(item);
         final remaining = isAudio ? remainingFor?.call(item) : null;
         final pct = item.playedPercentage;
         return Align(
@@ -178,6 +182,7 @@ class BookShelfRow extends StatelessWidget {
           child: BookCard(
             item: item,
             isAudiobook: isAudio,
+            isComic: isComic,
             subtitle: subtitleFor?.call(item),
             imageUrl: imageUrlFor(item),
             width: cardWidth,

--- a/test/data/models/aggregated_item_audiobook_test.dart
+++ b/test/data/models/aggregated_item_audiobook_test.dart
@@ -71,5 +71,41 @@ void main() {
 
       expect(item.isAudiobook, isFalse);
     });
+
+    test('a comic archive is not an audiobook even in a books library', () {
+      final item = _item({
+        'Type': 'Book',
+        'MediaType': 'Book',
+        'Container': 'cbz',
+        'CollectionType': 'books',
+      });
+
+      expect(item.isAudiobook, isFalse);
+      expect(item.isComic, isTrue);
+    });
+  });
+
+  group('AggregatedItem.isComic', () {
+    test('detects Comic type from server', () {
+      expect(_item({'Type': 'Comic'}).isComic, isTrue);
+    });
+
+    test('detects comic archive containers (cbz, cbr, cb7, cbt)', () {
+      expect(_item({'Type': 'Book', 'Container': 'cbz'}).isComic, isTrue);
+      expect(_item({'Type': 'Book', 'Container': 'cbr'}).isComic, isTrue);
+      expect(_item({'Type': 'Book', 'Container': 'cb7'}).isComic, isTrue);
+      expect(_item({'Type': 'Book', 'Container': 'cbt'}).isComic, isTrue);
+    });
+
+    test('detects comic file extension in path or file name', () {
+      expect(_item({'Path': '/media/comics/Spider-Man.cbz'}).isComic, isTrue);
+      expect(_item({'FileName': 'Batman.cbr'}).isComic, isTrue);
+      expect(_item({'Name': 'X-Men.cbt'}).isComic, isTrue);
+    });
+
+    test('ordinary books and audiobooks are not comics', () {
+      expect(_item({'Type': 'Book', 'Path': '/media/books/Dune.epub'}).isComic, isFalse);
+      expect(_item({'Type': 'AudioBook', 'Container': 'm4b'}).isComic, isFalse);
+    });
   });
 }

--- a/test/data/viewmodels/book_browse_comics_scope_test.dart
+++ b/test/data/viewmodels/book_browse_comics_scope_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/models/home_row.dart';
+import 'package:moonfin/data/services/row_data_source.dart';
+import 'package:moonfin/data/viewmodels/book_browse_view_model.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/widgets/book/book_scope_filter.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockClient extends Mock implements MediaServerClient {}
+
+class _MockImageApi extends Mock implements ImageApi {}
+
+Map<String, dynamic> _book(String id, String name) => {
+  'Id': id,
+  'Name': name,
+  'SortName': name,
+  'Type': 'Book',
+};
+
+/// A comic is a Book on the server and is only told apart by its container.
+Map<String, dynamic> _comic(String id, String name) => {
+  'Id': id,
+  'Name': name,
+  'SortName': name,
+  'Type': 'Book',
+  'Path': '/library/$name.cbz',
+};
+
+/// Serves one library's items and counts the requests, so a query that is
+/// only meant to run when the typed one came back empty can be checked.
+class _FakeItemsApi extends Fake implements ItemsApi {
+  _FakeItemsApi(this.items);
+
+  final List<Map<String, dynamic>> items;
+  int calls = 0;
+  int untypedCalls = 0;
+
+  /// Reproduces the server bug this screen works around: a query naming item
+  /// types matches nothing, while the same query without them answers.
+  bool typedQueriesReturnNothing = false;
+
+  /// Answers with none of the fields the readers expect.
+  bool bareResponses = false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    const empty = {'Items': <dynamic>[], 'TotalRecordCount': 0};
+    if (bareResponses) return Future.value(<String, dynamic>{});
+    if (invocation.memberName != #getItems) return Future.value(empty);
+    calls++;
+    final named = invocation.namedArguments;
+    final types =
+        named[#includeItemTypes] as List<String>? ?? const <String>[];
+    final filters = named[#filters] as List<String>?;
+    final isFavorite = named[#isFavorite] as bool?;
+    final limit = named[#limit] as int?;
+    if (types.isEmpty) untypedCalls++;
+
+    if ((filters != null && filters.isNotEmpty) || isFavorite == true) {
+      return Future.value(empty);
+    }
+    if (types.isNotEmpty && typedQueriesReturnNothing) {
+      return Future.value(empty);
+    }
+    final matching = types.isEmpty
+        ? items
+        : items.where((it) => types.contains(it['Type'])).toList();
+    return Future.value({
+      'Items': limit == null ? matching : matching.take(limit).toList(),
+      'TotalRecordCount': matching.length,
+    });
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockClient client;
+  late _FakeItemsApi itemsApi;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    GetIt.instance.registerSingleton<UserPreferences>(UserPreferences(store));
+
+    itemsApi = _FakeItemsApi([
+      _book('b1', 'Alpha'),
+      _book('b2', 'Beta'),
+      _comic('c1', 'Zeta Comic'),
+    ]);
+    client = _MockClient();
+    when(() => client.baseUrl).thenReturn('http://server');
+    when(() => client.userId).thenReturn('user-1');
+    when(() => client.itemsApi).thenReturn(itemsApi);
+    when(() => client.imageApi).thenReturn(_MockImageApi());
+  });
+
+  tearDown(() => GetIt.instance.reset());
+
+  BookBrowseViewModel buildVm() => BookBrowseViewModel(
+    libraryId: 'lib-1',
+    dataSource: RowDataSource(client),
+    client: client,
+    collectionType: 'books',
+  );
+
+  HomeRow rowWithId(String id) =>
+      HomeRow(id: id, title: '', rowType: HomeRowType.latestMedia);
+
+  test('the comics scope keeps every shelf on its own id', () async {
+    final vm = buildVm();
+    await vm.load();
+    vm.setScope(BookScope.comics);
+
+    final ids = vm.rows.map((r) => r.id).toList();
+    expect(
+      ids.length,
+      ids.toSet().length,
+      reason: 'two shelves sharing an id share a GlobalKey and crash',
+    );
+  });
+
+  test('a comic reaches the all titles shelf', () async {
+    final vm = buildVm();
+    await vm.load();
+
+    final all = vm.rows.firstWhere((r) => r.id == 'allTitles_lib-1');
+    expect(all.items.map((i) => i.id), contains('c1'));
+  });
+
+  test('comics rows ask the grid for a type the server knows', () {
+    final vm = buildVm();
+    for (final id in ['latestComics_lib-1', 'allComics_lib-1']) {
+      final types = vm.seeAllTypesFor(rowWithId(id));
+      expect(types, isNot(contains('Comic')));
+      expect(types, contains('Book'));
+    }
+  });
+
+  test('a typed query that answers is not asked twice', () async {
+    final row = await RowDataSource(client).loadLibraryItemsByType(
+      'lib-1',
+      'http://server',
+      title: 'Books',
+      includeItemTypes: const ['Book'],
+    );
+    expect(row.items, isNotEmpty);
+    expect(itemsApi.calls, 1);
+    expect(itemsApi.untypedCalls, 0);
+  });
+
+  test('a typed query that matches nothing is retried without types', () async {
+    itemsApi.typedQueriesReturnNothing = true;
+    final row = await RowDataSource(client).loadLibraryItemsByType(
+      'lib-1',
+      'http://server',
+      title: 'Books',
+      includeItemTypes: const ['Book'],
+    );
+    expect(row.items.map((i) => i.id), containsAll(['b1', 'b2']));
+    expect(itemsApi.untypedCalls, 1);
+  });
+
+  test('responses missing their fields leave the screen empty', () async {
+    itemsApi.bareResponses = true;
+    final vm = buildVm();
+    await vm.load();
+
+    expect(vm.isLoading, isFalse);
+    expect(vm.rows, isEmpty);
+    expect(vm.bookCount, 0);
+    expect(vm.comicCount, 0);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Checked the Books tab for the first time in a little while and was surprised to be greeted by a black screen. Dove in to figure out what was going on and found out that this occurs because Jellyfin 10.11's SQL engine fails to match items when IncludeItemTypes: ['Book'] or ['AudioBook'] is passed alongside ParentId: libraryId on a virtual collection folder that contains subdirectories. Furthermore, BookBrowseViewModel lacks support for Comics (e.g. .cbz, .cbr, .cb7, .cbt), and BookBrowseScreen lacks an empty-state fallback widget.

So, this PR fixes Books library browsing when folders contain subfolder topologies (Books, Audiobooks, Comics) where Jellyfin's `IncludeItemTypes` query returns empty sets, introduces Comics format detection and badge support, separates dedicated book and audiobook rows, properly filters the Authors row by scope (e.g. the Books page only shows authors with "Book" titles and vice versa), and standardizes shelf layout across all filter tabs.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Added fallback queries with `excludeItemTypes: const ['Folder', 'CollectionFolder', 'UserView']` in **row_data_source.dart** for book and audiobook libraries where Jellyfin's `topParentId` filter produces zero results under subfolder topologies.
- Added `People` and `Artists` fields to data source requests to ensure book authors and audiobook artists are populated for client filtering.
- Implemented comic format detection in **aggregated_item.dart** (`isComic`), supporting `.cbz`, `.cbr`, `.cb7`, `.cbt`, and Jellyfin `Comic` types, while updating `isAudiobook` to prevent misclassification.
- Added comic format badges in **book_format_badge.dart** and wired comic recognition into **book_card.dart** and **book_shelf_row.dart**.
- Added dynamic scope support for comics in **book_scope_filter.dart** (`BookScope.comics`) and dynamically adapted available scopes to only present formats existing in the library.
- Separated `allBooks` and `allAudiobooks` queries in **book_browse_view_model.dart** so alphabetical sorting does not starve books from appearing on the "All Books" shelf in mixed libraries.
- Implemented dynamic author filtering in **book_browse_view_model.dart**: Books scope filters to book authors (from item `People`), Audiobooks scope filters to audiobook artists, and All scope displays all authors.
- Standardized shelf layout across every filter tab to: Continue Reading -> Latest -> Authors -> All.
- Added empty-state UI in **book_browse_screen.dart** to prevent blank black canvases when no items match.
- Added localized strings for comics and empty states in **app_en.arb** and generated localization files.
- Added unit tests in **aggregated_item_audiobook_test.dart** verifying comic detection and format exclusivity.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin with a Books library containing subfolders for Books and Audiobooks.
2. Verify library loads with proper stat pills (Books, Audiobooks, Authors).
3. Toggle "Books" filter: verify shelves show Continue Reading, Latest Books, Authors (book authors only), and All Books.
4. Toggle "Audiobooks" filter: verify shelves show Continue Reading, Latest Audiobooks, Authors (audiobook artists only), and All Audiobooks.
5. Toggle "All": verify unified shelf layout including all formats and authors.
6. Verify all 1775 unit tests pass (`flutter test`).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### The Aforementioned Black Screen
<img width="2499" height="1433" alt="1-moonfin" src="https://github.com/user-attachments/assets/3ffabe36-e231-4faf-bdf4-4247557ed39f" />

### The Set-Up
<img width="942" height="306" alt="2-folders" src="https://github.com/user-attachments/assets/07a8e8c4-c0e7-4099-9e4a-b428733cedc3" />
<img width="1480" height="893" alt="3-jellyfin" src="https://github.com/user-attachments/assets/7f8b4744-25d2-4742-88c4-39256a1088ae" />

### Post-PR Main Page
<img width="2546" height="1433" alt="2026-09-07_11-21-18_moonfin" src="https://github.com/user-attachments/assets/573348f1-d46d-4753-bbbe-14f2851ae7e8" />
<img width="2546" height="1433" alt="2026-09-07_11-21-23_moonfin" src="https://github.com/user-attachments/assets/d5ecde7f-592c-4f22-826a-004f550c3d87" />

### Books Page only shows Book authors
<img width="2546" height="1433" alt="2026-09-07_11-32-54_moonfin" src="https://github.com/user-attachments/assets/c3357520-419f-4c98-af2e-ae6bb1d254b5" />

### Audiobooks Page only shows Audiobook authors
<img width="2546" height="1433" alt="2026-09-07_11-33-01_moonfin" src="https://github.com/user-attachments/assets/82ade335-0693-4b00-ae24-3cc19f6462dc" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
