### PR TITLE
Fixed Pagination of initial load of homescreen

### DIFF
--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -52,7 +52,7 @@ class FavoritesScreen extends StatefulWidget {
   State<FavoritesScreen> createState() => _FavoritesScreenState();
 }
 
-class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMixin<FavoritesScreen> {
+class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMixin<FavoritesScreen>, WidgetsBindingObserver{
   late final FavoritesViewModel _vm;
   final _scrollController = ScrollController();
   final _prefs = GetIt.instance<UserPreferences>();
@@ -77,6 +77,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
     _vm.addListener(_onChanged);
     _vm.load();
     _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addObserver(this);
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
       if (mounted) setState(() => _backdropUrl = url);
     });
@@ -86,6 +87,8 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
 
   @override
   void dispose() {
+    _resizeCheckDebounce?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
     _backgroundSub?.cancel();
     _scrollController.dispose();
     _vm.removeListener(_onChanged);
@@ -94,6 +97,20 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
     _tabsFocusNode.dispose();
     disposeGridFocusNodes();
     super.dispose();
+  }
+
+  Timer? _resizeCheckDebounce;
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    _resizeCheckDebounce?.cancel();
+    _resizeCheckDebounce = Timer(const Duration(milliseconds: 150), () {
+      if (!mounted) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _onScroll();
+      });
+    });
   }
 
   int _lastGridItemsLength = 0;
@@ -136,6 +153,9 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
   void _onChanged() {
     if (mounted) setState(() {});
     _maybeBumpGridVersion();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _onScroll();
+    });
   }
 
   void _onItemFocused(AggregatedItem item) {
@@ -156,6 +176,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
       }
     }
   }
+
 
   double _cardWidth() {
     final desktopScale = _desktopUiScaleFactor();

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -52,7 +52,8 @@ class FavoritesScreen extends StatefulWidget {
   State<FavoritesScreen> createState() => _FavoritesScreenState();
 }
 
-class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMixin<FavoritesScreen>, WidgetsBindingObserver{
+class _FavoritesScreenState extends State<FavoritesScreen>
+    with GridFocusNodeMixin<FavoritesScreen>, WidgetsBindingObserver {
   late final FavoritesViewModel _vm;
   final _scrollController = ScrollController();
   final _prefs = GetIt.instance<UserPreferences>();
@@ -176,7 +177,6 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
       }
     }
   }
-
 
   double _cardWidth() {
     final desktopScale = _desktopUiScaleFactor();

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1304,6 +1304,7 @@ class _ContentRowsState extends State<_ContentRows>
     HardwareKeyboard.instance.removeHandler(_handleGlobalHardwareKey);
     _audioArbiter.unregister(this);
     appRouter.routerDelegate.removeListener(_onRouteChanged);
+    _resizeCheckDebounce?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     if (PlatformDetection.isDesktop) {
       windowManager.removeListener(this);
@@ -2538,7 +2539,10 @@ class _ContentRowsState extends State<_ContentRows>
     });
   }
 
+  static const double _loadMoreTriggerDistance = 600.0;
+
   Timer? _resizeCheckDebounce;
+
   @override
   void didChangeMetrics() {
     super.didChangeMetrics();
@@ -2550,7 +2554,6 @@ class _ContentRowsState extends State<_ContentRows>
       });
     });
   }
-  static double _loadMoreTriggerDistance = 600.0;
 
   void _onRowScrolled(String rowId, ScrollController controller) {
     if (!controller.hasClients) return;
@@ -2571,9 +2574,7 @@ class _ContentRowsState extends State<_ContentRows>
 
   void _checkAllRowsFillViewport() {
     for (final entry in _rowHorizontalControllers.entries) {
-      final controller = entry.value;
-      if (!controller.hasClients) continue;
-      _maybeLoadMoreForRow(entry.key, controller);
+      _maybeLoadMoreForRow(entry.key, entry.value);
     }
   }
 

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -1191,6 +1191,9 @@ class _ContentRowsState extends State<_ContentRows>
     _invalidateStaticRowHeightCache();
     _updateOffsets();
     if (mounted) setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _checkAllRowsFillViewport();
+    });
   }
 
   void _onMediaBarStateChanged() {
@@ -2528,19 +2531,49 @@ class _ContentRowsState extends State<_ContentRows>
         initialScrollOffset: _rowHorizontalOffsetsById[rowId] ?? 0.0,
       );
       controller.addListener(() => _onRowScrolled(rowId, controller));
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _maybeLoadMoreForRow(rowId, controller);
+      });
       return controller;
     });
   }
 
