### PR TITLE
fix(windows): pin sqlite3_flutter_libs to bundle sqlite3.dll

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1913,10 +1913,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0+eol"
+    version: "0.5.42"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   path_provider: ^2.1.5
   permission_handler: ^12.0.1
   drift: ^2.28.2
-  sqlite3_flutter_libs: ^0.6.0
+  sqlite3_flutter_libs: 0.5.42
   sqlite3: ^2.7.0
 
   # Media Playback (Android, desktop and web. Apple runs on AetherEngine)


### PR DESCRIPTION
# Pull Request

## Summary
Resolves issue #1469 where Moonfin fails to open a window on older Windows 10 releases (such as Windows 10 1909 and older Enterprise/LTSC builds) by restoring `sqlite3.dll` compilation and bundling in the Windows application package. When `sqlite3_flutter_libs` was updated to `0.6.0+eol` in commit `51275af6`, upstream removed all native build scripts in preparation for `package:sqlite3` 3.x. However, because Moonfin-Core remains on `package:sqlite3` 2.x, this dropped `sqlite3_flutter_libs` from CMake's plugin list and left the Windows desktop package without a bundled `sqlite3.dll`.

On older Windows 10 releases, the system-supplied `winsqlite3.dll` fallback is older than SQLite 3.29 and lacks `sqlite3_stmt_isexplain`, throwing an unhandled FFI symbol lookup error (code 127) during startup before `window_manager.show()` can be called. Pinning `sqlite3_flutter_libs` to `0.5.42` restores the CMake build step that compiles SQLite 3.52.0 and bundles `sqlite3.dll` directly alongside `moonfin.exe` for both x64 and ARM64 targets.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1469 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [X] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **pubspec.yaml** / **pubspec.lock**: Pin `sqlite3_flutter_libs` to `0.5.42` to ensure `sqlite3.dll` is compiled and packaged into Windows desktop builds.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [X] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Verified that `sqlite3.dll` (SQLite 3.52.0) and `sqlite3_flutter_libs_plugin.dll` are compiled and installed into `build\windows\x64\runner\Debug\` by CMake.
2. Verified clean startup and window display on Windows desktop.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

N/A (Fixes background startup crash where window failed to appear).

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
