### PR TITLE
feat-recommendations - Incorporate JF12's Jellyfin Recommends and Speedy Server-Side Scoring

### DIFF
--- a/lib/data/database/offline_database.dart
+++ b/lib/data/database/offline_database.dart
@@ -79,8 +79,16 @@ class OfflineDatabase extends _$OfflineDatabase {
     onCreate: (m) => m.createAll(),
     onUpgrade: (m, from, to) async {
       if (from < 2) {
-        await m.addColumn(downloadedItems, downloadedItems.downloadSource);
-        await m.createTable(autoDownloadSubscriptions);
+        try {
+          await m.addColumn(downloadedItems, downloadedItems.downloadSource);
+        } catch (_) {
+          // Column may already exist from an unversioned migration or previous partial run
+        }
+        try {
+          await m.createTable(autoDownloadSubscriptions);
+        } catch (_) {
+          // Table may already exist
+        }
       }
     },
   );

--- a/lib/data/models/aggregated_item.dart
+++ b/lib/data/models/aggregated_item.dart
@@ -213,11 +213,6 @@ class AggregatedItem {
     return v != null ? DateTime.tryParse(v) : null;
   }
 
-  DateTime? get dateCreated {
-    final v = rawData['DateCreated'] as String?;
-    return v != null ? DateTime.tryParse(v) : null;
-  }
-
   List<String> get productionLocations =>
       _toListOfStrings(rawData['ProductionLocations']);
 

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -80,6 +80,9 @@ class PluginSyncService extends ChangeNotifier {
   bool get mdblistAvailable => _mdblistAvailable;
   bool _tmdbAvailable = false;
   bool get tmdbAvailable => _tmdbAvailable;
+  bool _recommendationsSupported = false;
+  bool get recommendationsSupported =>
+      _pluginAvailable && _recommendationsSupported;
   String? _activeThemeCacheServerId;
   void Function(
     String title,
@@ -205,6 +208,7 @@ class PluginSyncService extends ChangeNotifier {
     _seerrInfoAvailable = false;
     _mdblistAvailable = false;
     _tmdbAvailable = false;
+    _recommendationsSupported = false;
     _activeThemeCacheServerId = null;
     if (notify) {
       _setLocalSeerrEnabled(false);
@@ -261,6 +265,8 @@ class PluginSyncService extends ChangeNotifier {
       _seerrEnabled = _readBool(pingResult, 'seerrEnabled') ?? false;
       _mdblistAvailable = _readBool(pingResult, 'mdblistAvailable') ?? false;
       _tmdbAvailable = _readBool(pingResult, 'tmdbAvailable') ?? false;
+      _recommendationsSupported =
+          _readBool(pingResult, 'recommendationsSupported') ?? false;
       // Older plugins leave this out, which reads as false and hides the button.
       _messages?.setSupported(
         _readBool(pingResult, 'messagesSupported') ?? false,

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2432,7 +2432,8 @@ class RowDataSource {
     final prefs = GetIt.instance<UserPreferences>();
     final sourceType = prefs.get(UserPreferences.sinceYouWatchedSourceType);
     final sourceItemType = prefs.get(UserPreferences.sinceYouWatchedSourceItem);
-    final isLocal = prefs.get(UserPreferences.sinceYouWatchedSource) == SinceYouWatchedSource.local;
+    final source = prefs.get(UserPreferences.sinceYouWatchedSource);
+    final isLocal = source == SinceYouWatchedSource.local;
 
     final List<String> queryItemTypes;
     if (sourceItemType == SinceYouWatchedSourceItem.recentlyWatched) {
@@ -2575,13 +2576,65 @@ class RowDataSource {
     final baseItem = baseItems[sourceIdx];
     final baseItemName = baseItem.name;
 
-    final recommendedItems = await getRecommendations(
-      serverId: serverId,
-      baseItem: baseItem,
-      isLocal: isLocal,
-      candidateItemTypes: candidateItemTypes,
-      limit: 100,
-    );
+    List<AggregatedItem> recommendedItems = const [];
+    if (source == SinceYouWatchedSource.server) {
+      try {
+        final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
+        final parsed = _parseItems(data, serverId);
+
+        final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+        final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
+        final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+
+        recommendedItems = parsed.where((item) {
+          if (!effectiveIncludeWatched && item.isPlayed) return false;
+          if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
+          return true;
+        }).toList();
+      } catch (e) {
+        debugPrint('[RowDataSource] Server recommendation failed: $e');
+        recommendedItems = const [];
+      }
+    } else {
+      bool usedServerRecs = false;
+      if (isLocal) {
+        final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
+            ? GetIt.instance<PluginSyncService>()
+            : null;
+        if (pluginSync?.recommendationsSupported == true) {
+          try {
+            final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
+            final parsed = _parseItems(data, serverId);
+            final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+            final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
+            final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+
+            final filtered = parsed.where((item) {
+              if (!effectiveIncludeWatched && item.isPlayed) return false;
+              if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
+              return true;
+            }).toList();
+
+            if (filtered.isNotEmpty) {
+              recommendedItems = filtered;
+              usedServerRecs = true;
+            }
+          } catch (e) {
+            debugPrint('[RowDataSource] Moonbase server recommendation failed, falling back to local: $e');
+          }
+        }
+      }
+
+      if (!usedServerRecs) {
+        recommendedItems = await getRecommendations(
+          serverId: serverId,
+          baseItem: baseItem,
+          isLocal: isLocal,
+          candidateItemTypes: candidateItemTypes,
+          limit: 100,
+        );
+      }
+    }
 
     final rowId = 'sinceYouWatched$rowIndex';
     _scoredRecommendationsCache[rowId] = recommendedItems;

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1484,7 +1484,38 @@ class ItemDetailViewModel extends ChangeNotifier {
       try {
         final prefs = GetIt.instance<UserPreferences>();
         final sourceSetting = prefs.get(UserPreferences.recommendationSystemSource);
+
+        if (sourceSetting == RecommendationSystemSource.server) {
+          final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+          final items = (data['Items'] as List?) ?? [];
+          _similar = _mapItems(items);
+          notifyListeners();
+          return;
+        }
+
         final isLocal = sourceSetting == RecommendationSystemSource.local;
+
+        // Auto-detect server recommendations via Moonbase if "Moonfin Recommends" is selected
+        // and Moonbase announces recommendationsSupported.
+        if (isLocal) {
+          final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
+              ? GetIt.instance<PluginSyncService>()
+              : null;
+          if (pluginSync?.recommendationsSupported == true) {
+            try {
+              final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+              final items = (data['Items'] as List?) ?? [];
+              if (items.isNotEmpty) {
+                _similar = _mapItems(items);
+                notifyListeners();
+                return;
+              }
+            } catch (e) {
+              debugPrint('[ItemDetailViewModel] Moonbase server recommendation failed, falling back to local: $e');
+            }
+          }
+        }
+
         final serverId = _serverId ?? _client.baseUrl;
         final dataSource = GetIt.instance<RowDataSource>();
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -224,13 +224,17 @@
   "@recommendationSystem": {
     "description": "Label for the Recommendation System setting"
   },
-  "recommendationSystemSubtitle": "Use the Moonfin Recommends local-library algorithm or the online TMDb's Similarity Metrics. Note: Online recommendations require Seerr integration.",
+  "recommendationSystemSubtitle": "Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb's Similarity Metrics. Note: Online recommendations require Seerr integration.",
   "@recommendationSystemSubtitle": {
     "description": "Explanation under the recommendation system setting"
   },
   "recommendationSystemMoonfin": "Moonfin Recommends",
   "@recommendationSystemMoonfin": {
     "description": "Recommendation system option: Moonfin Recommends"
+  },
+  "recommendationSystemJellyfin": "Jellyfin Recommends",
+  "@recommendationSystemJellyfin": {
+    "description": "Recommendation system option: Jellyfin Recommends"
   },
   "recommendationSystemTmdb": "TMDb Similarity",
   "@recommendationSystemTmdb": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -517,7 +517,7 @@ abstract class AppLocalizations {
   /// Explanation under the recommendation system setting
   ///
   /// In en, this message translates to:
-  /// **'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.'**
+  /// **'Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.'**
   String get recommendationSystemSubtitle;
 
   /// Recommendation system option: Moonfin Recommends
@@ -525,6 +525,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Moonfin Recommends'**
   String get recommendationSystemMoonfin;
+
+  /// Recommendation system option: Jellyfin Recommends
+  ///
+  /// In en, this message translates to:
+  /// **'Jellyfin Recommends'**
+  String get recommendationSystemJellyfin;
 
   /// Recommendation system option: TMDb Similarity
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -179,6 +179,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-ooreenkoms';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -179,6 +179,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'تشابه TMDb';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -179,6 +179,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рэкамендуе';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Падабенства TMDb';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -179,6 +179,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Сходство по TMDb';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -179,6 +179,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb সাদৃশ্য';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -179,6 +179,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Recomanacions Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitud de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -180,6 +180,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin doporučuje';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnost podle TMDb';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -179,6 +179,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Tebygrwydd TMDb';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -181,6 +181,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Anbefaler';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-lighed';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -179,6 +179,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Empfehlungen';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Ähnlichkeit';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -181,6 +181,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Προτάσεις Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ομοιότητα TMDb';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -173,10 +173,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get recommendationSystemSubtitle =>
-      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
+      'Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
+
+  @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
 
   @override
   String get recommendationSystemTmdb => 'TMDb Similarity';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -179,6 +179,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-simileco';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -179,6 +179,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitud de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -180,6 +180,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin soovitab';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb sarnasus';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -179,6 +179,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'شباهت TMDb';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -181,6 +181,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Suositukset';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Samankaltaisuus';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -179,6 +179,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin recommande';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similarité TMDb';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -179,6 +179,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Recomendacións Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitude de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -179,6 +179,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'דמיון TMDb';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -179,6 +179,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb समानता';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -179,6 +179,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb sličnost';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -179,6 +179,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin ajánlásai';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb hasonlóság';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -179,6 +179,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Kemiripan TMDb';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -179,6 +179,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Suggerimenti Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similarità TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -176,6 +176,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 類似度';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -179,6 +179,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin ұсынады';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ұқсастығы';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -179,6 +179,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ಸಾಮ್ಯತೆ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -177,6 +177,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin 추천';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 유사도';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -179,6 +179,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb panašumas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -179,6 +179,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb līdzība';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -179,6 +179,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Сличност според TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -179,6 +179,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb സാമ്യത';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -179,6 +179,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-ийн ижил төстэй байдал';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -179,6 +179,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin anbefaler';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-likhet';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -180,6 +180,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Aanbeveling Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-gelijkenis';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -179,6 +179,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ਸਮਾਨਤਾ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -179,6 +179,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin poleca';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobieństwo TMDb';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -179,6 +179,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recomenda';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similaridade TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -179,6 +179,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similaritate TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -179,6 +179,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рекомендует';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Схожесть TMDb';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -179,6 +179,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin නිර්දේශ';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb සමානතාව';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -180,6 +180,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin odporúča';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnosť TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -180,6 +180,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin priporoča';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnost TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -180,6 +180,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ngjashmëria TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -179,6 +179,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb сличност';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -179,6 +179,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-likhet';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -179,6 +179,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ufanano wa TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -179,6 +179,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin பரிந்துரைகள்';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ஒற்றுமை';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -179,6 +179,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin సిఫార్సులు';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb సారూప్యత';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -180,6 +180,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin แนะนำ';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'ความคล้ายคลึงจาก TMDb';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -180,6 +180,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -179,6 +179,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Önerileri';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Benzerliği';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -179,6 +179,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ئوخشاشلىقى';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -179,6 +179,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рекомендує';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Схожість TMDb';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -179,6 +179,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Gợi ý';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Độ tương đồng TMDb';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -176,6 +176,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 相似度';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -175,6 +175,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin 智能推荐';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 相似影片推荐';
 
   @override

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -260,6 +260,7 @@ enum DetailScreenStyle {
 /// Selectable algorithm source for similarity recommendation system.
 enum RecommendationSystemSource {
   local,
+  server,
   online;
 }
 
@@ -839,9 +840,14 @@ enum ScreensaverTimeout {
 
 enum SinceYouWatchedSource {
   local,
+  server,
   online;
 
-  String get displayName => this == local ? 'Local' : 'Online';
+  String get displayName => switch (this) {
+    SinceYouWatchedSource.local => 'Moonfin Recommends',
+    SinceYouWatchedSource.server => 'Jellyfin Recommends',
+    SinceYouWatchedSource.online => 'TMDb Similarity',
+  };
 }
 
 enum SinceYouWatchedSourceType {

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -669,8 +669,8 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                   if (showSinceYouWatchedRows) ...[
                     EnumPreferenceTile<SinceYouWatchedSource>(
                       preference: UserPreferences.sinceYouWatchedSource,
-                      title: 'Source',
-                      description: "Choose recommendation source (the local-content-only Moonfin special or TMDB's similarity metric. Note: Online recommendations require Seerr integration).",
+                      title: 'Recommendation Source',
+                      description: "Choose recommendation source (Moonfin Recommends custom local algorithm, Jellyfin Recommends server engine, or TMDb's similarity metrics. Note: Online recommendations require Seerr integration).",
                       icon: Icons.source,
                       values: SinceYouWatchedSource.values,
                       labelOf: (v) => v.displayName,

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -150,6 +150,8 @@ class _DetailsScreenSettingsScreenState
                     labelOf: (v) => switch (v) {
                       RecommendationSystemSource.local =>
                         l10n.recommendationSystemMoonfin,
+                      RecommendationSystemSource.server =>
+                        l10n.recommendationSystemJellyfin,
                       RecommendationSystemSource.online =>
                         l10n.recommendationSystemTmdb,
                     },


### PR DESCRIPTION
# Pull Request

## Summary
JF12 did a lot of neat things with their recommendation system. This PR unifies the recommendation system source nomenclature across the Item Details screen and the "Since You Watched" home screen rows, introduces native support for Jellyfin 12's extensible similar items backend (`GET /Items/{id}/Similar`), and adds client-side capability auto-detection for server-backed recommendations via Moonbase with graceful fallback to local client scoring. What this means is that if Moonbase is installed and the server is running JF12, we can fully utilize the new pathing for super quick recommendation results without straining clients. If Moonbase isn't installed or the server is not on JF12 yet, we have the following fallbacks:

* JF 10.x + "Moonfin Recommends": Runs custom client-side scoring.
* JF 10.x + "Jellyfin Recommends": Runs Jellyfin 10's stock genre/tag similarity.
* JF 12 + "Moonfin Recommends" (with Moonbase updated): Automatically takes advantage of server-side scoring and disk caching.
* JF 12 + "Jellyfin Recommends": Uses Jellyfin 12's extensible provider system.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Recommendation Options Unification**: Unified the recommendation source options across both Item Details settings (**details_screen_settings_screen.dart**) and Since You Watched settings (**home_row_toggles_screen.dart**, **preference_constants.dart**) into three clear, standardized options:
  - **Moonfin Recommends** (Custom weighted algorithm)
  - **Jellyfin Recommends** (Native Jellyfin 12 extensible backend)
  - **TMDb Similarity** (Online TMDb API)
- **Jellyfin 12 Extensible Provider Support**: Added `server` source handling to **item_detail_view_model.dart** and **row_data_source.dart** calling native `GET /Items/{id}/Similar`, utilizing Jellyfin 12's extensible `ISimilarItemsProvider` pipeline and built-in server disk/memory caching (`TryReadSimilarItemsCacheAsync`).
- **Moonbase Capability Auto-Detection**: Enhanced **plugin_sync_service.dart** to detect `recommendationsSupported` from `/Moonfin/Ping`. When "Moonfin Recommends" is chosen and connected to a server running Moonbase with the similar items provider active, recommendations are automatically offloaded to the server for near-instant response times; if the server lacks the capability, returns empty, or encounters errors, it seamlessly falls back to our client-side Dart scoring algorithm with zero disruption.
- **Idempotent Database Migration**: Protected the schema migration in **offline_database.dart** so duplicate column checks on developer databases do not crash app initialization.
- **AggregatedItem Cleanup**: Removed duplicate `dateCreated` getter in **aggregated_item.dart** that was blocking test compilation.
- **Localization**: Added `recommendationSystemJellyfin` key to **app_en.arb** and regenerated localization files across all supported languages.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Details Screen -> Recommendation System Source.
2. Verify all three options ("Moonfin Recommends", "Jellyfin Recommends", "TMDb Similarity") are selectable and properly localized.
3. Navigate to Settings -> Home -> "Since you watched" Settings -> Recommendation Source.
4. Verify all three options match and switch correctly.
5. Open an item details screen under each source to verify recommendations load properly.
6. Verify "Since You Watched" home rows populate as expected.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previous Menus
<img width="250" alt="pre-detailspage" src="https://github.com/user-attachments/assets/e09a9c50-12e1-475c-9e9c-fa758cd0db31" />
<img width="250" alt="pre-sinceyouwatched" src="https://github.com/user-attachments/assets/531fb676-1b52-4259-8540-1f8823740dd0" />

### Post-PR Menus
<img width="2525" height="1514" alt="2026-09-08_10-05-31_moonfin" src="https://github.com/user-attachments/assets/5175442b-b27c-49cb-98c4-6e5c6c2fc159" />
<img width="2525" height="1514" alt="2026-09-08_10-05-52_moonfin" src="https://github.com/user-attachments/assets/3211c527-9b1f-4952-8dbe-266a59a35c1b" />

### Jellyfin Recommends Search Results (with filter for "include previous watched items" OFF)
<img width="2525" height="1514" alt="2026-09-08_10-08-17_moonfin" src="https://github.com/user-attachments/assets/5fb6827c-2e58-4ac5-9fea-003f52f6f090" />

### Jellyfin Recommends Search Results (with filter for "include previous watched items" ON)
<img width="2525" height="1514" alt="2026-09-08_10-06-28_moonfin" src="https://github.com/user-attachments/assets/e2757017-fac4-446d-88ec-b1039fa4dec2" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
