### PR TITLE
draw bottom navbar inside screen instead of under

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1320,6 +1320,7 @@ class _DetailContentState extends State<_DetailContent> {
     return QuickReturnWrapper(
       scrollController: _scrollController,
       topFocusNode: widget.initialFocusNode,
+      hideNavbar: true,
       child: Focus(
         focusNode: _contentFocusNode,
         onKeyEvent: (node, event) {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -5029,6 +5029,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     return QuickReturnWrapper(
       scrollController: _scrollController,
       topFocusNode: widget.initialFocusNode,
+      hideNavbar: true,
       child: layout,
     );
   }

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -172,38 +172,40 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       skipTraversal: true,
       child: widget.child,
     );
-    return Column(
+    return Stack(
       children: [
-        Expanded(
-          child: Stack(
+        Positioned.fill(child: content),
+        // The navbar goes last because it is the one that pads the system
+        // inset underneath itself. Above the bars it pads for an edge it no
+        // longer touches and leaves the music bar under the gesture area.
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Positioned.fill(child: content),
-              Positioned(
-                left: 0,
-                right: 0,
-                bottom: 0,
-                child: AnimatedOpacity(
-                  opacity: widget.showNavigationChrome ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 200),
-                  child: IgnorePointer(
-                    ignoring: !widget.showNavigationChrome,
-                    child: MobileBottomNavBar(activeRoute: widget.activeRoute),
-                  ),
+              const DownloadProgressBar(),
+              const BottomMusicBar(),
+              AnimatedOpacity(
+                opacity: widget.showNavigationChrome ? 1.0 : 0.0,
+                duration: const Duration(milliseconds: 200),
+                child: IgnorePointer(
+                  ignoring: !widget.showNavigationChrome,
+                  child: MobileBottomNavBar(activeRoute: widget.activeRoute),
                 ),
               ),
-              if (widget.showBackButton)
-                Positioned(
-                  top: 16,
-                  left: 16,
-                  child: SafeArea(
-                    child: _buildFloatingBackButton(),
-                  ),
-                ),
             ],
           ),
         ),
-        const DownloadProgressBar(),
-        const BottomMusicBar(),
+        if (widget.showBackButton)
+          Positioned(
+            top: 16,
+            left: 16,
+            child: SafeArea(
+              child: _buildFloatingBackButton(),
+            ),
+          ),
       ],
     );
   }

--- a/lib/ui/widgets/navigation_layout.dart
+++ b/lib/ui/widgets/navigation_layout.dart
@@ -172,31 +172,38 @@ class _NavigationLayoutState extends State<NavigationLayout> with WidgetsBinding
       skipTraversal: true,
       child: widget.child,
     );
-    return Stack(
+    return Column(
       children: [
-        Column(
-          children: [
-            Expanded(child: content),
-            const DownloadProgressBar(),
-            const BottomMusicBar(),
-            AnimatedOpacity(
-              opacity: widget.showNavigationChrome ? 1.0 : 0.0,
-              duration: const Duration(milliseconds: 200),
-              child: IgnorePointer(
-                ignoring: !widget.showNavigationChrome,
-                child: MobileBottomNavBar(activeRoute: widget.activeRoute),
+        Expanded(
+          child: Stack(
+            children: [
+              Positioned.fill(child: content),
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                child: AnimatedOpacity(
+                  opacity: widget.showNavigationChrome ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 200),
+                  child: IgnorePointer(
+                    ignoring: !widget.showNavigationChrome,
+                    child: MobileBottomNavBar(activeRoute: widget.activeRoute),
+                  ),
+                ),
               ),
-            ),
-          ],
-        ),
-        if (widget.showBackButton)
-          Positioned(
-            top: 16,
-            left: 16,
-            child: SafeArea(
-              child: _buildFloatingBackButton(),
-            ),
+              if (widget.showBackButton)
+                Positioned(
+                  top: 16,
+                  left: 16,
+                  child: SafeArea(
+                    child: _buildFloatingBackButton(),
+                  ),
+                ),
+            ],
           ),
+        ),
+        const DownloadProgressBar(),
+        const BottomMusicBar(),
       ],
     );
   }

--- a/lib/ui/widgets/quick_return_wrapper.dart
+++ b/lib/ui/widgets/quick_return_wrapper.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../util/platform_detection.dart';
+import '../../preference/preference_constants.dart';
+import '../../preference/user_preferences.dart';
 import '../navigation/route_lifecycle_observer.dart';
 import 'overlay_sheet.dart';
 
@@ -31,6 +34,7 @@ class QuickReturnWrapper extends StatefulWidget {
     this.topFocusNode,
     this.isAtStart,
     this.onReturn,
+    this.hideNavbar = false,
   }) : assert(
          scrollController != null || isAtStart != null,
          'Give it a controller to watch or a notifier telling it where it is.',
@@ -39,6 +43,7 @@ class QuickReturnWrapper extends StatefulWidget {
   final Widget child;
   final ScrollController? scrollController;
   final Axis scrollDirection;
+  final bool hideNavbar;
 
   /// Focused after the scroll finishes, so a remote carries on from the first
   /// card rather than from wherever the old focus scrolled away to.
@@ -175,13 +180,18 @@ class _QuickReturnWrapperState extends State<QuickReturnWrapper>
   Widget build(BuildContext context) {
     if (PlatformDetection.isTV) return widget.child;
 
+    final _prefs = GetIt.instance<UserPreferences>();
+    final navbarPosition = _prefs.get(UserPreferences.navbarPosition);
+    final raiseButton = navbarPosition == NavbarPosition.bottom && !widget.hideNavbar;
+    final bottomPadding = raiseButton ? 78.0 : 24.0;
+
     return Stack(
       fit: StackFit.expand,
       children: [
         widget.child,
         Positioned(
           right: 24,
-          bottom: 24,
+          bottom: bottomPadding,
           child: SafeArea(
             child: AnimatedOpacity(
               opacity: _isScrolledAway ? 1.0 : 0.0,

--- a/lib/ui/widgets/quick_return_wrapper.dart
+++ b/lib/ui/widgets/quick_return_wrapper.dart
@@ -180,8 +180,8 @@ class _QuickReturnWrapperState extends State<QuickReturnWrapper>
   Widget build(BuildContext context) {
     if (PlatformDetection.isTV) return widget.child;
 
-    final _prefs = GetIt.instance<UserPreferences>();
-    final navbarPosition = _prefs.get(UserPreferences.navbarPosition);
+    final prefs = GetIt.instance<UserPreferences>();
+    final navbarPosition = prefs.get(UserPreferences.navbarPosition);
     final raiseButton = navbarPosition == NavbarPosition.bottom && !widget.hideNavbar;
     final bottomPadding = raiseButton ? 78.0 : 24.0;
 

--- a/test/ui/widgets/bottom_navbar_order_test.dart
+++ b/test/ui/widgets/bottom_navbar_order_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/auth/models/user.dart';
+import 'package:moonfin/auth/repositories/session_repository.dart';
+import 'package:moonfin/auth/repositories/user_repository.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/data/models/aggregated_library.dart';
+import 'package:moonfin/data/repositories/user_views_repository.dart';
+import 'package:moonfin/data/services/media_server_client_factory.dart';
+import 'package:moonfin/data/services/plugin_sync_service.dart';
+import 'package:moonfin/data/services/server_messages_service.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/seerr_preferences.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/widgets/mobile_bottom_nav_bar.dart';
+import 'package:moonfin/ui/widgets/navigation_layout.dart';
+import 'package:moonfin/util/game_library.dart';
+import 'package:moonfin/util/platform_detection.dart';
+import 'package:playback_core/playback_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeUserRepository extends Fake implements UserRepository {
+  @override
+  User? get currentUser => null;
+
+  @override
+  Stream<User?> get currentUserStream => const Stream.empty();
+}
+
+class _FakeUserViewsRepository extends ChangeNotifier
+    implements UserViewsRepository {
+  @override
+  Future<List<AggregatedLibrary>> getUserViews() async => [];
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePluginSyncService extends ChangeNotifier
+    implements PluginSyncService {
+  @override
+  bool get seerrAvailable => false;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeSessionRepository extends Fake implements SessionRepository {
+  @override
+  String? get activeUserId => null;
+}
+
+class _FakeGameLibraryRegistry extends Fake implements GameLibraryRegistry {
+  @override
+  Future<void> refresh() async {}
+}
+
+class _FakePlaybackManager extends Fake implements PlaybackManager {
+  @override
+  final PlayerState state = PlayerState();
+
+  @override
+  final QueueService queueService = QueueService();
+}
+
+class _FakeClientFactory extends Fake implements MediaServerClientFactory {}
+
+class _FakeServerMessages extends ChangeNotifier
+    implements ServerMessagesService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+const _track = AggregatedItem(
+  id: 'a1',
+  serverId: 'srv',
+  rawData: {'Id': 'a1', 'Name': 'A Song', 'Type': 'Audio'},
+);
+
+void main() {
+  late _FakePlaybackManager playback;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    playback = _FakePlaybackManager();
+    final getIt = GetIt.instance;
+    getIt.registerSingleton<PreferenceStore>(store);
+    getIt.registerSingleton<UserPreferences>(UserPreferences(store));
+    getIt.registerSingleton<UserRepository>(_FakeUserRepository());
+    getIt.registerSingleton<UserViewsRepository>(_FakeUserViewsRepository());
+    getIt.registerSingleton<PluginSyncService>(_FakePluginSyncService());
+    getIt.registerSingleton<SeerrPreferences>(
+      SeerrPreferences(store, _FakeSessionRepository()),
+    );
+    getIt.registerSingleton<GameLibraryRegistry>(_FakeGameLibraryRegistry());
+    getIt.registerSingleton<PlaybackManager>(playback);
+    getIt.registerSingleton<MediaServerClientFactory>(_FakeClientFactory());
+    getIt.registerSingleton<ServerMessagesService>(_FakeServerMessages());
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.phone);
+  });
+
+  tearDown(() async {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.automatic);
+    NavigationLayout.chromeFocusRoots.clear();
+    await GetIt.instance.reset();
+  });
+
+  testWidgets('the navbar keeps the screen edge while music is playing', (
+    tester,
+  ) async {
+    await GetIt.instance<UserPreferences>().set(
+      UserPreferences.navbarPosition,
+      NavbarPosition.bottom,
+    );
+    playback.queueService.setQueue([_track]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const Scaffold(
+          body: NavigationLayout(child: SizedBox.expand()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final navbar = find.byType(MobileBottomNavBar);
+    final musicBar = find.byType(BottomMusicBar);
+    expect(navbar, findsOneWidget);
+    expect(musicBar, findsOneWidget);
+
+    // The navbar is what pads the system inset, so nothing may sit between
+    // it and the bottom of the screen.
+    expect(
+      tester.getBottomLeft(navbar).dy,
+      greaterThan(tester.getBottomLeft(musicBar).dy),
+    );
+  });
+}

--- a/test/ui/widgets/quick_return_wrapper_test.dart
+++ b/test/ui/widgets/quick_return_wrapper_test.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:moonfin/l10n/app_localizations.dart';
 import 'package:moonfin/ui/navigation/route_lifecycle_observer.dart';
 import 'package:moonfin/ui/widgets/overlay_sheet.dart';
 import 'package:moonfin/ui/widgets/quick_return_wrapper.dart';
 import 'package:moonfin/util/platform_detection.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
 
 /// Long enough that there is always somewhere left to scroll.
 Widget _scrollingBody(ScrollController controller, {Axis axis = Axis.vertical}) {
@@ -51,6 +56,14 @@ Future<ScrollController> _pumpWrapper(
 
 void main() {
   tearDown(() => PlatformDetection.setTvMode(false));
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    GetIt.instance.registerSingleton<UserPreferences>(UserPreferences(store));
+  });
 
   group('on TV', () {
     setUp(() => PlatformDetection.setTvMode(true));


### PR DESCRIPTION
# Pull Request

## Summary
Bottom navbar was being drawn outside/under the screen contents instead of inside the contents like the other 2 navbars. This resulted in a few issues:
1. black space behind it at the bottom of the screen, most noticeable when navbar is hidden on details screens (#1337)
2. the safeArea that accounts for the space needed by phone's native navigation buttons/gesture bar was being duplicated above the navbar space (#1443)

I reorganized the NavigationLayout for the bottom bar builder. This solved the main issue, but now the "back to top" button is drawn underneath the navbar, so I had to account for that. Now content is visible around/behind the navbar, and the "back to top" button shift upwards to leave room for it only on screens where the navbar doesn't hide on scroll. 

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1337 
- Fixes #1443
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- reorganized layout from stack(column(expanded(content),navbar)) to column(expanded(stack(content,navbar))), which better matches the layout/structure used for top/sidebar already
- raise bottom padding for "back to top" button if navbar = bottom
- skip raising the bottom padding on screens where the navbar disappears on scroll anyway 

## Platform
- [X] Android
- [ ] Android TV
- [X] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
4.
5.

## Screenshots (if applicable)
Before (black box behind navbar, safeArea pushed up so not aligned with phone's native ui):
<img width="1080" height="2340" alt="Screenshot_20260907_164755" src="https://github.com/user-attachments/assets/6263a0d5-2336-4ec7-a352-4119385dd360" />
<img width="1080" height="2340" alt="Screenshot_20260907_164731" src="https://github.com/user-attachments/assets/cd942f46-8caa-4c03-be4f-acc9ca6ffbcc" />

After (no more black box, safeArea aligns with phone's native ui elements, and the "back to top" button aligns correctly):
<img width="1080" height="2340" alt="Screenshot_20260907_164714" src="https://github.com/user-attachments/assets/a895c8ea-473f-45f9-821f-bf4f7ec1ece0" />
<img width="1080" height="2340" alt="Screenshot_20260907_164659" src="https://github.com/user-attachments/assets/cae93338-f7a9-4447-a280-7cf3ab86c200" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