+  Timer? _resizeCheckDebounce;
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+    _resizeCheckDebounce?.cancel();
+    _resizeCheckDebounce = Timer(const Duration(milliseconds: 150), () {
+      if (!mounted) return;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _checkAllRowsFillViewport();
+      });
+    });
+  }
+  static double _loadMoreTriggerDistance = 600.0;
+
   void _onRowScrolled(String rowId, ScrollController controller) {
     if (!controller.hasClients) return;
     _rowHorizontalOffsetsById[rowId] = controller.offset;
-    const loadMoreTriggerDistance = 600.0;
-    final remaining =
-        controller.position.maxScrollExtent - controller.offset;
-    if (remaining <= loadMoreTriggerDistance) {
-      final index = widget.viewModel.rows.indexWhere((r) => r.id == rowId);
-      if (index >= 0) widget.viewModel.loadMoreForRow(index);
+    _maybeLoadMoreForRow(rowId, controller);
+  }
+
+  void _maybeLoadMoreForRow(String rowId, ScrollController controller) {
+    if (!controller.hasClients) return;
+    final rowIndex = widget.viewModel.rows.indexWhere((r) => r.id == rowId);
+    if (rowIndex < 0) return;
+    if (!widget.viewModel.rows[rowIndex].hasMore) return;
+    final remaining = controller.position.maxScrollExtent - controller.offset;
+    if (remaining <= _loadMoreTriggerDistance) {
+      widget.viewModel.loadMoreForRow(rowIndex);
+    }
+  }
+
+  void _checkAllRowsFillViewport() {
+    for (final entry in _rowHorizontalControllers.entries) {
+      final controller = entry.value;
+      if (!controller.hasClients) continue;
+      _maybeLoadMoreForRow(entry.key, controller);
     }
   }
 

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -53,6 +53,7 @@ class HomeViewModel extends ChangeNotifier {
   final HomeRowCacheStore _cacheStore = HomeRowCacheStore();
   final Set<String> _inFlightPagingRowIds = {};
   final Map<String, int> _rowOffsets = {};
+  final Set<String> _rowsPagedThisLoad = {};
 
   /// How many items a row asks for per page, matching what RowDataSource
   /// requests so the offsets tracked here stay in step with it.
@@ -333,6 +334,19 @@ class HomeViewModel extends ChangeNotifier {
     required bool hasVisibleRow,
   }) => (preserveExisting || hydratedFromCache) && hasVisibleRow;
 
+  /// Whether a freshly fetched row gives way to the one already on screen.
+  ///
+  /// A section fetch only brings back the first page, so a row that paged while
+  /// it was out would lose those pages and be handed straight back to the
+  /// viewport to page in again. A row nobody paged takes the shorter answer,
+  /// since that is how an item leaving a row reaches the screen.
+  @visibleForTesting
+  static bool keepsPagedRow({
+    required bool pagedDuringLoad,
+    required int existingItemCount,
+    required int freshItemCount,
+  }) => pagedDuringLoad && existingItemCount > freshItemCount;
+
   /// Whether the home has to load again because the server came back.
   ///
   /// Rows built while it was unreachable came from the downloads catalog, so
@@ -358,6 +372,7 @@ class HomeViewModel extends ChangeNotifier {
     notifyListeners();
     _rowOffsets.clear();
     _multiServerRepo.clearOffsets();
+    _rowsPagedThisLoad.clear();
     try {
       var hydratedFromCache = false;
       if (_rows.isEmpty) {
@@ -544,24 +559,25 @@ class HomeViewModel extends ChangeNotifier {
         // Cleanup runs even when the load failed, so the section's loading
         // placeholder is cleared instead of spinning forever.
         final loadedRows = sectionRows
-          .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
-          .where(
-            (r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv,
-          )
-          .map((freshRow) {
-            final existing = _rows.firstWhereOrNull((r) => r.id == freshRow.id);
-            // If pagination already advanced this row past the freshly-fetched
-            // first page (e.g. a background full refresh landing after the user
-            // scrolled or the viewport auto-loaded more), keep the paginated
-            // version rather than regressing it.
-            if (existing != null &&
-                !existing.isLoading &&
-                existing.items.length > freshRow.items.length) {
-              return existing;
-            }
-            return freshRow;
-          })
-          .toList();
+            .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
+            .where(
+              (r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv,
+            )
+            .map((freshRow) {
+              final existing = _rows.firstWhereOrNull(
+                (r) => r.id == freshRow.id,
+              );
+              if (existing == null) return freshRow;
+              if (keepsPagedRow(
+                pagedDuringLoad: _rowsPagedThisLoad.contains(freshRow.id),
+                existingItemCount: existing.items.length,
+                freshItemCount: freshRow.items.length,
+              )) {
+                return existing;
+              }
+              return freshRow;
+            })
+            .toList();
         final placeholder = _placeholderForConfig(cfg);
         final loadedIds = loadedRows.map((r) => r.id).toSet();
         // Find the row that immediately follows this section's placeholder /
@@ -608,7 +624,6 @@ class HomeViewModel extends ChangeNotifier {
           }
         }
         _rows = newRows;
-        print('[loadConfigItem] cfg=${cfg.stableId} replaced rowIds=${loadedIds} at ${DateTime.now()}');
         notifyListeners();
       }
 
@@ -927,6 +942,7 @@ class HomeViewModel extends ChangeNotifier {
     if (!row.hasMore || _inFlightPagingRowIds.contains(row.id)) return;
 
     _inFlightPagingRowIds.add(row.id);
+    _rowsPagedThisLoad.add(row.id);
     try {
       final seerrType = _seerrRowTypeForId(row.id);
       if (seerrType != null) {

--- a/lib/ui/screens/home/home_view_model.dart
+++ b/lib/ui/screens/home/home_view_model.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get_it/get_it.dart';
 import 'package:server_core/server_core.dart';
+import 'package:collection/collection.dart';
 
 import '../../../data/models/aggregated_item.dart';
 import '../../../data/models/aggregated_library.dart';
@@ -543,11 +544,24 @@ class HomeViewModel extends ChangeNotifier {
         // Cleanup runs even when the load failed, so the section's loading
         // placeholder is cleared instead of spinning forever.
         final loadedRows = sectionRows
-            .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
-            .where(
-              (r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv,
-            )
-            .toList();
+          .map((r) => r.copyWith(items: _filterEmptyElements(r.items)))
+          .where(
+            (r) => r.items.isNotEmpty || r.rowType == HomeRowType.liveTv,
+          )
+          .map((freshRow) {
+            final existing = _rows.firstWhereOrNull((r) => r.id == freshRow.id);
+            // If pagination already advanced this row past the freshly-fetched
+            // first page (e.g. a background full refresh landing after the user
+            // scrolled or the viewport auto-loaded more), keep the paginated
+            // version rather than regressing it.
+            if (existing != null &&
+                !existing.isLoading &&
+                existing.items.length > freshRow.items.length) {
+              return existing;
+            }
+            return freshRow;
+          })
+          .toList();
         final placeholder = _placeholderForConfig(cfg);
         final loadedIds = loadedRows.map((r) => r.id).toSet();
         // Find the row that immediately follows this section's placeholder /
@@ -594,6 +608,7 @@ class HomeViewModel extends ChangeNotifier {
           }
         }
         _rows = newRows;
+        print('[loadConfigItem] cfg=${cfg.stableId} replaced rowIds=${loadedIds} at ${DateTime.now()}');
         notifyListeners();
       }
 

--- a/test/ui/screens/home/home_paged_row_refresh_test.dart
+++ b/test/ui/screens/home/home_paged_row_refresh_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/screens/home/home_view_model.dart';
+
+void main() {
+  // Getting this wrong is visible either way. Keep too much and an item the
+  // user removed sits on the row for the rest of the session, keep too little
+  // and the row loses its pages, refills, and flickers doing it.
+  group('a section landing on top of a row', () {
+    bool keeps({
+      bool pagedDuringLoad = true,
+      int existing = 45,
+      int fresh = 15,
+    }) => HomeViewModel.keepsPagedRow(
+      pagedDuringLoad: pagedDuringLoad,
+      existingItemCount: existing,
+      freshItemCount: fresh,
+    );
+
+    test('leaves a row that paged while the fetch was out alone', () {
+      expect(keeps(), isTrue);
+    });
+
+    test('takes a shorter answer for a row that did not page', () {
+      expect(keeps(pagedDuringLoad: false), isFalse);
+    });
+
+    test('takes a fetch that is not short', () {
+      expect(keeps(existing: 45, fresh: 45), isFalse);
+      expect(keeps(existing: 45, fresh: 60), isFalse);
+      expect(keeps(existing: 0, fresh: 15), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
When the app is initially opened or the window is resized, rows now check whether they already fill the available space and, if not, call the same load-more logic that previously only ran on manual scroll, so a wide/tall window no longer shows short rows until the user happens to scroll them.

This also surfaced and fixed a pre-existing bug where a row's items could load, then briefly disappear, then reload. The root cause was a race between the initial (cache-then-network) home load and row pagination: if pagination ran on a row while its section's background network refresh was still in flight, the network refresh would land afterward and silently overwrite the paginated row with a fresh, shorter first page; which then re-triggered pagination again, repeating indefinitely. `loadConfigItem` now keeps the paginated version of a row instead of regressing it when this race occurs.

The same fill-on-load/resize behavior has been added to the Favorites screen.

## Related Issues
No current open issues.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- **Home screen (`home_screen.dart`):** rows now check on initial layout, on window resize (debounced), and after data refreshes whether they need more items to fill the viewport, reusing the existing scroll-triggered load-more logic instead of duplicating it.
- **Home screen (`home_view_model.dart`):** fixed a race in `loadConfigItem` where a background section refresh could overwrite a row that pagination had already advanced, resetting it to a shorter first page and causing items to flicker (load → disappear → reload). The fix keeps the already-paginated row instead of regressing it when this happens.
- **Favorites screen (`favorites_screen.dart`):** added the same initial-load and resize-triggered fill check as the home screen, so the favorites grid also loads enough items to fill large windows without requiring a manual scroll.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Build and launch on a large monitor / wide window; confirm home rows and the favorites grid fill the available width on first launch without needing to scroll.
2. Resize the window larger after launch; confirm rows load additional items to fill the new space.
3. Watch a row that initially has fewer items than its total (e.g. a "Recently Added" row); confirm items no longer flicker (load, disappear, reload) shortly after launch.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced