### PR TITLE
feat-homescreen - Add toggle and mirrored sizing for Modern cards on My Media row

### DIFF
--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -95,6 +95,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('homeRowsStyle', UserPreferences.homeRowsStyle, SyncCodec.enumName, enumValues: prefs.HomeRowsStyle.values),
   SyncedField('modernHomeRowsPadding', UserPreferences.modernHomeRowsPadding, SyncCodec.integer),
   SyncedField('classicHomeRowsPadding', UserPreferences.classicHomeRowsPadding, SyncCodec.integer),
+  SyncedField('modernCardsOnMyMediaRow', UserPreferences.modernCardsOnMyMediaRow, SyncCodec.boolean),
   SyncedField('recommendationSystemSource', UserPreferences.recommendationSystemSource, SyncCodec.enumName, enumValues: prefs.RecommendationSystemSource.values),
   SyncedField('detailScreenStyle', UserPreferences.detailScreenStyle, SyncCodec.enumName, enumValues: prefs.DetailScreenStyle.values),
   SyncedField('personalRatingStyle', UserPreferences.personalRatingStyle, SyncCodec.enumName, enumValues: prefs.PersonalRatingStyle.values),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9185,6 +9185,8 @@
   "homeRowTogglesDescription": "Enable the following toggles to display the rows in Home Sections.",
   "rowsType": "Row Type",
   "rowsTypeDescription": "Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.",
