### PR TITLE
feat: improve audiobook player layout

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -9761,6 +9761,7 @@
   "audiobookTimeline": "Timeline",
   "audiobookTimelineEmpty": "Timeline is empty",
   "audiobookFocusedTimeline": "Focused Timeline",
+  "audiobookFullTimeline": "Full Timeline",
   "audiobookExportBookmarks": "Export Bookmarks",
   "audiobookExportNotes": "Export Notes",
   "audiobookExportAll": "Export All",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -19288,6 +19288,12 @@ abstract class AppLocalizations {
   /// **'Focused Timeline'**
   String get audiobookFocusedTimeline;
 
+  /// No description provided for @audiobookFullTimeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Full Timeline'**
+  String get audiobookFullTimeline;
+
   /// No description provided for @audiobookExportBookmarks.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -10934,6 +10934,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Gefokusde tydlyn';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Voer boekmerke uit';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -10911,6 +10911,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get audiobookFocusedTimeline => 'المخطط الزمني المركّز';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'تصدير الإشارات المرجعية';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -10998,6 +10998,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Сфакусаваная шкала';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Экспартаваць закладкі';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -11037,6 +11037,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Фокусирана хронология';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Експортиране на отметките';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -10913,6 +10913,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get audiobookFocusedTimeline => 'নির্দিষ্ট টাইমলাইন';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'বুকমার্ক এক্সপোর্ট করুন';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -11102,6 +11102,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Cronologia enfocada';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exporta els marcadors';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -10971,6 +10971,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Přiblížená časová osa';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportovat záložky';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -10990,6 +10990,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Llinell Amser â Ffocws';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Allforio\'r Nodau Tudalen';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -10925,6 +10925,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokuseret tidslinje';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksportér bogmærker';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -11097,6 +11097,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokussierte Zeitleiste';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Lesezeichen exportieren';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -11095,6 +11095,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Εστιασμένο χρονολόγιο';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Εξαγωγή σελιδοδεικτών';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -10849,6 +10849,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Export Bookmarks';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -10920,6 +10920,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokusita templinio';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksporti legosignojn';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -11044,6 +11044,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Cronología centrada';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportar marcadores';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -10944,6 +10944,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Kitsendatud ajajoon';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Ekspordi järjehoidjad';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -10870,6 +10870,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get audiobookFocusedTimeline => 'خط زمانی متمرکز';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'برون‌بری نشانک‌ها';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -10967,6 +10967,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Rajattu aikajana';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Vie kirjanmerkit';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -11066,6 +11066,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Chronologie ciblée';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exporter les marque-pages';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -11071,6 +11071,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Cronoloxía enfocada';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportar os marcadores';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -10791,6 +10791,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get audiobookFocusedTimeline => 'ציר זמן ממוקד';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ייצוא סימניות';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -10905,6 +10905,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get audiobookFocusedTimeline => 'केंद्रित टाइमलाइन';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'बुकमार्क एक्सपोर्ट करें';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -11157,6 +11157,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokusirana vremenska crta';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Izvezi oznake';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -11027,6 +11027,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fókuszált idővonal';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Könyvjelzők exportálása';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -10932,6 +10932,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Lini Masa Terfokus';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Ekspor Markah';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -11018,6 +11018,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Timeline Focalizzata';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Esporta Segnalibri';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -10626,6 +10626,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get audiobookFocusedTimeline => '注目のタイムライン';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ブックマークを書き出す';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -10978,6 +10978,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Фокустелген шкала';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Бетбелгілерді экспорттау';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -11001,6 +11001,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get audiobookFocusedTimeline => 'ಕೇಂದ್ರೀಕೃತ ಟೈಮ್‌ಲೈನ್';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ಬುಕ್‌ಮಾರ್ಕ್‌ಗಳನ್ನು ರಫ್ತು ಮಾಡಿ';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -10599,6 +10599,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get audiobookFocusedTimeline => '집중 타임라인';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => '북마크 내보내기';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -10995,6 +10995,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Sutelkta laiko juosta';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksportuoti žymes';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -10990,6 +10990,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokusētā laika josla';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksportēt grāmatzīmes';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -11009,6 +11009,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Фокусирана временска линија';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Извези ги обележувачите';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -11050,6 +11050,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'കേന്ദ്രീകൃത ടൈംലൈൻ';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ബുക്ക്മാർക്കുകൾ എക്സ്പോർട്ട് ചെയ്യുക';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -10955,6 +10955,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Төвлөрсөн цагийн шугам';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Хавчуургыг экспортлох';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -10927,6 +10927,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokusert tidslinje';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksporter bokmerker';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -10991,6 +10991,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Gerichte tijdlijn';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Bladwijzers exporteren';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -10890,6 +10890,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get audiobookFocusedTimeline => 'ਕੇਂਦਰਿਤ ਟਾਈਮਲਾਈਨ';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ਬੁੱਕਮਾਰਕ ਨਿਰਯਾਤ ਕਰੋ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -11219,6 +11219,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Aktywna oś czasu';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksportuj zakładki';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -11010,6 +11010,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Linha do Tempo Focada';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportar Marcadores';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -11018,6 +11018,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Cronologie focalizată';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportă marcajele';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -11011,6 +11011,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Текущий фрагмент';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Экспорт закладок';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -10923,6 +10923,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get audiobookFocusedTimeline => 'නාභිගත කාල රේඛාව';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'පිටු සලකුණු නිර්යාත කරන්න';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -10999,6 +10999,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Zameraná časová os';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportovať záložky';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -10999,6 +10999,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Osredotočena časovnica';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Izvozi zaznamke';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -11021,6 +11021,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Vija kohore e fokusuar';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Eksporto faqeshënuesit';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -11148,6 +11148,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Фокусирана временска линија';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Извези обележиваче';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -10943,6 +10943,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Fokuserad tidslinje';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Exportera bokmärken';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -11011,6 +11011,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Ratiba ya Muda Iliyolengwa';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Hamisha Alamisho';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -11012,6 +11012,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get audiobookFocusedTimeline => 'மையப்படுத்திய காலவரிசை';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'புக்மார்க்குகளை ஏற்றுமதி செய்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -11004,6 +11004,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get audiobookFocusedTimeline => 'కేంద్రీకృత టైమ్‌లైన్';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'బుక్‌మార్క్‌లను ఎగుమతి చేయండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -10855,6 +10855,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get audiobookFocusedTimeline => 'ไทม์ไลน์เฉพาะจุด';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'ส่งออกที่คั่นหนังสือ';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -11044,6 +11044,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Focused Timeline';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'I-export ang Mga Bookmark';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -10942,6 +10942,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Odaklanmış Zaman Çizelgesi';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Yer İmlerini Dışarı Aktar';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -10965,6 +10965,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get audiobookFocusedTimeline => 'مەركەزلەشكەن ۋاقىت ئوقى';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'خەتكۈشلەرنى چىقىرىش';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -11019,6 +11019,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Сфокусована хронологія';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Експортувати закладки';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -10932,6 +10932,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get audiobookFocusedTimeline => 'Dòng thời gian thu hẹp';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => 'Xuất dấu trang';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -10544,6 +10544,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get audiobookFocusedTimeline => '聚焦時間軸';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => '匯出書籤';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -10488,6 +10488,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get audiobookFocusedTimeline => '聚焦时间轴';
 
   @override
+  String get audiobookFullTimeline => 'Full Timeline';
+
+  @override
   String get audiobookExportBookmarks => '导出书签';
 
   @override

--- a/lib/ui/screens/playback/audiobook_player_view.dart
+++ b/lib/ui/screens/playback/audiobook_player_view.dart
@@ -78,6 +78,11 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
   String? _favoriteItemId;
 
   _AudiobookFocusArea _tvArea = _AudiobookFocusArea.transport;
+  // Which split column holds focus: drawer on the left, controls on the right.
+  bool _tvLeftColumn = false;
+  // True when the last build used the split layout. The d-pad code runs
+  // outside build and reads it from here.
+  bool _splitLayout = false;
   int _tvHeaderIndex = 0;
   int _tvTransportIndex = 2;
   int _tvRailIndex = 0;
@@ -643,6 +648,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     final layout = LayoutBuilder(
       builder: (context, constraints) {
         final isWide = constraints.maxWidth >= 760;
+        _splitLayout = isWide;
         return Stack(
           fit: StackFit.expand,
           children: [
@@ -709,33 +715,46 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           tvFocusIndex: _tvArea == _AudiobookFocusArea.header ? _tvHeaderIndex : -1,
         ),
         Expanded(
-          child: SingleChildScrollView(
-            padding:
-                const EdgeInsets.symmetric(horizontal: AppSpacing.spaceLg),
-            child: Column(
-              children: [
-                const SizedBox(height: AppSpacing.spaceMd),
-                _CoverArt(
-                  coverUrl: coverUrl,
-                  localPosterPath: localPoster,
-                  size: 260,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // Cover takes the space left by the title and chapter strip, so
+              // a short phone fits the whole player without scrolling. 190 is
+              // those two at their tallest, with the title over two lines,
+              // plus the gaps and a little slack.
+              final coverSize = (constraints.maxHeight - 190)
+                  .clamp(120.0, 260.0)
+                  .toDouble();
+              return SingleChildScrollView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.spaceLg,
                 ),
-                const SizedBox(height: AppSpacing.spaceLg),
-                _TitleBlock(item: item, centered: true),
-                const SizedBox(height: AppSpacing.spaceMd),
-                ValueListenableBuilder<Duration>(
-                  valueListenable: _positionNotifier,
-                  builder: (context, pos, _) => AudiobookChapterContextStrip(
-                    chapters: chapters,
-                    position: pos,
-                    onTap: () {
-                      _setDrawerTab(AudiobookDrawerTab.chapters);
-                      _openDrawerSheet(context, item, chapters);
-                    },
-                  ),
+                child: Column(
+                  children: [
+                    const SizedBox(height: AppSpacing.spaceMd),
+                    _CoverArt(
+                      coverUrl: coverUrl,
+                      localPosterPath: localPoster,
+                      size: coverSize,
+                    ),
+                    const SizedBox(height: AppSpacing.spaceLg),
+                    _TitleBlock(item: item, centered: true),
+                    const SizedBox(height: AppSpacing.spaceMd),
+                    ValueListenableBuilder<Duration>(
+                      valueListenable: _positionNotifier,
+                      builder: (context, pos, _) =>
+                          AudiobookChapterContextStrip(
+                            chapters: chapters,
+                            position: pos,
+                            onTap: () {
+                              _setDrawerTab(AudiobookDrawerTab.chapters);
+                              _openDrawerSheet(context, item, chapters);
+                            },
+                          ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              );
+            },
           ),
         ),
         _buildBottomControls(context, item, chapters),
@@ -750,7 +769,9 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     String? localPoster,
     List<Chapter> chapters,
   ) {
-    final coverSize = PlatformDetection.isTV ? 240.0 : 200.0;
+    // Left column is the drawer alone. Everything else stays in the right
+    // column, always in the same order, so closing the drawer just drops a
+    // column.
     return Column(
       children: [
         AudiobookHeader(
@@ -765,6 +786,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
               _drawerOpen = !_drawerOpen;
               if (_dpadNav && !_drawerOpen) {
                 _drawerContentActive = false;
+                _tvLeftColumn = false;
                 _tvArea = _AudiobookFocusArea.header;
                 _tvHeaderIndex = 1;
               }
@@ -776,62 +798,97 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
         Expanded(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: AppSpacing.spaceXl),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Expanded(
-                  flex: 4,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: AppSpacing.spaceLg),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        _CoverArt(
-                          coverUrl: coverUrl,
-                          localPosterPath: localPoster,
-                          size: coverSize,
-                        ),
-                        const SizedBox(height: AppSpacing.spaceLg),
-                        _TitleBlock(item: item, centered: true),
-                      ],
-                    ),
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.spaceXl),
-                Expanded(
-                  flex: 5,
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                        vertical: AppSpacing.spaceLg),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        ValueListenableBuilder<Duration>(
-                          valueListenable: _positionNotifier,
-                          builder: (context, pos, _) =>
-                              AudiobookChapterContextStrip(
-                            chapters: chapters,
-                            position: pos,
-                            onTap: () => setState(() {
-                              _drawerOpen = true;
-                              _drawerTab = AudiobookDrawerTab.chapters;
-                            }),
+            child: LayoutBuilder(
+              builder: (context, columnConstraints) {
+                final columnHeight = columnConstraints.maxHeight;
+                return Row(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    if (_drawerOpen) ...[
+                      Expanded(
+                        flex: 4,
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            vertical: AppSpacing.spaceLg,
+                          ),
+                          // Keep it off both edges so it does not dwarf the
+                          // controls facing it, and centred against them.
+                          child: Padding(
+                            padding: EdgeInsets.symmetric(
+                              vertical: columnHeight * 0.075,
+                            ),
+                            child: _buildDrawer(context, item, chapters),
                           ),
                         ),
-                        const SizedBox(height: AppSpacing.spaceMd),
-                        Expanded(
-                          child: _drawerOpen
-                              ? _buildDrawer(context, item, chapters)
-                              : const SizedBox.shrink(),
+                      ),
+                      const SizedBox(width: AppSpacing.spaceXl),
+                    ],
+                    Expanded(
+                      flex: 5,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          vertical: AppSpacing.spaceLg,
                         ),
-                        const SizedBox(height: AppSpacing.spaceMd),
-                        _buildBottomControls(context, item, chapters, splitLayout: true),
-                      ],
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            // Flexible so the cover gets the height the controls
+                            // leave: large on a desktop window, small on a TV,
+                            // dropped when there is no room. heightFactor stops
+                            // the Center from eating the spare space.
+                            Flexible(
+                              child: LayoutBuilder(
+                                builder: (context, coverConstraints) {
+                                  final size =
+                                      (coverConstraints.maxHeight -
+                                              AppSpacing.spaceMd)
+                                          .clamp(0.0, 220.0);
+                                  if (size < 96) return const SizedBox.shrink();
+                                  return Padding(
+                                    padding: const EdgeInsets.only(
+                                      bottom: AppSpacing.spaceMd,
+                                    ),
+                                    child: Center(
+                                      heightFactor: 1,
+                                      child: _CoverArt(
+                                        coverUrl: coverUrl,
+                                        localPosterPath: localPoster,
+                                        size: size,
+                                      ),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                            _TitleBlock(item: item, centered: true),
+                            const SizedBox(height: AppSpacing.spaceXl),
+                            ValueListenableBuilder<Duration>(
+                              valueListenable: _positionNotifier,
+                              builder: (context, pos, _) =>
+                                  AudiobookChapterContextStrip(
+                                    chapters: chapters,
+                                    position: pos,
+                                    onTap: () => setState(() {
+                                      _drawerOpen = true;
+                                      _drawerTab = AudiobookDrawerTab.chapters;
+                                    }),
+                                  ),
+                            ),
+                            const SizedBox(height: AppSpacing.spaceXl),
+                            _buildBottomControls(
+                              context,
+                              item,
+                              chapters,
+                              splitLayout: true,
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
-                  ),
-                ),
-              ],
+                  ],
+                );
+              },
             ),
           ),
         ),
@@ -872,7 +929,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
                       _tvArea == _AudiobookFocusArea.progress,
                   onSeek: (d) => _manager.seekTo(d),
                 ),
-                const SizedBox(height: AppSpacing.spaceXs),
+                const SizedBox(height: AppSpacing.spaceSm),
                 AudiobookBookOverview(
                   position: pos,
                   duration: _state.duration,
@@ -1222,26 +1279,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
 
   void _moveVertical(int delta) {
     if (_tvArea == _AudiobookFocusArea.drawerContent && _drawerContentActive) {
-      final item = _resolveItem();
-      final chapters = _chapters(item);
-      int count = 0;
-      switch (_drawerTab) {
-        case AudiobookDrawerTab.timeline:
-          count = _getTimelineEvents(chapters).length;
-          break;
-        case AudiobookDrawerTab.chapters:
-          count = chapters.length;
-          break;
-        case AudiobookDrawerTab.bookmarks:
-          count = _bookmarksList.length;
-          break;
-        case AudiobookDrawerTab.notes:
-          count = _notesList.length;
-          break;
-        case AudiobookDrawerTab.queue:
-          count = _queue.items.length;
-          break;
-      }
+      final count = _drawerItemCount();
       final hasExport = _tabHasExport(_drawerTab);
       final minIdx = hasExport ? -1 : 0;
       if (count > 0 || hasExport) {
@@ -1254,22 +1292,45 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           return;
         }
       }
+      // Off the top, focus goes back to the tabs. Off the bottom with the
+      // drawer in its own column there is nothing below, so hold the last row
+      // and let right cross to the controls. Stacked, keep going down.
+      if (_tvTwoColumns && delta > 0) return;
       setState(() => _drawerContentActive = false);
     }
 
+    // With two columns, up and down stay inside one. The header spans both,
+    // so it returns focus to the column the user came from.
+    if (!_tvTwoColumns) {
+      _tvLeftColumn = false;
+    } else if (_tvArea == _AudiobookFocusArea.drawerTabs ||
+        _tvArea == _AudiobookFocusArea.drawerContent) {
+      _tvLeftColumn = true;
+    } else if (_tvArea != _AudiobookFocusArea.header) {
+      _tvLeftColumn = false;
+    }
+
     final List<_AudiobookFocusArea> list;
-    if (_drawerOpen) {
+    if (_tvTwoColumns) {
       list = [
         _AudiobookFocusArea.header,
-        _AudiobookFocusArea.drawerTabs,
-        _AudiobookFocusArea.drawerContent,
-        _AudiobookFocusArea.progress,
-        _AudiobookFocusArea.transport,
-        _AudiobookFocusArea.actionRail,
+        if (_tvLeftColumn) ...[
+          _AudiobookFocusArea.drawerTabs,
+          _AudiobookFocusArea.drawerContent,
+        ] else ...[
+          _AudiobookFocusArea.progress,
+          _AudiobookFocusArea.transport,
+          _AudiobookFocusArea.actionRail,
+        ],
       ];
     } else {
+      // Stacked: one flat list top to bottom, the drawer included when open.
       list = [
         _AudiobookFocusArea.header,
+        if (_drawerOpen) ...[
+          _AudiobookFocusArea.drawerTabs,
+          _AudiobookFocusArea.drawerContent,
+        ],
         _AudiobookFocusArea.progress,
         _AudiobookFocusArea.transport,
         _AudiobookFocusArea.actionRail,
@@ -1303,6 +1364,49 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
     }
 
     setState(() => _tvArea = candidate);
+  }
+
+  /// Whether the drawer has its own column to cross to. True in the split
+  /// layout. Stacked, the drawer is a sheet and up/down walks one flat list.
+  bool get _tvTwoColumns => _splitLayout && _drawerOpen;
+
+  /// How many rows the drawer's current tab shows.
+  int _drawerItemCount() {
+    final chapters = _chapters(_resolveItem());
+    switch (_drawerTab) {
+      case AudiobookDrawerTab.timeline:
+        return _getTimelineEvents(chapters).length;
+      case AudiobookDrawerTab.chapters:
+        return chapters.length;
+      case AudiobookDrawerTab.bookmarks:
+        return _bookmarksList.length;
+      case AudiobookDrawerTab.notes:
+        return _notesList.length;
+      case AudiobookDrawerTab.queue:
+        return _queue.items.length;
+    }
+  }
+
+  /// Crosses between the drawer on the left and the controls on the right.
+  void _focusColumn({required bool left}) {
+    if (!_tvTwoColumns) return;
+    _tvLeftColumn = left;
+    if (left) {
+      _tvArea = _AudiobookFocusArea.drawerContent;
+      _drawerContentActive = true;
+      final minIdx = _tabHasExport(_drawerTab) ? -1 : 0;
+      final lastIdx = _drawerItemCount() - 1;
+      _tvListIndex = _tvListIndex.clamp(
+        minIdx,
+        lastIdx < minIdx ? minIdx : lastIdx,
+      );
+      _tvSubIndex = 0;
+    } else {
+      _drawerContentActive = false;
+      _tvArea = _AudiobookFocusArea.transport;
+      // Land on the leftmost control so one press of left crosses back.
+      _tvTransportIndex = 0;
+    }
   }
 
   int _maxSubIndex() {
@@ -1342,27 +1446,47 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
           _manager.seekTo(next < Duration.zero ? Duration.zero : next);
           break;
         case _AudiobookFocusArea.transport:
+          // Left from the first button crosses to the drawer.
+          if (delta < 0 && _tvTransportIndex == 0) {
+            _focusColumn(left: true);
+            break;
+          }
           _tvTransportIndex = (_tvTransportIndex + delta).clamp(0, 4);
           break;
         case _AudiobookFocusArea.actionRail:
+          if (delta < 0 && _tvRailIndex == 0) {
+            _focusColumn(left: true);
+            break;
+          }
           _tvRailIndex = (_tvRailIndex + delta).clamp(0, 4);
           break;
         case _AudiobookFocusArea.drawerTabs:
           final item = _resolveItem();
           final chapters = _chapters(item);
           final availableTabs = _getAvailableTabs(chapters);
-          _tvTabIndex =
-              (_tvTabIndex + delta).clamp(0, availableTabs.length - 1);
+          // Right from the last tab crosses to the controls.
+          if (delta > 0 && _tvTabIndex >= availableTabs.length - 1) {
+            _focusColumn(left: false);
+            break;
+          }
+          _tvTabIndex = (_tvTabIndex + delta).clamp(
+            0,
+            availableTabs.length - 1,
+          );
           _drawerTab = availableTabs[_tvTabIndex];
           unawaited(_prefs.set(
               UserPreferences.audiobookDrawerTab, _drawerTab.name));
           break;
         case _AudiobookFocusArea.drawerContent:
-          if (_drawerContentActive) {
-            final maxIdx = _maxSubIndex();
-            if (maxIdx > 0) {
-              _tvSubIndex = (_tvSubIndex + delta).clamp(0, maxIdx);
-            }
+          // Bookmarks and notes have per-row actions: right walks those
+          // first, then crosses to the controls.
+          final maxIdx = _drawerContentActive ? _maxSubIndex() : 0;
+          if (delta > 0 && _tvSubIndex >= maxIdx) {
+            _focusColumn(left: false);
+            break;
+          }
+          if (_drawerContentActive && maxIdx > 0) {
+            _tvSubIndex = (_tvSubIndex + delta).clamp(0, maxIdx);
           }
           break;
       }
@@ -1381,6 +1505,7 @@ class _AudiobookPlayerViewState extends State<AudiobookPlayerView> {
             _drawerOpen = !_drawerOpen;
             if (!_drawerOpen) {
               _drawerContentActive = false;
+              _tvLeftColumn = false;
             }
           });
         }

--- a/lib/ui/widgets/audiobook/audiobook_action_rail.dart
+++ b/lib/ui/widgets/audiobook/audiobook_action_rail.dart
@@ -6,6 +6,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';
 import 'audiobook_focus_ring.dart';
 import 'audiobook_glass.dart';
+import 'audiobook_pointer.dart';
 import 'audiobook_time.dart';
 
 class AudiobookActionRail extends StatelessWidget {
@@ -78,14 +79,27 @@ class AudiobookActionRail extends StatelessWidget {
       ),
     ];
 
+    // On mobile each entry takes an equal slice so its caption can use the
+    // full width and wrap. Wrapped captions differ in height, so align on the
+    // icons.
+    final mobile = PlatformDetection.useMobileUi;
     final row = Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
         for (var i = 0; i < entries.length; i++)
-          entries[i].build(
-            apple: apple,
-            focused: tvFocusIndex == i,
-          ),
+          if (mobile)
+            Expanded(
+              child: entries[i].build(
+                apple: apple,
+                focused: tvFocusIndex == i,
+              ),
+            )
+          else
+            entries[i].build(
+              apple: apple,
+              focused: tvFocusIndex == i,
+            ),
       ],
     );
 
@@ -180,15 +194,16 @@ class _RailEntryWidgetState extends State<_RailEntryWidget> {
         ),
         if (caption != null) ...[
           const SizedBox(height: 6),
-          SizedBox(
-            width: 62,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
             child: Text(
               caption,
               textAlign: TextAlign.center,
-              maxLines: 1,
+              maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
                 fontSize: 10,
+                height: 1.2,
                 fontWeight: FontWeight.w600,
                 color: captionColor,
               ),
@@ -199,13 +214,16 @@ class _RailEntryWidgetState extends State<_RailEntryWidget> {
     );
 
     if (widget.apple) {
-      return CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: widget.onTap,
-        child: content,
+      return audiobookClickable(
+        child: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: widget.onTap,
+          child: content,
+        ),
       );
     }
     return InkWell(
+      mouseCursor: SystemMouseCursors.click,
       borderRadius: BorderRadius.circular(14),
       onTap: widget.onTap,
       child: Padding(
@@ -336,16 +354,22 @@ class _RailEntryWidgetState extends State<_RailEntryWidget> {
     );
 
     if (widget.apple) {
-      return CupertinoButton(
-        padding: EdgeInsets.zero,
-        onPressed: widget.onTap,
-        child: child,
+      return audiobookClickable(
+        // CupertinoButton has no onHover of its own, so the label needs this
+        // to show up on macOS.
+        onHover: (h) => setState(() => _isHovered = h),
+        child: CupertinoButton(
+          padding: EdgeInsets.zero,
+          onPressed: widget.onTap,
+          child: child,
+        ),
       );
     }
 
     final inkWellRadius = BorderRadius.circular(20);
 
     return InkWell(
+      mouseCursor: SystemMouseCursors.click,
       borderRadius: inkWellRadius,
       onTap: widget.onTap,
       onHover: (h) => setState(() => _isHovered = h),

--- a/lib/ui/widgets/audiobook/audiobook_chapter_strip.dart
+++ b/lib/ui/widgets/audiobook/audiobook_chapter_strip.dart
@@ -5,6 +5,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../util/platform_detection.dart';
 import 'audiobook_glass.dart';
+import 'audiobook_pointer.dart';
 import 'chapter.dart';
 
 class AudiobookChapterContextStrip extends StatelessWidget {
@@ -87,23 +88,29 @@ class AudiobookChapterContextStrip extends StatelessWidget {
               ],
             ),
           ),
-          const SizedBox(width: AppSpacing.spaceSm),
-          Icon(
-            apple ? CupertinoIcons.chevron_right : Icons.chevron_right,
-            size: apple ? 18 : 24,
-            color: onSurface.withValues(alpha: 0.5),
-          ),
+          // No chevron on TV: the strip is not in the focus order, so a
+          // remote cannot open it.
+          if (!PlatformDetection.isTV) ...[
+            const SizedBox(width: AppSpacing.spaceSm),
+            Icon(
+              apple ? CupertinoIcons.chevron_right : Icons.chevron_right,
+              size: apple ? 18 : 24,
+              color: onSurface.withValues(alpha: 0.5),
+            ),
+          ],
         ],
       ),
     );
 
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: audiobookGlassOrSolid(
-        cornerRadius: 14,
-        fallbackColor: AppColorScheme.surface.withValues(alpha: 0.55),
-        child: content,
+    return audiobookClickable(
+      child: GestureDetector(
+        onTap: onTap,
+        behavior: HitTestBehavior.opaque,
+        child: audiobookGlassOrSolid(
+          cornerRadius: 14,
+          fallbackColor: AppColorScheme.surface.withValues(alpha: 0.55),
+          child: content,
+        ),
       ),
     );
   }

--- a/lib/ui/widgets/audiobook/audiobook_drawer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_drawer.dart
@@ -11,6 +11,142 @@ import '../../../util/platform_detection.dart';
 import 'audiobook_time.dart';
 import 'chapter.dart';
 
+/// The TV drawer shares a column with the player instead of filling a sheet,
+/// so it runs denser: the tab bar fits and more rows show.
+bool get _dense => PlatformDetection.isTV;
+
+/// Every TV drawer row is this tall, so the tabs line up.
+const double _denseRowHeight = 30.0;
+const double _denseRowPitch = _denseRowHeight + 2; // + vertical margins
+
+/// One row of a drawer list on TV.
+///
+/// A ListTile is taller than 30px whatever you pass it, and its text spills
+/// outside the focus rectangle. This is a plain centred Row instead, shared by
+/// every tab so the rows match.
+class _DenseRow extends StatelessWidget {
+  const _DenseRow({
+    required this.focused,
+    required this.title,
+    this.leading,
+    this.trailingText,
+    this.actions = const [],
+    this.titleColor,
+    this.bold = false,
+    this.highlighted = false,
+    this.onTap,
+  });
+
+  final bool focused;
+  final String title;
+  final Widget? leading;
+  final String? trailingText;
+  final List<Widget> actions;
+  final Color? titleColor;
+  final bool bold;
+
+  /// The row holds the sub-focus rather than one of its [actions].
+  final bool highlighted;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final radius = BorderRadius.circular(8);
+    return Container(
+      height: _denseRowHeight,
+      margin: const EdgeInsets.symmetric(vertical: 1, horizontal: 4),
+      decoration: BoxDecoration(
+        color: highlighted
+            ? AppColorScheme.accent.withValues(alpha: 0.12)
+            : null,
+        border: Border.all(
+          color: focused ? AppColorScheme.accent : Colors.transparent,
+          width: 2.0,
+        ),
+        borderRadius: radius,
+      ),
+      child: InkWell(
+        mouseCursor: SystemMouseCursors.click,
+        borderRadius: radius,
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          child: Row(
+            children: [
+              if (leading != null) ...[leading!, const SizedBox(width: 6)],
+              Expanded(
+                child: Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: highlighted ? Colors.white : titleColor,
+                    fontWeight: bold || highlighted
+                        ? FontWeight.w700
+                        : FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (trailingText != null) ...[
+                const SizedBox(width: 6),
+                Text(
+                  trailingText!,
+                  style: TextStyle(
+                    fontFeatures: const [FontFeature.tabularFigures()],
+                    fontSize: 11,
+                    color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                ),
+              ],
+              ...actions,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Circled icon sized to sit inside a [_DenseRow].
+Widget _denseIcon(IconData icon, Color color, {required bool focused}) {
+  return Container(
+    width: 22,
+    height: 22,
+    decoration: BoxDecoration(
+      color:
+          focused ? AppColorScheme.accent.withValues(alpha: 0.2) : Colors.transparent,
+      shape: BoxShape.circle,
+      border: Border.all(
+        color: focused ? Colors.white : Colors.transparent,
+        width: 1.5,
+      ),
+    ),
+    child: Icon(icon, size: 13, color: focused ? Colors.white : color),
+  );
+}
+
+/// Per-row action. An IconButton is 48px by default and would not fit.
+Widget _denseAction({
+  required IconData icon,
+  required bool focused,
+  required VoidCallback onPressed,
+}) {
+  return Padding(
+    padding: const EdgeInsets.only(left: 4),
+    child: InkWell(
+      mouseCursor: SystemMouseCursors.click,
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(11),
+      child: _denseIcon(
+        icon,
+        AppColorScheme.onSurface.withValues(alpha: 0.75),
+        focused: focused,
+      ),
+    ),
+  );
+}
+
 enum AudiobookDrawerTab { timeline, chapters, bookmarks, notes, queue }
 
 class AudiobookDrawerTabBar extends StatelessWidget {
@@ -33,27 +169,38 @@ class AudiobookDrawerTabBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bar = Container(
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: AppColorScheme.surface.withValues(alpha: 0.55),
+        borderRadius: AppRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          for (var i = 0; i < tabs.length; i++)
+            AudiobookPillSegment(
+              label: labels[tabs[i]] ?? tabs[i].name,
+              selected: tabs[i] == current,
+              tvFocused: tvFocused && tvIndex == i,
+              onTap: () => onChanged(tabs[i]),
+            ),
+        ],
+      ),
+    );
+
+    // A d-pad cannot drag a scroll view, so on TV the bar scales down to fit
+    // its column. Translations run long here, so a fixed size would not hold.
+    if (_dense) {
+      return FittedBox(
+        fit: BoxFit.scaleDown,
+        alignment: Alignment.centerLeft,
+        child: bar,
+      );
+    }
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
-      child: Container(
-        padding: const EdgeInsets.all(3),
-        decoration: BoxDecoration(
-          color: AppColorScheme.surface.withValues(alpha: 0.55),
-          borderRadius: AppRadius.circular(12),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            for (var i = 0; i < tabs.length; i++)
-              AudiobookPillSegment(
-                label: labels[tabs[i]] ?? tabs[i].name,
-                selected: tabs[i] == current,
-                tvFocused: tvFocused && tvIndex == i,
-                onTap: () => onChanged(tabs[i]),
-              ),
-          ],
-        ),
-      ),
+      child: bar,
     );
   }
 }
@@ -105,16 +252,20 @@ class AudiobookPillSegment extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
+          mouseCursor: SystemMouseCursors.click,
           borderRadius: radius,
           splashColor: apple ? Colors.transparent : null,
           highlightColor: apple ? Colors.transparent : null,
           onTap: onTap,
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 8),
+            padding: EdgeInsets.symmetric(
+              horizontal: _dense ? 9 : 15,
+              vertical: _dense ? 6 : 8,
+            ),
             child: Text(
               label,
               style: TextStyle(
-                fontSize: 13,
+                fontSize: _dense ? 11 : 13,
                 fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
                 color: fg,
               ),
@@ -164,7 +315,7 @@ class _AudiobookChaptersListState extends State<AudiobookChaptersList> {
 
   void _scrollToFocused() {
     if (!_scrollController.hasClients) return;
-    const double itemHeight = 44.0; // container height 40 + margin vertical 2*2
+    final double itemHeight = _dense ? _denseRowPitch : 44.0;
     final double target = widget.tvFocusedIndex * itemHeight;
     final double currentScroll = _scrollController.offset;
     
@@ -208,6 +359,33 @@ class _AudiobookChaptersListState extends State<AudiobookChaptersList> {
             final c = widget.chapters[index];
             final isCurrent = index == current;
             final isTvFocused = index == widget.tvFocusedIndex;
+
+            if (_dense) {
+              return _DenseRow(
+                focused: isTvFocused,
+                title: c.title,
+                bold: isCurrent,
+                titleColor: isCurrent ? AppColorScheme.accent : null,
+                trailingText:
+                    formatAudiobookClock(Duration(milliseconds: c.startMs)),
+                onTap: () => widget.onTap(c),
+                leading: SizedBox(
+                  width: 22,
+                  child: Text(
+                    '${index + 1}',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                      color: isCurrent
+                          ? AppColorScheme.accent
+                          : AppColorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ),
+              );
+            }
 
             return Container(
               height: 40.0,
@@ -312,7 +490,7 @@ class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
       );
       return;
     }
-    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double itemHeight = _dense ? _denseRowPitch : 56.0;
     final double target = widget.tvFocusedIndex * itemHeight;
     final double currentScroll = _scrollController.offset;
     
@@ -377,6 +555,34 @@ class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
                       final isTvFocused = index == widget.tvFocusedIndex;
                       final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
                       final isDeleteFocused = isTvFocused && widget.tvSubIndex == 1;
+                      if (_dense) {
+                        return _DenseRow(
+                          focused: isTvFocused,
+                          highlighted: isPlayFocused,
+                          title: 'Bookmark ${index + 1}: ${b.label}',
+                          trailingText: formatAudiobookClock(
+                              Duration(milliseconds: b.positionMs)),
+                          onTap: () => widget.onJump(b),
+                          leading: _denseIcon(
+                            apple ? CupertinoIcons.bookmark_fill : Icons.bookmark,
+                            AppColorScheme.accent,
+                            focused: isPlayFocused,
+                          ),
+                          actions: [
+                            _denseAction(
+                              icon: apple
+                                  ? CupertinoIcons.delete
+                                  : Icons.delete_outline,
+                              focused: isDeleteFocused,
+                              onPressed: () => widget.service.removeAt(
+                                  widget.item!.serverId,
+                                  widget.item!.id,
+                                  b.positionMs),
+                            ),
+                          ],
+                        );
+                      }
+
                       return Container(
                         height: 52.0,
                         margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
@@ -409,6 +615,8 @@ class _AudiobookBookmarksListState extends State<AudiobookBookmarksList> {
                           ),
                           title: Text(
                             'Bookmark ${index + 1}: ${b.label}',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                             style: TextStyle(
                               color: isPlayFocused ? Colors.white : null,
                               fontWeight: isPlayFocused ? FontWeight.w700 : null,
@@ -507,7 +715,7 @@ class _AudiobookNotesListState extends State<AudiobookNotesList> {
       );
       return;
     }
-    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double itemHeight = _dense ? _denseRowPitch : 56.0;
     final double target = widget.tvFocusedIndex * itemHeight;
     final double currentScroll = _scrollController.offset;
     
@@ -574,7 +782,43 @@ class _AudiobookNotesListState extends State<AudiobookNotesList> {
                       final isPlayFocused = isTvFocused && widget.tvSubIndex == 0;
                       final isEditFocused = isTvFocused && widget.tvSubIndex == 1;
                       final isDeleteFocused = isTvFocused && widget.tvSubIndex == 2;
+                      if (_dense) {
+                        return _DenseRow(
+                          focused: isTvFocused,
+                          highlighted: isPlayFocused,
+                          title: n.body,
+                          trailingText: formatAudiobookClock(
+                              Duration(milliseconds: n.positionMs)),
+                          onTap: () => widget.onJump(n),
+                          leading: _denseIcon(
+                            apple
+                                ? CupertinoIcons.chat_bubble_text
+                                : Icons.note_outlined,
+                            AppColorScheme.accent,
+                            focused: isPlayFocused,
+                          ),
+                          actions: [
+                            _denseAction(
+                              icon: apple
+                                  ? CupertinoIcons.pencil
+                                  : Icons.edit_outlined,
+                              focused: isEditFocused,
+                              onPressed: () => widget.onEdit(n),
+                            ),
+                            _denseAction(
+                              icon: apple
+                                  ? CupertinoIcons.delete
+                                  : Icons.delete_outline,
+                              focused: isDeleteFocused,
+                              onPressed: () => widget.service.remove(
+                                  widget.item!.serverId, widget.item!.id, n.id),
+                            ),
+                          ],
+                        );
+                      }
+
                       return InkWell(
+                        mouseCursor: SystemMouseCursors.click,
                         onTap: () => widget.onJump(n),
                         borderRadius: BorderRadius.circular(8),
                         child: Container(
@@ -754,7 +998,7 @@ class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
       );
       return;
     }
-    const double itemHeight = 56.0; // container height 52 + margin vertical 2*2
+    final double itemHeight = _dense ? _denseRowPitch : 56.0;
     final double target = widget.tvFocusedIndex * itemHeight;
     final double currentScroll = _scrollController.offset;
     
@@ -830,6 +1074,45 @@ class _AudiobookTimelineListState extends State<AudiobookTimelineList> {
                   } else if (e.type == TimelineEventType.chapter) {
                     icon = Icons.menu_open;
                     iconColor = Colors.teal;
+                  }
+
+                  if (_dense) {
+                    return _DenseRow(
+                      focused: isTvFocused,
+                      highlighted: isPlayFocused,
+                      title: e.title,
+                      trailingText: formatAudiobookClock(
+                          Duration(milliseconds: e.positionMs)),
+                      onTap: () => widget.onJump(e),
+                      leading: _denseIcon(icon, iconColor, focused: isPlayFocused),
+                      actions: [
+                        if (showEdit)
+                          _denseAction(
+                            icon: apple
+                                ? CupertinoIcons.pencil
+                                : Icons.edit_outlined,
+                            focused: isEditFocused,
+                            onPressed: () => widget
+                                .onEditNote(e.originalObject as AudiobookNote),
+                          ),
+                        if (showDelete)
+                          _denseAction(
+                            icon: apple
+                                ? CupertinoIcons.delete
+                                : Icons.delete_outline,
+                            focused: isDeleteFocused,
+                            onPressed: () {
+                              if (e.type == TimelineEventType.note) {
+                                widget.onDeleteNote(
+                                    e.originalObject as AudiobookNote);
+                              } else {
+                                widget.onDeleteBookmark(
+                                    e.originalObject as AudiobookBookmark);
+                              }
+                            },
+                          ),
+                      ],
+                    );
                   }
 
                   return Container(
@@ -991,7 +1274,7 @@ class _AudiobookQueueListState extends State<AudiobookQueueList> {
       );
       return;
     }
-    const double itemHeight = 34.0; // exact container height
+    final double itemHeight = _dense ? _denseRowPitch : 34.0;
     final double target = widget.tvFocusedIndex * itemHeight;
     final double currentScroll = _scrollController.offset;
     
@@ -1031,17 +1314,43 @@ class _AudiobookQueueListState extends State<AudiobookQueueList> {
             final isTvFocused = index == widget.tvFocusedIndex;
             final titleText = item?.name ?? AppLocalizations.of(context).trackNumber(index + 1);
 
+            // The playing track is marked by its accent title only. A filled
+            // background competes with the focus rectangle.
+            if (_dense) {
+              return _DenseRow(
+                focused: isTvFocused,
+                title: titleText,
+                bold: isCurrent,
+                titleColor: isCurrent ? AppColorScheme.accent : null,
+                onTap: () => widget.onPlay(index),
+                leading: SizedBox(
+                  width: 22,
+                  child: Text(
+                    '${index + 1}.',
+                    textAlign: TextAlign.right,
+                    style: TextStyle(
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                      fontSize: 11,
+                      fontWeight: isCurrent ? FontWeight.bold : null,
+                      color: isCurrent
+                          ? AppColorScheme.accent
+                          : AppColorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              );
+            }
+
             return InkWell(
+              mouseCursor: SystemMouseCursors.click,
               onTap: () => widget.onPlay(index),
               child: Container(
                 height: 34.0,
                 alignment: Alignment.centerLeft,
                 padding: const EdgeInsets.symmetric(horizontal: 12),
-                color: isTvFocused
-                    ? AppColorScheme.accent.withValues(alpha: 0.22)
-                    : (isCurrent
-                        ? AppColorScheme.accent.withValues(alpha: 0.08)
-                        : Colors.transparent),
+                color: isCurrent
+                    ? AppColorScheme.accent.withValues(alpha: 0.08)
+                    : Colors.transparent,
                 child: Row(
                   children: [
                     SizedBox(

--- a/lib/ui/widgets/audiobook/audiobook_header.dart
+++ b/lib/ui/widgets/audiobook/audiobook_header.dart
@@ -8,6 +8,7 @@ import '../../../data/services/cast/cast_target.dart';
 import '../../../util/platform_detection.dart';
 import 'audiobook_focus_ring.dart';
 import 'audiobook_glass.dart';
+import 'audiobook_pointer.dart';
 
 class AudiobookHeader extends StatelessWidget {
   const AudiobookHeader({
@@ -45,11 +46,13 @@ class AudiobookHeader extends StatelessWidget {
       double size = 24,
     }) {
       if (apple) {
-        return CupertinoButton(
-          padding: EdgeInsets.zero,
-          minimumSize: const Size.square(kAudiobookButtonSize),
-          onPressed: onPressed,
-          child: Icon(icon, size: size, color: color ?? onSurface),
+        return audiobookClickable(
+          child: CupertinoButton(
+            padding: EdgeInsets.zero,
+            minimumSize: const Size.square(kAudiobookButtonSize),
+            onPressed: onPressed,
+            child: Icon(icon, size: size, color: color ?? onSurface),
+          ),
         );
       }
       return IconButton(

--- a/lib/ui/widgets/audiobook/audiobook_pointer.dart
+++ b/lib/ui/widgets/audiobook/audiobook_pointer.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/widgets.dart';
+
+/// Gives a control the mouse affordances Cupertino widgets lack.
+///
+/// CupertinoButton and a bare GestureDetector carry no cursor and no hover
+/// callback, so on desktop they need this to behave like the Material path.
+/// [onHover] fires on enter and exit.
+Widget audiobookClickable({
+  required Widget child,
+  bool enabled = true,
+  ValueChanged<bool>? onHover,
+}) {
+  if (!enabled) return child;
+  return MouseRegion(
+    cursor: SystemMouseCursors.click,
+    onEnter: onHover == null ? null : (_) => onHover(true),
+    onExit: onHover == null ? null : (_) => onHover(false),
+    child: child,
+  );
+}

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -44,6 +44,15 @@ class AudiobookBookOverview extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        Text(
+          l10n.audiobookFullTimeline,
+          style: TextStyle(
+            fontSize: 11,
+            fontStyle: FontStyle.italic,
+            color: AppColorScheme.onSurface.withValues(alpha: 0.5),
+          ),
+        ),
+        const SizedBox(height: 4),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4),
           child: SizedBox(
@@ -297,12 +306,17 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
     if (apple) {
       slider = Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: CupertinoSlider(
+        // CupertinoSlider pins itself to 176px unless the parent constrains
+        // it tightly.
+        child: SizedBox(
+          width: double.infinity,
+          child: CupertinoSlider(
           value: sliderValue,
           min: startMs,
           max: endMs,
-          activeColor: AppColorScheme.rangeProgress,
-          onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
+            activeColor: AppColorScheme.rangeProgress,
+            onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
+          ),
         ),
       );
     } else {
@@ -328,16 +342,56 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
       );
     }
 
+    // The window is clamped at both ends of the book, so the offsets are not
+    // always a round half hour. Offsets rather than clock times: two absolute
+    // times here read as "elapsed / total".
+    final startOffset = Duration(milliseconds: (startMs - posMs).round());
+    final endOffset = Duration(milliseconds: (endMs - posMs).round());
+
     final double horizontalPadding = apple ? 20.0 : 24.0;
     final groupChapters = chapters.length > 40;
     final labelStyle = TextStyle(
-      fontSize: 12,
-      color: AppColorScheme.onSurface.withValues(alpha: 0.85),
+      fontFeatures: const [FontFeature.tabularFigures()],
+      fontSize: 11,
+      color: AppColorScheme.onSurface.withValues(alpha: 0.6),
+    );
+    final captionStyle = TextStyle(
+      fontSize: 11,
+      fontStyle: FontStyle.italic,
+      color: AppColorScheme.onSurface.withValues(alpha: 0.5),
     );
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  '-${formatAudiobookClock(startOffset.abs())}',
+                  style: labelStyle,
+                  textAlign: TextAlign.left,
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  l10n.audiobookFocusedTimeline,
+                  style: captionStyle,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              Expanded(
+                child: Text(
+                  '+${formatAudiobookClock(endOffset)}',
+                  style: labelStyle,
+                  textAlign: TextAlign.right,
+                ),
+              ),
+            ],
+          ),
+        ),
         SizedBox(
           height: 32,
           child: Stack(
@@ -366,30 +420,6 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
                   ),
                 ),
               slider,
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 4),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                formatAudiobookClock(Duration(milliseconds: startMs.toInt())),
-                style: labelStyle,
-              ),
-              Text(
-                l10n.audiobookFocusedTimeline,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontStyle: FontStyle.italic,
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.5),
-                ),
-              ),
-              Text(
-                formatAudiobookClock(Duration(milliseconds: endMs.toInt())),
-                style: labelStyle,
-              ),
             ],
           ),
         ),

--- a/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
+++ b/lib/ui/widgets/audiobook/audiobook_progress_bar.dart
@@ -311,9 +311,9 @@ class AudiobookZoomedProgressBar extends StatelessWidget {
         child: SizedBox(
           width: double.infinity,
           child: CupertinoSlider(
-          value: sliderValue,
-          min: startMs,
-          max: endMs,
+            value: sliderValue,
+            min: startMs,
+            max: endMs,
             activeColor: AppColorScheme.rangeProgress,
             onChanged: (v) => onSeek(Duration(milliseconds: v.toInt())),
           ),

--- a/lib/ui/widgets/audiobook/audiobook_sheets.dart
+++ b/lib/ui/widgets/audiobook/audiobook_sheets.dart
@@ -196,6 +196,7 @@ class _SheetChoiceState extends State<_SheetChoice> {
     }
 
     return InkWell(
+      mouseCursor: SystemMouseCursors.click,
       onTap: widget.onTap,
       onFocusChange: (f) => setState(() => _isFocused = f),
       onHover: (h) => setState(() => _isHovered = h),
@@ -534,6 +535,7 @@ class _SleepSheet extends StatelessWidget {
                   children: [
                     Expanded(
                       child: InkWell(
+                        mouseCursor: SystemMouseCursors.click,
                         onTap: () {
                           if (controller.isPaused) {
                             controller.resumeTimer();
@@ -574,6 +576,7 @@ class _SleepSheet extends StatelessWidget {
                     const SizedBox(width: 8),
                     Expanded(
                       child: InkWell(
+                        mouseCursor: SystemMouseCursors.click,
                         onTap: () {
                           onCancel();
                           Navigator.of(context).maybePop();
@@ -1009,6 +1012,7 @@ class _SheetActionButtonState extends State<_SheetActionButton> {
     }
 
     return InkWell(
+      mouseCursor: SystemMouseCursors.click,
       onTap: widget.onPressed,
       onFocusChange: (f) => setState(() => _isFocused = f),
       onHover: (h) => setState(() => _isHovered = h),

--- a/lib/ui/widgets/audiobook/audiobook_transport_row.dart
+++ b/lib/ui/widgets/audiobook/audiobook_transport_row.dart
@@ -6,6 +6,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../util/platform_detection.dart';
 import 'audiobook_focus_ring.dart';
+import 'audiobook_pointer.dart';
 
 class AudiobookTransportRow extends StatelessWidget {
   const AudiobookTransportRow({
@@ -38,11 +39,13 @@ class AudiobookTransportRow extends StatelessWidget {
 
     Widget chapterButton(IconData icon, VoidCallback onTap) {
       if (apple) {
-        return CupertinoButton(
-          padding: EdgeInsets.zero,
-          minimumSize: const Size.square(44),
-          onPressed: onTap,
-          child: Icon(icon, size: 26, color: onSurface),
+        return audiobookClickable(
+          child: CupertinoButton(
+            padding: EdgeInsets.zero,
+            minimumSize: const Size.square(44),
+            onPressed: onTap,
+            child: Icon(icon, size: 26, color: onSurface),
+          ),
         );
       }
       return IconButton(icon: Icon(icon, size: 28), onPressed: onTap);
@@ -114,26 +117,29 @@ class AudiobookPlayButton extends StatelessWidget {
       final icon = isPlaying
           ? CupertinoIcons.pause_fill
           : CupertinoIcons.play_fill;
-      return GestureDetector(
-        onTap: onTap,
-        behavior: HitTestBehavior.opaque,
-        child: SizedBox(
-          width: _size,
-          height: _size,
-          child: ClipOval(
-            child: _withTransportBlur(
-              DecoratedBox(
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: AppColorScheme.accent.withValues(
-                    alpha: GlassSettings.blursBackdrop ? 0.32 : 0.55,
+      return audiobookClickable(
+        child: GestureDetector(
+          onTap: onTap,
+          behavior: HitTestBehavior.opaque,
+          child: SizedBox(
+            width: _size,
+            height: _size,
+            child: ClipOval(
+              child: _withTransportBlur(
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: AppColorScheme.accent.withValues(
+                      alpha: GlassSettings.blursBackdrop ? 0.32 : 0.55,
+                    ),
+                    border: Border.all(
+                      color: Colors.white.withValues(alpha: 0.30),
+                      width: 0.8,
+                    ),
                   ),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.30),
-                    width: 0.8,
-                  ),
+                  child:
+                      Center(child: Icon(icon, size: 30, color: Colors.white)),
                 ),
-                child: Center(child: Icon(icon, size: 30, color: Colors.white)),
               ),
             ),
           ),
@@ -148,6 +154,7 @@ class AudiobookPlayButton extends StatelessWidget {
         color: AppColorScheme.accent,
         shape: const CircleBorder(),
         child: InkWell(
+          mouseCursor: SystemMouseCursors.click,
           customBorder: const CircleBorder(),
           onTap: onTap,
           child: Icon(
@@ -199,17 +206,20 @@ class AudiobookSkipButton extends StatelessWidget {
     );
 
     if (apple) {
-      return CupertinoButton(
-        padding: const EdgeInsets.all(8),
-        minimumSize: const Size.square(44),
-        onPressed: onTap,
-        child: glyph,
+      return audiobookClickable(
+        child: CupertinoButton(
+          padding: const EdgeInsets.all(8),
+          minimumSize: const Size.square(44),
+          onPressed: onTap,
+          child: glyph,
+        ),
       );
     }
 
     return Material(
       color: Colors.transparent,
       child: InkWell(
+        mouseCursor: SystemMouseCursors.click,
         borderRadius: BorderRadius.circular(28),
         onTap: onTap,
         child: Padding(padding: const EdgeInsets.all(8), child: glyph),

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -2502,18 +2502,57 @@ class _TopMusicBarState extends State<TopMusicBar> {
                     ),
                   ),
                   const SizedBox(width: 12),
+                  // Focusable, not just tappable: a remote cannot tap, and
+                  // this title is the only way back to the player. Same focus
+                  // treatment as the transport buttons beside it.
                   Flexible(
-                    child: GestureDetector(
-                      onTap: () => appRouter.push(Destinations.audioPlayer),
-                      child: Text(
-                        displayText,
-                        style: TextStyle(
-                          color: AppColorScheme.onSurface,
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
+                    child: Focus(
+                      onKeyEvent: (node, event) {
+                        if (isActivateKey(event)) {
+                          appRouter.push(Destinations.audioPlayer);
+                          return KeyEventResult.handled;
+                        }
+                        return KeyEventResult.ignored;
+                      },
+                      child: Builder(
+                        builder: (context) {
+                          final focused = InputModeTracker.showFocusVisuals(
+                            context,
+                            Focus.of(context).hasFocus,
+                          );
+                          return MouseRegion(
+                            cursor: SystemMouseCursors.click,
+                            child: GestureDetector(
+                              onTap: () =>
+                                  appRouter.push(Destinations.audioPlayer),
+                              child: AnimatedContainer(
+                                duration: const Duration(milliseconds: 90),
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 3,
+                                ),
+                                decoration: BoxDecoration(
+                                  borderRadius: AppRadius.circular(12),
+                                  color: focused
+                                      ? AppColorScheme.onSurface.withValues(
+                                          alpha: 0.22,
+                                        )
+                                      : Colors.transparent,
+                                ),
+                                child: Text(
+                                  displayText,
+                                  style: TextStyle(
+                                    color: AppColorScheme.onSurface,
+                                    fontSize: 13,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                            ),
+                          );
+                        },
                       ),
                     ),
                   ),


### PR DESCRIPTION
# Pull Request

---

## Summary

On TV the chapter drawer was squeezed between the chapter strip and the transport controls, so one row fitted at a time, and once focus was inside there was no way back out. On macos almost nothing reacted to the mouse: no cursor change, no button labels, and the focused-timeline slider sat as a 176px stub in a full-width row. macos builds Cupertino widgets, and those carry no cursor, no hover callback and a hard-coded slider width.

The split layout now has two columns with one job each. The drawer owns the left column, so closing it drops a column.
Everything else lives in the right column in a fixed order. D-pad navigation follows the same shape: up and down stay inside a column, left and right cross between them.

The drawer rows on TV are a shared 30px row instead of `ListTile`, which fits way more chapters than before, and gives every tab the same focus rectangle.

## Related Issues

- Closes #
- Fixes #1481 
- Related to #

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

**Split layout** (`audiobook_player_view.dart`)

- The left column holds the drawer and nothing else. Cover, title, chapter strip, timelines, transport and action rail all live in the right column, in an order that does not change when the drawer opens or closes.
- The cover is `Flexible`: it takes the height the controls leave, so it is large on a desktop window, small on a TV, and dropped rather than overflowing when there is no room.
- The drawer keeps 7.5% clear at the top and bottom so it sits centred against the controls instead of running the full height of the window.
- On phones the cover is sized from the space the title and chapter strip leave, so a 640dp screen shows the whole player without scrolling.

**D-pad navigation** (`audiobook_player_view.dart`)

- Up and down walk one column at a time. The header spans both and returns focus to the column you came from.
- A row in Bookmarks or Notes has its own edit and delete buttons. Right steps through those before it crosses to the controls.

**Drawer on TV** (`audiobook_drawer.dart`)

- One shared `_DenseRow` for all five tabs: 30px, single line, same focus rectangle everywhere. `ListTile` cannot do this, it sizes itself from its baselines and the text spills outside the box.
- The queue no longer fills the focused row's background, which competed with the focus rectangle.
- The tab bar scales down to fit its column, since a d-pad cannot scroll it.

**Timelines** (`audiobook_progress_bar.dart`)

- The focused window is labelled by offset (`-30:00` / `+30:00`) above the slider, computed from the real window so it stays right at the ends of the book. Two absolute clock times there read as elapsed and total.
- "Full Timeline" now titles the bar it describes.
- `CupertinoSlider` gets a tight width constraint, otherwise it pins itself to 176px.

**Mouse affordances** (`audiobook_pointer.dart` and the widgets around it)

- New `audiobookClickable` helper: cursor and hover for the Cupertino widgets the player uses on macos, which carry neither.
- Applied to the header, transport, action rail and chapter strip. Every`InkWell` in the player states its cursor.
- The action rail expands to show its label on hover, as it already did on focus with a remote and web
- The chapter strip chevron is hidden on TV, where the strip is not focusable.

**Mini player** (`top_toolbar.dart`)

- The title is focusable and activates with the remote, so a TV can get back to the player page when playback started without opening it.

**Mobile action rail** (`audiobook_action_rail.dart`)

- Captions take an equal slice of the row and wrap over two lines instead of being cut to "Playback s…".

## Platform

- [ ] Android
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

Physical device for macos. Emulators for Android TV and Android.

### Test Steps

1. TV, open an audiobook with chapters. The drawer is on the left, way more chapters visible and smoother dpad navigation.
2. Walk the chapter list with down. From any row, press right: focus lands on the first transport button. Press left: back to the same row.
3. On desktops, close the drawer with the header button. The left column disappears and the player spreads over the full width.
4. Desktop macos, hover the action rail. The pointer becomes a hand and each button shows its label. The focused-timeline slider spans the full row.
5. Desktop, check the timeline labels read `-30:00` and `+30:00`, and that near the start of the book they read the real offsets instead.
6. On phone the bottom captions wrap instead of clipping.
7. Start an audiobook that is already playing, then focus the mini bar title with the remote and press OK. The player page opens.

## Screenshots (if applicable)

### TV
**Before**
<img width="1076" height="628" alt="Screenshot 2026-09-10 at 17 15 18" src="https://github.com/user-attachments/assets/cc05f311-ef2a-45ac-a351-bbb2911159a7" />
**After**
<img width="1076" height="628" alt="Screenshot 2026-09-10 at 14 38 46" src="https://github.com/user-attachments/assets/60e5bf55-1bb9-4a10-ac70-64d4c9f60d87" />

### Desktop
**Before**
<img width="1840" height="1115" alt="Screenshot 2026-09-10 at 17 14 17" src="https://github.com/user-attachments/assets/f70bbe9b-311a-42e8-8682-b007363eb0fb" />
**After**
<img width="1840" height="1115" alt="Screenshot 2026-09-10 at 14 38 10" src="https://github.com/user-attachments/assets/6d35211d-99c8-4704-a070-13e343a068b4" />

### Mobile
**Before**
<img width="510" height="1014" alt="Screenshot 2026-09-10 at 17 17 06" src="https://github.com/user-attachments/assets/37dc35f2-ce91-402f-a12d-31a1e606a740" />
**After**
<img width="510" height="1014" alt="Screenshot 2026-09-10 at 14 51 15" src="https://github.com/user-attachments/assets/23bb6e43-500a-4e7e-a27a-76775155018e" />

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
