### PR TITLE
fix escape handling when player is active

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -624,10 +624,12 @@ class _GlobalShortcutScopeState extends State<_GlobalShortcutScope>
   }
 
   bool _isPlayerRoute() {
-    final path = appRouter.routerDelegate.currentConfiguration.uri.path;
+    final matches = appRouter.routerDelegate.currentConfiguration.matches;
+    if (matches.isEmpty) return false;
+    final path = matches.last.matchedLocation;
     return path.startsWith('/player/') ||
-        path == '/live-tv/player' ||
-        path.startsWith('/game-player/');
+      path == '/live-tv/player' ||
+      path.startsWith('/game-player/');
   }
 
   bool _isHomeRoute() {


### PR DESCRIPTION
_isPlayerRoute always returns false
appRouter.routerDelegate.currentConfiguration.uri.path is alwaays /home

appRouter.routerDelegate.currentConfiguration.matches contains /player/

# Pull Request

## Summary
Change the _isPlayerRoute method to consider the currentConfiguration.matches instead of uri.path. I added some instrumentation to the method like this:
```
ServerLog.emit(
  'navigation',
  ServerLogLevel.debug,
  '========== ROUTER CONFIGURATION ==========\n'
  'configuration.runtimeType=${configuration.runtimeType}\n'
  'configuration=$configuration\n'
  'uri=${configuration.uri}\n'
  'uri.path=${configuration.uri.path}\n'
  'uri.query=${configuration.uri.query}\n'
  'uri.fragment=${configuration.uri.fragment}\n'
  'matches.length=${configuration.matches.length}\n'
  'matches:',
);
                                                             
for (var i = 0; i < configuration.matches.length; i++) {
  final match = configuration.matches[i];
                                                             
  ServerLog.emit(
    'navigation',
    ServerLogLevel.debug,
    'MATCH[$i]: '
    'runtimeType=${match.runtimeType} '
    'matchedLocation=${match.matchedLocation} '
    'match=$match',
  );
}
```

I see something like this:
> 2026-09-09T00:18:35.299708 DEBUG [general] ========== ROUTER CONFIGURATION ==========
> configuration.runtimeType=RouteMatchList
> configuration=Instance of 'RouteMatchList'
> uri=/home
> uri.path=/home
> uri.query=
> uri.fragment=
> matches.length=3
> matches:
> 2026-09-09T00:18:35.299716 DEBUG [general] MATCH[0]: runtimeType=RouteMatch matchedLocation=/home match=Instance of 'RouteMatch'
> 2026-09-09T00:18:35.299723 DEBUG [general] MATCH[1]: runtimeType=ImperativeRouteMatch matchedLocation=/item/ee6ba08d8e79f4a1e5e5de1445ca1629 match=Instance of 'ImperativeRouteMatch'
> 2026-09-09T00:18:35.299728 DEBUG [general] MATCH[2]: runtimeType=ImperativeRouteMatch matchedLocation=/player/video match=Instance of 'ImperativeRouteMatch'


## Related Issues
- Fixes #1440


## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
-  Use currentConfiguration.matches instead of uri.path

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [X] macOS
- [X] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start playing content
2. Enable full screen (either press F shortcut or click the button)
3. Press the escape key

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
