### PR TITLE
feat-recs - Incorporate JF12's Jellyfin Recommends and Speedy Server-Side Scoring (take 2)

### DIFF
--- a/lib/data/database/offline_database.dart
+++ b/lib/data/database/offline_database.dart
@@ -79,8 +79,16 @@ class OfflineDatabase extends _$OfflineDatabase {
     onCreate: (m) => m.createAll(),
     onUpgrade: (m, from, to) async {
       if (from < 2) {
-        await m.addColumn(downloadedItems, downloadedItems.downloadSource);
-        await m.createTable(autoDownloadSubscriptions);
+        try {
+          await m.addColumn(downloadedItems, downloadedItems.downloadSource);
+        } catch (_) {
+          // Column may already exist from an unversioned migration or previous partial run
+        }
+        try {
+          await m.createTable(autoDownloadSubscriptions);
+        } catch (_) {
+          // Table may already exist
+        }
       }
     },
   );

--- a/lib/data/database/offline_database.dart
+++ b/lib/data/database/offline_database.dart
@@ -79,17 +79,32 @@ class OfflineDatabase extends _$OfflineDatabase {
     onCreate: (m) => m.createAll(),
     onUpgrade: (m, from, to) async {
       if (from < 2) {
-        try {
-          await m.addColumn(downloadedItems, downloadedItems.downloadSource);
-        } catch (_) {
-          // Column may already exist from an unversioned migration or previous partial run
-        }
-        try {
-          await m.createTable(autoDownloadSubscriptions);
-        } catch (_) {
-          // Table may already exist
-        }
+        await _tolerateExisting(
+          () => m.addColumn(downloadedItems, downloadedItems.downloadSource),
+        );
+        await _tolerateExisting(() => m.createTable(autoDownloadSubscriptions));
       }
     },
   );
+
+  /// Runs one migration step, letting through only the failure that says the
+  /// column or table is already there. A database from before the schema was
+  /// versioned can already carry both, and adding them again throws.
+  ///
+  /// Anything else has to surface. Drift marks the upgrade done either way, so
+  /// swallowing a locked file or a full disk would leave the schema half built
+  /// and turn a startup failure into a query that fails much later with
+  /// nothing to point at. The match is on the message because the database
+  /// runs on a background isolate, which wraps whatever sqlite threw.
+  static Future<void> _tolerateExisting(Future<void> Function() step) async {
+    try {
+      await step();
+    } catch (e) {
+      final message = e.toString().toLowerCase();
+      if (!message.contains('duplicate column name') &&
+          !message.contains('already exists')) {
+        rethrow;
+      }
+    }
+  }
 }

