### PR TITLE
bugfix-browse: Allow Playlist Images to Change

### DIFF
--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -624,7 +624,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
 
     if (_vm.isPlaylistBrowse) {
       return item.primaryImageTag != null
-          ? api.getPrimaryImageUrl(item.id, maxWidth: posterMaxW)
+          ? api.getPrimaryImageUrl(
+              item.id,
+              maxWidth: posterMaxW,
+              tag: item.primaryImageTag,
+            )
           : null;
     }
 


### PR DESCRIPTION
# Pull Request

## Summary
Realized after upgrading to JF12 that I couldn't change the image for a playlist away from the auto-generated JF collage. This PR passes the item's `primaryImageTag` when requesting primary image URLs for playlist cards in the library browse grid view. Without the tag parameter, the URL remained static across image updates and edits, causing local disk image caches to serve stale, obsolete artwork (e.g., auto-generated collage artwork instead of newly uploaded custom cover art).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- In **library_browse_screen.dart**, updated `_buildCard` for playlist browse mode to supply `tag: item.primaryImageTag` when calling `api.getPrimaryImageUrl`.
- Ensures URL cache-busting occurs whenever the server updates a playlist's primary image tag.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to a library browse view containing a playlist with newly uploaded or updated artwork on the media server.
2. Verify the library browse grid card now fetches the image URL containing the updated tag parameter instead of caching the initial tag-less request.
3. Verify that running `flutter analyze lib/ui/screens/browse/library_browse_screen.dart` reports 0 issues.
4. Verify existing library browse unit tests (`library_browse_grid_focus_test.dart` and `library_browse_search_test.dart`) pass without regression.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Pre-PR
<img width="1409" height="691" alt="2026-09-07_22-02-45_moonfin" src="https://github.com/user-attachments/assets/f287a6c2-255e-49a6-b701-17db9b915a92" />

### Post-Change
<img width="1413" height="683" alt="2026-09-07_22-03-11_moonfin" src="https://github.com/user-attachments/assets/f102732e-5a83-4ae9-afc4-6a28f4440d14" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
