### PR TITLE
Putting Some Shine on Spotlight: A Tale in ~6/7~ 8 Commits

### DIFF
--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -44,7 +44,11 @@ class BackgroundService {
   Stream<String?> get backgroundStream => _backgroundController.stream;
   Stream<BlurContext> get blurContextStream => _blurContextController.stream;
 
-  void setBackground(AggregatedItem? item, {BlurContext context = BlurContext.details}) {
+  void setBackground(
+    AggregatedItem? item, {
+    BlurContext context = BlurContext.details,
+    int? startIndex,
+  }) {
     if (item == null) return clearBackgrounds();
 
     _blurContext = context;
@@ -126,7 +130,9 @@ class BackgroundService {
       }
     }
 
-    _loadBackgrounds(urls);
+    final initialIndex =
+        startIndex ?? (context == BlurContext.details ? 1 : 0);
+    _loadBackgrounds(urls, startIndex: initialIndex);
   }
 
   void setBackgroundUrl(String url, {BlurContext context = BlurContext.browsing}) {
@@ -144,12 +150,13 @@ class BackgroundService {
     _evictBackgrounds(previousUrls);
   }
 
-  void _loadBackgrounds(List<String> urls) {
+  void _loadBackgrounds(List<String> urls, {int startIndex = 0}) {
     final uniqueUrls = urls.where((u) => u.isNotEmpty).toSet().toList();
     if (uniqueUrls.isEmpty) return clearBackgrounds();
     _slideshowTimer?.cancel();
     _backgrounds = uniqueUrls;
-    _currentIndex = 0;
+    _currentIndex =
+        (startIndex > 0 && startIndex < uniqueUrls.length) ? startIndex : 0;
     _update();
   }
 

--- a/lib/data/services/background_service.dart
+++ b/lib/data/services/background_service.dart
@@ -130,9 +130,7 @@ class BackgroundService {
       }
     }
 
-    final initialIndex =
-        startIndex ?? (context == BlurContext.details ? 1 : 0);
-    _loadBackgrounds(urls, startIndex: initialIndex);
+    _loadBackgrounds(urls, startIndex: startIndex ?? 0);
   }
 
   void setBackgroundUrl(String url, {BlurContext context = BlurContext.browsing}) {

--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -184,6 +184,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('tmdbApiKey', UserPreferences.tmdbApiKey, SyncCodec.text, receiveOnly: true),
   SyncedField('seerrEnabled', UserPreferences.seerrEnabled, SyncCodec.boolean),
   SyncedField('seerrBlockNsfw', UserPreferences.seerrBlockNsfw, SyncCodec.boolean),
+  SyncedField('seerrShowMissingCollectionItems', UserPreferences.seerrShowMissingCollectionItems, SyncCodec.boolean),
   SyncedField('recentlyReleasedSeriesType', UserPreferences.recentlyReleasedSeriesType, SyncCodec.enumName, enumValues: prefs.RecentlyReleasedSeriesType.values),
 
   // Settings that previously stayed on the device. Grouped roughly by the screen they

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1149,6 +1149,7 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> _loadBoxSetSeerrItems() async {
     final item = _item;
     if (item == null || item.type != 'BoxSet') return;
+    if (!GetIt.instance<SeerrPreferences>().showMissingCollectionItems) return;
     if (!GetIt.instance<PluginSyncService>().seerrAvailable) return;
 
     try {
@@ -1492,7 +1493,9 @@ class ItemDetailViewModel extends ChangeNotifier {
 
       final collections = ordered.whereType<ParentCollection>().toList();
 
-      if (GetIt.instance<PluginSyncService>().seerrAvailable) {
+      final showMissing =
+          GetIt.instance<SeerrPreferences>().showMissingCollectionItems;
+      if (showMissing && GetIt.instance<PluginSyncService>().seerrAvailable) {
         try {
           final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
           await seerrRepo.ensureInitialized();

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -20,6 +20,8 @@ import '../../preference/seerr_preferences.dart';
 import '../../util/episode_playability.dart';
 import '../services/plugin_sync_service.dart';
 import '../services/user_data_sync.dart';
+import '../services/seerr/seerr_api_models.dart';
+import 'seerr_discover_view_model.dart';
 import 'seerr_media_detail_view_model.dart';
 
 enum CollectionSortOption {
@@ -81,17 +83,114 @@ class DeleteItemFailure {
 class ParentCollection {
   final String id;
   final String name;
-  final String? primaryImageTag;
-  final AggregatedItem? boxSetItem;
+
+  /// The collection itself as an item, for a grid cell that opens it.
+  final AggregatedItem boxSetItem;
+
+  /// The collection's library members, in release order.
   final List<AggregatedItem> items;
+
+  /// Titles TMDB files under this collection that the library lacks, from
+  /// Seerr. Kept apart from [items] because the library lists feed user-data
+  /// sync and the classic collection row, and neither can take a Seerr id.
+  final List<AggregatedItem> missingItems;
 
   ParentCollection({
     required this.id,
     required this.name,
-    this.primaryImageTag,
-    this.boxSetItem,
+    required this.boxSetItem,
     required this.items,
+    this.missingItems = const [],
   });
+
+  /// Library members with the missing titles slotted in by release date.
+  List<AggregatedItem> get itemsWithMissing =>
+      mergeMissingByReleaseOrder(items, missingItems);
+
+  ParentCollection withMissingItems(List<AggregatedItem> missing) =>
+      ParentCollection(
+        id: id,
+        name: name,
+        boxSetItem: boxSetItem,
+        items: items,
+        missingItems: missing,
+      );
+}
+
+/// Where the detail page's similar-titles list came from, so a section can be
+/// named for the source that produced it.
+enum SimilarSource { jellyfin, moonfin, tmdb }
+
+/// Slots [missing] into [library] by release date without reordering the
+/// library entries, so a collection keeps whatever order the server gave it
+/// and each absent title lands where it belongs in the run.
+List<AggregatedItem> mergeMissingByReleaseOrder(
+  List<AggregatedItem> library,
+  List<AggregatedItem> missing,
+) {
+  if (missing.isEmpty) return library;
+  DateTime? released(AggregatedItem item) {
+    final date = item.premiereDate;
+    if (date != null) return date;
+    final year = item.productionYear;
+    return year == null ? null : DateTime(year);
+  }
+
+  final merged = List<AggregatedItem>.of(library);
+  for (final item in missing) {
+    final key = released(item);
+    var at = merged.length;
+    if (key != null) {
+      final later = merged.indexWhere((existing) {
+        final date = released(existing);
+        return date != null && key.isBefore(date);
+      });
+      if (later >= 0) at = later;
+    }
+    merged.insert(at, item);
+  }
+  return merged;
+}
+
+/// The parts of a TMDB collection the library lacks, as Seerr-backed items.
+/// Ids are bare TMDB numbers carrying a `SeerrMediaType`, the shape every
+/// other Seerr item in the app has, so the Seerr detail route resolves them.
+/// Adult titles are dropped under the same rule the discover rows apply.
+@visibleForTesting
+List<AggregatedItem> seerrMissingCollectionItems({
+  required Iterable<SeerrDiscoverItem> parts,
+  required Set<String> libraryTmdbIds,
+  required bool blockNsfw,
+}) {
+  final missing = <AggregatedItem>[];
+  for (final part in parts) {
+    final tmdbId = part.id.toString();
+    if (libraryTmdbIds.contains(tmdbId)) continue;
+    if (blockNsfw && SeerrDiscoverViewModel.isNsfw(part)) continue;
+    final releaseDate = part.releaseDate;
+    missing.add(
+      AggregatedItem(
+        id: tmdbId,
+        serverId: 'seerr',
+        rawData: {
+          'Id': tmdbId,
+          'Name': part.title ?? part.name ?? '',
+          'Type': 'Movie',
+          'Overview': part.overview,
+          'PosterPath': part.posterPath,
+          'BackdropPath': part.backdropPath,
+          'PremiereDate': releaseDate,
+          'ProductionYear': releaseDate != null && releaseDate.length >= 4
+              ? int.tryParse(releaseDate.substring(0, 4))
+              : null,
+          'SeerrMediaType': 'movie',
+          'SeerrStatus': part.mediaInfo?.status,
+          'ProviderIds': {'Tmdb': tmdbId},
+        },
+      ),
+    );
+  }
+  return missing;
 }
 
 class ItemDetailViewModel extends ChangeNotifier {
@@ -151,6 +250,11 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   List<AggregatedItem> _similar = const [];
   List<AggregatedItem> get similar => _similar;
+
+  SimilarSource _similarSource = SimilarSource.jellyfin;
+
+  /// Where [similar] came from, for a label that matches the list.
+  SimilarSource get similarSource => _similarSource;
 
   List<AggregatedItem> _filmography = const [];
   List<AggregatedItem> get filmography => _filmography;
@@ -293,6 +397,10 @@ class ItemDetailViewModel extends ChangeNotifier {
   List<AggregatedItem> get parentCollectionItems => _parentCollectionItems;
 
   List<ParentCollection> _parentCollections = const [];
+
+  /// Bumped on every publication of [_parentCollections], so a Seerr pass
+  /// started for an earlier load can tell it has gone stale.
+  int _parentCollectionsLoad = 0;
   List<ParentCollection> get parentCollections => _parentCollections;
 
   List<AggregatedItem> _features = const [];
@@ -728,10 +836,10 @@ class ItemDetailViewModel extends ChangeNotifier {
     } else if (type == 'Audio') {
       futures.add(_loadLyrics());
     } else if (type == 'BoxSet') {
-      futures.add(() async {
-        await _loadCollectionItems();
-        await _loadBoxSetSeerrItems();
-      }());
+      futures.add(_loadCollectionItems());
+      // Deliberately not awaited, so a slow Seerr server never holds the
+      // collection's own members back.
+      unawaited(_loadBoxSetSeerrItems());
       futures.add(_buildPlaylistIndex());  // playlist — Phase 1, runs concurrently
     } else if (type == 'MusicVideo' ||
         type == 'Movie' ||
@@ -1131,7 +1239,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       parentId: itemId,
       startIndex: _collectionFetchedCount,
       limit: _collectionPageSize,
-      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People,ProviderIds',
+      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
     );
     final newItems = _mapItems((data['Items'] as List?) ?? []);
     final total = data['TotalRecordCount'] as int?;
@@ -1146,69 +1254,144 @@ class ItemDetailViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool get _showMissingCollectionItems =>
+      GetIt.instance<UserPreferences>().get(
+        UserPreferences.seerrShowMissingCollectionItems,
+      ) &&
+      GetIt.instance<PluginSyncService>().seerrAvailable;
+
+  /// Fills [missingCollectionItems] with the titles TMDB files under this box
+  /// set's collection that the library lacks. The grid is paged, so the diff
+  /// runs against the whole membership. Every title past the first page would
+  /// otherwise come back as missing.
   Future<void> _loadBoxSetSeerrItems() async {
     final item = _item;
     if (item == null || item.type != 'BoxSet') return;
-    if (!GetIt.instance<SeerrPreferences>().showMissingCollectionItems) return;
-    if (!GetIt.instance<PluginSyncService>().seerrAvailable) return;
-
+    if (!_showMissingCollectionItems) return;
     try {
-      int? collectionTmdbId = int.tryParse(item.tmdbId ?? '');
-      final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
-      await seerrRepo.ensureInitialized();
-
-      if (collectionTmdbId == null && _collectionItems.isNotEmpty) {
-        for (final child in _collectionItems) {
-          final childTmdb = int.tryParse(child.tmdbId ?? '');
-          if (childTmdb != null && childTmdb > 0) {
-            try {
-              final movie = await seerrRepo.getMovieDetails(childTmdb);
-              if (movie.collection?.id != null) {
-                collectionTmdbId = movie.collection!.id;
-                break;
-              }
-            } catch (_) {}
-          }
-        }
-      }
-
-      if (collectionTmdbId == null) return;
-
-      final seerrCol = await seerrRepo.getCollectionDetails(collectionTmdbId);
-      final existingTmdbIds = _collectionItems
-          .map((i) => i.tmdbId)
-          .whereType<String>()
-          .toSet();
-
-      final missing = <AggregatedItem>[];
-      for (final part in seerrCol.parts) {
-        if (!existingTmdbIds.contains(part.id.toString())) {
-          missing.add(
-            AggregatedItem(
-              id: part.id.toString(),
-              serverId: 'seerr',
-              rawData: {
-                'Id': part.id.toString(),
-                'Name': part.title ?? part.name ?? '',
-                'Type': 'Movie',
-                'SeerrMediaType': 'movie',
-                'Overview': part.overview,
-                'PosterPath': part.posterPath,
-                'BackdropPath': part.backdropPath,
-                'PremiereDate': part.releaseDate,
-                'ProductionYear': (part.releaseDate != null && part.releaseDate!.length >= 4)
-                    ? int.tryParse(part.releaseDate!.substring(0, 4))
-                    : null,
-                'ProviderIds': {'Tmdb': part.id.toString()},
-              },
-            ),
-          );
-        }
-      }
-
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      final data = await _client.itemsApi.getItems(
+        parentId: itemId,
+        fields: 'ProviderIds',
+      );
+      final members = _mapItems((data['Items'] as List?) ?? []);
+      final collectionId = await _resolveSeerrCollectionId(
+        repo,
+        boxSetTmdbId: item.tmdbId,
+        members: members,
+      );
+      if (collectionId == null) return;
+      final missing = await _fetchMissingCollectionItems(
+        repo,
+        collectionId,
+        members,
+      );
+      if (_isDisposed || _item?.id != item.id) return;
       _missingCollectionItems = missing;
       notifyListeners();
     } catch (_) {}
+  }
+
+  /// Seerr's missing-title pass for the parent collections, run after they
+  /// are on screen so a slow Seerr server never holds the library rows back.
+  /// [load] is the publication this pass belongs to, and a reload in the
+  /// meantime makes the result stale, so it's dropped.
+  Future<void> _loadMissingParentCollectionItems(
+    List<ParentCollection> collections,
+    int load,
+  ) async {
+    if (collections.isEmpty || !_showMissingCollectionItems) return;
+    try {
+      final repo = await GetIt.instance.getAsync<SeerrRepository>();
+      await repo.ensureInitialized();
+      for (final collection in collections) {
+        final collectionId = await _resolveSeerrCollectionId(
+          repo,
+          boxSetTmdbId: collection.boxSetItem.tmdbId,
+          members: collection.items,
+        );
+        if (collectionId == null) continue;
+        final missing = await _fetchMissingCollectionItems(
+          repo,
+          collectionId,
+          collection.items,
+        );
+        if (missing.isEmpty) continue;
+        if (_isDisposed || load != _parentCollectionsLoad) return;
+        _parentCollections = [
+          for (final current in _parentCollections)
+            current.id == collection.id
+                ? current.withMissingItems(missing)
+                : current,
+        ];
+        notifyListeners();
+      }
+    } catch (_) {}
+  }
+
+  /// TMDB's collection id for a set of library members: the box set's own
+  /// TMDB id when the server scraped one, else the first movie member TMDB
+  /// files under a collection. Movie and TV ids share no namespace on TMDB,
+  /// so only movies are probed. A series id would resolve to a stranger.
+  Future<int?> _resolveSeerrCollectionId(
+    SeerrRepository repo, {
+    required String? boxSetTmdbId,
+    required List<AggregatedItem> members,
+  }) async {
+    final own = int.tryParse(boxSetTmdbId ?? '');
+    if (own != null && own > 0) return own;
+    final candidates = <int>[
+      for (final member in members)
+        if (member.type == 'Movie')
+          if (int.tryParse(member.tmdbId ?? '') case final id? when id > 0)
+            id,
+    ];
+    // A few at a time: one awaited request per member would cost a long
+    // collection seconds of serial round trips.
+    const maxConcurrent = 4;
+    for (var i = 0; i < candidates.length; i += maxConcurrent) {
+      final batch = candidates.skip(i).take(maxConcurrent);
+      final found = await Future.wait(
+        batch.map((id) async {
+          try {
+            return (await repo.getMovieDetails(id)).collection?.id;
+          } catch (_) {
+            return null;
+          }
+        }),
+      );
+      for (final id in found) {
+        if (id != null) return id;
+      }
+    }
+    return null;
+  }
+
+  /// The collection's parts the library lacks, or nothing when the collection
+  /// doesn't actually describe these members. A hand-made box set of
+  /// unrelated films would otherwise adopt whichever franchise its first
+  /// member happens to belong to.
+  Future<List<AggregatedItem>> _fetchMissingCollectionItems(
+    SeerrRepository repo,
+    int collectionId,
+    List<AggregatedItem> members,
+  ) async {
+    final collection = await repo.getCollectionDetails(collectionId);
+    final memberTmdbIds = <String>{
+      for (final member in members)
+        if (member.tmdbId case final id?) id,
+    };
+    final movieCount = members.where((m) => m.type == 'Movie').length;
+    final overlap = collection.parts
+        .where((part) => memberTmdbIds.contains(part.id.toString()))
+        .length;
+    if (overlap < (movieCount < 2 ? movieCount : 2)) return const [];
+    return seerrMissingCollectionItems(
+      parts: collection.parts,
+      libraryTmdbIds: memberTmdbIds,
+      blockNsfw: GetIt.instance<SeerrPreferences>().blockNsfw,
+    );
   }
 
   /// Puts [_flattenedIds] in place, either from a saved order or by scanning
@@ -1410,7 +1593,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
 
     try {
-      final Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})> boxSetInfo = {};
+      final Map<String, ({String name, Map<String, dynamic> rawData})> boxSetInfo = {};
       final ancestors = await _client.itemsApi.getAncestors(item.id);
       for (final ancestor in ancestors) {
         if (ancestor['Type'] == 'BoxSet') {
@@ -1419,11 +1602,8 @@ class ItemDetailViewModel extends ChangeNotifier {
           if (boxSetId != null && boxSetId.isNotEmpty && name != null) {
             final isMember = await _boxSetContainsItem(boxSetId, item.id);
             if (isMember && !boxSetInfo.containsKey(boxSetId)) {
-              final tag = (ancestor['ImageTags'] as Map?)?['Primary'] as String? ??
-                  ancestor['PrimaryImageTag'] as String?;
               boxSetInfo[boxSetId] = (
                 name: name,
-                primaryImageTag: tag,
                 rawData: Map<String, dynamic>.from(ancestor),
               );
             }
@@ -1464,102 +1644,21 @@ class ItemDetailViewModel extends ChangeNotifier {
           );
 
           final items = (data['Items'] as List?) ?? [];
-          final mappedItems = _sortCollectionByReleaseOrder(_mapItems(items));
-          final tag = info.primaryImageTag;
-          final raw = info.rawData;
-          final boxSetItem = AggregatedItem(
-            id: boxSetId,
-            serverId: item.serverId,
-            rawData: raw ?? {
-              'Id': boxSetId,
-              'Name': info.name,
-              'Type': 'BoxSet',
-              'IsFolder': true,
-              if (tag != null) ...{
-                'PrimaryImageTag': tag,
-                'ImageTags': {'Primary': tag},
-              },
-            },
-          );
           ordered[index] = ParentCollection(
             id: boxSetId,
             name: info.name,
-            primaryImageTag: tag,
-            boxSetItem: boxSetItem,
-            items: mappedItems,
+            boxSetItem: AggregatedItem(
+              id: boxSetId,
+              serverId: item.serverId,
+              rawData: info.rawData,
+            ),
+            items: _sortCollectionByReleaseOrder(_mapItems(items)),
           );
         }());
       }
       await Future.wait(fetchFutures);
 
       final collections = ordered.whereType<ParentCollection>().toList();
-
-      final showMissing =
-          GetIt.instance<SeerrPreferences>().showMissingCollectionItems;
-      if (showMissing && GetIt.instance<PluginSyncService>().seerrAvailable) {
-        try {
-          final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
-          await seerrRepo.ensureInitialized();
-          for (var i = 0; i < collections.length; i++) {
-            final col = collections[i];
-            int? colTmdbId;
-            for (final child in col.items) {
-              final childTmdb = int.tryParse(child.tmdbId ?? '');
-              if (childTmdb != null && childTmdb > 0) {
-                try {
-                  final movie = await seerrRepo.getMovieDetails(childTmdb);
-                  if (movie.collection?.id != null) {
-                    colTmdbId = movie.collection!.id;
-                    break;
-                  }
-                } catch (_) {}
-              }
-            }
-            if (colTmdbId != null) {
-              final seerrCol = await seerrRepo.getCollectionDetails(colTmdbId);
-              final existingTmdbIds = col.items
-                  .map((item) => item.tmdbId)
-                  .whereType<String>()
-                  .toSet();
-              final missing = <AggregatedItem>[];
-              for (final part in seerrCol.parts) {
-                if (!existingTmdbIds.contains(part.id.toString())) {
-                  missing.add(
-                    AggregatedItem(
-                      id: part.id.toString(),
-                      serverId: 'seerr',
-                      rawData: {
-                        'Id': part.id.toString(),
-                        'Name': part.title ?? part.name ?? '',
-                        'Type': 'Movie',
-                        'SeerrMediaType': 'movie',
-                        'Overview': part.overview,
-                        'PosterPath': part.posterPath,
-                        'BackdropPath': part.backdropPath,
-                        'PremiereDate': part.releaseDate,
-                        'ProductionYear': (part.releaseDate != null && part.releaseDate!.length >= 4)
-                            ? int.tryParse(part.releaseDate!.substring(0, 4))
-                            : null,
-                        'ProviderIds': {'Tmdb': part.id.toString()},
-                      },
-                    ),
-                  );
-                }
-              }
-              if (missing.isNotEmpty) {
-                final allItems = _sortCollectionByReleaseOrder([...col.items, ...missing]);
-                collections[i] = ParentCollection(
-                  id: col.id,
-                  name: col.name,
-                  primaryImageTag: col.primaryImageTag,
-                  boxSetItem: col.boxSetItem,
-                  items: allItems,
-                );
-              }
-            }
-          }
-        } catch (_) {}
-      }
 
       _parentCollections = collections;
       if (collections.isNotEmpty) {
@@ -1571,6 +1670,8 @@ class ItemDetailViewModel extends ChangeNotifier {
       }
 
       notifyListeners();
+      final load = ++_parentCollectionsLoad;
+      unawaited(_loadMissingParentCollectionItems(collections, load));
     } catch (_) {}
   }
 
@@ -1593,8 +1694,8 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
   }
 
-  Future<Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})>> _findParentCollectionsByScanningBoxSets(String itemId) async {
-    final Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})> result = {};
+  Future<Map<String, ({String name, Map<String, dynamic> rawData})>> _findParentCollectionsByScanningBoxSets(String itemId) async {
+    final Map<String, ({String name, Map<String, dynamic> rawData})> result = {};
     try {
       const pageSize = 200;
       var startIndex = 0;
@@ -1604,7 +1705,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           includeItemTypes: ['BoxSet'],
           recursive: true,
           sortBy: 'SortName',
-          fields: 'BasicSyncInfo,PrimaryImageAspectRatio,ImageTags',
+          fields: 'BasicSyncInfo,PrimaryImageAspectRatio,ImageTags,ProviderIds',
           startIndex: startIndex,
           limit: pageSize,
           enableTotalRecordCount: true,
@@ -1614,7 +1715,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           break;
         }
 
-        final candidates = <({String id, String name, String? primaryImageTag, Map<String, dynamic> rawData})>[];
+        final candidates = <({String id, String name, Map<String, dynamic> rawData})>[];
         for (final raw in boxSets.whereType<Map>()) {
           final boxSet = raw.cast<String, dynamic>();
           final boxSetId = boxSet['Id']?.toString();
@@ -1622,14 +1723,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           if (boxSetId == null || boxSetId.isEmpty || boxSetName == null) {
             continue;
           }
-          final tag = (boxSet['ImageTags'] as Map?)?['Primary'] as String? ??
-              boxSet['PrimaryImageTag'] as String?;
-          candidates.add((
-            id: boxSetId,
-            name: boxSetName,
-            primaryImageTag: tag,
-            rawData: boxSet,
-          ));
+          candidates.add((id: boxSetId, name: boxSetName, rawData: boxSet));
         }
 
         // Cap how many membership lookups run at once so a large library
@@ -1650,7 +1744,6 @@ class ItemDetailViewModel extends ChangeNotifier {
             if (hasItem) {
               result[candidate.id] = (
                 name: candidate.name,
-                primaryImageTag: candidate.primaryImageTag,
                 rawData: candidate.rawData,
               );
             }
@@ -1761,6 +1854,7 @@ class ItemDetailViewModel extends ChangeNotifier {
         // falls through to Jellyfin's similar-items below.
         if (recommended.isNotEmpty) {
           _similar = recommended;
+          _similarSource = isLocal ? SimilarSource.moonfin : SimilarSource.tmdb;
           notifyListeners();
           return;
         }
@@ -1773,6 +1867,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       final data = await _client.itemsApi.getSimilarItems(itemId, limit: 15);
       final items = (data['Items'] as List?) ?? [];
       _similar = _mapItems(items);
+      _similarSource = SimilarSource.jellyfin;
       notifyListeners();
     } catch (_) {}
   }

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -81,9 +81,17 @@ class DeleteItemFailure {
 class ParentCollection {
   final String id;
   final String name;
+  final String? primaryImageTag;
+  final AggregatedItem? boxSetItem;
   final List<AggregatedItem> items;
 
-  ParentCollection({required this.id, required this.name, required this.items});
+  ParentCollection({
+    required this.id,
+    required this.name,
+    this.primaryImageTag,
+    this.boxSetItem,
+    required this.items,
+  });
 }
 
 class ItemDetailViewModel extends ChangeNotifier {
@@ -174,6 +182,9 @@ class ItemDetailViewModel extends ChangeNotifier {
 
   List<AggregatedItem> _collectionItems = const [];
   List<AggregatedItem> get collectionItems => _collectionItems;
+
+  List<AggregatedItem> _missingCollectionItems = const [];
+  List<AggregatedItem> get missingCollectionItems => _missingCollectionItems;
 
   // --- Collection grid pagination state ---
   static const _collectionPageSize = 50;
@@ -572,6 +583,7 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> load({String? mediaSourceId}) async {
     _state = ItemDetailState.loading;
     _collectionItems = const [];
+    _missingCollectionItems = const [];
     _parentCollectionItems = const [];
     _parentCollectionName = null;
     _parentCollections = const [];
@@ -716,7 +728,10 @@ class ItemDetailViewModel extends ChangeNotifier {
     } else if (type == 'Audio') {
       futures.add(_loadLyrics());
     } else if (type == 'BoxSet') {
-      futures.add(_loadCollectionItems()); // grid — Phase 2, starts immediately
+      futures.add(() async {
+        await _loadCollectionItems();
+        await _loadBoxSetSeerrItems();
+      }());
       futures.add(_buildPlaylistIndex());  // playlist — Phase 1, runs concurrently
     } else if (type == 'MusicVideo' ||
         type == 'Movie' ||
@@ -1116,7 +1131,7 @@ class ItemDetailViewModel extends ChangeNotifier {
       parentId: itemId,
       startIndex: _collectionFetchedCount,
       limit: _collectionPageSize,
-      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People',
+      fields: 'PrimaryImageAspectRatio,BasicSyncInfo,People,ProviderIds',
     );
     final newItems = _mapItems((data['Items'] as List?) ?? []);
     final total = data['TotalRecordCount'] as int?;
@@ -1129,6 +1144,69 @@ class ItemDetailViewModel extends ChangeNotifier {
         : newItems.length == _collectionPageSize;
     _collectionItems = [..._collectionItems, ...newItems];
     notifyListeners();
+  }
+
+  Future<void> _loadBoxSetSeerrItems() async {
+    final item = _item;
+    if (item == null || item.type != 'BoxSet') return;
+    if (!GetIt.instance<PluginSyncService>().seerrAvailable) return;
+
+    try {
+      int? collectionTmdbId = int.tryParse(item.tmdbId ?? '');
+      final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
+      await seerrRepo.ensureInitialized();
+
+      if (collectionTmdbId == null && _collectionItems.isNotEmpty) {
+        for (final child in _collectionItems) {
+          final childTmdb = int.tryParse(child.tmdbId ?? '');
+          if (childTmdb != null && childTmdb > 0) {
+            try {
+              final movie = await seerrRepo.getMovieDetails(childTmdb);
+              if (movie.collection?.id != null) {
+                collectionTmdbId = movie.collection!.id;
+                break;
+              }
+            } catch (_) {}
+          }
+        }
+      }
+
+      if (collectionTmdbId == null) return;
+
+      final seerrCol = await seerrRepo.getCollectionDetails(collectionTmdbId);
+      final existingTmdbIds = _collectionItems
+          .map((i) => i.tmdbId)
+          .whereType<String>()
+          .toSet();
+
+      final missing = <AggregatedItem>[];
+      for (final part in seerrCol.parts) {
+        if (!existingTmdbIds.contains(part.id.toString())) {
+          missing.add(
+            AggregatedItem(
+              id: 'tmdb:movie:${part.id}',
+              serverId: 'seerr',
+              rawData: {
+                'Id': 'tmdb:movie:${part.id}',
+                'Name': part.title ?? part.name ?? '',
+                'Type': 'Movie',
+                'Overview': part.overview,
+                'PosterPath': part.posterPath,
+                'BackdropPath': part.backdropPath,
+                'PremiereDate': part.releaseDate,
+                'ProductionYear': (part.releaseDate != null && part.releaseDate!.length >= 4)
+                    ? int.tryParse(part.releaseDate!.substring(0, 4))
+                    : null,
+                'ProviderIds': {'Tmdb': part.id.toString()},
+              },
+            ),
+          );
+        }
+      }
+
+      _missingCollectionItems = missing;
+      notifyListeners();
+    } catch (_) {}
   }
 
   /// Puts [_flattenedIds] in place, either from a saved order or by scanning
@@ -1330,7 +1408,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
 
     try {
-      final Map<String, String> boxSetIds = {};
+      final Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})> boxSetInfo = {};
       final ancestors = await _client.itemsApi.getAncestors(item.id);
       for (final ancestor in ancestors) {
         if (ancestor['Type'] == 'BoxSet') {
@@ -1338,17 +1416,23 @@ class ItemDetailViewModel extends ChangeNotifier {
           final name = ancestor['Name']?.toString();
           if (boxSetId != null && boxSetId.isNotEmpty && name != null) {
             final isMember = await _boxSetContainsItem(boxSetId, item.id);
-            if (isMember && !boxSetIds.containsKey(boxSetId)) {
-              boxSetIds[boxSetId] = name;
+            if (isMember && !boxSetInfo.containsKey(boxSetId)) {
+              final tag = (ancestor['ImageTags'] as Map?)?['Primary'] as String? ??
+                  ancestor['PrimaryImageTag'] as String?;
+              boxSetInfo[boxSetId] = (
+                name: name,
+                primaryImageTag: tag,
+                rawData: Map<String, dynamic>.from(ancestor),
+              );
             }
           }
         }
       }
 
       final scannedCollections = await _findParentCollectionsByScanningBoxSets(item.id);
-      boxSetIds.addAll(scannedCollections);
+      boxSetInfo.addAll(scannedCollections);
 
-      if (boxSetIds.isEmpty) {
+      if (boxSetInfo.isEmpty) {
         _parentCollections = const [];
         _parentCollectionItems = const [];
         _parentCollectionName = null;
@@ -1358,14 +1442,14 @@ class ItemDetailViewModel extends ChangeNotifier {
 
       // Keep collections in a stable order so the rows and the legacy
       // single-collection fields don't shuffle around between opens.
-      final entries = boxSetIds.entries.toList();
+      final entries = boxSetInfo.entries.toList();
       final ordered = List<ParentCollection?>.filled(entries.length, null);
       final fetchFutures = <Future<void>>[];
 
       for (var i = 0; i < entries.length; i++) {
         final index = i;
         final boxSetId = entries[i].key;
-        final name = entries[i].value;
+        final info = entries[i].value;
 
         fetchFutures.add(() async {
           // Not recursive and not filtered, same as the collection grid, so a
@@ -1374,20 +1458,104 @@ class ItemDetailViewModel extends ChangeNotifier {
             parentId: boxSetId,
             sortBy: 'PremiereDate,SortName',
             sortOrder: 'Ascending',
-            fields: 'PrimaryImageAspectRatio,BasicSyncInfo',
+            fields: 'PrimaryImageAspectRatio,BasicSyncInfo,ProviderIds',
           );
 
           final items = (data['Items'] as List?) ?? [];
+          final mappedItems = _sortCollectionByReleaseOrder(_mapItems(items));
+          final tag = info.primaryImageTag;
+          final raw = info.rawData;
+          final boxSetItem = AggregatedItem(
+            id: boxSetId,
+            serverId: item.serverId,
+            rawData: raw ?? {
+              'Id': boxSetId,
+              'Name': info.name,
+              'Type': 'BoxSet',
+              'IsFolder': true,
+              if (tag != null) ...{
+                'PrimaryImageTag': tag,
+                'ImageTags': {'Primary': tag},
+              },
+            },
+          );
           ordered[index] = ParentCollection(
             id: boxSetId,
-            name: name,
-            items: _sortCollectionByReleaseOrder(_mapItems(items)),
+            name: info.name,
+            primaryImageTag: tag,
+            boxSetItem: boxSetItem,
+            items: mappedItems,
           );
         }());
       }
       await Future.wait(fetchFutures);
 
       final collections = ordered.whereType<ParentCollection>().toList();
+
+      if (GetIt.instance<PluginSyncService>().seerrAvailable) {
+        try {
+          final seerrRepo = await GetIt.instance.getAsync<SeerrRepository>();
+          await seerrRepo.ensureInitialized();
+          for (var i = 0; i < collections.length; i++) {
+            final col = collections[i];
+            int? colTmdbId;
+            for (final child in col.items) {
+              final childTmdb = int.tryParse(child.tmdbId ?? '');
+              if (childTmdb != null && childTmdb > 0) {
+                try {
+                  final movie = await seerrRepo.getMovieDetails(childTmdb);
+                  if (movie.collection?.id != null) {
+                    colTmdbId = movie.collection!.id;
+                    break;
+                  }
+                } catch (_) {}
+              }
+            }
+            if (colTmdbId != null) {
+              final seerrCol = await seerrRepo.getCollectionDetails(colTmdbId);
+              final existingTmdbIds = col.items
+                  .map((item) => item.tmdbId)
+                  .whereType<String>()
+                  .toSet();
+              final missing = <AggregatedItem>[];
+              for (final part in seerrCol.parts) {
+                if (!existingTmdbIds.contains(part.id.toString())) {
+                  missing.add(
+                    AggregatedItem(
+                      id: 'tmdb:movie:${part.id}',
+                      serverId: 'seerr',
+                      rawData: {
+                        'Id': 'tmdb:movie:${part.id}',
+                        'Name': part.title ?? part.name ?? '',
+                        'Type': 'Movie',
+                        'Overview': part.overview,
+                        'PosterPath': part.posterPath,
+                        'BackdropPath': part.backdropPath,
+                        'PremiereDate': part.releaseDate,
+                        'ProductionYear': (part.releaseDate != null && part.releaseDate!.length >= 4)
+                            ? int.tryParse(part.releaseDate!.substring(0, 4))
+                            : null,
+                        'ProviderIds': {'Tmdb': part.id.toString()},
+                      },
+                    ),
+                  );
+                }
+              }
+              if (missing.isNotEmpty) {
+                final allItems = _sortCollectionByReleaseOrder([...col.items, ...missing]);
+                collections[i] = ParentCollection(
+                  id: col.id,
+                  name: col.name,
+                  primaryImageTag: col.primaryImageTag,
+                  boxSetItem: col.boxSetItem,
+                  items: allItems,
+                );
+              }
+            }
+          }
+        } catch (_) {}
+      }
+
       _parentCollections = collections;
       if (collections.isNotEmpty) {
         _parentCollectionName = collections.first.name;
@@ -1420,8 +1588,8 @@ class ItemDetailViewModel extends ChangeNotifier {
     }
   }
 
-  Future<Map<String, String>> _findParentCollectionsByScanningBoxSets(String itemId) async {
-    final Map<String, String> result = {};
+  Future<Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})>> _findParentCollectionsByScanningBoxSets(String itemId) async {
+    final Map<String, ({String name, String? primaryImageTag, Map<String, dynamic>? rawData})> result = {};
     try {
       const pageSize = 200;
       var startIndex = 0;
@@ -1431,7 +1599,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           includeItemTypes: ['BoxSet'],
           recursive: true,
           sortBy: 'SortName',
-          fields: 'BasicSyncInfo',
+          fields: 'BasicSyncInfo,PrimaryImageAspectRatio,ImageTags',
           startIndex: startIndex,
           limit: pageSize,
           enableTotalRecordCount: true,
@@ -1441,7 +1609,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           break;
         }
 
-        final candidates = <MapEntry<String, String>>[];
+        final candidates = <({String id, String name, String? primaryImageTag, Map<String, dynamic> rawData})>[];
         for (final raw in boxSets.whereType<Map>()) {
           final boxSet = raw.cast<String, dynamic>();
           final boxSetId = boxSet['Id']?.toString();
@@ -1449,7 +1617,14 @@ class ItemDetailViewModel extends ChangeNotifier {
           if (boxSetId == null || boxSetId.isEmpty || boxSetName == null) {
             continue;
           }
-          candidates.add(MapEntry(boxSetId, boxSetName));
+          final tag = (boxSet['ImageTags'] as Map?)?['Primary'] as String? ??
+              boxSet['PrimaryImageTag'] as String?;
+          candidates.add((
+            id: boxSetId,
+            name: boxSetName,
+            primaryImageTag: tag,
+            rawData: boxSet,
+          ));
         }
 
         // Cap how many membership lookups run at once so a large library
@@ -1459,7 +1634,7 @@ class ItemDetailViewModel extends ChangeNotifier {
           final batch = candidates.skip(i).take(maxConcurrent);
           await Future.wait(batch.map((candidate) async {
             final membership = await _client.itemsApi.getItems(
-              parentId: candidate.key,
+              parentId: candidate.id,
               fields: 'BasicSyncInfo',
             );
             final members = (membership['Items'] as List?) ?? const [];
@@ -1468,7 +1643,11 @@ class ItemDetailViewModel extends ChangeNotifier {
               return map['Id'] == itemId;
             });
             if (hasItem) {
-              result[candidate.key] = candidate.value;
+              result[candidate.id] = (
+                name: candidate.name,
+                primaryImageTag: candidate.primaryImageTag,
+                rawData: candidate.rawData,
+              );
             }
           }));
         }

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -1185,12 +1185,13 @@ class ItemDetailViewModel extends ChangeNotifier {
         if (!existingTmdbIds.contains(part.id.toString())) {
           missing.add(
             AggregatedItem(
-              id: 'tmdb:movie:${part.id}',
+              id: part.id.toString(),
               serverId: 'seerr',
               rawData: {
-                'Id': 'tmdb:movie:${part.id}',
+                'Id': part.id.toString(),
                 'Name': part.title ?? part.name ?? '',
                 'Type': 'Movie',
+                'SeerrMediaType': 'movie',
                 'Overview': part.overview,
                 'PosterPath': part.posterPath,
                 'BackdropPath': part.backdropPath,
@@ -1525,12 +1526,13 @@ class ItemDetailViewModel extends ChangeNotifier {
                 if (!existingTmdbIds.contains(part.id.toString())) {
                   missing.add(
                     AggregatedItem(
-                      id: 'tmdb:movie:${part.id}',
+                      id: part.id.toString(),
                       serverId: 'seerr',
                       rawData: {
-                        'Id': 'tmdb:movie:${part.id}',
+                        'Id': part.id.toString(),
                         'Name': part.title ?? part.name ?? '',
                         'Type': 'Movie',
+                        'SeerrMediaType': 'movie',
                         'Overview': part.overview,
                         'PosterPath': part.posterPath,
                         'BackdropPath': part.backdropPath,

--- a/lib/data/viewmodels/seerr_discover_view_model.dart
+++ b/lib/data/viewmodels/seerr_discover_view_model.dart
@@ -505,7 +505,12 @@ class SeerrDiscoverViewModel extends ChangeNotifier {
     }).toList();
   }
 
-  bool _isNsfw(SeerrDiscoverItem item) {
+  bool _isNsfw(SeerrDiscoverItem item) => isNsfw(item);
+
+  /// Whether [item] is adult content, by TMDB's flag or by a title or
+  /// overview that trips the keyword list. Shared with the other Seerr
+  /// ingestion paths so "hide adult content" means one thing everywhere.
+  static bool isNsfw(SeerrDiscoverItem item) {
     if (item.adult) return true;
     final text = '${item.displayTitle} ${item.overview ?? ''}';
     return nsfwPatterns.any((p) => p.hasMatch(text));

--- a/lib/data/viewmodels/seerr_media_detail_view_model.dart
+++ b/lib/data/viewmodels/seerr_media_detail_view_model.dart
@@ -478,7 +478,9 @@ class SeerrMediaDetailViewModel extends ChangeNotifier {
         tmdbId = match.id;
         resolvedMediaType = match.mediaType ?? mediaType;
       } else {
-        final parsed = int.tryParse(itemId);
+        final cleanId =
+            itemId.replaceAll(RegExp(r'^tmdb:(?:movie:|tv:|person:)?'), '');
+        final parsed = int.tryParse(cleanId);
         if (parsed == null) {
           throw Exception('Invalid media ID');
         }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -224,10 +224,6 @@
   "@spotlightSimilarRecommendations": {
     "description": "Title of the spotlight summary card that opens the similar titles and recommendations modal"
   },
-  "spotlightSeerrRecommendations": "Similar and Seerr Recommendations",
-  "@spotlightSeerrRecommendations": {
-    "description": "Title of the spotlight similar card when Seerr recommendations are available"
-  },
   "spotlightSeasonsEpisodes": "Seasons and Episodes",
   "@spotlightSeasonsEpisodes": {
     "description": "Title of the spotlight summary card that opens the seasons grid modal for a series"

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -256,6 +256,10 @@
   "@spotlightSimilarSeerr": {
     "description": "Header of the Seerr similar-titles section when it appears beside the library's own similar section"
   },
+  "spotlightRecommendationsSeerr": "Recommendations (Seerr)",
+  "@spotlightRecommendationsSeerr": {
+    "description": "Header of the Seerr recommendations section when it appears in the Spotlight recommendations modal"
+  },
   "spotlightPeopleCount": "{count, plural, =1{1 person} other{{count} people}}",
   "@spotlightPeopleCount": {
     "description": "Count fragment on spotlight summary cards: people",
@@ -5880,6 +5884,14 @@
   "hideAdultContent": "Hide adult content in results",
   "@hideAdultContent": {
     "description": "Description for NSFW filter"
+  },
+  "showMissingCollectionItems": "Show Missing Collection Items",
+  "@showMissingCollectionItems": {
+    "description": "Setting title to show missing items from Seerr on Collection pages"
+  },
+  "showMissingCollectionItemsDesc": "Include missing items on Collection pages",
+  "@showMissingCollectionItemsDesc": {
+    "description": "Setting subtitle explaining that missing items will be included on Collection pages"
   },
   "seerrNotificationsSection": "Notifications",
   "@seerrNotificationsSection": {

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -514,12 +514,6 @@ abstract class AppLocalizations {
   /// **'Similar and Recommendations'**
   String get spotlightSimilarRecommendations;
 
-  /// Title of the spotlight similar card when Seerr recommendations are available
-  ///
-  /// In en, this message translates to:
-  /// **'Similar and Seerr Recommendations'**
-  String get spotlightSeerrRecommendations;
-
   /// Title of the spotlight summary card that opens the seasons grid modal for a series
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -562,6 +562,12 @@ abstract class AppLocalizations {
   /// **'Similar (Seerr)'**
   String get spotlightSimilarSeerr;
 
+  /// Header of the Seerr recommendations section when it appears in the Spotlight recommendations modal
+  ///
+  /// In en, this message translates to:
+  /// **'Recommendations (Seerr)'**
+  String get spotlightRecommendationsSeerr;
+
   /// Count fragment on spotlight summary cards: people
   ///
   /// In en, this message translates to:
@@ -7887,6 +7893,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Hide adult content in results'**
   String get hideAdultContent;
+
+  /// Setting title to show missing items from Seerr on Collection pages
+  ///
+  /// In en, this message translates to:
+  /// **'Show Missing Collection Items'**
+  String get showMissingCollectionItems;
+
+  /// Setting subtitle explaining that missing items will be included on Collection pages
+  ///
+  /// In en, this message translates to:
+  /// **'Include missing items on Collection pages'**
+  String get showMissingCollectionItemsDesc;
 
   /// Header for the Seerr notifications settings section
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -195,6 +195,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4444,6 +4447,13 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Versteek volwasse inhoud in resultate';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Kennisgewings';

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -170,10 +170,6 @@ class AppLocalizationsAf extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -170,10 +170,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -195,6 +195,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4446,6 +4449,13 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'إخفاء محتوى البالغين في النتائج';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'الإشعارات';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -170,10 +170,6 @@ class AppLocalizationsBe extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -195,6 +195,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4459,6 +4462,13 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Схаваць змесціва для дарослых у выніках';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Апавяшчэнні';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -195,6 +195,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4461,6 +4464,13 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Скриване на съдържание за възрастни в резултатите';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Известия';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -170,10 +170,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -195,6 +195,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4430,6 +4433,13 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ফলাফলে প্রাপ্তবয়স্কদের সামগ্রী লুকান';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'বিজ্ঞপ্তি';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -170,10 +170,6 @@ class AppLocalizationsBn extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -195,6 +195,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4494,6 +4497,13 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Amaga contingut per a adults als resultats';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notificacions';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -170,10 +170,6 @@ class AppLocalizationsCa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -196,6 +196,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4449,6 +4452,13 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Skrýt ve výsledcích obsah pouze pro dospělé';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Oznámení';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -171,10 +171,6 @@ class AppLocalizationsCs extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -195,6 +195,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4464,6 +4467,13 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Cuddio cynnwys oedolion yn y canlyniadau';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Hysbysiadau';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -170,10 +170,6 @@ class AppLocalizationsCy extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -172,10 +172,6 @@ class AppLocalizationsDa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -197,6 +197,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4437,6 +4440,13 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Skjul voksenindhold i resultater';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notifikationer';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -195,6 +195,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4543,6 +4546,13 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Inhalte für Erwachsene in Ergebnissen ausblenden';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Benachrichtigungen';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -170,10 +170,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -172,10 +172,6 @@ class AppLocalizationsEl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -197,6 +197,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4485,6 +4488,13 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Απόκρυψη περιεχομένου για ενηλίκους στα αποτελέσματα';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Ειδοποιήσεις';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -195,6 +195,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4418,6 +4421,13 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Hide adult content in results';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notifications';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -170,10 +170,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -195,6 +195,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4436,6 +4439,13 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Kaŝi plenkreskan enhavon en rezultoj';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Sciigoj';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -170,10 +170,6 @@ class AppLocalizationsEo extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -170,10 +170,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -195,6 +195,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4468,6 +4471,13 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ocultar contenido adulto en los resultados';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notificaciones';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -171,10 +171,6 @@ class AppLocalizationsEt extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -196,6 +196,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4443,6 +4446,13 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Peida tulemustes täiskasvanutele mõeldud sisu';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Teavitused';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -195,6 +195,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4417,6 +4420,13 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'محتوای بزرگسالان را در نتایج پنهان کنید';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'اعلان‌ها';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -170,10 +170,6 @@ class AppLocalizationsFa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -172,10 +172,6 @@ class AppLocalizationsFi extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -197,6 +197,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4458,6 +4461,13 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Piilota vain aikuisille suunnattu sisältö tuloksissa';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Ilmoitukset';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -170,10 +170,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -195,6 +195,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4489,6 +4492,13 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Masquer le contenu adulte dans les résultats';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notifications';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -170,10 +170,6 @@ class AppLocalizationsGl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -195,6 +195,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4483,6 +4486,13 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ocultar contido para adultos nos resultados';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notificacións';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -170,10 +170,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -195,6 +195,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4402,6 +4405,13 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'הסתר תוכן למבוגרים בתוצאות';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'התראות';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -195,6 +195,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4429,6 +4432,13 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'परिणामों में वयस्क सामग्री छिपाएँ';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'सूचनाएँ';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -170,10 +170,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -170,10 +170,6 @@ class AppLocalizationsHr extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -195,6 +195,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4560,6 +4563,13 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Sakrij sadržaj za odrasle u rezultatima';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Obavijesti';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -170,10 +170,6 @@ class AppLocalizationsHu extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -195,6 +195,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4469,6 +4472,13 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'A felnőtteknek szánt tartalom elrejtése a találatok között';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Értesítések';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -170,10 +170,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -195,6 +195,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4442,6 +4445,13 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Sembunyikan konten dewasa dari hasil';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notifikasi';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -195,6 +195,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4463,6 +4466,13 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Nascondi contenuti per adulti nei risultati';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notifiche';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -170,10 +170,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -194,6 +194,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4352,6 +4355,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get hideAdultContent => '結果内のアダルト コンテンツを非表示にする';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => '通知';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -169,10 +169,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -195,6 +195,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4457,6 +4460,13 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Нәтижелерде ересектерге арналған мазмұнды жасыру';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Хабарландырулар';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -170,10 +170,6 @@ class AppLocalizationsKk extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -195,6 +195,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4461,6 +4464,13 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ಫಲಿತಾಂಶಗಳಲ್ಲಿ ವಯಸ್ಕ ವಿಷಯವನ್ನು ಮರೆಮಾಡಿ';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'ಅಧಿಸೂಚನೆಗಳು';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -170,10 +170,6 @@ class AppLocalizationsKn extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -169,10 +169,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -194,6 +194,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4335,6 +4338,13 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get hideAdultContent => '검색결과에서 성인용 콘텐츠 숨기기';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => '알림';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -170,10 +170,6 @@ class AppLocalizationsLt extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -195,6 +195,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4460,6 +4463,13 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Slėpti suaugusiesiems skirtą turinį rezultatuose';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Pranešimai';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -195,6 +195,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4458,6 +4461,13 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Paslēpt rezultātos pieaugušajiem paredzētu saturu';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Paziņojumi';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -170,10 +170,6 @@ class AppLocalizationsLv extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -195,6 +195,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4459,6 +4462,13 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Сокријте содржини за возрасни во резултатите';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Известувања';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -170,10 +170,6 @@ class AppLocalizationsMk extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -195,6 +195,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4465,6 +4468,13 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'ഫലങ്ങളിൽ മുതിർന്നവർക്കുള്ള ഉള്ളടക്കം മറയ്ക്കുക';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'അറിയിപ്പുകൾ';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -170,10 +170,6 @@ class AppLocalizationsMl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -195,6 +195,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4449,6 +4452,13 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Үр дүнд нь насанд хүрэгчдэд зориулсан контентыг нуу';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Мэдэгдэл';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -170,10 +170,6 @@ class AppLocalizationsMn extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -195,6 +195,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4434,6 +4437,13 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Skjul voksent innhold i resultater';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Varsler';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -170,10 +170,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -196,6 +196,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4461,6 +4464,13 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Inhoud voor volwassenen verbergen in de resultaten';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Meldingen';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -171,10 +171,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -170,10 +170,6 @@ class AppLocalizationsPa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -195,6 +195,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4427,6 +4430,13 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ਨਤੀਜਿਆਂ ਵਿੱਚ ਬਾਲਗ ਸਮੱਗਰੀ ਨੂੰ ਲੁਕਾਓ';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'ਸੂਚਨਾਵਾਂ';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -195,6 +195,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4589,6 +4592,13 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ukryj w wynikach treści dla dorosłych';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Powiadomienia';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -170,10 +170,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -170,10 +170,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -195,6 +195,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4460,6 +4463,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ocultar conteúdo adulto nos resultados';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notificações';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -170,10 +170,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -195,6 +195,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4470,6 +4473,13 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Ascunde conținutul pentru adulți în rezultate';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Notificări';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -170,10 +170,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -195,6 +195,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4470,6 +4473,13 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Скрыть контент для взрослых в результатах';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Уведомления';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -170,10 +170,6 @@ class AppLocalizationsSi extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -195,6 +195,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4439,6 +4442,13 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ප්‍රතිඵලවල වැඩිහිටි අන්තර්ගතය සඟවන්න';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'දැනුම්දීම්';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -196,6 +196,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4462,6 +4465,13 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Skryť obsah pre dospelých vo výsledkoch';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Upozornenia';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -171,10 +171,6 @@ class AppLocalizationsSk extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -196,6 +196,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4465,6 +4468,13 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Skrij vsebino za odrasle v rezultatih';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Obvestila';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -171,10 +171,6 @@ class AppLocalizationsSl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -196,6 +196,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4470,6 +4473,13 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Fshih përmbajtjen për të rritur në rezultate';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Njoftimet';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -171,10 +171,6 @@ class AppLocalizationsSq extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -170,10 +170,6 @@ class AppLocalizationsSr extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -195,6 +195,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4562,6 +4565,13 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Сакриј садржај за одрасле у резултатима';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Обавештења';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -195,6 +195,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4443,6 +4446,13 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Dölj barnförbjudet innehåll i resultaten';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Aviseringar';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -170,10 +170,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -195,6 +195,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4466,6 +4469,13 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ficha maudhui ya watu wazima katika matokeo';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Arifa';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -170,10 +170,6 @@ class AppLocalizationsSw extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -195,6 +195,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4469,6 +4472,13 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'முடிவுகளில் வயது வந்தோருக்கான உள்ளடக்கத்தை மறை';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'அறிவிப்புகள்';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -170,10 +170,6 @@ class AppLocalizationsTa extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -170,10 +170,6 @@ class AppLocalizationsTe extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -195,6 +195,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4460,6 +4463,13 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ఫలితాల్లో పెద్దల కంటెంట్‌ను దాచండి';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'నోటిఫికేషన్‌లు';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -196,6 +196,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4411,6 +4414,13 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'ซ่อนเนื้อหาสำหรับผู้ใหญ่ในผลลัพธ์';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'การแจ้งเตือน';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -171,10 +171,6 @@ class AppLocalizationsTh extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -196,6 +196,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4474,6 +4477,13 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Itago ang nilalamang pang-adulto sa mga resulta';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Mga Notification';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -171,10 +171,6 @@ class AppLocalizationsTl extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -170,10 +170,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -195,6 +195,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4449,6 +4452,13 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get hideAdultContent =>
       'Sonuçlardaki yetişkinlere uygun içeriği gizle';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Bildirimler';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -170,10 +170,6 @@ class AppLocalizationsUg extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -195,6 +195,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4446,6 +4449,13 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'نەتىجىدە چوڭلارنىڭ مەزمۇنىنى يوشۇرۇش';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'ئۇقتۇرۇشلار';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -195,6 +195,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4464,6 +4467,13 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Приховати вміст для дорослих у результатах';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Сповіщення';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -170,10 +170,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -170,10 +170,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -195,6 +195,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4445,6 +4448,13 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get hideAdultContent => 'Ẩn nội dung người lớn trong kết quả';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => 'Thông báo';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -169,10 +169,6 @@ class AppLocalizationsYue extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -194,6 +194,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4318,6 +4321,13 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get hideAdultContent => '在結果中隱藏成人內容';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => '通知';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -193,6 +193,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get spotlightSimilarSeerr => 'Similar (Seerr)';
 
   @override
+  String get spotlightRecommendationsSeerr => 'Recommendations (Seerr)';
+
+  @override
   String spotlightPeopleCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -4288,6 +4291,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get hideAdultContent => '在结果中隐藏成人内容';
+
+  @override
+  String get showMissingCollectionItems => 'Show Missing Collection Items';
+
+  @override
+  String get showMissingCollectionItemsDesc =>
+      'Include missing items on Collection pages';
 
   @override
   String get seerrNotificationsSection => '通知';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -168,10 +168,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get spotlightSimilarRecommendations => 'Similar and Recommendations';
 
   @override
-  String get spotlightSeerrRecommendations =>
-      'Similar and Seerr Recommendations';
-
-  @override
   String get spotlightSeasonsEpisodes => 'Seasons and Episodes';
 
   @override

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -83,11 +83,6 @@ class SeerrPreferences {
   bool get blockNsfw => _store.getBool(_userKey('block_nsfw')) ?? true;
   Future<void> setBlockNsfw(bool value) => _store.setBool(_userKey('block_nsfw'), value);
 
-  bool get showMissingCollectionItems =>
-      _store.getBool(_userKey('show_missing_collection_items')) ?? true;
-  Future<void> setShowMissingCollectionItems(bool value) =>
-      _store.setBool(_userKey('show_missing_collection_items'), value);
-
   bool get notifyOnNewRequests => _store.getBool(_userKey('notify_new_requests')) ?? true;
   Future<void> setNotifyOnNewRequests(bool value) =>
       _store.setBool(_userKey('notify_new_requests'), value);

--- a/lib/preference/seerr_preferences.dart
+++ b/lib/preference/seerr_preferences.dart
@@ -83,6 +83,11 @@ class SeerrPreferences {
   bool get blockNsfw => _store.getBool(_userKey('block_nsfw')) ?? true;
   Future<void> setBlockNsfw(bool value) => _store.setBool(_userKey('block_nsfw'), value);
 
+  bool get showMissingCollectionItems =>
+      _store.getBool(_userKey('show_missing_collection_items')) ?? true;
+  Future<void> setShowMissingCollectionItems(bool value) =>
+      _store.setBool(_userKey('show_missing_collection_items'), value);
+
   bool get notifyOnNewRequests => _store.getBool(_userKey('notify_new_requests')) ?? true;
   Future<void> setNotifyOnNewRequests(bool value) =>
       _store.setBool(_userKey('notify_new_requests'), value);

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -548,6 +548,7 @@ class UserPreferences extends ChangeNotifier {
     'pref_personal_rating_style',
     'tmdbApiKey',
     'seerrBlockNsfw',
+    'seerrShowMissingCollectionItems',
     'enabledRatings',
     'home_sections_config',
     'pref_audio_display_latest',
@@ -2901,6 +2902,11 @@ class UserPreferences extends ChangeNotifier {
   static final seerrBlockNsfw = Preference(
     key: 'seerrBlockNsfw',
     defaultValue: false,
+  );
+
+  static final seerrShowMissingCollectionItems = Preference(
+    key: 'seerrShowMissingCollectionItems',
+    defaultValue: true,
   );
 
   static final defaultDownloadQuality = Preference(

--- a/lib/ui/navigation/app_router.dart
+++ b/lib/ui/navigation/app_router.dart
@@ -811,11 +811,11 @@ final appRouter = GoRouter(
     GoRoute(
       path: Destinations.seerrMediaDetail,
       builder: (context, state) {
-        final tmdbId = state.pathParameters['itemId']!;
+        final rawId = state.pathParameters['itemId']!;
         final kind = state.uri.queryParameters['mediaType'] == 'tv'
             ? TmdbItemKind.tv
             : TmdbItemKind.movie;
-        final ref = TmdbItemRef(kind, tmdbId);
+        final ref = TmdbItemRef.tryParse(rawId) ?? TmdbItemRef(kind, rawId);
         return ItemDetailScreen(
           key: ValueKey(ref.itemId),
           itemId: ref.itemId,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -558,6 +558,55 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       child: _buildBody(context),
     );
 
+    if (!PlatformDetection.isTV && !_showNavbar) {
+      final isSidebar =
+          NavigationLayout.positionNotifier.value == NavbarPosition.left;
+      body = Stack(
+        children: [
+          Positioned.fill(child: body),
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 90,
+            child: MouseRegion(
+              opaque: false,
+              onEnter: (_) {
+                if (!_showNavbar && mounted) {
+                  setState(() => _showNavbar = true);
+                }
+              },
+              onHover: (_) {
+                if (!_showNavbar && mounted) {
+                  setState(() => _showNavbar = true);
+                }
+              },
+            ),
+          ),
+          if (isSidebar)
+            Positioned(
+              top: 0,
+              left: 0,
+              bottom: 0,
+              width: 80,
+              child: MouseRegion(
+                opaque: false,
+                onEnter: (_) {
+                  if (!_showNavbar && mounted) {
+                    setState(() => _showNavbar = true);
+                  }
+                },
+                onHover: (_) {
+                  if (!_showNavbar && mounted) {
+                    setState(() => _showNavbar = true);
+                  }
+                },
+              ),
+            ),
+        ],
+      );
+    }
+
     body = PopScope(canPop: !wasCollapsedRecently, child: body);
     return RequestInitialFocus(
       targetNode: node,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -280,6 +280,14 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   bool _seerrRedirectDone = false;
   String? _selectedMediaSourceId;
   bool _showNavbar = true;
+
+  /// Spotlight's summary cards fall back to the item's first backdrop, so its
+  /// slideshow opens on the second one and the hero doesn't repeat the cards.
+  int get _detailBackdropStartIndex =>
+      _prefs.get(UserPreferences.detailScreenStyle) ==
+          DetailScreenStyle.spotlight
+      ? 1
+      : 0;
   bool _actionsExpanded = false;
   Timer? _focusedBackdropDebounce;
   String? _lastFocusedBackdropItemId;
@@ -346,7 +354,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     unawaited(_viewModel.syncUserDataIfStale());
     final item = _viewModel.item;
     if (item != null) {
-      _backgroundService.setBackground(item, context: BlurContext.details);
+      _backgroundService.setBackground(
+        item,
+        context: BlurContext.details,
+        startIndex: _detailBackdropStartIndex,
+      );
       final nextUrl = _backgroundService.currentUrl;
       // Keep the last good backdrop if the service has none to give (e.g. after
       // returning from a child with no backdrop that cleared the shared service).
@@ -443,7 +455,11 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
         final target = (item.type == 'Playlist' && _viewModel.tracks.isNotEmpty)
             ? _viewModel.tracks.first
             : item;
-        _backgroundService.setBackground(target, context: BlurContext.details);
+        _backgroundService.setBackground(
+          target,
+          context: BlurContext.details,
+          startIndex: _detailBackdropStartIndex,
+        );
         _backdropUrl.value = _backgroundService.currentUrl;
 
         if (item.type == 'Playlist' && _viewModel.tracks.isNotEmpty) {

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -559,37 +559,18 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       child: _buildBody(context),
     );
 
-    if (!PlatformDetection.isTV && !_showNavbar) {
+    if (!PlatformDetection.isTV) {
       final isSidebar =
           NavigationLayout.positionNotifier.value == NavbarPosition.left;
       body = Stack(
         children: [
           Positioned.fill(child: body),
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 90,
-            child: MouseRegion(
-              opaque: false,
-              onEnter: (_) {
-                if (!_showNavbar && mounted) {
-                  setState(() => _showNavbar = true);
-                }
-              },
-              onHover: (_) {
-                if (!_showNavbar && mounted) {
-                  setState(() => _showNavbar = true);
-                }
-              },
-            ),
-          ),
-          if (isSidebar)
+          if (!_showNavbar) ...[
             Positioned(
               top: 0,
               left: 0,
-              bottom: 0,
-              width: 80,
+              right: 0,
+              height: 90,
               child: MouseRegion(
                 opaque: false,
                 onEnter: (_) {
@@ -604,6 +585,27 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
                 },
               ),
             ),
+            if (isSidebar)
+              Positioned(
+                top: 0,
+                left: 0,
+                bottom: 0,
+                width: 80,
+                child: MouseRegion(
+                  opaque: false,
+                  onEnter: (_) {
+                    if (!_showNavbar && mounted) {
+                      setState(() => _showNavbar = true);
+                    }
+                  },
+                  onHover: (_) {
+                    if (!_showNavbar && mounted) {
+                      setState(() => _showNavbar = true);
+                    }
+                  },
+                ),
+              ),
+          ],
         ],
       );
     }

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -506,6 +506,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
       _backgroundService.setBackground(
         focusedItem,
         context: BlurContext.details,
+        startIndex: 0,
       );
       final nextUrl = _backgroundService.currentUrl;
       if (nextUrl != _backdropUrl.value) {

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -6,7 +6,6 @@ import '../../../../data/repositories/tmdb_repository.dart';
 import '../../../../data/services/seerr/seerr_api_models.dart';
 import '../../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../../preference/preference_constants.dart';
 import '../../../../preference/user_preferences.dart';
 import '../../../widgets/seerr/seerr_item_status.dart' show seerrItemTabState;
 import '../item_detail_screen.dart' show DetailTrackList;
@@ -393,10 +392,14 @@ class _SpotlightCardsBuilder {
                     : seerrSimilar,
               ) ??
             fallbackImageUrl);
-    final sourceSetting = prefs.get(UserPreferences.recommendationSystemSource);
-    final librarySectionTitle = switch (sourceSetting) {
-      RecommendationSystemSource.local => l10n.recommendationSystemMoonfin,
-      RecommendationSystemSource.online => l10n.recommendationSystemTmdb,
+    // Named for where the list actually came from. The recommendation source
+    // preference only applies to movies and series, and even then the view
+    // model falls back to Jellyfin's own similar items when the chosen
+    // source has nothing, so the preference alone would mislabel those.
+    final librarySectionTitle = switch (vm.similarSource) {
+      SimilarSource.jellyfin => l10n.similar,
+      SimilarSource.moonfin => l10n.recommendationSystemMoonfin,
+      SimilarSource.tmdb => l10n.recommendationSystemTmdb,
     };
     return SpotlightCardSpec(
       id: 'similar',
@@ -426,6 +429,9 @@ class _SpotlightCardsBuilder {
     final collections = vm.parentCollections;
     if (collections.isEmpty) return null;
     final imageUrl = _firstCollectionImage(collections) ?? fallbackImageUrl;
+    final showMissing = prefs.get(
+      UserPreferences.seerrShowMissingCollectionItems,
+    );
     return SpotlightCardSpec(
       id: 'collections',
       title: l10n.spotlightCollectionsCard,
@@ -434,27 +440,10 @@ class _SpotlightCardsBuilder {
       icon: Icons.collections_bookmark_outlined,
       sections: [
         for (final collection in collections)
-          _mediaSection(
-            collection.name,
-            [
-              collection.boxSetItem ??
-                  AggregatedItem(
-                    id: collection.id,
-                    serverId: item.serverId,
-                    rawData: {
-                      'Id': collection.id,
-                      'Name': collection.name,
-                      'Type': 'BoxSet',
-                      'IsFolder': true,
-                      if (collection.primaryImageTag != null) ...{
-                        'PrimaryImageTag': collection.primaryImageTag,
-                        'ImageTags': {'Primary': collection.primaryImageTag},
-                      },
-                    },
-                  ),
-              ...collection.items,
-            ],
-          ),
+          _mediaSection(collection.name, [
+            collection.boxSetItem,
+            ...(showMissing ? collection.itemsWithMissing : collection.items),
+          ]),
       ],
     );
   }
@@ -658,9 +647,14 @@ class _SpotlightCardsBuilder {
 
   SpotlightCardSpec? _boxSetItemsCard() {
     final libraryItems = vm.collectionItems;
-    final showMissing = prefs.get(UserPreferences.seerrShowMissingCollectionItems);
-    final missing = showMissing ? vm.missingCollectionItems : const <AggregatedItem>[];
-    final items = [...libraryItems, ...missing];
+    final showMissing = prefs.get(
+      UserPreferences.seerrShowMissingCollectionItems,
+    );
+    // Slotted in by release date, the same way the parent-collection card
+    // orders its own missing titles.
+    final items = showMissing
+        ? mergeMissingByReleaseOrder(libraryItems, vm.missingCollectionItems)
+        : libraryItems;
     if (items.isEmpty) return null;
     final movies = items.where((i) => i.type == 'Movie').toList();
     final series = items.where((i) => i.type == 'Series').toList();

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -658,7 +658,8 @@ class _SpotlightCardsBuilder {
 
   SpotlightCardSpec? _boxSetItemsCard() {
     final libraryItems = vm.collectionItems;
-    final missing = vm.missingCollectionItems;
+    final showMissing = prefs.get(UserPreferences.seerrShowMissingCollectionItems);
+    final missing = showMissing ? vm.missingCollectionItems : const <AggregatedItem>[];
     final items = [...libraryItems, ...missing];
     if (items.isEmpty) return null;
     final movies = items.where((i) => i.type == 'Movie').toList();

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -657,7 +657,9 @@ class _SpotlightCardsBuilder {
   }
 
   SpotlightCardSpec? _boxSetItemsCard() {
-    final items = vm.collectionItems;
+    final libraryItems = vm.collectionItems;
+    final missing = vm.missingCollectionItems;
+    final items = [...libraryItems, ...missing];
     if (items.isEmpty) return null;
     final movies = items.where((i) => i.type == 'Movie').toList();
     final series = items.where((i) => i.type == 'Series').toList();

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -6,8 +6,8 @@ import '../../../../data/repositories/tmdb_repository.dart';
 import '../../../../data/services/seerr/seerr_api_models.dart';
 import '../../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../../l10n/app_localizations.dart';
+import '../../../../preference/preference_constants.dart';
 import '../../../../preference/user_preferences.dart';
-import '../../../widgets/seerr/seerr_image_urls.dart';
 import '../../../widgets/seerr/seerr_item_status.dart' show seerrItemTabState;
 import '../item_detail_screen.dart' show DetailTrackList;
 import '../modern/modern_detail_content.dart'
@@ -274,7 +274,7 @@ class _SpotlightCardsBuilder {
       id: 'people',
       title: l10n.spotlightCastCrewStudios,
       subtitle: subtitle,
-      imageUrl: _firstPersonImage(cast) ?? fallbackImageUrl,
+      imageUrl: fallbackImageUrl,
       icon: Icons.people_outline,
       sections: [
         if (cast.isNotEmpty) _peopleSection(l10n.castMembers, cast),
@@ -306,7 +306,11 @@ class _SpotlightCardsBuilder {
       imageUrl:
           _firstChapterImage() ??
           (extras.isNotEmpty
-              ? spotlightItemImageUrl(_imageApi, extras.first)
+              ? spotlightLandscapeImageUrl(
+                  _imageApi,
+                  extras.first,
+                  fallbackUrl: fallbackImageUrl,
+                )
               : null) ??
           fallbackImageUrl,
       icon: Icons.video_library_outlined,
@@ -377,29 +381,38 @@ class _SpotlightCardsBuilder {
         seerrSimilar.isEmpty) {
       return null;
     }
-    final hasSeerrSections =
-        seerrRecommendations.isNotEmpty || seerrSimilar.isNotEmpty;
     final imageUrl = similar.isNotEmpty
-        ? spotlightItemImageUrl(_imageApi, similar.first)
-        : _firstSeerrPoster(
-            seerrRecommendations.isNotEmpty
-                ? seerrRecommendations
-                : seerrSimilar,
-          );
+        ? spotlightLandscapeImageUrl(
+            _imageApi,
+            similar.first,
+            fallbackUrl: fallbackImageUrl,
+          )
+        : (_firstSeerrBackdrop(
+                seerrRecommendations.isNotEmpty
+                    ? seerrRecommendations
+                    : seerrSimilar,
+              ) ??
+            fallbackImageUrl);
+    final sourceSetting = prefs.get(UserPreferences.recommendationSystemSource);
+    final librarySectionTitle = switch (sourceSetting) {
+      RecommendationSystemSource.local => l10n.recommendationSystemMoonfin,
+      RecommendationSystemSource.online => l10n.recommendationSystemTmdb,
+    };
     return SpotlightCardSpec(
       id: 'similar',
-      title: hasSeerrSections
-          ? l10n.spotlightSeerrRecommendations
-          : l10n.spotlightSimilarRecommendations,
+      title: l10n.recommendations,
       subtitle: l10n.spotlightTitlesCount(
         similar.length + seerrRecommendations.length + seerrSimilar.length,
       ),
       imageUrl: imageUrl ?? fallbackImageUrl,
       icon: Icons.auto_awesome_outlined,
       sections: [
-        if (similar.isNotEmpty) _mediaSection(l10n.similar, similar),
+        if (similar.isNotEmpty) _mediaSection(librarySectionTitle, similar),
         if (seerrRecommendations.isNotEmpty)
-          _seerrSection(l10n.recommendations, seerrRecommendations),
+          _seerrSection(
+            l10n.spotlightRecommendationsSeerr,
+            seerrRecommendations,
+          ),
         if (seerrSimilar.isNotEmpty)
           _seerrSection(
             similar.isEmpty ? l10n.similar : l10n.spotlightSimilarSeerr,
@@ -412,20 +425,36 @@ class _SpotlightCardsBuilder {
   SpotlightCardSpec? _collectionsCard() {
     final collections = vm.parentCollections;
     if (collections.isEmpty) return null;
-    final firstItem = collections
-        .expand((collection) => collection.items)
-        .firstOrNull;
+    final imageUrl = _firstCollectionImage(collections) ?? fallbackImageUrl;
     return SpotlightCardSpec(
       id: 'collections',
       title: l10n.spotlightCollectionsCard,
       subtitle: l10n.spotlightCollectionsCount(collections.length),
-      imageUrl: firstItem != null
-          ? (spotlightItemImageUrl(_imageApi, firstItem) ?? fallbackImageUrl)
-          : fallbackImageUrl,
+      imageUrl: imageUrl,
       icon: Icons.collections_bookmark_outlined,
       sections: [
         for (final collection in collections)
-          _mediaSection(collection.name, collection.items),
+          _mediaSection(
+            collection.name,
+            [
+              collection.boxSetItem ??
+                  AggregatedItem(
+                    id: collection.id,
+                    serverId: item.serverId,
+                    rawData: {
+                      'Id': collection.id,
+                      'Name': collection.name,
+                      'Type': 'BoxSet',
+                      'IsFolder': true,
+                      if (collection.primaryImageTag != null) ...{
+                        'PrimaryImageTag': collection.primaryImageTag,
+                        'ImageTags': {'Primary': collection.primaryImageTag},
+                      },
+                    },
+                  ),
+              ...collection.items,
+            ],
+          ),
       ],
     );
   }
@@ -646,7 +675,7 @@ class _SpotlightCardsBuilder {
       title: l10n.spotlightMoviesAndShows,
       subtitle: subtitle,
       imageUrl:
-          spotlightItemImageUrl(_imageApi, items.first) ?? fallbackImageUrl,
+          _firstItemLandscape(items) ?? fallbackImageUrl,
       icon: Icons.collections_bookmark_outlined,
       sections: [
         if (movies.isNotEmpty) _mediaSection(l10n.movies, movies),
@@ -687,7 +716,7 @@ class _SpotlightCardsBuilder {
         if (peopleCount > 0) l10n.spotlightPeopleCount(peopleCount),
         if (studios.isNotEmpty) l10n.spotlightStudiosCount(studios.length),
       ].join(' · '),
-      imageUrl: _firstPersonImage(cast.values.toList()) ?? fallbackImageUrl,
+      imageUrl: fallbackImageUrl,
       icon: Icons.people_outline,
       sections: [
         if (cast.isNotEmpty)
@@ -707,7 +736,11 @@ class _SpotlightCardsBuilder {
       title: l10n.spotlightPlaylistOrder,
       subtitle: l10n.spotlightItemsCount(items.length),
       imageUrl:
-          spotlightItemImageUrl(_imageApi, items.first) ?? fallbackImageUrl,
+          spotlightLandscapeImageUrl(
+            _imageApi,
+            items.first,
+            fallbackUrl: fallbackImageUrl,
+          ),
       icon: Icons.format_list_numbered,
       sections: [
         SpotlightModalSection(
@@ -728,17 +761,28 @@ class _SpotlightCardsBuilder {
   // ---------------------------------------------------------------------------
   // Card imagery
 
-  String? _firstPersonImage(List<Map<String, dynamic>> people) {
-    for (final person in people) {
-      final url = spotlightPersonImageUrl(
-        _imageApi,
-        id: person['Id']?.toString(),
-        tag: person['PrimaryImageTag'] as String?,
-        profilePath: person['ProfilePath'] as String?,
-        maxHeight: 400,
-        tmdbProfileBase: seerrProfileLargeBase,
-      );
+  String? _firstItemLandscape(List<AggregatedItem> items) {
+    for (final child in items) {
+      final url = spotlightLandscapeImageUrl(_imageApi, child);
       if (url != null) return url;
+    }
+    return null;
+  }
+
+  String? _firstSeerrBackdrop(List<SeerrDiscoverItem> items) {
+    for (final item in items) {
+      final url = spotlightSeerrBackdropUrl(item.backdropPath);
+      if (url != null) return url;
+    }
+    return null;
+  }
+
+  String? _firstCollectionImage(List<ParentCollection> collections) {
+    for (final col in collections) {
+      for (final child in col.items) {
+        final url = spotlightLandscapeImageUrl(_imageApi, child);
+        if (url != null) return url;
+      }
     }
     return null;
   }

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -330,6 +330,15 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
     );
   }
 
+  /// Whether the cards band drives the navbar through focus. That is the TV
+  /// and keyboard model, where a focused card means the navbar steps aside
+  /// and focus leaving brings it back. Touch has no such focus traffic, and
+  /// closing a modal refocuses the card, so letting it hide the navbar there
+  /// would strand the viewer with no back button.
+  bool get _navbarFollowsFocus =>
+      PlatformDetection.isTV ||
+      FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
+
   Future<void> _openCard(SpotlightCardSpec spec) async {
     if (_modalOpen) return;
     _modalOpen = true;
@@ -1051,7 +1060,9 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
       canRequestFocus: false,
       skipTraversal: true,
       onFocusChange: (focused) {
-        if (mounted) widget.onToggleNavbar?.call(!focused);
+        if (mounted && _navbarFollowsFocus) {
+          widget.onToggleNavbar?.call(!focused);
+        }
       },
       child: band,
     );

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -987,14 +987,27 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
 
     final Widget band;
     if (_landscape) {
-      band = Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (var i = 0; i < cards.length; i++) ...[
-            if (i > 0) const SizedBox(width: 16),
-            Expanded(child: SizedBox(height: cardHeight, child: cardAt(i))),
-          ],
-        ],
+      band = LayoutBuilder(
+        builder: (context, constraints) {
+          final maxCardWidth = cardHeight * (16 / 9);
+          final cardWidth = math.min(
+            maxCardWidth,
+            (constraints.maxWidth - (cards.length - 1) * 16) / cards.length,
+          );
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (var i = 0; i < cards.length; i++) ...[
+                if (i > 0) const SizedBox(width: 16),
+                SizedBox(
+                  width: cardWidth,
+                  height: cardHeight,
+                  child: cardAt(i),
+                ),
+              ],
+            ],
+          );
+        },
       );
     } else if (cards.length == 1) {
       band = Padding(

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -323,6 +323,7 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
   Future<void> _openCard(SpotlightCardSpec spec) async {
     if (_modalOpen) return;
     _modalOpen = true;
+    widget.onToggleNavbar?.call(false);
     try {
       await SpotlightSectionModal.show(
         context,

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -375,8 +375,16 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
   Widget _buildBackdrop(bool landscape, String? backdropUrl) {
     final base = AppColorScheme.background;
     final item = _vm.item;
+    final itemBackdrop = item != null && item.backdropImageTags.isNotEmpty
+        ? _vm.imageApi.getBackdropImageUrl(
+            item.id,
+            maxWidth: 1920,
+            tag: item.backdropImageTags.first,
+          )
+        : null;
     final url =
         backdropUrl ??
+        itemBackdrop ??
         (item?.type == 'Person' ? _personProfileUrl(item!) : null);
     final blurAmount = widget.prefs
         .get(UserPreferences.detailsBackgroundBlurAmount)
@@ -927,6 +935,13 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
     BuildContext context,
     AggregatedItem item,
   ) {
+    final itemBackdrop = item.backdropImageTags.isNotEmpty
+        ? _vm.imageApi.getBackdropImageUrl(
+            item.id,
+            maxWidth: 960,
+            tag: item.backdropImageTags.first,
+          )
+        : widget.backdropUrl.value;
     final cards = spotlightCardsFor(
       vm: _vm,
       item: item,
@@ -936,7 +951,7 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
       actions: _cardActions(item),
       seerrAppearances: _seerrAppearances,
       seerrCrewCredits: _seerrCrewCredits,
-      fallbackImageUrl: widget.backdropUrl.value,
+      fallbackImageUrl: itemBackdrop,
     );
     for (final card in cards) {
       _cardFocusNodes.putIfAbsent(

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -247,20 +247,29 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
   /// route, so the back stack stays predictable.
   void _closeModalThen(VoidCallback action) {
     if (_modalOpen) {
-      Navigator.of(context, rootNavigator: true).pop();
+      Navigator.of(context, rootNavigator: true).pop(action);
+    } else {
+      action();
     }
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) action();
-    });
   }
 
   SpotlightCardActions _cardActions(AggregatedItem item) {
     return SpotlightCardActions(
       openItem: (entry) => _closeModalThen(() {
         if (entry.serverId == 'seerr') {
-          final mediaType =
-              entry.seerrMediaType ?? (entry.type == 'Series' ? 'tv' : 'movie');
-          context.push(Destinations.seerrMedia(entry.id, mediaType: mediaType));
+          final mediaType = entry.seerrMediaType ??
+              (entry.type == 'Series' || entry.type == 'tv' ? 'tv' : 'movie');
+          final tmdbId = entry.tmdbId;
+          final targetId = (tmdbId != null && tmdbId.isNotEmpty)
+              ? tmdbId
+              : entry.id.replaceAll(RegExp(r'^tmdb:(?:movie:|tv:)?'), '');
+          context.push(
+            Destinations.seerrMedia(
+              targetId,
+              mediaType: mediaType,
+              title: entry.name,
+            ),
+          );
         } else {
           context.push(Destinations.item(entry.id, serverId: entry.serverId));
         }
@@ -277,6 +286,7 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
           Destinations.seerrMedia(
             entry.id.toString(),
             mediaType: entry.mediaType ?? 'movie',
+            title: entry.displayTitle,
           ),
         );
       }),
@@ -323,9 +333,8 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
   Future<void> _openCard(SpotlightCardSpec spec) async {
     if (_modalOpen) return;
     _modalOpen = true;
-    widget.onToggleNavbar?.call(false);
     try {
-      await SpotlightSectionModal.show(
+      final action = await SpotlightSectionModal.show<VoidCallback>(
         context,
         title: spec.title,
         icon: spec.icon,
@@ -339,6 +348,13 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
         refreshOn: _vm,
         refresh: () => _liveCardContent(spec),
       );
+      if (mounted && action != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) {
+            action();
+          }
+        });
+      }
     } finally {
       _modalOpen = false;
     }

--- a/lib/ui/screens/detail/spotlight/spotlight_images.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_images.dart
@@ -6,19 +6,30 @@ import '../../../widgets/seerr/seerr_image_urls.dart';
 /// The poster or primary image for [item], with the TMDB fallbacks a
 /// Seerr-only item needs.
 String? spotlightItemImageUrl(ImageApi imageApi, AggregatedItem item) {
+  final isLibraryItem =
+      item.serverId != 'seerr' && !item.id.startsWith('tmdb:');
   final tag = item.primaryImageTag ?? item.primaryImageTagField;
-  if (!item.id.startsWith('tmdb:')) {
-    if (tag != null || item.type == 'BoxSet' || item.isFolder) {
-      return imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
-    }
+  if (isLibraryItem && tag != null) {
+    return imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
   }
-  return spotlightSeerrPosterUrl(item.rawData['PosterPath'] as String?) ??
+  final seerrArt =
+      spotlightSeerrPosterUrl(item.rawData['PosterPath'] as String?) ??
       spotlightPersonImageUrl(
         imageApi,
         profilePath: item.rawData['ProfilePath'] as String?,
         maxHeight: 360,
         tmdbProfileBase: seerrProfileLargeBase,
       );
+  if (seerrArt != null) return seerrArt;
+  // A collection built from an ancestor record can arrive without its image
+  // tag while the server still holds a primary image for it. Only box sets
+  // get the tagless request: any folder with children would qualify
+  // otherwise, and one with no image at all would fetch a 404 in place of
+  // its placeholder.
+  if (isLibraryItem && item.type == 'BoxSet') {
+    return imageApi.getPrimaryImageUrl(item.id, maxHeight: 360);
+  }
+  return null;
 }
 
 /// A person's portrait: the server image when [id] and [tag] name a library

--- a/lib/ui/screens/detail/spotlight/spotlight_images.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_images.dart
@@ -6,9 +6,11 @@ import '../../../widgets/seerr/seerr_image_urls.dart';
 /// The poster or primary image for [item], with the TMDB fallbacks a
 /// Seerr-only item needs.
 String? spotlightItemImageUrl(ImageApi imageApi, AggregatedItem item) {
-  final tag = item.primaryImageTag;
-  if (tag != null && !item.id.startsWith('tmdb:')) {
-    return imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
+  final tag = item.primaryImageTag ?? item.primaryImageTagField;
+  if (!item.id.startsWith('tmdb:')) {
+    if (tag != null || item.type == 'BoxSet' || item.isFolder) {
+      return imageApi.getPrimaryImageUrl(item.id, maxHeight: 360, tag: tag);
+    }
   }
   return spotlightSeerrPosterUrl(item.rawData['PosterPath'] as String?) ??
       spotlightPersonImageUrl(
@@ -38,8 +40,50 @@ String? spotlightPersonImageUrl(
   return null;
 }
 
+/// A landscape thumbnail or backdrop for [item], prioritizing 16:9 artwork
+/// (Thumb, then Backdrop) over posters.
+String? spotlightLandscapeImageUrl(
+  ImageApi imageApi,
+  AggregatedItem item, {
+  int maxWidth = 640,
+  String? fallbackUrl,
+}) {
+  final thumbTag = item.thumbImageTag;
+  if (thumbTag != null && !item.id.startsWith('tmdb:')) {
+    return imageApi.getThumbImageUrl(item.id, maxWidth: maxWidth, tag: thumbTag);
+  }
+  if (item.backdropImageTags.isNotEmpty && !item.id.startsWith('tmdb:')) {
+    return imageApi.getBackdropImageUrl(
+      item.id,
+      maxWidth: maxWidth,
+      tag: item.backdropImageTags.first,
+    );
+  }
+  final parentBackdropId = item.parentBackdropItemId;
+  if (parentBackdropId != null &&
+      item.parentBackdropImageTags.isNotEmpty &&
+      !parentBackdropId.startsWith('tmdb:')) {
+    return imageApi.getBackdropImageUrl(
+      parentBackdropId,
+      maxWidth: maxWidth,
+      tag: item.parentBackdropImageTags.first,
+    );
+  }
+  final seerrBackdrop =
+      spotlightSeerrBackdropUrl(item.rawData['BackdropPath'] as String?);
+  if (seerrBackdrop != null) return seerrBackdrop;
+
+  return fallbackUrl;
+}
+
 /// A Seerr poster path as a TMDB URL, or null when Seerr sent none.
 String? spotlightSeerrPosterUrl(String? posterPath) =>
     posterPath == null || posterPath.isEmpty
     ? null
     : '$seerrPosterBase$posterPath';
+
+/// A Seerr backdrop path as a TMDB URL, or null when Seerr sent none.
+String? spotlightSeerrBackdropUrl(String? backdropPath) =>
+    backdropPath == null || backdropPath.isEmpty
+    ? null
+    : '$seerrBackdropBase$backdropPath';

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
@@ -130,11 +130,13 @@ class SpotlightMediaGridSection extends StatelessWidget {
             children: [
               for (var i = 0; i < items.length; i++)
                 Builder(
+                  key: ValueKey(items[i].id),
                   builder: (cellContext) {
                     final entry = items[i];
                     final isSeerrItem =
                         entry.id.startsWith('tmdb:') || entry.serverId == 'seerr';
                     return MediaCard(
+                      key: ValueKey(entry.id),
                       title: entry.name,
                       titleColor: titleColor,
                       imageUrl: spotlightItemImageUrl(imageApi, entry),
@@ -221,9 +223,11 @@ class SpotlightSeerrGridSection extends StatelessWidget {
             children: [
               for (var i = 0; i < items.length; i++)
                 Builder(
+                  key: ValueKey(items[i].id),
                   builder: (cellContext) {
                     final entry = items[i];
                     return MediaCard(
+                      key: ValueKey(entry.id),
                       title: entry.displayTitle,
                       subtitle: showCredit
                           ? (entry.character ?? entry.job)
@@ -285,11 +289,17 @@ class SpotlightPeopleGridSection extends StatelessWidget {
           children: [
             for (var i = 0; i < people.length; i++)
               Builder(
+                key: ValueKey(
+                  people[i]['Id']?.toString() ??
+                      people[i]['Name']?.toString() ??
+                      '$i',
+                ),
                 builder: (cellContext) {
                   final person = people[i];
-                  final name = person['Name'] as String? ?? '';
-                  final role = person['Role'] as String?;
                   final personId = person['Id']?.toString();
+                  final name = person['Name']?.toString() ?? '';
+                  final role = (person['Roles'] as Set<String>?)?.join(' · ') ??
+                      person['Role']?.toString();
                   final imageUrl = spotlightPersonImageUrl(
                     imageApi,
                     id: personId,
@@ -298,6 +308,11 @@ class SpotlightPeopleGridSection extends StatelessWidget {
                     maxHeight: 200,
                   );
                   return _SpotlightPersonCell(
+                    key: ValueKey(
+                      person['Id']?.toString() ??
+                          people[i]['Name']?.toString() ??
+                          '$i',
+                    ),
                     width: metrics.cellWidth,
                     name: name,
                     role: role,
@@ -326,6 +341,7 @@ class _SpotlightPersonCell extends StatefulWidget {
   final VoidCallback? onTap;
 
   const _SpotlightPersonCell({
+    super.key,
     required this.width,
     required this.name,
     required this.role,

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
@@ -133,8 +133,13 @@ class SpotlightMediaGridSection extends StatelessWidget {
                   key: ValueKey(items[i].id),
                   builder: (cellContext) {
                     final entry = items[i];
+                    // A title the library lacks, standing in from Seerr. It
+                    // has no play state, so the watched slot goes to
+                    // MediaCard's own request-status dot and the Seerr mark
+                    // takes the corner a favourite would otherwise use.
                     final isSeerrItem =
-                        entry.id.startsWith('tmdb:') || entry.serverId == 'seerr';
+                        entry.serverId == 'seerr' ||
+                        entry.id.startsWith('tmdb:');
                     return MediaCard(
                       key: ValueKey(entry.id),
                       title: entry.name,
@@ -142,8 +147,8 @@ class SpotlightMediaGridSection extends StatelessWidget {
                       imageUrl: spotlightItemImageUrl(imageApi, entry),
                       width: metrics.cellWidth,
                       aspectRatio: aspectRatio,
-                      isPlayed: isSeerrItem ? false : entry.isPlayed,
-                      isFavorite: isSeerrItem ? false : entry.isFavorite,
+                      isPlayed: entry.isPlayed,
+                      isFavorite: entry.isFavorite,
                       itemType: entry.type,
                       focusNode: i == 0 ? firstFocusNode : null,
                       focusColor: focusColor,
@@ -152,11 +157,13 @@ class SpotlightMediaGridSection extends StatelessWidget {
                       watchedBehavior: isSeerrItem
                           ? WatchedIndicatorBehavior.never
                           : watchedBehavior,
+                      seerrStatus: isSeerrItem ? entry.seerrStatus : null,
+                      overlayOccupiesTopLeft: isSeerrItem,
                       imageOverlays: [
                         if (isSeerrItem)
                           const Positioned(
-                            top: 4,
-                            right: 4,
+                            top: 6,
+                            left: 6,
                             child: SeerrBadge(size: 18),
                           ),
                       ],

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
@@ -471,6 +471,7 @@ class SpotlightStudiosGridSection extends StatelessWidget {
               width: 160,
               height: 100,
               decoration: BoxDecoration(
+                color: Colors.white.withValues(alpha: 0.06),
                 borderRadius: AppRadius.circular(12),
                 border: Border.all(
                   color: Colors.white.withValues(alpha: 0.15),

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
@@ -4,6 +4,7 @@ import 'package:server_core/server_core.dart';
 
 import '../../../../../data/models/aggregated_item.dart';
 import '../../../../../data/services/seerr/seerr_api_models.dart';
+import '../../../../../preference/preference_constants.dart';
 import '../../../../../preference/user_preferences.dart';
 import '../../../../../util/focus/dpad_keys.dart';
 import '../../../../mixins/focus_state_mixin.dart';
@@ -12,6 +13,7 @@ import '../../../../widgets/focus/focus_theme.dart';
 import '../../../../widgets/focus/focusable_wrapper.dart';
 import '../../../../widgets/media_card.dart';
 import '../../../../widgets/offline_aware_image.dart';
+import '../../../../widgets/seerr_icons.dart';
 import '../../modern/modern_detail_content.dart'
     show StudioLogoIndex, studioLogoUrlFor;
 import '../spotlight_images.dart';
@@ -130,20 +132,32 @@ class SpotlightMediaGridSection extends StatelessWidget {
                 Builder(
                   builder: (cellContext) {
                     final entry = items[i];
+                    final isSeerrItem =
+                        entry.id.startsWith('tmdb:') || entry.serverId == 'seerr';
                     return MediaCard(
                       title: entry.name,
                       titleColor: titleColor,
                       imageUrl: spotlightItemImageUrl(imageApi, entry),
                       width: metrics.cellWidth,
                       aspectRatio: aspectRatio,
-                      isPlayed: entry.isPlayed,
-                      isFavorite: entry.isFavorite,
+                      isPlayed: isSeerrItem ? false : entry.isPlayed,
+                      isFavorite: isSeerrItem ? false : entry.isFavorite,
                       itemType: entry.type,
                       focusNode: i == 0 ? firstFocusNode : null,
                       focusColor: focusColor,
                       cardFocusExpansion: cardExpansion,
                       suppressFocusGlow: isNeon,
-                      watchedBehavior: watchedBehavior,
+                      watchedBehavior: isSeerrItem
+                          ? WatchedIndicatorBehavior.never
+                          : watchedBehavior,
+                      imageOverlays: [
+                        if (isSeerrItem)
+                          const Positioned(
+                            top: 4,
+                            right: 4,
+                            child: SeerrBadge(size: 18),
+                          ),
+                      ],
                       onFocus: () => spotlightScrollCellIntoView(cellContext),
                       onTap: () => onItemTap(entry),
                     );
@@ -487,8 +501,8 @@ class SpotlightStudiosGridSection extends StatelessWidget {
                         imageBuilder: (context, imageProvider) => Container(
                           color: Colors.white,
                           padding: const EdgeInsets.symmetric(
-                            horizontal: 12,
-                            vertical: 8,
+                            horizontal: 16,
+                            vertical: 12,
                           ),
                           child: Image(
                             image: imageProvider,

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
@@ -38,7 +38,7 @@ typedef SpotlightModalContent = ({
 /// ([TraversalEdgeBehavior.stop]); pressing back closes the modal and returns
 /// focus to [returnFocus] (the summary card that opened it).
 abstract final class SpotlightSectionModal {
-  static Future<void> show(
+  static Future<T?> show<T>(
     BuildContext context, {
     required String title,
     required List<SpotlightModalSection> sections,
@@ -48,7 +48,7 @@ abstract final class SpotlightSectionModal {
     SpotlightModalContent Function()? refresh,
   }) {
     FocusManager.instance.primaryFocus?.unfocus();
-    final future = showGeneralDialog<void>(
+    final future = showGeneralDialog<T>(
       context: context,
       barrierDismissible: true,
       barrierLabel: title,
@@ -124,7 +124,10 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
     if (refresh == null || !mounted) return;
     final next = refresh();
     final signature = _signatureOf(next.title, next.sections);
-    if (signature == _signature) return;
+    if (signature == _signature) {
+      _sections = next.sections;
+      return;
+    }
     setState(() {
       _signature = signature;
       _title = next.title;

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_summary_card.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_summary_card.dart
@@ -121,10 +121,12 @@ class _SpotlightSummaryCardState extends State<SpotlightSummaryCard>
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      // A slow zoom on focus and hover. Skipped under reduce
-                      // motion, where the border and chevron carry the state.
+                      // A slow zoom on focus and hover when card focus expansion
+                      // is enabled. Skipped when disabled or under reduce motion.
                       AnimatedScale(
-                        scale: active && !reduceMotion ? 1.06 : 1.0,
+                        scale: cardFocusExpansion && active && !reduceMotion
+                            ? 1.06
+                            : 1.0,
                         duration: const Duration(milliseconds: 400),
                         curve: curve,
                         child: widget.imageUrl != null

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -255,14 +255,17 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     setState(() {});
   }
 
+  /// Kept in [UserPreferences] alone. That is the store the profile sync
+  /// carries, and a second copy in [SeerrPreferences] would never hear about
+  /// a change made on another device.
   Future<void> _setShowMissingCollectionItems(bool value) async {
-    await _seerrPrefs.setShowMissingCollectionItems(value);
     await GetIt.instance<UserPreferences>().set(
       UserPreferences.seerrShowMissingCollectionItems,
       value,
     );
-    if (!mounted) return;
-    setState(() {});
+    if (mounted) setState(() {});
+    // Pushed even after a quick back-navigation, or the next pull would
+    // quietly undo the change.
     await _pushSync();
   }
 
@@ -554,7 +557,9 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
                       : AppColorScheme.onSurface.withValues(alpha: 0.7),
                 ),
               ),
-              value: _seerrPrefs.showMissingCollectionItems,
+              value: GetIt.instance<UserPreferences>().get(
+                UserPreferences.seerrShowMissingCollectionItems,
+              ),
               onChanged: _setShowMissingCollectionItems,
             ),
           ),

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -255,6 +255,17 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     setState(() {});
   }
 
+  Future<void> _setShowMissingCollectionItems(bool value) async {
+    await _seerrPrefs.setShowMissingCollectionItems(value);
+    await GetIt.instance<UserPreferences>().set(
+      UserPreferences.seerrShowMissingCollectionItems,
+      value,
+    );
+    if (!mounted) return;
+    setState(() {});
+    await _pushSync();
+  }
+
   Future<void> _setNotifyOnNewRequests(bool value) async {
     await _seerrPrefs.setNotifyOnNewRequests(value);
     if (mounted) setState(() {});
@@ -515,6 +526,36 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
               ),
               value: _seerrPrefs.blockNsfw,
               onChanged: _setBlockNsfw,
+            ),
+          ),
+        if (showSeerrSettings)
+          TvFocusHighlight(
+            builder: (context, focused) => SwitchListTile.adaptive(
+              secondary: Icon(
+                Icons.video_collection_outlined,
+                color: focused ? AppColors.black.withValues(alpha: 0.54) : null,
+              ),
+              title: Text(
+                l10n.showMissingCollectionItems,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.87)
+                      : AppColorScheme.onSurface,
+                ),
+              ),
+              subtitle: Text(
+                l10n.showMissingCollectionItemsDesc,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              value: _seerrPrefs.showMissingCollectionItems,
+              onChanged: _setShowMissingCollectionItems,
             ),
           ),
         if (showSeerrSettings) ...[

--- a/lib/ui/widgets/seerr_icons.dart
+++ b/lib/ui/widgets/seerr_icons.dart
@@ -23,8 +23,11 @@ class SeerrIcon extends StatelessWidget {
   }
 }
 
-/// Circular corner badge for items available on Seerr, matching the placement
-/// and presence of the watched/played indicator.
+/// Seerr's indigo, as its own UI paints it.
+const seerrBrandColor = Color(0xFF6366F1);
+
+/// Circular corner badge marking a title that stands in from Seerr rather
+/// than the library. Sized to sit where a card's favourite mark would.
 class SeerrBadge extends StatelessWidget {
   final double size;
   final Color? backgroundColor;
@@ -41,7 +44,7 @@ class SeerrBadge extends StatelessWidget {
       width: size,
       height: size,
       decoration: BoxDecoration(
-        color: backgroundColor ?? const Color(0xFF6366F1),
+        color: backgroundColor ?? seerrBrandColor,
         shape: BoxShape.circle,
         boxShadow: const [
           BoxShadow(

--- a/lib/ui/widgets/seerr_icons.dart
+++ b/lib/ui/widgets/seerr_icons.dart
@@ -4,15 +4,60 @@ import 'package:flutter/widgets.dart';
 class SeerrIcon extends StatelessWidget {
   final double size;
   final Color color;
+  final bool solid;
 
-  const SeerrIcon({super.key, this.size = 24, required this.color});
+  const SeerrIcon({
+    super.key,
+    this.size = 24,
+    required this.color,
+    this.solid = false,
+  });
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       width: size,
       height: size,
-      child: CustomPaint(painter: _SeerrPainter(color)),
+      child: CustomPaint(painter: _SeerrPainter(color, solid: solid)),
+    );
+  }
+}
+
+/// Circular corner badge for items available on Seerr, matching the placement
+/// and presence of the watched/played indicator.
+class SeerrBadge extends StatelessWidget {
+  final double size;
+  final Color? backgroundColor;
+
+  const SeerrBadge({
+    super.key,
+    this.size = 18,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: backgroundColor ?? const Color(0xFF6366F1),
+        shape: BoxShape.circle,
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x66000000),
+            blurRadius: 3,
+            offset: Offset(0, 1),
+          ),
+        ],
+      ),
+      child: Center(
+        child: SeerrIcon(
+          size: size * 0.82,
+          color: const Color(0xFFFFFFFF),
+          solid: true,
+        ),
+      ),
     );
   }
 }
@@ -36,7 +81,8 @@ class _SeerrPainter extends CustomPainter {
   );
 
   final Color color;
-  _SeerrPainter(this.color);
+  final bool solid;
+  _SeerrPainter(this.color, {this.solid = false});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -48,26 +94,33 @@ class _SeerrPainter extends CustomPainter {
     canvas.scale(s, s);
     final paint = Paint()..style = PaintingStyle.fill;
 
-    paint.color = color.withValues(alpha: 0.15);
-    canvas.drawPath(_outerCircle, paint);
+    if (solid) {
+      paint.color = color;
+      canvas.drawPath(_crescent, paint);
+      canvas.drawPath(_topLeftArc, paint);
+    } else {
+      paint.color = color.withValues(alpha: 0.15);
+      canvas.drawPath(_outerCircle, paint);
 
-    paint.color = color.withValues(alpha: 0.35);
-    canvas.drawCircle(const Offset(52, 52), 28, paint);
+      paint.color = color.withValues(alpha: 0.35);
+      canvas.drawCircle(const Offset(52, 52), 28, paint);
 
-    paint.color = color.withValues(alpha: 0.55);
-    canvas.drawPath(_crescent, paint);
+      paint.color = color.withValues(alpha: 0.55);
+      canvas.drawPath(_crescent, paint);
 
-    paint.color = color.withValues(alpha: 0.25);
-    canvas.drawPath(_topLeftArc, paint);
+      paint.color = color.withValues(alpha: 0.25);
+      canvas.drawPath(_topLeftArc, paint);
 
-    paint.color = color.withValues(alpha: 0.12);
-    canvas.drawPath(_shadowRing, paint);
+      paint.color = color.withValues(alpha: 0.12);
+      canvas.drawPath(_shadowRing, paint);
+    }
 
     canvas.restore();
   }
 
   @override
-  bool shouldRepaint(_SeerrPainter old) => old.color != color;
+  bool shouldRepaint(_SeerrPainter old) =>
+      old.color != color || old.solid != solid;
 }
 
 Path _parsePath(String d) {

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -217,6 +217,7 @@ void main() {
     'seasonalSurprise',
     'seerrBlockNsfw',
     'seerrEnabled',
+    'seerrShowMissingCollectionItems',
     'showDescriptionOnPause',
     'showDownloadsButton',
     'showFavoritesButton',

--- a/test/data/viewmodels/seerr_missing_collection_items_test.dart
+++ b/test/data/viewmodels/seerr_missing_collection_items_test.dart
@@ -1,0 +1,110 @@
+// The Spotlight collection cards fill in titles the library lacks from
+// Seerr. Those items must look like every other Seerr item in the app so the
+// Seerr detail route resolves them, must honour the adult-content filter, and
+// must land in release order among the library's own members.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/data/services/seerr/seerr_api_models.dart';
+import 'package:moonfin/data/viewmodels/item_detail_view_model.dart';
+
+AggregatedItem _library(String id, {String? tmdbId, String? premiere, int? year}) =>
+    AggregatedItem(
+      id: id,
+      serverId: 'server-1',
+      rawData: {
+        'Id': id,
+        'Name': id,
+        'Type': 'Movie',
+        if (tmdbId != null) 'ProviderIds': {'Tmdb': tmdbId},
+        if (premiere != null) 'PremiereDate': premiere,
+        if (year != null) 'ProductionYear': year,
+      },
+    );
+
+void main() {
+  group('seerrMissingCollectionItems', () {
+    test('skips parts the library holds and shapes the rest as Seerr items', () {
+      final missing = seerrMissingCollectionItems(
+        parts: const [
+          SeerrDiscoverItem(id: 603, title: 'In Library'),
+          SeerrDiscoverItem(
+            id: 604,
+            title: 'Missing Sequel',
+            posterPath: '/p.jpg',
+            releaseDate: '2003-05-15',
+            mediaInfo: SeerrMediaInfo(status: 3),
+          ),
+        ],
+        libraryTmdbIds: {'603'},
+        blockNsfw: true,
+      );
+
+      final item = missing.single;
+      // A bare TMDB id plus the media type, never a pre-prefixed id: the
+      // router adds the prefix itself and would otherwise double it.
+      expect(item.id, '604');
+      expect(item.serverId, 'seerr');
+      expect(item.seerrMediaType, 'movie');
+      expect(item.seerrStatus, 3);
+      expect(item.tmdbId, '604');
+      expect(item.name, 'Missing Sequel');
+      expect(item.productionYear, 2003);
+      expect(item.rawData['PosterPath'], '/p.jpg');
+    });
+
+    test('drops adult titles only while the NSFW filter is on', () {
+      const parts = [
+        SeerrDiscoverItem(id: 1, title: 'Fine'),
+        SeerrDiscoverItem(id: 2, title: 'Adult', adult: true),
+      ];
+
+      expect(
+        seerrMissingCollectionItems(
+          parts: parts,
+          libraryTmdbIds: const {},
+          blockNsfw: true,
+        ).map((i) => i.id),
+        ['1'],
+      );
+      expect(
+        seerrMissingCollectionItems(
+          parts: parts,
+          libraryTmdbIds: const {},
+          blockNsfw: false,
+        ).map((i) => i.id),
+        ['1', '2'],
+      );
+    });
+  });
+
+  group('mergeMissingByReleaseOrder', () {
+    test('slots missing titles by date without reordering the library', () {
+      final library = [
+        _library('a', premiere: '2010-01-01'),
+        _library('b', premiere: '2013-01-01'),
+      ];
+      final missing = [
+        _library('x', premiere: '2012-06-01'),
+        _library('y', year: 2024),
+      ];
+
+      expect(
+        mergeMissingByReleaseOrder(library, missing).map((i) => i.id),
+        ['a', 'x', 'b', 'y'],
+      );
+    });
+
+    test('an undated missing title goes last', () {
+      final library = [_library('a', premiere: '2010-01-01')];
+      expect(
+        mergeMissingByReleaseOrder(library, [_library('z')]).map((i) => i.id),
+        ['a', 'z'],
+      );
+    });
+
+    test('nothing missing hands the library list back as is', () {
+      final library = [_library('a')];
+      expect(identical(mergeMissingByReleaseOrder(library, const []), library), isTrue);
+    });
+  });
+}

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -37,6 +37,20 @@ AggregatedItem _child(String id, String type) => AggregatedItem(
   rawData: {'Id': id, 'Type': type, 'Name': id},
 );
 
+/// Shaped like the view model's real missing items: a bare TMDB id with the
+/// Seerr media type, the way every other Seerr item in the app is built.
+AggregatedItem _seerrMissing(String tmdbId, String name) => AggregatedItem(
+  id: tmdbId,
+  serverId: 'seerr',
+  rawData: {
+    'Id': tmdbId,
+    'Name': name,
+    'Type': 'Movie',
+    'SeerrMediaType': 'movie',
+    'ProviderIds': {'Tmdb': tmdbId},
+  },
+);
+
 SpotlightCardActions _actions() => SpotlightCardActions(
   openItem: (_) {},
   openSeerrItem: (_) {},
@@ -87,6 +101,7 @@ void main() {
     when(() => vm.writers).thenReturn(const []);
     when(() => vm.features).thenReturn(const []);
     when(() => vm.similar).thenReturn(const []);
+    when(() => vm.similarSource).thenReturn(SimilarSource.jellyfin);
     when(() => vm.seasons).thenReturn(const []);
     when(() => vm.episodes).thenReturn(const []);
     when(() => vm.seriesEpisodes).thenReturn(const []);
@@ -250,6 +265,7 @@ void main() {
     );
     when(() => vm.seerr).thenReturn(seerrVm);
     when(() => vm.similar).thenReturn([_child('s1', 'Movie')]);
+    when(() => vm.similarSource).thenReturn(SimilarSource.moonfin);
 
     final cards = cardsFor(_item('Movie'));
 
@@ -262,12 +278,22 @@ void main() {
     ]);
   });
 
+  test('the library similar list keeps the Similar label when Jellyfin made it', () {
+    when(() => vm.similar).thenReturn([_child('s1', 'Movie')]);
+    // The default recommendation source is Moonfin, but the view model fell
+    // back to Jellyfin's own similar items, so that is what the section says.
+    final cards = cardsFor(_item('Movie'));
+
+    final similarCard = cards.singleWhere((c) => c.id == 'similar');
+    expect(similarCard.sections.single.title, _l10n.similar);
+  });
+
   test('collections card prepends the collection itself as the first item with artwork', () {
     when(() => vm.parentCollections).thenReturn([
       ParentCollection(
         id: 'box-1',
         name: 'Alien Anthology',
-        primaryImageTag: 'tag-box-1',
+        boxSetItem: _child('box-1', 'BoxSet'),
         items: [_child('m1', 'Movie'), _child('m2', 'Movie')],
       ),
     ]);
@@ -280,22 +306,39 @@ void main() {
     expect(collectionsCard.sections.single.count, 3);
   });
 
+  test('collections card slots in the titles the library is missing', () async {
+    when(() => vm.parentCollections).thenReturn([
+      ParentCollection(
+        id: 'box-1',
+        name: 'Alien Anthology',
+        boxSetItem: _child('box-1', 'BoxSet'),
+        items: [_child('m1', 'Movie'), _child('m2', 'Movie')],
+        missingItems: [_seerrMissing('999', 'Missing Sequel')],
+      ),
+    ]);
+
+    var section = cardsFor(_item('Movie'))
+        .singleWhere((c) => c.id == 'collections')
+        .sections
+        .single;
+    expect(section.count, 4);
+
+    // The toggle hides them again without a reload.
+    await prefs.set(UserPreferences.seerrShowMissingCollectionItems, false);
+    section = cardsFor(_item('Movie'))
+        .singleWhere((c) => c.id == 'collections')
+        .sections
+        .single;
+    expect(section.count, 3);
+  });
+
   test('boxset items card combines library items and missing seerr items', () {
     when(() => vm.collectionItems).thenReturn([
       _child('m1', 'Movie'),
       _child('m2', 'Movie'),
     ]);
     when(() => vm.missingCollectionItems).thenReturn([
-      AggregatedItem(
-        id: '999',
-        serverId: 'seerr',
-        rawData: const {
-          'Id': '999',
-          'Name': 'Missing Sequel',
-          'Type': 'Movie',
-          'SeerrMediaType': 'movie',
-        },
-      ),
+      _seerrMissing('999', 'Missing Sequel'),
     ]);
     final cards = cardsFor(_item('BoxSet'));
     final boxSetCard = cards.singleWhere((c) => c.id == 'boxset_items');

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -97,6 +97,7 @@ void main() {
     when(() => vm.filmographyMovies).thenReturn(const []);
     when(() => vm.filmographySeries).thenReturn(const []);
     when(() => vm.collectionItems).thenReturn(const []);
+    when(() => vm.missingCollectionItems).thenReturn(const []);
     when(() => vm.playlistItems).thenReturn(const []);
     when(() => vm.parentCollections).thenReturn(const []);
     when(() => vm.canManagePlaylistTracks).thenReturn(false);
@@ -253,12 +254,52 @@ void main() {
     final cards = cardsFor(_item('Movie'));
 
     final similarCard = cards.singleWhere((c) => c.id == 'similar');
-    expect(similarCard.title, 'Similar and Seerr Recommendations');
+    expect(similarCard.title, _l10n.recommendations);
     expect(similarCard.sections.map((s) => s.title), [
-      _l10n.similar,
-      _l10n.recommendations,
+      _l10n.recommendationSystemMoonfin,
+      _l10n.spotlightRecommendationsSeerr,
       'Similar (Seerr)',
     ]);
+  });
+
+  test('collections card prepends the collection itself as the first item with artwork', () {
+    when(() => vm.parentCollections).thenReturn([
+      ParentCollection(
+        id: 'box-1',
+        name: 'Alien Anthology',
+        primaryImageTag: 'tag-box-1',
+        items: [_child('m1', 'Movie'), _child('m2', 'Movie')],
+      ),
+    ]);
+    final cards = cardsFor(_item('Movie'));
+
+    final collectionsCard = cards.singleWhere((c) => c.id == 'collections');
+    expect(collectionsCard.title, _l10n.spotlightCollectionsCard);
+    expect(collectionsCard.subtitle, '1 collection');
+    expect(collectionsCard.sections.single.title, 'Alien Anthology');
+    expect(collectionsCard.sections.single.count, 3);
+  });
+
+  test('boxset items card combines library items and missing seerr items', () {
+    when(() => vm.collectionItems).thenReturn([
+      _child('m1', 'Movie'),
+      _child('m2', 'Movie'),
+    ]);
+    when(() => vm.missingCollectionItems).thenReturn([
+      AggregatedItem(
+        id: 'tmdb:movie:999',
+        serverId: 'seerr',
+        rawData: const {
+          'Id': 'tmdb:movie:999',
+          'Name': 'Missing Sequel',
+          'Type': 'Movie',
+        },
+      ),
+    ]);
+    final cards = cardsFor(_item('BoxSet'));
+    final boxSetCard = cards.singleWhere((c) => c.id == 'boxset_items');
+    expect(boxSetCard.title, _l10n.spotlightMoviesAndShows);
+    expect(boxSetCard.sections.first.count, 3);
   });
 
   test('a person keeps their seerr credits sections', () {

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -287,12 +287,13 @@ void main() {
     ]);
     when(() => vm.missingCollectionItems).thenReturn([
       AggregatedItem(
-        id: 'tmdb:movie:999',
+        id: '999',
         serverId: 'seerr',
         rawData: const {
-          'Id': 'tmdb:movie:999',
+          'Id': '999',
           'Name': 'Missing Sequel',
           'Type': 'Movie',
+          'SeerrMediaType': 'movie',
         },
       ),
     ]);

--- a/test/ui/screens/detail/spotlight_section_modal_test.dart
+++ b/test/ui/screens/detail/spotlight_section_modal_test.dart
@@ -4,9 +4,18 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart';
 import 'package:moonfin/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart';
 import 'package:moonfin/ui/widgets/overlay_sheet.dart';
 import 'package:moonfin/util/platform_detection.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _ImageApi extends Mock implements ImageApi {}
 
 void main() {
   tearDown(() {
@@ -231,4 +240,79 @@ void main() {
     expect(returnFocus.hasFocus, isTrue);
     expect(DialogBackSuppressor.consume(), isFalse);
   });
+
+  testWidgets('tapping a MediaCard in SpotlightMediaGridSection pops with action', (
+    tester,
+  ) async {
+    PlatformDetection.setTvMode(false);
+    VoidCallback? returnedAction;
+    var actionExecuted = false;
+
+    final item = AggregatedItem(
+      id: 'item-1',
+      serverId: 'server-1',
+      rawData: {
+        'Id': 'item-1',
+        'Name': 'Critters',
+        'Type': 'Movie',
+      },
+    );
+
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    final prefs = UserPreferences(store);
+    final imageApi = _ImageApi();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                final action = await SpotlightSectionModal.show<VoidCallback>(
+                  context,
+                  title: 'Movies & Shows',
+                  sections: [
+                    SpotlightModalSection(
+                      title: 'Critters Collection',
+                      builder: (modalContext, firstFocusNode) => SpotlightMediaGridSection(
+                        items: [item],
+                        imageApi: imageApi,
+                        prefs: prefs,
+                        firstFocusNode: firstFocusNode,
+                        onItemTap: (tappedItem) {
+                          Navigator.of(context, rootNavigator: true).pop(() {
+                            actionExecuted = true;
+                          });
+                        },
+                      ),
+                    ),
+                  ],
+                );
+                returnedAction = action;
+                action?.call();
+              },
+              child: const Text('open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Movies & Shows'), findsOneWidget);
+    expect(find.text('Critters'), findsOneWidget);
+
+    await tester.tap(find.text('Critters'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Movies & Shows'), findsNothing);
+    expect(returnedAction, isNotNull);
+    expect(actionExecuted, isTrue);
+  });
 }
+
+


### PR DESCRIPTION
# Spotlight Detail View Refinements & Enhancements
A collection of refinements, visual fixes, and enhancements built on top of the experimental `spotlight` branch. Each major change is separated into its own commit to allow reviewing, testing, or cherry-picking individual changes independently.

## Commit 1: fix(spotlight): restore hidden navbar on desktop mouse hover
On desktop and web platforms, the top navigation bar and floating back button hide automatically when scrolling down with the keyboard or entering Spotlight modal cards. When a modal was closed using only a mouse (e.g., clicking the "X" button), focus remained on the modal launcher card, leaving no way to retrieve the top navigation bar or back button without pressing the keyboard "Up" key.

### Changes
- In **item_detail_screen.dart**, introduced non-blocking `MouseRegion` hover detection zones along the top 90px (and left 80px when sidebar layout is active) that are active when the navbar is hidden on desktop/web (`!PlatformDetection.isTV && !_showNavbar`). Moving the mouse to the edge of the window restores `_showNavbar = true` and brings back the toolbar and back button.
- In **spotlight_detail_content.dart**, ensured that entering any Spotlight section modal invokes `widget.onToggleNavbar?.call(false)` to reliably dismiss the navbar while inspecting modal content.

### Demonstration
https://github.com/user-attachments/assets/b09ad346-c14a-4123-8a9c-53aa0bdc8863

---
## Commit 2: fix(spotlight): preserve authentic studio logo rendering in cast and crew modal
In the Cast, Crew, and Studios modal, studio company logo graphics were tinted with `color: Colors.white` and `colorBlendMode: BlendMode.srcIn`. While designed for transparent monochrome masks, this caused any non-transparent logo asset (rectangular containers, color marks, gradient badges, and network pills) to render as an opaque solid white box.

### Changes
- In **spotlight_modal_grids.dart**, removed the white tint and `srcIn` blend mode from `Image`, rendering studio marks with authentic corporate colors, clean transparency, and crispness on top of the white container card (matching **ModernDetailContent** behavior).

### Demonstration
Broken:
<img width="1650" height="1024" alt="2026-09-10_15-49-20_Antigravity_IDE" src="https://github.com/user-attachments/assets/6880b123-e2dd-4b2d-a28b-7a19277ddae4" />
Fixed:
<img width="2534" height="1514" alt="2026-09-10_15-10-28_moonfin" src="https://github.com/user-attachments/assets/1700f753-8bda-462b-8fa7-3707e3f5061e" />

---
## Commit 3: feat(spotlight): offset dynamic backdrop start index to avoid duplicate thumbnail
First change was in terms of the Cast/Crew/Studios image. The headshots were pretty much showing just the lead actor's forehead, so switched it to a backdrop image instead. Further, added logic so the backdrop used here is not selected immediately (if possible) by the actual backdrop. Additionally, `SpotlightDetailContent._buildBackdrop` was evaluating `itemBackdrop ?? backdropUrl`, which blocked updates from the rotating dynamic backdrop stream, so that was fixed too.

### Changes
- In **background_service.dart**, added `startIndex` parameter support to `setBackground` and `_loadBackgrounds`. When `context == BlurContext.details` and multiple backdrop images exist, the slideshow defaults to `startIndex: 1` so the initial screen backdrop starts on image 2, while the Cast/Crew thumbnail retains image 1.
- In **item_detail_screen.dart**, passed `startIndex: 0` when focusing child items (such as tracks or episodes) to ensure child focus highlights their primary image.
- In **spotlight_detail_content.dart**, prioritized `backdropUrl ?? itemBackdrop` so the background receives live stream updates as backdrops rotate.

### Demonstration
<img width="2534" height="1514" alt="2026-09-10_15-07-34_moonfin" src="https://github.com/user-attachments/assets/250acd52-2c21-48d0-8a30-0c640b91d291" />
<img width="2534" height="1514" alt="2026-09-10_15-08-08_moonfin" src="https://github.com/user-attachments/assets/ebab2877-619f-4c22-9c7f-13552eedb373" />

With description text on:
<img width="2534" height="1514" alt="2026-09-10_16-04-06_moonfin" src="https://github.com/user-attachments/assets/42c1daa6-171d-4d6f-8c9d-d212666859d8" />

---
## Commit 4: feat(spotlight): enhance card thumbnails, landscape fallbacks, and max width constraints
1. Horizontal 16:9 summary cards for Recommendations, Collections, and BoxSet items were cropping 2:3 vertical posters into horizontal containers.
2. BoxSet collection items lacked fallback primary image tags when prepended to modal collections.
3. The recommendation card title was verbose ("Similar and Seerr Recommendations").
4. In landscape view on wide displays, rows with only 1 or 2 cards stretched into excessively wide horizontal banners.

### Changes
- In **spotlight_images.dart**, implemented `spotlightLandscapeImageUrl` prioritizing 16:9 `Thumb` and `Backdrop` artwork (including parent series backdrops and Seerr backdrop URLs) over cropped posters. Allowed primary image fallback resolution for `BoxSet` and folder items.
- In **spotlight_cards.dart**, switched Recommendations, Collections, and Movies & Shows summary cards to use landscape artwork fallbacks, and simplified the recommendation card title to "Recommendations".
- In **spotlight_detail_content.dart**, wrapped landscape card rows in a `LayoutBuilder` enforcing a maximum card width based on a 16:9 aspect ratio (`cardHeight * (16 / 9)`), keeping 1- and 2-card layouts visually balanced without horizontal over-expansion.

### Demonstration
Rows are now labelled with their sources:
<img width="2524" height="1514" alt="2026-09-10_14-25-28_moonfin" src="https://github.com/user-attachments/assets/a1756a77-9c1d-4265-a44e-269ff67ad463" />
<img width="2524" height="1514" alt="2026-09-10_14-25-47_moonfin" src="https://github.com/user-attachments/assets/580fa1e5-549a-4a3c-bb79-875e3303ddb8" />

---
## Commit 5: feat(spotlight): discover missing collection items from Seerr with high-contrast badge
When viewing collections (or movies that belong to a parent collection), users only see items already present in their personal library. Missing collection entries (e.g., unacquired sequels/prequels) were invisible, preventing users from realizing the collection was incomplete or discovering missing entries.

### Changes
- In **item_detail_view_model.dart**, added `_loadBoxSetSeerrItems()` and collection scanning using `SeerrRepository.getCollectionDetails()` to discover missing collection items from TMDB/Seerr. Missing items are converted into `AggregatedItem` entries and merged with library titles in chronological release order.
- In **spotlight_cards.dart**, combined library items and missing Seerr items in the Movies & Shows card and Parent Collections sections.
- Created `SeerrBadge` in **seerr_icons.dart** and enabled `solid: true` mode for `SeerrIcon`. Renders an 18px solid indigo circular badge with a high-contrast white crescent icon positioned at `top: 4, right: 4`, matching the exact dimensions and prominence of the played indicator.
- In **spotlight_modal_grids.dart**, displayed the high-contrast `SeerrBadge` on missing items and suppressed the watched indicator. Clicking a missing item routes directly to its Seerr detail page for requesting.
- Added unit tests in **spotlight_cards_test.dart**.

### Demonstration
Collection with no missing items:
<img width="2534" height="1514" alt="2026-09-10_15-32-31_moonfin" src="https://github.com/user-attachments/assets/40f3bb49-cb18-4738-bd63-71f58c7c99dd" />

Collection with 1 missing item:
<img width="2534" height="1514" alt="2026-09-10_15-02-58_moonfin" src="https://github.com/user-attachments/assets/fb29b798-7083-42d5-90af-0bfd2896edcb" />

Collection with 1 played item, 1 unplayed (but available) item, and 1 missing item that I imagine probably should not have been made:
<img width="2534" height="1514" alt="2026-09-10_15-33-15_moonfin" src="https://github.com/user-attachments/assets/5a76c062-6e4e-4d42-b6ef-63bb9c71a122" />

---
## Commit 6: feat(settings): add show missing collection items toggle with cross-client sync
Because missing collection items are sourced from TMDB via Seerr, some users may prefer seeing strictly local library content on collection pages and modals.

### Changes
- In **user_preferences.dart**, added `seerrShowMissingCollectionItems` preference (default: `true`) and registered it in `serverScopedKeys`.
- In **seerr_preferences.dart**, added getter and setter methods.
- In **synced_fields.dart** and **synced_fields_test.dart**, registered `seerrShowMissingCollectionItems` for cross-client synchronization.
- In **seerr_config_screen.dart**, added the "Show Missing Collection Items" toggle immediately below the NSFW Filter.
- In **item_detail_view_model.dart** and **spotlight_cards.dart**, gated Seerr collection queries and card integration behind the preference.
- Localized in **app_en.arb** and regenerated all language files via `flutter gen-l10n`.

### Demonstration
New toggle! Woo!
<img width="2534" height="1514" alt="2026-09-10_15-54-12_moonfin" src="https://github.com/user-attachments/assets/99b24f0a-5196-42e3-bb76-9728c2517933" />

---
## Commit 7: fix(spotlight): tie card image zoom to focus expansion animation setting
When focusing or hovering Spotlight summary cards on the details page, the card background artwork performed a subtle zoom-in animation (`scale: 1.06`) over 400ms. Unlike other focus expansions across Moonfin, this image zoom was active even when the user had explicitly turned off the "Focus Expansion Animation" setting under General Style.

### Changes
- In **spotlight_summary_card.dart**, gated the inner image `AnimatedScale` behind `cardFocusExpansion && active && !reduceMotion`. When focus expansion is disabled, summary cards and their background imagery remain completely static upon focus.


---
## Commit 8: fix(spotlight): resolve modal tile tap cancellation and sanitize seerr navigation id

Two issues arose during testing on mobile. First, clicking on items from the pop-ups weren't registering properly unless you opened the popup, closed it, and opened it again. Commit 8 adds persistent `ValueKey`s across grid builder items in `spotlight_section_modal.dart` to prevent background viewmodel rebuilds from replacing widgets mid-touch (`onTapCancel`). Converted modal navigation to pop-before-push to eliminate route transition races.

The second issue was the collection items not available locally were not pathing correctly. So, this commit sanitizes the missing collection item IDs to raw numeric strings matching home screen patterns and added defensive prefix-stripping in `SeerrMediaDetailViewModel` to eliminate `Exception: Invalid media ID` errors. Because noone likes those.

---
## Testing
- [x] Tested on physical Windows desktop build (`mfdbW`)
- [x] Manual testing completed
- [x] Analyzer: `flutter analyze` completed with 0 errors
- [x] Automated unit tests: `flutter test test/data/synced_fields_test.dart test/ui/screens/detail/spotlight_cards_test.dart` passed (18/18 tests)

### Test Steps
1. Navigate to a movie detail page with a mouse, scroll down until the navigation bar hides, and move the mouse cursor to the top edge to verify the navbar and back button smoothly reappear.
2. Open the Cast, Crew, and Studios card modal to verify studio logos render clearly with original corporate colors and transparency against the white background.
3. Observe media backdrops on detail view to ensure backdrops cycle through alternative fanart without duplicating the Cast & Crew thumbnail.
4. Inspect collection cards and recommendation cards to confirm 16:9 landscape thumbnails are used in place of cropped vertical posters.
5. Open a BoxSet collection (e.g., Alien or Critters) to verify missing titles appear in chronological release order with the high-contrast circular Seerr badge.
6. Toggle "Show Missing Collection Items" under Settings -> Seerr to verify missing collection items are dynamically hidden or shown according to user preference.

## Checklist
- [x] Code builds successfully on local target
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] Multi-language localizations generated