--- a/lib/data/offline/offline_items_api.dart
+++ b/lib/data/offline/offline_items_api.dart
@@ -481,6 +481,7 @@ class OfflineItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getSimilarItems(
     String itemId, {
     int? limit,
+    String? bypass,
   }) async {
     final entry = _catalog.byId(itemId);
     if (entry == null) return _envelope(const []);

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -80,6 +80,9 @@ class PluginSyncService extends ChangeNotifier {
   bool get mdblistAvailable => _mdblistAvailable;
   bool _tmdbAvailable = false;
   bool get tmdbAvailable => _tmdbAvailable;
+  bool _recommendationsSupported = false;
+  bool get recommendationsSupported =>
+      _pluginAvailable && _recommendationsSupported;
   String? _activeThemeCacheServerId;
   void Function(
     String title,
@@ -205,6 +208,7 @@ class PluginSyncService extends ChangeNotifier {
     _seerrInfoAvailable = false;
     _mdblistAvailable = false;
     _tmdbAvailable = false;
+    _recommendationsSupported = false;
     _activeThemeCacheServerId = null;
     if (notify) {
       _setLocalSeerrEnabled(false);
@@ -261,6 +265,8 @@ class PluginSyncService extends ChangeNotifier {
       _seerrEnabled = _readBool(pingResult, 'seerrEnabled') ?? false;
       _mdblistAvailable = _readBool(pingResult, 'mdblistAvailable') ?? false;
       _tmdbAvailable = _readBool(pingResult, 'tmdbAvailable') ?? false;
+      _recommendationsSupported =
+          _readBool(pingResult, 'recommendationsSupported') ?? false;
       // Older plugins leave this out, which reads as false and hides the button.
       _messages?.setSupported(
         _readBool(pingResult, 'messagesSupported') ?? false,

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1038,7 +1038,7 @@ class PluginSyncService extends ChangeNotifier {
   Future<Map<String, dynamic>?> fetchSimilarItems(
     MediaServerClient client,
     String itemId, {
-    int limit = 30,
+    int limit = 100,
   }) async {
     final headers = _authHeaders(client);
     if (headers == null) return null;

--- a/lib/data/services/plugin_sync_service.dart
+++ b/lib/data/services/plugin_sync_service.dart
@@ -1035,6 +1035,29 @@ class PluginSyncService extends ChangeNotifier {
     return null;
   }
 
+  Future<Map<String, dynamic>?> fetchSimilarItems(
+    MediaServerClient client,
+    String itemId, {
+    int limit = 30,
+  }) async {
+    final headers = _authHeaders(client);
+    if (headers == null) return null;
+
+    try {
+      final response = await _dio.get(
+        '${client.baseUrl}/Moonfin/Items/$itemId/Similar',
+        queryParameters: {'limit': limit},
+        options: Options(headers: headers),
+      );
+      if (response.data is Map<String, dynamic>) {
+        return response.data as Map<String, dynamic>;
+      }
+    } catch (e) {
+      debugPrint('[PluginSyncService] fetchSimilarItems failed: $e');
+    }
+    return null;
+  }
+
   Future<dynamic> _fetchThemesPayload(MediaServerClient client) async {
     final headers = _authHeaders(client);
     if (headers == null) return null;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2432,7 +2432,8 @@ class RowDataSource {
     final prefs = GetIt.instance<UserPreferences>();
     final sourceType = prefs.get(UserPreferences.sinceYouWatchedSourceType);
     final sourceItemType = prefs.get(UserPreferences.sinceYouWatchedSourceItem);
-    final isLocal = prefs.get(UserPreferences.sinceYouWatchedSource) == SinceYouWatchedSource.local;
+    final source = prefs.get(UserPreferences.sinceYouWatchedSource);
+    final isLocal = source == SinceYouWatchedSource.local;
 
     final List<String> queryItemTypes;
     if (sourceItemType == SinceYouWatchedSourceItem.recentlyWatched) {
@@ -2575,13 +2576,65 @@ class RowDataSource {
     final baseItem = baseItems[sourceIdx];
     final baseItemName = baseItem.name;
 
-    final recommendedItems = await getRecommendations(
-      serverId: serverId,
-      baseItem: baseItem,
-      isLocal: isLocal,
-      candidateItemTypes: candidateItemTypes,
-      limit: 100,
-    );
+    List<AggregatedItem> recommendedItems = const [];
+    if (source == SinceYouWatchedSource.server) {
+      try {
+        final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
+        final parsed = _parseItems(data, serverId);
+
+        final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+        final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
+        final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+
+        recommendedItems = parsed.where((item) {
+          if (!effectiveIncludeWatched && item.isPlayed) return false;
+          if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
+          return true;
+        }).toList();
+      } catch (e) {
+        debugPrint('[RowDataSource] Server recommendation failed: $e');
+        recommendedItems = const [];
+      }
+    } else {
+      bool usedServerRecs = false;
+      if (isLocal) {
+        final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
+            ? GetIt.instance<PluginSyncService>()
+            : null;
+        if (pluginSync?.recommendationsSupported == true) {
+          try {
+            final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
+            final parsed = _parseItems(data, serverId);
+            final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+            final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
+            final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+
+            final filtered = parsed.where((item) {
+              if (!effectiveIncludeWatched && item.isPlayed) return false;
+              if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
+              return true;
+            }).toList();
+
+            if (filtered.isNotEmpty) {
+              recommendedItems = filtered;
+              usedServerRecs = true;
+            }
+          } catch (e) {
+            debugPrint('[RowDataSource] Moonbase server recommendation failed, falling back to local: $e');
+          }
+        }
+      }
+
+      if (!usedServerRecs) {
+        recommendedItems = await getRecommendations(
+          serverId: serverId,
+          baseItem: baseItem,
+          isLocal: isLocal,
+          candidateItemTypes: candidateItemTypes,
+          limit: 100,
+        );
+      }
+    }
 
     final rowId = 'sinceYouWatched$rowIndex';
     _scoredRecommendationsCache[rowId] = recommendedItems;

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2601,11 +2601,9 @@ class RowDataSource {
       }
     } else {
       bool usedServerRecs = false;
-      if (isLocal) {
-        final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
-            ? GetIt.instance<PluginSyncService>()
-            : null;
-        if (pluginSync != null && pluginSync.recommendationsSupported) {
+      if (isLocal && GetIt.instance.isRegistered<PluginSyncService>()) {
+        final pluginSync = GetIt.instance<PluginSyncService>();
+        if (pluginSync.recommendationsSupported) {
           try {
             final data = await pluginSync.fetchSimilarItems(
               _client,

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2581,7 +2581,7 @@ class RowDataSource {
       try {
         final data = await _client.itemsApi.getSimilarItems(
           baseItem.id,
-          limit: 30,
+          limit: 100,
           bypass: 'moonfin',
         );
         final parsed = _parseItems(data, serverId);
@@ -2610,7 +2610,7 @@ class RowDataSource {
             final data = await pluginSync.fetchSimilarItems(
               _client,
               baseItem.id,
-              limit: 30,
+              limit: 100,
             );
             if (data != null) {
               final parsed = _parseItems(data, serverId);

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2579,7 +2579,11 @@ class RowDataSource {
     List<AggregatedItem> recommendedItems = const [];
     if (source == SinceYouWatchedSource.server) {
       try {
-        final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
+        final data = await _client.itemsApi.getSimilarItems(
+          baseItem.id,
+          limit: 30,
+          bypass: 'moonfin',
+        );
         final parsed = _parseItems(data, serverId);
 
         final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
@@ -2601,23 +2605,29 @@ class RowDataSource {
         final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
             ? GetIt.instance<PluginSyncService>()
             : null;
-        if (pluginSync?.recommendationsSupported == true) {
+        if (pluginSync != null && pluginSync.recommendationsSupported) {
           try {
-            final data = await _client.itemsApi.getSimilarItems(baseItem.id, limit: 30);
-            final parsed = _parseItems(data, serverId);
-            final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
-            final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
-            final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+            final data = await pluginSync.fetchSimilarItems(
+              _client,
+              baseItem.id,
+              limit: 30,
+            );
+            if (data != null) {
+              final parsed = _parseItems(data, serverId);
+              final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
+              final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
+              final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
 
-            final filtered = parsed.where((item) {
-              if (!effectiveIncludeWatched && item.isPlayed) return false;
-              if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
-              return true;
-            }).toList();
+              final filtered = parsed.where((item) {
+                if (!effectiveIncludeWatched && item.isPlayed) return false;
+                if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
+                return true;
+              }).toList();
 
-            if (filtered.isNotEmpty) {
-              recommendedItems = filtered;
-              usedServerRecs = true;
+              if (filtered.isNotEmpty) {
+                recommendedItems = filtered;
+                usedServerRecs = true;
+              }
             }
           } catch (e) {
             debugPrint('[RowDataSource] Moonbase server recommendation failed, falling back to local: $e');

--- a/lib/data/services/row_data_source.dart
+++ b/lib/data/services/row_data_source.dart
@@ -2428,6 +2428,32 @@ class RowDataSource {
     return 3; // Default intermediate severity level
   }
 
+  /// Applies the row's watched and parental-rating rules. Both server paths
+  /// get their candidates back unfiltered, so the rule lives here rather than
+  /// in each of them.
+  List<AggregatedItem> _filterServerRecommendations(
+    List<AggregatedItem> candidates,
+    AggregatedItem baseItem,
+  ) {
+    final prefs = GetIt.instance<UserPreferences>();
+    final includeWatched = prefs.get(
+      UserPreferences.sinceYouWatchedIncludeWatched,
+    );
+    final applyRatingCap = prefs.get(
+      UserPreferences.recommendationsApplyParentalRatingCap,
+    );
+    final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
+
+    return candidates.where((item) {
+      if (!includeWatched && item.isPlayed) return false;
+      if (applyRatingCap &&
+          _getRatingLevel(item.officialRating) > sourceRatingLevel) {
+        return false;
+      }
+      return true;
+    }).toList();
+  }
+
   Future<HomeRow> loadSinceYouWatchedRow(String serverId, int rowIndex) async {
     final prefs = GetIt.instance<UserPreferences>();
     final sourceType = prefs.get(UserPreferences.sinceYouWatchedSourceType);
@@ -2584,17 +2610,10 @@ class RowDataSource {
           limit: 100,
           bypass: 'moonfin',
         );
-        final parsed = _parseItems(data, serverId);
-
-        final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
-        final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
-        final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
-
-        recommendedItems = parsed.where((item) {
-          if (!effectiveIncludeWatched && item.isPlayed) return false;
-          if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
-          return true;
-        }).toList();
+        recommendedItems = _filterServerRecommendations(
+          _parseItems(data, serverId),
+          baseItem,
+        );
       } catch (e) {
         debugPrint('[RowDataSource] Server recommendation failed: $e');
         recommendedItems = const [];
@@ -2611,16 +2630,10 @@ class RowDataSource {
               limit: 100,
             );
             if (data != null) {
-              final parsed = _parseItems(data, serverId);
-              final bool effectiveIncludeWatched = prefs.get(UserPreferences.sinceYouWatchedIncludeWatched);
-              final bool applyRatingCap = prefs.get(UserPreferences.recommendationsApplyParentalRatingCap);
-              final sourceRatingLevel = _getRatingLevel(baseItem.officialRating);
-
-              final filtered = parsed.where((item) {
-                if (!effectiveIncludeWatched && item.isPlayed) return false;
-                if (applyRatingCap && _getRatingLevel(item.officialRating) > sourceRatingLevel) return false;
-                return true;
-              }).toList();
+              final filtered = _filterServerRecommendations(
+                _parseItems(data, serverId),
+                baseItem,
+              );
 
               if (filtered.isNotEmpty) {
                 recommendedItems = filtered;

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1941,12 +1941,42 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> _loadSimilar() async {
     try {
       final item = _item;
-
       if (item != null && (item.type == 'Movie' || item.type == 'Series')) {
         try {
           final prefs = GetIt.instance<UserPreferences>();
           final sourceSetting = prefs.get(UserPreferences.recommendationSystemSource);
+
+          if (sourceSetting == RecommendationSystemSource.server) {
+            final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+            final items = (data['Items'] as List?) ?? [];
+            _similar = _mapItems(items);
+            _similarSource = SimilarSource.jellyfin;
+            return;
+          }
+
           final isLocal = sourceSetting == RecommendationSystemSource.local;
+
+          // Auto-detect server recommendations via Moonbase if "Moonfin Recommends" is selected
+          // and Moonbase announces recommendationsSupported.
+          if (isLocal) {
+            final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
+                ? GetIt.instance<PluginSyncService>()
+                : null;
+            if (pluginSync?.recommendationsSupported == true) {
+              try {
+                final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+                final items = (data['Items'] as List?) ?? [];
+                if (items.isNotEmpty) {
+                  _similar = _mapItems(items);
+                  _similarSource = SimilarSource.moonfin;
+                  return;
+                }
+              } catch (e) {
+                debugPrint('[ItemDetailViewModel] Moonbase server recommendation failed, falling back to local: $e');
+              }
+            }
+          }
+
           final serverId = _serverId ?? _client.baseUrl;
           final dataSource = GetIt.instance<RowDataSource>();
 
@@ -1957,7 +1987,6 @@ class ItemDetailViewModel extends ChangeNotifier {
             limit: 15,
             includeWatched: true,
           );
-
           // Only short-circuit when we actually have results. An empty list (e.g.
           // the online source without Seerr configured, or no local matches)
           // falls through to Jellyfin's similar-items below.

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1949,7 +1949,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           if (sourceSetting == RecommendationSystemSource.server) {
             final data = await _client.itemsApi.getSimilarItems(
               itemId,
-              limit: 15,
+              limit: 100,
               bypass: 'moonfin',
             );
             final items = (data['Items'] as List?) ?? [];
@@ -1971,7 +1971,7 @@ class ItemDetailViewModel extends ChangeNotifier {
                 final data = await pluginSync.fetchSimilarItems(
                   _client,
                   itemId,
-                  limit: 15,
+                  limit: 100,
                 );
                 final items = (data?['Items'] as List?) ?? [];
                 if (items.isNotEmpty) {
@@ -2009,7 +2009,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       }
 
       try {
-        final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+        final data = await _client.itemsApi.getSimilarItems(itemId, limit: 100);
         final items = (data['Items'] as List?) ?? [];
         _similar = _mapItems(items);
         _similarSource = SimilarSource.jellyfin;

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1962,11 +1962,9 @@ class ItemDetailViewModel extends ChangeNotifier {
 
           // Auto-detect server recommendations via Moonbase if "Moonfin Recommends" is selected
           // and Moonbase announces recommendationsSupported.
-          if (isLocal) {
-            final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
-                ? GetIt.instance<PluginSyncService>()
-                : null;
-            if (pluginSync != null && pluginSync.recommendationsSupported) {
+          if (isLocal && GetIt.instance.isRegistered<PluginSyncService>()) {
+            final pluginSync = GetIt.instance<PluginSyncService>();
+            if (pluginSync.recommendationsSupported) {
               try {
                 final data = await pluginSync.fetchSimilarItems(
                   _client,

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1947,7 +1947,11 @@ class ItemDetailViewModel extends ChangeNotifier {
           final sourceSetting = prefs.get(UserPreferences.recommendationSystemSource);
 
           if (sourceSetting == RecommendationSystemSource.server) {
-            final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
+            final data = await _client.itemsApi.getSimilarItems(
+              itemId,
+              limit: 15,
+              bypass: 'moonfin',
+            );
             final items = (data['Items'] as List?) ?? [];
             _similar = _mapItems(items);
             _similarSource = SimilarSource.jellyfin;
@@ -1962,10 +1966,14 @@ class ItemDetailViewModel extends ChangeNotifier {
             final pluginSync = GetIt.instance.isRegistered<PluginSyncService>()
                 ? GetIt.instance<PluginSyncService>()
                 : null;
-            if (pluginSync?.recommendationsSupported == true) {
+            if (pluginSync != null && pluginSync.recommendationsSupported) {
               try {
-                final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
-                final items = (data['Items'] as List?) ?? [];
+                final data = await pluginSync.fetchSimilarItems(
+                  _client,
+                  itemId,
+                  limit: 15,
+                );
+                final items = (data?['Items'] as List?) ?? [];
                 if (items.isNotEmpty) {
                   _similar = _mapItems(items);
                   _similarSource = SimilarSource.moonfin;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -397,13 +397,17 @@
   "@recommendationSystem": {
     "description": "Label for the Recommendation System setting"
   },
-  "recommendationSystemSubtitle": "Use the Moonfin Recommends local-library algorithm or the online TMDb's Similarity Metrics. Note: Online recommendations require Seerr integration.",
+  "recommendationSystemSubtitle": "Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb's Similarity Metrics. Note: Online recommendations require Seerr integration.",
   "@recommendationSystemSubtitle": {
     "description": "Explanation under the recommendation system setting"
   },
   "recommendationSystemMoonfin": "Moonfin Recommends",
   "@recommendationSystemMoonfin": {
     "description": "Recommendation system option: Moonfin Recommends"
+  },
+  "recommendationSystemJellyfin": "Jellyfin Recommends",
+  "@recommendationSystemJellyfin": {
+    "description": "Recommendation system option: Jellyfin Recommends"
   },
   "recommendationSystemTmdb": "TMDb Similarity",
   "@recommendationSystemTmdb": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -679,7 +679,7 @@ abstract class AppLocalizations {
   /// Explanation under the recommendation system setting
   ///
   /// In en, this message translates to:
-  /// **'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.'**
+  /// **'Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.'**
   String get recommendationSystemSubtitle;
 
   /// Recommendation system option: Moonfin Recommends
@@ -687,6 +687,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Moonfin Recommends'**
   String get recommendationSystemMoonfin;
+
+  /// Recommendation system option: Jellyfin Recommends
+  ///
+  /// In en, this message translates to:
+  /// **'Jellyfin Recommends'**
+  String get recommendationSystemJellyfin;
 
   /// Recommendation system option: TMDb Similarity
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -364,6 +364,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-ooreenkoms';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -364,6 +364,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'تشابه TMDb';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -364,6 +364,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рэкамендуе';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Падабенства TMDb';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -364,6 +364,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Сходство по TMDb';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -364,6 +364,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb সাদৃশ্য';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -364,6 +364,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Recomanacions Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitud de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -365,6 +365,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin doporučuje';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnost podle TMDb';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -364,6 +364,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Tebygrwydd TMDb';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -366,6 +366,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Anbefaler';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-lighed';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -364,6 +364,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Empfehlungen';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Ähnlichkeit';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -366,6 +366,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Προτάσεις Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ομοιότητα TMDb';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -358,10 +358,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get recommendationSystemSubtitle =>
-      'Use the Moonfin Recommends local-library algorithm or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
+      'Use the Moonfin Recommends local-library algorithm, Jellyfin Recommends server engine, or the online TMDb\'s Similarity Metrics. Note: Online recommendations require Seerr integration.';
 
   @override
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
+
+  @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
 
   @override
   String get recommendationSystemTmdb => 'TMDb Similarity';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -364,6 +364,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-simileco';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -364,6 +364,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitud de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -365,6 +365,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin soovitab';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb sarnasus';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -364,6 +364,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'شباهت TMDb';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -366,6 +366,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Suositukset';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Samankaltaisuus';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -364,6 +364,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin recommande';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similarité TMDb';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -364,6 +364,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Recomendacións Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similitude de TMDb';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -364,6 +364,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'דמיון TMDb';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -364,6 +364,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb समानता';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -364,6 +364,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb sličnost';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -364,6 +364,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin ajánlásai';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb hasonlóság';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -364,6 +364,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Kemiripan TMDb';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -364,6 +364,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Suggerimenti Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similarità TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -361,6 +361,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 類似度';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -364,6 +364,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin ұсынады';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ұқсастығы';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -364,6 +364,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ಸಾಮ್ಯತೆ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -362,6 +362,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin 추천';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 유사도';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -364,6 +364,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb panašumas';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -364,6 +364,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb līdzība';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -364,6 +364,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Сличност според TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -364,6 +364,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb സാമ്യത';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -364,6 +364,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-ийн ижил төстэй байдал';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -364,6 +364,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin anbefaler';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-likhet';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -365,6 +365,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Aanbeveling Moonfin';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-gelijkenis';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -364,6 +364,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ਸਮਾਨਤਾ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -364,6 +364,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin poleca';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobieństwo TMDb';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -364,6 +364,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recomenda';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similaridade TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -364,6 +364,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Similaritate TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -364,6 +364,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рекомендует';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Схожесть TMDb';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -364,6 +364,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin නිර්දේශ';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb සමානතාව';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -365,6 +365,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin odporúča';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnosť TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -365,6 +365,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin priporoča';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Podobnost TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -365,6 +365,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ngjashmëria TMDb';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -364,6 +364,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Мунфин (Moonfin) препоручује';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'ТМДБ (TMDb) сличност';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -364,6 +364,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb-likhet';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -364,6 +364,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Ufanano wa TMDb';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -364,6 +364,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin பரிந்துரைகள்';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ஒற்றுமை';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -364,6 +364,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin సిఫార్సులు';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb సారూప్యత';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -365,6 +365,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin แนะนำ';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'ความคล้ายคลึงจาก TMDb';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -365,6 +365,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Similarity';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -364,6 +364,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Önerileri';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb Benzerliği';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -364,6 +364,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb ئوخشاشلىقى';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -364,6 +364,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin рекомендує';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Схожість TMDb';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -364,6 +364,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Gợi ý';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'Độ tương đồng TMDb';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -361,6 +361,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin Recommends';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 相似度';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2860,7 +2860,6 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get trickplayFollowScrubPositionSubtitle => '预览画面跟随滑块沿进度条移动，而非固定居中';
-
   @override
   String get trickplayPauseWhileScrubbing => 'Pause While Scrubbing';
 

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -360,6 +360,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get recommendationSystemMoonfin => 'Moonfin 智能推荐';
 
   @override
+  String get recommendationSystemJellyfin => 'Jellyfin Recommends';
+
+  @override
   String get recommendationSystemTmdb => 'TMDb 相似影片推荐';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2860,6 +2860,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get trickplayFollowScrubPositionSubtitle => '预览画面跟随滑块沿进度条移动，而非固定居中';
+
   @override
   String get trickplayPauseWhileScrubbing => 'Pause While Scrubbing';
 

--- a/lib/preference/preference_constants.dart
+++ b/lib/preference/preference_constants.dart
@@ -269,6 +269,7 @@ enum DetailScreenStyle {
 /// Selectable algorithm source for similarity recommendation system.
 enum RecommendationSystemSource {
   local,
+  server,
   online;
 }
 
@@ -860,9 +861,14 @@ enum ScreensaverTimeout {
 
 enum SinceYouWatchedSource {
   local,
+  server,
   online;
 
-  String get displayName => this == local ? 'Local' : 'Online';
+  String get displayName => switch (this) {
+    SinceYouWatchedSource.local => 'Moonfin Recommends',
+    SinceYouWatchedSource.server => 'Jellyfin Recommends',
+    SinceYouWatchedSource.online => 'TMDb Similarity',
+  };
 }
 
 enum SinceYouWatchedSourceType {

--- a/lib/ui/screens/settings/home_row_toggles_screen.dart
+++ b/lib/ui/screens/settings/home_row_toggles_screen.dart
@@ -669,8 +669,8 @@ class _HomeRowTogglesScreenState extends State<HomeRowTogglesScreen> {
                   if (showSinceYouWatchedRows) ...[
                     EnumPreferenceTile<SinceYouWatchedSource>(
                       preference: UserPreferences.sinceYouWatchedSource,
-                      title: 'Source',
-                      description: "Choose recommendation source (the local-content-only Moonfin special or TMDB's similarity metric. Note: Online recommendations require Seerr integration).",
+                      title: 'Recommendation Source',
+                      description: "Choose recommendation source (Moonfin Recommends custom local algorithm, Jellyfin Recommends server engine, or TMDb's similarity metrics. Note: Online recommendations require Seerr integration).",
                       icon: Icons.source,
                       values: SinceYouWatchedSource.values,
                       labelOf: (v) => v.displayName,

--- a/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
+++ b/lib/ui/screens/settings/panel/details_screen_settings_screen.dart
@@ -155,6 +155,8 @@ class _DetailsScreenSettingsScreenState
                     labelOf: (v) => switch (v) {
                       RecommendationSystemSource.local =>
                         l10n.recommendationSystemMoonfin,
+                      RecommendationSystemSource.server =>
+                        l10n.recommendationSystemJellyfin,
                       RecommendationSystemSource.online =>
                         l10n.recommendationSystemTmdb,
                     },

--- a/packages/server_core/lib/src/api/items_api.dart
+++ b/packages/server_core/lib/src/api/items_api.dart
@@ -72,7 +72,11 @@ abstract class ItemsApi {
     String? fields,
   });
   Future<List<Map<String, dynamic>>> getAncestors(String itemId);
-  Future<Map<String, dynamic>> getSimilarItems(String itemId, {int? limit});
+  Future<Map<String, dynamic>> getSimilarItems(
+    String itemId, {
+    int? limit,
+    String? bypass,
+  });
 
   Future<Map<String, dynamic>> getNextUp({
     String? seriesId,

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -214,10 +214,15 @@ class EmbyItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getSimilarItems(
     String itemId, {
     int? limit,
+    String? bypass,
   }) async {
+    final params = <String, dynamic>{
+      'Limit': ?limit,
+      'bypass': ?bypass,
+    };
     final response = await _dio.get(
       '/Items/$itemId/Similar',
-      queryParameters: {'Limit': ?limit},
+      queryParameters: params,
     );
     return response.data as Map<String, dynamic>;
   }

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -192,10 +192,15 @@ class JellyfinItemsApi implements ItemsApi {
   Future<Map<String, dynamic>> getSimilarItems(
     String itemId, {
     int? limit,
+    String? bypass,
   }) async {
+    final params = <String, dynamic>{
+      'Limit': ?limit,
+      'bypass': ?bypass,
+    };
     final response = await _dio.get(
       '/Items/$itemId/Similar',
-      queryParameters: {'Limit': ?limit},
+      queryParameters: params,
     );
     return response.data as Map<String, dynamic>;
   }


### PR DESCRIPTION
# Pull Request

## Summary
JF12 did a lot of neat things with their recommendation system. This PR unifies the recommendation system source nomenclature across the Item Details screen and the "Since You Watched" home screen rows, introduces native support for Jellyfin 12's extensible similar items backend (`GET /Items/{id}/Similar`), and adds client-side capability auto-detection for server-backed recommendations via Moonbase with graceful fallback to local client scoring. What this means is that if Moonbase is installed and the server is running JF12, we can fully utilize the new pathing for super quick recommendation results without straining clients. If Moonbase isn't installed or the server is not on JF12 yet, we have the following fallbacks:

* JF 10.x + "Moonfin Recommends": Runs custom client-side scoring.
* JF 10.x + "Jellyfin Recommends": Runs Jellyfin 10's stock genre/tag similarity.
* JF 12 + "Moonfin Recommends" (with Moonbase updated): Automatically takes advantage of server-side scoring and disk caching.
* JF 12 + "Jellyfin Recommends": Uses Jellyfin 12's extensible provider system.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Recommendation Options Unification**: Unified the recommendation source options across both Item Details settings (**details_screen_settings_screen.dart**) and Since You Watched settings (**home_row_toggles_screen.dart**, **preference_constants.dart**) into three clear, standardized options:
  - **Moonfin Recommends** (Custom weighted algorithm)
  - **Jellyfin Recommends** (Native Jellyfin 12 extensible backend)
  - **TMDb Similarity** (Online TMDb API)
- **Jellyfin 12 Extensible Provider Support**: Added `server` source handling to **item_detail_view_model.dart** and **row_data_source.dart** calling native `GET /Items/{id}/Similar`, utilizing Jellyfin 12's extensible `ISimilarItemsProvider` pipeline and built-in server disk/memory caching (`TryReadSimilarItemsCacheAsync`).
- **Moonbase Capability Auto-Detection**: Enhanced **plugin_sync_service.dart** to detect `recommendationsSupported` from `/Moonfin/Ping`. When "Moonfin Recommends" is chosen and connected to a server running Moonbase with the similar items provider active, recommendations are automatically offloaded to the server for near-instant response times; if the server lacks the capability, returns empty, or encounters errors, it seamlessly falls back to our client-side Dart scoring algorithm with zero disruption.
- **Idempotent Database Migration**: Protected the schema migration in **offline_database.dart** so duplicate column checks on developer databases do not crash app initialization.
- **AggregatedItem Cleanup**: Removed duplicate `dateCreated` getter in **aggregated_item.dart** that was blocking test compilation.
- **Localization**: Added `recommendationSystemJellyfin` key to **app_en.arb** and regenerated localization files across all supported languages.

### 2nd Commit: Note a second commit was also made to this PR which does the following:
* Adds fetchSimilarItems to PluginSyncService calling `${client.baseUrl}/Moonfin/Items/$itemId/Similar`.
* Passes `bypass: 'moonfin'` when querying Jellyfin stock similarity.
* Updates ItemDetailViewModel and RowDataSource to route between the two endpoints.
Basically, Jellyfin treats its stock suggestions as a "fallback" only if a custom one isn't selected. Since we want to give an option, it is important to allow the fetch to bypass Moonfin's algorithm.

### 3rd Commit: Candidate Pool Scaling for Server-Side Recommendations
* In Jellyfin 12, `MovieSimilarItemsProvider` applies `Take(limit)` to raw candidate score matches *before* filtering by library membership and played status (`IsPlayed = false`). In real-world libraries where users have watched many relevant movies, low query limits (such as 30 for home rows or 15 on details pages) severely starve the candidate pool down to 1–4 items.
* Increases the server similarity query limit to `100` in **row_data_source.dart**, **item_detail_view_model.dart**, and **plugin_sync_service.dart**.
* Preserves bounded client-side candidate limits (`limit: 40` per genre/tag, `10` per person) for the pure local fallback when Moonbase is not installed, preventing heavy network payloads on client devices while ensuring server-backed recommendations deliver full, rich rows.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Details Screen -> Recommendation System Source.
2. Verify all three options ("Moonfin Recommends", "Jellyfin Recommends", "TMDb Similarity") are selectable and properly localized.
3. Navigate to Settings -> Home -> "Since you watched" Settings -> Recommendation Source.
4. Verify all three options match and switch correctly.
5. Open an item details screen under each source to verify recommendations load properly.
6. Verify "Since You Watched" home rows populate as expected.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previous Menus
<img width="250" alt="pre-detailspage" src="https://github.com/user-attachments/assets/e09a9c50-12e1-475c-9e9c-fa758cd0db31" />
<img width="250" alt="pre-sinceyouwatched" src="https://github.com/user-attachments/assets/531fb676-1b52-4259-8540-1f8823740dd0" />

### Post-PR Menus
<img width="2525" height="1514" alt="2026-09-08_10-05-31_moonfin" src="https://github.com/user-attachments/assets/5175442b-b27c-49cb-98c4-6e5c6c2fc159" />
<img width="2525" height="1514" alt="2026-09-08_10-05-52_moonfin" src="https://github.com/user-attachments/assets/3211c527-9b1f-4952-8dbe-266a59a35c1b" />

### Jellyfin Recommends Search Results (with filter for "include previous watched items" OFF)
<img width="2525" height="1514" alt="2026-09-08_10-08-17_moonfin" src="https://github.com/user-attachments/assets/5fb6827c-2e58-4ac5-9fea-003f52f6f090" />

### Jellyfin Recommends Search Results (with filter for "include previous watched items" ON)
<img width="2525" height="1514" alt="2026-09-08_10-06-28_moonfin" src="https://github.com/user-attachments/assets/e2757017-fac4-446d-88ec-b1039fa4dec2" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
