### PR TITLE
add current time to osd time slot options

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9900,6 +9900,10 @@
   "@mixedPlaylistsSection": {
     "description": "Section header above mixed playlists when Group by Type is enabled"
   },
+  "currentTime": "Current Time",
+  "@currentTime": {
+    "description": "The current time as it appears on a clock"
+  },
   "playbackTimeDisplay": "Progress Bar Time",
   "@playbackTimeDisplay": {
     "description": "Setting title for what is shown next to the playback progress bar"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -19846,6 +19846,12 @@ abstract class AppLocalizations {
   /// **'Mixed Playlists'**
   String get mixedPlaylistsSection;
 
+  /// The current time as it appears on a clock
+  ///
+  /// In en, this message translates to:
+  /// **'Current Time'**
+  String get currentTime;
+
   /// Setting title for what is shown next to the playback progress bar
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -11164,6 +11164,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -11141,6 +11141,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -11229,6 +11229,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -11267,6 +11267,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -11138,6 +11138,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -11336,6 +11336,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Llistes de reproducció mixtes';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Temps a la barra de progrés';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -11202,6 +11202,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -11219,6 +11219,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -11155,6 +11155,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11328,6 +11328,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mixedPlaylistsSection => 'Gemischte Wiedergabelisten';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Fortschrittsanzeige';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -11331,6 +11331,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -11075,6 +11075,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -11150,6 +11150,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11280,6 +11280,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -11168,6 +11168,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -11096,6 +11096,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -11191,6 +11191,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get mixedPlaylistsSection => 'Sekalaiset soittolistat';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Edistymispalkin aika';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11299,6 +11299,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mixedPlaylistsSection => 'Playlists mixtes';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Temps sur la barre de progression';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -11305,6 +11305,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -11017,6 +11017,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -11131,6 +11131,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -11384,6 +11384,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -11256,6 +11256,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -11160,6 +11160,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11251,6 +11251,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get mixedPlaylistsSection => 'Playlist Miste';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Orari sulla Barra di Avanzamento';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -10844,6 +10844,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -11207,6 +11207,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -11230,6 +11230,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -10817,6 +10817,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get mixedPlaylistsSection => '혼합 재생목록';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => '진행 바 시간';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -11223,6 +11223,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -11223,6 +11223,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -11238,6 +11238,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -11283,6 +11283,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -11180,6 +11180,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -11152,6 +11152,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -11221,6 +11221,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Algemene afspeellijst';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Tijd voortgangsbalk';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -11119,6 +11119,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -11451,6 +11451,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Playlisty mieszane';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Czas przy pasku postępu';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11245,6 +11245,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11251,6 +11251,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -11239,6 +11239,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -11151,6 +11151,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -11231,6 +11231,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -11225,6 +11225,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -11256,6 +11256,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -11372,6 +11372,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -11169,6 +11169,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get mixedPlaylistsSection => 'Spellistor (blandat)';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -11244,6 +11244,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -11244,6 +11244,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -11231,6 +11231,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -11082,6 +11082,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -11275,6 +11275,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -11169,6 +11169,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get mixedPlaylistsSection => 'Karışık Oynatma Listesi';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'İlerleme Çubuğu Süresi';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -11193,6 +11193,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -11248,6 +11248,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -11163,6 +11163,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -10758,6 +10758,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get mixedPlaylistsSection => 'Mixed Playlists';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => 'Progress Bar Time';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -10710,6 +10710,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mixedPlaylistsSection => '混合播放列表';
 
   @override
+  String get currentTime => 'Current Time';
+
+  @override
   String get playbackTimeDisplay => '进度条时间';
 
   @override

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -189,6 +189,9 @@ enum PlaybackTimeSlot {
 
   /// Wall-clock time the item will finish at, e.g. `Ends at 21:45`.
   endsAt,
+
+  /// The current time
+  time,
 }
 
 enum DesktopScrollWheelAction {

--- a/lib/ui/screens/settings/panel/playback_time_layout_screen.dart
+++ b/lib/ui/screens/settings/panel/playback_time_layout_screen.dart
@@ -40,6 +40,7 @@ class _PlaybackTimeLayoutScreenState extends State<_PlaybackTimeLayoutScreen> {
       PlaybackTimeSlot.totalDuration => l10n.playbackTimeTotal,
       PlaybackTimeSlot.timeRemaining => l10n.playbackTimeRemaining,
       PlaybackTimeSlot.endsAt => l10n.playbackTimeEndsAt,
+      PlaybackTimeSlot.time => l10n.currentTime,
     };
   }
 

--- a/lib/util/playback_time_label.dart
+++ b/lib/util/playback_time_label.dart
@@ -70,6 +70,11 @@ String formatPlaybackTimeSlot(
         use24Hour: use24Hour,
         playbackSpeed: playbackSpeed,
       );
+    case PlaybackTimeSlot.time:
+      return formatClockTime(
+        DateTime.now(),
+        use24Hour: use24Hour,
+      );
   }
 }
 

--- a/test/util/playback_time_label_test.dart
+++ b/test/util/playback_time_label_test.dart
@@ -195,6 +195,14 @@ void main() {
       );
     });
 
+    testWidgets('time reads the clock rather than the media', (tester) async {
+      final context = await _localizedContext(tester);
+      expect(
+        slot(context, PlaybackTimeSlot.time),
+        matches(RegExp(r'^\d{2}:\d{2}$')),
+      );
+    });
+
     testWidgets('only none renders nothing', (tester) async {
       final context = await _localizedContext(tester);
       for (final value in PlaybackTimeSlot.values) {


### PR DESCRIPTION
# Pull Request

## Summary
Add "current time" as one of the osd timeslot options. This already exists on Roku (go figure, roku getting something before core)

## Related Issues
Link related issues or tickets separated by commas.

- Closes #1435
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- add time as osd timeslot option (I would've put currentTime but on roku it's just 'time' so I figured for consistency)
- add Current Time localization
- 

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1.
2.
3.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.
<img width="516" height="643" alt="image" src="https://github.com/user-attachments/assets/6158bdfc-6829-4b91-87bc-231697f28f4f" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