+  "modernCardsOnMyMediaRow": "Modern cards on My Media row",
+  "modernCardsOnMyMediaRowDescription": "Display customizable posters that expand on focus. Disable to always show landscape thumbnail.",
   "sortOrder": "Sort Order",
   "ascending": "Ascending",
   "descending": "Descending",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -17518,6 +17518,18 @@ abstract class AppLocalizations {
   /// **'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.'**
   String get rowsTypeDescription;
 
+  /// No description provided for @modernCardsOnMyMediaRow.
+  ///
+  /// In en, this message translates to:
+  /// **'Modern cards on My Media row'**
+  String get modernCardsOnMyMediaRow;
+
+  /// No description provided for @modernCardsOnMyMediaRowDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.'**
+  String get modernCardsOnMyMediaRowDescription;
+
   /// No description provided for @sortOrder.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -9843,6 +9843,13 @@ class AppLocalizationsAf extends AppLocalizations {
       'Klassiek hou per-ry beeldtipe en inligting-oorleg. Moderne gebruik portret-na-agtergrond-rye.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -9820,6 +9820,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'يحتفظ الإصدار الكلاسيكي بنوع الصورة وتراكب المعلومات لكل صف. يستخدم الحديث الصفوف العمودية للخلفية.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -9900,6 +9900,13 @@ class AppLocalizationsBe extends AppLocalizations {
       'Classic захоўвае тып выявы і накладанне інфармацыі для кожнага радка. У Modern выкарыстоўваюцца радкі з партрэтам на фон.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -9939,6 +9939,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Classic запазва типа на изображението на ред и наслагването на информация. Modern използва редове от портрет към фон.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -9823,6 +9823,13 @@ class AppLocalizationsBn extends AppLocalizations {
       'ক্লাসিক প্রতি-সারি ছবির ধরন এবং তথ্য ওভারলে রাখে। আধুনিক পোর্ট্রেট-টু-ব্যাকড্রপ সারি ব্যবহার করে।';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -9999,6 +9999,13 @@ class AppLocalizationsCa extends AppLocalizations {
       'El clàssic manté el tipus d\'imatge per fila i la superposició d\'informació. Modern utilitza files de retrat a fons.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Ordre de classificació';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -9873,6 +9873,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Classic zachovává typ obrázku na řádku a překryvné informace. Moderní používá řady na výšku na pozadí.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -9892,6 +9892,13 @@ class AppLocalizationsCy extends AppLocalizations {
       'Mae Classic yn cadw\'r math o ddelwedd fesul rhes a throshaen gwybodaeth. Mae Modern yn defnyddio rhesi portread-i-gefndir.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -9835,6 +9835,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Classic beholder billedtype og infooverlejring pr. række. Moderne bruger portræt-til-bagtæppe rækker.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -9999,6 +9999,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Classic behält den Bildtyp und die Informationsüberlagerung pro Zeile bei. Modern verwendet Hochformat-zu-Hintergrund-Reihen.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sortierreihenfolge';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -9993,6 +9993,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Το Classic διατηρεί τον τύπο εικόνας ανά σειρά και την επικάλυψη πληροφοριών. Το Modern χρησιμοποιεί σειρές από πορτραίτο σε φόντο.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9762,6 +9762,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Classic keeps per-row image type and info overlay. Modern uses portrait-to-backdrop rows.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -9827,6 +9827,13 @@ class AppLocalizationsEo extends AppLocalizations {
       'Klasika konservas po-vican bildspecon kaj informan tegmenton. Modernaj uzoj portret-al-fono vicoj.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -9946,6 +9946,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Classic mantiene el tipo de imagen por fila y la superposición de información. Modern utiliza filas de retrato a fondo.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -9851,6 +9851,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Classic säilitab reapõhise pilditüübi ja teabe ülekatte. Modern kasutab portree-taustadekoratsiooni ridu.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -9780,6 +9780,13 @@ class AppLocalizationsFa extends AppLocalizations {
       'کلاسیک نوع تصویر هر ردیف و همپوشانی اطلاعات را حفظ می کند. مدرن از ردیف های پرتره به پس زمینه استفاده می کند.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -9874,6 +9874,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Classic säilyttää rivikohtaisen kuvatyypin ja tietopeittokuvan. Moderni käyttää muotokuvasta taustaan -rivejä.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Lajittelujärjestys';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -9965,6 +9965,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Classique conserve la disposition classique en portrait. Moderne passe du portrait à la vignette au survol.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Ordre de tri';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -9971,6 +9971,13 @@ class AppLocalizationsGl extends AppLocalizations {
       'Clásico mantén o tipo de imaxe e a superposición de información por fila. Moderno usa filas de retrato a imaxe de fondo.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -9710,6 +9710,13 @@ class AppLocalizationsHe extends AppLocalizations {
       'קלאסי שומר על סוג תמונה ושכבת מידע לכל שורה. מודרני משתמש בשורות מפוסטר לתמונת רקע.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -9812,6 +9812,13 @@ class AppLocalizationsHi extends AppLocalizations {
       'क्लासिक में हर पंक्ति का इमेज टाइप और इन्फ़ो ओवरले बना रहता है। मॉडर्न पोर्ट्रेट-से-बैकड्रॉप पंक्तियों का उपयोग करता है।';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -10059,6 +10059,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Klasični zadržava vrstu slike po redu i informacijski sloj. Moderni koristi redove od portreta do pozadinske slike.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -9930,6 +9930,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'A klasszikus megtartja a soronkénti képtípust és az információs fedvényt. A modern állóképről háttérképre váltó sorokat használ.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -9841,6 +9841,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Klasik mempertahankan tipe gambar per baris dan overlay info. Modern menggunakan baris potret-ke-backdrop.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -9921,6 +9921,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Classico mantiene il tipo di immagine per riga e l\'overlay informativo. Moderno usa righe da verticale a sfondo.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Ordine';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9564,6 +9564,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'クラシックは行ごとの画像タイプと情報オーバーレイを維持します。モダンは縦長から横長へ変化する行を使用します。';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -9886,6 +9886,13 @@ class AppLocalizationsKk extends AppLocalizations {
       '«Классикалық» әр жолдың кескін түрі мен ақпарат қабатын сақтайды. «Заманауи» тік бағыттан фондық кескінге өтетін жолдарды пайдаланады.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -9906,6 +9906,13 @@ class AppLocalizationsKn extends AppLocalizations {
       'ಕ್ಲಾಸಿಕ್ ಪ್ರತಿ-ಸಾಲಿನ ಚಿತ್ರ ಪ್ರಕಾರ ಮತ್ತು ಮಾಹಿತಿ ಓವರ್‌ಲೇ ಅನ್ನು ಉಳಿಸಿಕೊಳ್ಳುತ್ತದೆ. ಮಾಡರ್ನ್ ಪೋರ್ಟ್ರೇಟ್-ನಿಂದ-ಬ್ಯಾಕ್‌ಡ್ರಾಪ್ ಸಾಲುಗಳನ್ನು ಬಳಸುತ್ತದೆ.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -9540,6 +9540,13 @@ class AppLocalizationsKo extends AppLocalizations {
       '클래식은 행별 이미지 유형과 정보 오버레이를 유지합니다. 모던은 세로형에서 가로형으로 이어지는 행을 사용합니다.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => '정렬 순서';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -9899,6 +9899,13 @@ class AppLocalizationsLt extends AppLocalizations {
       '„Classic“ išlaiko kiekvienos eilutės vaizdo tipą ir informacijos perdangą. Modernus naudoja portreto ir fono eilutes.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -9893,6 +9893,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Classic saglabā katras rindas attēla veidu un informācijas pārklājumu. Modern izmanto rindas no portreta uz fonu.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -9915,6 +9915,13 @@ class AppLocalizationsMk extends AppLocalizations {
       'Класичниот задржува тип на слика по ред и информативен слој. Модерниот користи редови од портрет до позадина.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -9956,6 +9956,13 @@ class AppLocalizationsMl extends AppLocalizations {
       'ക്ലാസിക് ഓരോ വരി ചിത്ര തരവും വിവര ഓവർലേയും നിലനിർത്തുന്നു. മോഡേൺ പോർട്രെയ്‌റ്റ്-ടു-ബാക്ക്‌ഡ്രോപ്പ് വരികൾ ഉപയോഗിക്കുന്നു.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -9862,6 +9862,13 @@ class AppLocalizationsMn extends AppLocalizations {
       'Сонгодог нь мөр бүрийн зургийн төрөл болон мэдээллийн давхаргыг хадгалдаг. Орчин үеийн загвар нь хөрөгөөс дэвсгэр рүү чиглэсэн мөрүүдийг ашигладаг.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -9837,6 +9837,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Klassisk beholder bildetype og infooverlegg per rad. Moderne bruker rader fra portrett til bakgrunnsbilde.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -9899,6 +9899,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Klassiek behoudt per rij het afbeeldingstype en de info-overlay. Modern gebruikt rijen die van portret naar achtergrond lopen.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sorteervolgorde';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -9799,6 +9799,13 @@ class AppLocalizationsPa extends AppLocalizations {
       'ਕਲਾਸਿਕ ਪ੍ਰਤੀ-ਕਤਾਰ ਚਿੱਤਰ ਕਿਸਮ ਅਤੇ ਜਾਣਕਾਰੀ ਓਵਰਲੇ ਰੱਖਦਾ ਹੈ। ਮਾਡਰਨ ਪੋਰਟਰੇਟ-ਤੋਂ-ਪਿਛੋਕੜ ਕਤਾਰਾਂ ਵਰਤਦਾ ਹੈ।';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -10118,6 +10118,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Klasyczny zachowuje osobny typ grafiki i nakładkę informacyjną dla każdej sekcji. Nowoczesny używa sekcji z grafikami przechodzącymi od pionowych do grafik tła.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Kolejność sortowania';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -9913,6 +9913,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Classic mantém o tipo de imagem por linha e a sobreposição de informações. Moderno usa linhas do retrato ao pano de fundo.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -9920,6 +9920,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Modul Clasic păstrează tipul de imagine și suprapunerea cu informații pentru fiecare rând. Modul Modern folosește rânduri de la portret la fundal.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -9919,6 +9919,13 @@ class AppLocalizationsRu extends AppLocalizations {
       '«Классический» сохраняет тип изображения для каждого ряда и информационный оверлей. «Современный» использует ряды с переходом от постера к фону.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -9831,6 +9831,13 @@ class AppLocalizationsSi extends AppLocalizations {
       'සම්භාව්‍ය මඟින් පේළියකට රූප වර්ගය සහ තොරතුරු උඩැතිරිය තබා ගනී. නවීන මඟින් සිරස්-සිට-පසුබිම පේළි භාවිත කරයි.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -9901,6 +9901,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Klasický zachováva typ obrázka a informačnú vrstvu pre každý riadok. Moderný používa riadky s prechodom z portrétu na pozadie.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -9899,6 +9899,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Klasični ohrani vrsto slike in informacijsko prekrivko za vsako vrstico. Sodobni uporablja vrstice s prehodom iz pokončne slike v ozadje.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -9925,6 +9925,13 @@ class AppLocalizationsSq extends AppLocalizations {
       'Klasik ruan llojin e imazhit për çdo rresht dhe mbishtresën e informacionit. Moderne përdor rreshta nga portreti te sfondi.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -10052,6 +10052,13 @@ class AppLocalizationsSr extends AppLocalizations {
       'Класични задржава врсту слике по реду и информациони слој. Модерни користи редове од портрета до позадинске слике.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -9855,6 +9855,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Klassisk behåller bildtyp per rad och infoöverlägg. Modern använder rader som går från stående format till bakgrundsbild.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -9916,6 +9916,13 @@ class AppLocalizationsSw extends AppLocalizations {
       'Klasiki huhifadhi aina ya picha ya kila safu na kifuniko cha maelezo. Kisasa hutumia safu za wima hadi mandharinyuma.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -9916,6 +9916,13 @@ class AppLocalizationsTa extends AppLocalizations {
       'கிளாசிக் ஒவ்வொரு வரிசைக்கும் படவகை மற்றும் தகவல் மேலடுக்கைத் தக்கவைக்கும். மாடர்ன் போர்ட்ரெய்ட்-டு-பேக்டிராப் வரிசைகளைப் பயன்படுத்தும்.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -9910,6 +9910,13 @@ class AppLocalizationsTe extends AppLocalizations {
       'క్లాసిక్ ప్రతి వరుస చిత్ర రకాన్ని మరియు సమాచార అతివ్యాప్తిని ఉంచుతుంది. ఆధునిక పోర్ట్రెయిట్-టు-బ్యాక్‌డ్రాప్ అడ్డు వరుసలను ఉపయోగిస్తుంది.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -9769,6 +9769,13 @@ class AppLocalizationsTh extends AppLocalizations {
       'Classic เก็บประเภทรูปภาพต่อแถวและการซ้อนทับข้อมูล สมัยใหม่ใช้แถวแนวตั้งเป็นฉากหลัง';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -9948,6 +9948,13 @@ class AppLocalizationsTl extends AppLocalizations {
       'Pinapanatili ng Classic ang per-row na uri ng larawan at info overlay. Gumagamit ang Modern ng mga portrait-to-backdrop na row.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -9848,6 +9848,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Klasik mod, satır başına görsel türünü ve bilgi katmanını korur. Modern mod ise dikey görsellerden yatay arka planlara uzanan satırlar kullanır.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sıralama Düzeni';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -9872,6 +9872,13 @@ class AppLocalizationsUg extends AppLocalizations {
       'كلاسسىك ھەر قۇرنىڭ رەسىم تىپى ۋە ئۇچۇر قاپلىمىسىنى ساقلايدۇ. زامانىۋى بوي پوستېردىن تەگلىككە ئۆتىدىغان قۇرلارنى ئىشلىتىدۇ.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -9920,6 +9920,13 @@ class AppLocalizationsUk extends AppLocalizations {
       'Classic зберігає тип зображення та накладення інформації для кожного рядка. У Modern використовуються рядки з портретом на фон.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -9837,6 +9837,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Classic giữ loại hình ảnh và lớp phủ thông tin trên mỗi hàng. Hiện đại sử dụng các hàng từ dọc đến phông nền.';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -9494,6 +9494,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get rowsTypeDescription => '「經典」保留逐行嘅圖片類型同資訊覆蓋層。「現代」用直度轉背景圖嘅列表。';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => 'Sort Order';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -9450,6 +9450,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get rowsTypeDescription => '经典模式保留每行的图片类型和信息浮层。现代模式使用竖版图到背景图的行布局。';
 
   @override
+  String get modernCardsOnMyMediaRow => 'Modern cards on My Media row';
+
+  @override
+  String get modernCardsOnMyMediaRowDescription =>
+      'Display customizable posters that expand on focus. Disable to always show landscape thumbnail.';
+
+  @override
   String get sortOrder => '排序顺序';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -484,6 +484,7 @@ class UserPreferences extends ChangeNotifier {
     'pref_home_rows_style',
     'pref_modern_home_rows_padding',
     'pref_classic_home_rows_padding',
+    'pref_modern_cards_my_media',
     'poster_size',
     'pref_display_favorites_rows',
     'pref_display_collections_rows',
@@ -972,6 +973,11 @@ class UserPreferences extends ChangeNotifier {
   static final classicHomeRowsPadding = Preference<int>(
     key: 'pref_classic_home_rows_padding',
     defaultValue: 30,
+  );
+
+  static final modernCardsOnMyMediaRow = Preference<bool>(
+    key: 'pref_modern_cards_my_media',
+    defaultValue: true,
   );
 
   /// How far a mouse wheel notch scrolls, as a percentage of what the platform

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -100,6 +100,14 @@ double classicHomeRowOverlayClipTop({
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
 
+  @visibleForTesting
+  static bool isRowModern(HomeRow row, UserPreferences prefs) =>
+      _ContentRowsState._isRowModern(row, prefs);
+
+  @visibleForTesting
+  static bool isModernMyMediaStatic(HomeRow row, UserPreferences prefs) =>
+      _ContentRowsState._isModernMyMediaStatic(row, prefs);
+
   @override
   Widget build(BuildContext context) {
     return const ResponsiveLayout(
@@ -2559,7 +2567,7 @@ class _ContentRowsState extends State<_ContentRows>
 
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
-    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
+    final isRowsV2 = _isRowModern(row, prefs);
     final fullScreenRows = _fullScreenRowsEnabled(prefs);
     final platformScale = _rowPlatformScale(row, desktopScale);
 
@@ -2647,8 +2655,7 @@ class _ContentRowsState extends State<_ContentRows>
     final defaultTop = _overlayBottom + 8.0;
     final row = rowIndex < widget.viewModel.rows.length ? widget.viewModel.rows[rowIndex] : null;
     if (row == null) return defaultTop;
-    final isRowsV2 = widget.prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-        !_isWideArtworkRow(row);
+    final isRowsV2 = _isRowModern(row, widget.prefs);
 
     final fullScreenRows = _fullScreenRowsEnabled(widget.prefs);
     if (fullScreenRows) {
@@ -3566,9 +3573,7 @@ class _ContentRowsState extends State<_ContentRows>
       return _libraryRowExtent(rowHeight, metadataScale: metadataScale);
     } else {
       final isSeerrRowOverride = _isSeerrFilterRow(row);
-      final isRowsV2 =
-          prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-          !_isWideArtworkRow(row);
+      final isRowsV2 = _isRowModern(row, prefs);
       final rowImageType = isSeerrRowOverride
           ? ImageType.thumb
           : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
@@ -3617,9 +3622,7 @@ class _ContentRowsState extends State<_ContentRows>
       final desktopScale = _desktopUiScaleFactor();
       final viewportHeight = MediaQuery.sizeOf(context).height;
       final safeTop = MediaQuery.paddingOf(context).top;
-      final isRowsV2 =
-          prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-          !_isWideArtworkRow(row);
+      final isRowsV2 = _isRowModern(row, prefs);
 
       final navbarIsTop =
           prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
@@ -4239,7 +4242,7 @@ class _ContentRowsState extends State<_ContentRows>
 
                     final contentHeight = _rowContentHeight(row, posterSize, prefs);
                     final targetExtent = rowExtents[rowIndex];
-                    final isRowsV2 = prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 && !_isWideArtworkRow(row);
+                    final isRowsV2 = _isRowModern(row, prefs);
                     final extraTopPadding = isRowsV2
                         ? ((targetExtent - contentHeight) * 0.1).clamp(0.0, double.infinity)
                         : ((targetExtent - contentHeight) / 2.0).clamp(0.0, double.infinity);
@@ -4543,12 +4546,13 @@ class _ContentRowsState extends State<_ContentRows>
       row.items,
     );
     final isSeerrRowOverride = _isSeerrFilterRow(row);
-    final isRowsV2 =
-        prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2 &&
-        !_isWideArtworkRow(row);
+    final isRowsV2 = _isRowModern(row, prefs);
+    final isModernMyMediaStatic = _isModernMyMediaStatic(row, prefs);
     final rowImageType = isSeerrRowOverride
         ? ImageType.thumb
-        : (isRowsV2 ? ImageType.poster : _homeRowImageTypeForRow(row, prefs));
+        : (isRowsV2
+            ? (isModernMyMediaStatic ? ImageType.thumb : ImageType.poster)
+            : _homeRowImageTypeForRow(row, prefs));
     final desktopScale = _desktopUiScaleFactor();
     final metadataScale = desktopScale;
     final platformScale = _rowPlatformScale(row, desktopScale);
@@ -4582,13 +4586,15 @@ class _ContentRowsState extends State<_ContentRows>
     double firstCardWidth = 0;
     if (isRowsV2) {
       maxCardHeight = v2ImageHeight + (v2MetadataHeightBudget * metadataScale);
-      firstCardWidth = v2PortraitWidth;
-      _prefetchV2RowLeadImage(
-        row: row,
-        v2ImageHeight: v2ImageHeight,
-        v2FocusedWidth: v2FocusedWidth,
-        useSeriesThumbs: useSeriesThumbs,
-      );
+      firstCardWidth = isModernMyMediaStatic ? v2FocusedWidth : v2PortraitWidth;
+      if (!isModernMyMediaStatic) {
+        _prefetchV2RowLeadImage(
+          row: row,
+          v2ImageHeight: v2ImageHeight,
+          v2FocusedWidth: v2FocusedWidth,
+          useSeriesThumbs: useSeriesThumbs,
+        );
+      }
     } else {
       for (final item in row.items) {
         final ar = _aspectRatioForRowItem(item, row, rowImageType);
@@ -4646,7 +4652,7 @@ class _ContentRowsState extends State<_ContentRows>
           final forceReveal = _forceRevealOnNextRowFocusFromMediaBar;
           _forceRevealOnNextRowFocusFromMediaBar = false;
           widget.onItemSelected(item);
-          if (isRowsV2 && !row.isAudio) {
+          if (isRowsV2 && !row.isAudio && !isModernMyMediaStatic) {
             _primeV2FocusedRatings(item);
             _prefetchV2FocusNeighbors(
               row: row,
@@ -4723,32 +4729,47 @@ class _ContentRowsState extends State<_ContentRows>
                     .clamp(v2PortraitWidth, v2ExtendedWidth)
                     .toDouble()
               : v2FocusedWidth;
-          final canUseExpandedV2Card = isRowsV2 && effectiveV2Focused && !row.isAudio;
+          final canUseExpandedV2Card =
+              isRowsV2 && effectiveV2Focused && !row.isAudio && !isModernMyMediaStatic;
 
           if (isRowsV2) {
-            ar = canUseExpandedV2Card ? v2FocusedAspect : v2PortraitAspect;
-            width = canUseExpandedV2Card
-                ? v2FocusedWidthForCurrentViewport
-                : v2PortraitWidth;
-            final posterUrl = _cachedRowImageUrl(
-              item,
-              imageApi,
-              v2ImageHeight,
-              ImageType.poster,
-              item.type == 'Episode' ? true : useSeriesThumbs,
-              requestScale,
-              isMyMediaRow: row.rowType == HomeRowType.libraryTiles,
-            );
-            imageUrl = canUseExpandedV2Card
-                ? (_resolveV2FocusedImageUrl(
-                        item,
-                        imageApi,
-                        v2ImageHeight,
-                        useSeriesThumbs,
-                        requestScale,
-                      ) ??
-                      posterUrl)
-                : posterUrl;
+            if (isModernMyMediaStatic) {
+              ar = v2FocusedAspect;
+              width = v2FocusedWidth;
+              imageUrl = _cachedRowImageUrl(
+                item,
+                imageApi,
+                v2ImageHeight,
+                ImageType.thumb,
+                false,
+                requestScale,
+                isMyMediaRow: true,
+              );
+            } else {
+              ar = canUseExpandedV2Card ? v2FocusedAspect : v2PortraitAspect;
+              width = canUseExpandedV2Card
+                  ? v2FocusedWidthForCurrentViewport
+                  : v2PortraitWidth;
+              final posterUrl = _cachedRowImageUrl(
+                item,
+                imageApi,
+                v2ImageHeight,
+                ImageType.poster,
+                item.type == 'Episode' ? true : useSeriesThumbs,
+                requestScale,
+                isMyMediaRow: row.rowType == HomeRowType.libraryTiles,
+              );
+              imageUrl = canUseExpandedV2Card
+                  ? (_resolveV2FocusedImageUrl(
+                          item,
+                          imageApi,
+                          v2ImageHeight,
+                          useSeriesThumbs,
+                          requestScale,
+                        ) ??
+                        posterUrl)
+                  : posterUrl;
+            }
           } else {
             final itemAr = _aspectRatioForRowItem(item, row, rowImageType);
             final itemHeight =
@@ -5284,6 +5305,23 @@ class _ContentRowsState extends State<_ContentRows>
       _isSeerrFilterRow(row) ||
       (row.rowType == HomeRowType.studios && row.id == 'studios');
 
+  static bool _isRowModern(HomeRow row, UserPreferences prefs) {
+    if (prefs.get(UserPreferences.homeRowsStyle) != HomeRowsStyle.v2) {
+      return false;
+    }
+    if (_isWideArtworkRow(row)) {
+      return false;
+    }
+    return true;
+  }
+
+  static bool _isModernMyMediaStatic(HomeRow row, UserPreferences prefs) {
+    return _isRowModern(row, prefs) &&
+        (row.rowType == HomeRowType.libraryTiles ||
+            row.rowType == HomeRowType.libraryTilesSmall) &&
+        !prefs.get(UserPreferences.modernCardsOnMyMediaRow);
+  }
+
   static String? _seerrTmdbImageUrl(String? path, int width) {
     if (path == null || path.isEmpty) return null;
     if (path.startsWith('http')) return path;
@@ -5597,6 +5635,11 @@ class _ContentRowsState extends State<_ContentRows>
     }
     if (row.rowType == HomeRowType.latestMedia && _isLatestMusicRow(row)) {
       return ImageType.poster;
+    }
+    if ((row.rowType == HomeRowType.libraryTiles ||
+            row.rowType == HomeRowType.libraryTilesSmall) &&
+        !prefs.get(UserPreferences.modernCardsOnMyMediaRow)) {
+      return ImageType.thumb;
     }
 
     if (prefs.get(UserPreferences.homeRowsUniversalOverride)) {

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -4581,12 +4581,21 @@ class _ContentRowsState extends State<_ContentRows>
               .clamp(v2PortraitWidth, double.infinity)
               .toDouble()
         : v2PortraitWidth;
+    // A phone caps a focused card at the row width, so the static My Media
+    // card has to use the capped number or it ends up wider than any focused
+    // card ever gets.
+    final v2FocusedWidthForCurrentViewport =
+        isRowsV2 && PlatformDetection.useMobileUi
+        ? v2FocusedWidth.clamp(v2PortraitWidth, v2ExtendedWidth).toDouble()
+        : v2FocusedWidth;
 
     double maxCardHeight = 0;
     double firstCardWidth = 0;
     if (isRowsV2) {
       maxCardHeight = v2ImageHeight + (v2MetadataHeightBudget * metadataScale);
-      firstCardWidth = isModernMyMediaStatic ? v2FocusedWidth : v2PortraitWidth;
+      firstCardWidth = isModernMyMediaStatic
+          ? v2FocusedWidthForCurrentViewport
+          : v2PortraitWidth;
       if (!isModernMyMediaStatic) {
         _prefetchV2RowLeadImage(
           row: row,
@@ -4723,19 +4732,13 @@ class _ContentRowsState extends State<_ContentRows>
                     ? isTouchFocused
                     : (isFocused || isHoverFocused))
               : isFocused;
-          final v2FocusedWidthForCurrentViewport =
-              isRowsV2 && PlatformDetection.useMobileUi
-              ? v2FocusedWidth
-                    .clamp(v2PortraitWidth, v2ExtendedWidth)
-                    .toDouble()
-              : v2FocusedWidth;
           final canUseExpandedV2Card =
               isRowsV2 && effectiveV2Focused && !row.isAudio && !isModernMyMediaStatic;
 
           if (isRowsV2) {
             if (isModernMyMediaStatic) {
               ar = v2FocusedAspect;
-              width = v2FocusedWidth;
+              width = v2FocusedWidthForCurrentViewport;
               imageUrl = _cachedRowImageUrl(
                 item,
                 imageApi,
@@ -5635,11 +5638,6 @@ class _ContentRowsState extends State<_ContentRows>
     }
     if (row.rowType == HomeRowType.latestMedia && _isLatestMusicRow(row)) {
       return ImageType.poster;
-    }
-    if ((row.rowType == HomeRowType.libraryTiles ||
-            row.rowType == HomeRowType.libraryTilesSmall) &&
-        !prefs.get(UserPreferences.modernCardsOnMyMediaRow)) {
-      return ImageType.thumb;
     }
 
     if (prefs.get(UserPreferences.homeRowsUniversalOverride)) {

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -1806,6 +1806,20 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
             _pushSyncSettings();
           },
         ),
+        if (_prefs.get(UserPreferences.homeRowsStyle) == HomeRowsStyle.v2) ...[
+          const Divider(),
+          SwitchListTile.adaptive(
+            secondary: const Icon(Icons.photo_library_outlined),
+            title: Text(l10n.modernCardsOnMyMediaRow),
+            subtitle: Text(l10n.modernCardsOnMyMediaRowDescription),
+            value: _prefs.get(UserPreferences.modernCardsOnMyMediaRow),
+            onChanged: (value) async {
+              await _prefs.set(UserPreferences.modernCardsOnMyMediaRow, value);
+              setState(() {});
+              _pushSyncSettings();
+            },
+          ),
+        ],
         const Divider(),
         SwitchListTile.adaptive(
           secondary: const Icon(Icons.merge_type),

--- a/lib/ui/screens/settings/panel/home_screen_category_screen.dart
+++ b/lib/ui/screens/settings/panel/home_screen_category_screen.dart
@@ -55,6 +55,19 @@ class _HomeScreenCategoryScreenState extends State<_HomeScreenCategoryScreen> {
                   setState(() {});
                 },
               ),
+              if (rowsStyle == HomeRowsStyle.v2)
+                SwitchPreferenceTile(
+                  preference: UserPreferences.modernCardsOnMyMediaRow,
+                  title: l10n.modernCardsOnMyMediaRow,
+                  subtitle: l10n.modernCardsOnMyMediaRowDescription,
+                  icon: Icons.photo_library_outlined,
+                  onChanged: () {
+                    _pushPersonalizationSync();
+                    _reloadHomeRows();
+                    if (!mounted) return;
+                    setState(() {});
+                  },
+                ),
               EnumPreferenceTile<PosterSize>(
                 preference: UserPreferences.posterSize,
                 title: l10n.cardSize,

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -107,6 +107,7 @@ void main() {
     'homeRowsStyle',
     'modernHomeRowsPadding',
     'classicHomeRowsPadding',
+    'modernCardsOnMyMediaRow',
     'imdbLowestRatedMoviesEnabled',
     'imdbMostPopularMoviesEnabled',
     'imdbMostPopularTvShowsEnabled',

--- a/test/ui/screens/home/modern_my_media_row_test.dart
+++ b/test/ui/screens/home/modern_my_media_row_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:moonfin/data/models/home_row.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/screens/home/home_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<UserPreferences> createPreferences({
+    HomeRowsStyle style = HomeRowsStyle.v2,
+    bool modernCardsOnMyMedia = true,
+  }) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'pref_home_rows_style': style.name,
+      'pref_modern_cards_my_media': modernCardsOnMyMedia,
+    });
+    final store = PreferenceStore();
+    await store.init();
+    return UserPreferences(store);
+  }
+
+  group('Modern My Media cards row behavior', () {
+    test('all rows are not modern when Classic layout is active', () async {
+      final prefs = await createPreferences(
+        style: HomeRowsStyle.v1,
+        modernCardsOnMyMedia: true,
+      );
+
+      const resumeRow = HomeRow(
+        id: 'resume',
+        title: 'Continue Watching',
+        rowType: HomeRowType.resume,
+      );
+      const myMediaRow = HomeRow(
+        id: 'libraryTiles',
+        title: 'My Media',
+        rowType: HomeRowType.libraryTiles,
+      );
+
+      expect(HomeScreen.isRowModern(resumeRow, prefs), isFalse);
+      expect(HomeScreen.isRowModern(myMediaRow, prefs), isFalse);
+      expect(HomeScreen.isModernMyMediaStatic(myMediaRow, prefs), isFalse);
+    });
+
+    test('My Media row uses modern layout with expansion when toggle is enabled in Modern style', () async {
+      final prefs = await createPreferences(
+        style: HomeRowsStyle.v2,
+        modernCardsOnMyMedia: true,
+      );
+
+      const resumeRow = HomeRow(
+        id: 'resume',
+        title: 'Continue Watching',
+        rowType: HomeRowType.resume,
+      );
+      const myMediaRow = HomeRow(
+        id: 'libraryTiles',
+        title: 'My Media',
+        rowType: HomeRowType.libraryTiles,
+      );
+
+      expect(HomeScreen.isRowModern(resumeRow, prefs), isTrue);
+      expect(HomeScreen.isRowModern(myMediaRow, prefs), isTrue);
+      expect(HomeScreen.isModernMyMediaStatic(myMediaRow, prefs), isFalse);
+    });
+
+    test('My Media row remains in modern layout with static mirrored thumbnails when toggle is disabled in Modern style', () async {
+      final prefs = await createPreferences(
+        style: HomeRowsStyle.v2,
+        modernCardsOnMyMedia: false,
+      );
+
+      const resumeRow = HomeRow(
+        id: 'resume',
+        title: 'Continue Watching',
+        rowType: HomeRowType.resume,
+      );
+      const myMediaRow = HomeRow(
+        id: 'libraryTiles',
+        title: 'My Media',
+        rowType: HomeRowType.libraryTiles,
+      );
+      const myMediaSmallRow = HomeRow(
+        id: 'libraryTilesSmall',
+        title: 'My Media',
+        rowType: HomeRowType.libraryTilesSmall,
+      );
+
+      // Sizing stays in modern engine to mirror the expanded thumbnail dimensions of the next rows
+      expect(HomeScreen.isRowModern(resumeRow, prefs), isTrue);
+      expect(HomeScreen.isRowModern(myMediaRow, prefs), isTrue);
+      expect(HomeScreen.isModernMyMediaStatic(myMediaRow, prefs), isTrue);
+      expect(HomeScreen.isModernMyMediaStatic(myMediaSmallRow, prefs), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Adds a user preference toggle `modernCardsOnMyMediaRow` (default `true`) under Home Screen settings when Modern row layout is active. When toggled off, My Media cards remain within the modern row layout engine and display static landscape artwork that mirrors the exact dimensions of the modern expanded focused thumbnail on neighboring rows across all card display sizes.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #354 
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/279

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Registered `modernCardsOnMyMediaRow` in **user_preferences.dart** and added to **synced_fields.dart**.
- Added conditional toggle to **home_sections_screen.dart** and **home_screen_category_screen.dart** visible when Home Rows Style is Modern.
- In **home_screen.dart**, kept My Media row within the modern layout engine when expansion is disabled; set card width to `v2FocusedWidth`, aspect ratio to 16:9, and requested `ImageType.thumb` landscape artwork to mirror neighboring focused thumbnails.
- Generated localization across all supported locales in **app_en.arb** and **app_localizations_*.dart**.
- Added comprehensive unit tests in **modern_my_media_row_test.dart** and updated **synced_fields_test.dart**.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. In Settings, verify "Modern cards on My Media row" setting exists under Home Screen settings.
2. With Modern Home Rows enabled, disable "Modern cards on My Media row".
3. Verify My Media row displays wide landscape posters sized to match the modern focus thumbnail overlay.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-08_20-58-27" src="https://github.com/user-attachments/assets/7f42794a-312d-4c14-95c7-1f18432a8d50" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-08_20-58-47" src="https://github.com/user-attachments/assets/407273da-8972-48b3-a936-a830809d1d4e" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
