### PR TITLE
Spotlight Refinements, Take 2

### DIFF
--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -72,6 +72,7 @@ import '../../../widgets/seerr/seerr_request_dialog.dart';
 import '../../../widgets/seerr/seerr_item_status.dart';
 import '../../../widgets/seerr/seerr_status_pill.dart';
 import '../../../widgets/seerr/seerr_stats_card.dart';
+import '../../../widgets/seerr_icons.dart';
 
 double _desktopUiScale({UserPreferences? prefs}) {
   final effectivePrefs = prefs ?? GetIt.instance<UserPreferences>();
@@ -998,8 +999,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             _ModernTab(l10n.appearances, (_, _) => _itemGrid(_sortJellyfinItems(_vm.filmography))),
         ];
       case 'BoxSet':
-        final moviesList = _vm.collectionItems.where((i) => i.type == 'Movie').toList();
-        moviesList.sort((a, b) {
+        final showMissing = widget.prefs.get(
+          UserPreferences.seerrShowMissingCollectionItems,
+        );
+        final libraryMovies = _vm.collectionItems.where((i) => i.type == 'Movie').toList();
+        libraryMovies.sort((a, b) {
           final aIndex = _vm.playlistItems.indexWhere((p) => p.id == a.id);
           final bIndex = _vm.playlistItems.indexWhere((p) => p.id == b.id);
           if (aIndex == -1 && bIndex == -1) return 0;
@@ -1007,9 +1011,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (bIndex == -1) return -1;
           return aIndex.compareTo(bIndex);
         });
+        final missingMovies = _vm.missingCollectionItems.where((i) => i.type == 'Movie').toList();
+        final moviesList = showMissing
+            ? mergeMissingByReleaseOrder(libraryMovies, missingMovies)
+            : libraryMovies;
 
-        final seriesList = _vm.collectionItems.where((i) => i.type == 'Series').toList();
-        seriesList.sort((a, b) {
+        final librarySeries = _vm.collectionItems.where((i) => i.type == 'Series').toList();
+        librarySeries.sort((a, b) {
           final aIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == a.id || p.id == a.id);
           final bIndex = _vm.playlistItems.indexWhere((p) => p.seriesId == b.id || p.id == b.id);
           if (aIndex == -1 && bIndex == -1) return 0;
@@ -1017,6 +1025,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           if (bIndex == -1) return -1;
           return aIndex.compareTo(bIndex);
         });
+        final missingSeries = _vm.missingCollectionItems.where((i) => i.type == 'Series').toList();
+        final seriesList = showMissing
+            ? mergeMissingByReleaseOrder(librarySeries, missingSeries)
+            : librarySeries;
 
         return [
           if (moviesList.isNotEmpty)
@@ -3301,6 +3313,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                 Builder(
                   builder: (cellContext) {
                     final entry = items[i];
+                    final isSeerrItem =
+                        entry.id.startsWith('tmdb:') || entry.serverId == 'seerr';
                     final topRow = i < columns;
                     return MediaCard(
                       title: entry.name,
@@ -3308,13 +3322,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                       imageUrl: _imageUrl(entry),
                       width: cardWidth,
                       aspectRatio: cardRatio,
-                      isPlayed: entry.isPlayed,
-                      isFavorite: entry.isFavorite,
+                      isPlayed: isSeerrItem ? false : entry.isPlayed,
+                      isFavorite: isSeerrItem ? false : entry.isFavorite,
                       itemType: entry.type,
                       focusNode: i == 0 ? firstFocusNode : null,
                       focusColor: focusColor,
                       cardFocusExpansion: cardExpansion,
                       suppressFocusGlow: isNeon,
+                      watchedBehavior: isSeerrItem
+                          ? WatchedIndicatorBehavior.never
+                          : watchedBehavior,
+                      imageOverlays: [
+                        if (isSeerrItem)
+                          const Positioned(
+                            top: 4,
+                            right: 4,
+                            child: SeerrBadge(size: 18),
+                          ),
+                      ],
                       onFocus: () => Scrollable.ensureVisible(
                         cellContext,
                         alignment: 0.5,
@@ -3332,14 +3357,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
                               return KeyEventResult.ignored;
                             }
                           : null,
-                      watchedBehavior: watchedBehavior,
                       onTap: () {
                         if (entry.serverId == 'seerr') {
                           final mediaType = entry.seerrMediaType ??
                               (entry.type == 'Series' ? 'tv' : 'movie');
+                          final tmdbId = entry.tmdbId;
+                          final targetId = (tmdbId != null && tmdbId.isNotEmpty)
+                              ? tmdbId
+                              : entry.id.replaceAll(
+                                  RegExp(r'^tmdb:(?:movie:|tv:)?'),
+                                  '',
+                                );
                           context.push(
-                            Destinations.seerrMedia(entry.id,
-                                mediaType: mediaType),
+                            Destinations.seerrMedia(
+                              targetId,
+                              mediaType: mediaType,
+                              title: entry.name,
+                            ),
                           );
                         } else {
                           context.push(

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
@@ -303,26 +303,40 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
       ],
     );
 
+    final radius = AppRadius.circular(compact ? 0 : 20);
+    final clippedBody = ClipRRect(
+      borderRadius: radius,
+      child: body,
+    );
+
+    final borderDecoration = compact
+        ? null
+        : BoxDecoration(
+            borderRadius: radius,
+            border: Border.fromBorderSide(
+              ThemeRegistry.active.borders.chipBorder,
+            ),
+          );
+
     final decorated = glass
         ? GlassSurface(
             cornerRadius: compact ? 0 : 20,
             reinforced: true,
             fallbackColor: Colors.transparent,
-            child: body,
+            child: Container(
+              foregroundDecoration: borderDecoration,
+              child: clippedBody,
+            ),
           )
-        : DecoratedBox(
+        : Container(
             decoration: BoxDecoration(
               color: AppColorScheme.surface.withValues(
                 alpha: compact ? 0.98 : 0.94,
               ),
-              borderRadius: AppRadius.circular(compact ? 0 : 20),
-              border: compact
-                  ? null
-                  : Border.fromBorderSide(
-                      ThemeRegistry.active.borders.chipBorder,
-                    ),
+              borderRadius: radius,
             ),
-            child: body,
+            foregroundDecoration: borderDecoration,
+            child: clippedBody,
           );
 
     final panel = compact

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_summary_card.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_summary_card.dart
@@ -179,7 +179,7 @@ class _SpotlightSummaryCardState extends State<SpotlightSummaryCard>
                       ),
                       Positioned(
                         left: 14,
-                        right: 40,
+                        right: 32,
                         bottom: 10,
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
@@ -194,6 +194,7 @@ class _SpotlightSummaryCardState extends State<SpotlightSummaryCard>
                                       ?.copyWith(
                                         color: Colors.white,
                                         fontWeight: FontWeight.w700,
+                                        fontSize: compact ? 12.0 : 13.0,
                                       ) ??
                                   const TextStyle(color: Colors.white),
                             ),
@@ -204,6 +205,7 @@ class _SpotlightSummaryCardState extends State<SpotlightSummaryCard>
                               overflow: TextOverflow.ellipsis,
                               style: textTheme.bodySmall?.copyWith(
                                 color: Colors.white.withValues(alpha: 0.75),
+                                fontSize: compact ? 10.5 : 11.5,
                               ),
                             ),
                           ],


### PR DESCRIPTION
# Pull Request

## Summary
Refines the Spotlight theme details layout by ensuring summary card labels fit cleanly on a single line, strictly contains modal grid posters within the dialog boundary with proper border layering, and brings Modern theme BoxSet collection discovery into parity with Spotlight.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1487 

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Summary Card Label Sizing**: Scaled title and subtitle font sizes and adjusted right margin in **spotlight_summary_card.dart** so long section labels like "Recommendations" fit on a single line across all themes (including wide display fonts such as Orbitron in Neon Pulse).
- **Modal Corner Poster Clipping**: Wrapped the dialog body in **spotlight_section_modal.dart** in a `ClipRRect` matching the dialog corner radius (20px) and rendered `chipBorder` via `foregroundDecoration`, ensuring scrolling poster grids are properly contained and cannot paint over the bottom border corners.
- **Modern BoxSet Parity**: Added Seerr missing collection items discovery support to the Modern detail BoxSet view in **modern_detail_content.dart**, gated behind the `seerrShowMissingCollectionItems` preference.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Install beta
2. Mess around

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Before
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_19-32-53" src="https://github.com/user-attachments/assets/6fc64d1f-77f4-4a0c-bbc8-3b7e99f24666" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_19-33-33" src="https://github.com/user-attachments/assets/604a0a7d-65af-42be-b50e-a26c4422e16c" />

### After
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_19-42-34" src="https://github.com/user-attachments/assets/ec5c28a8-fb88-4c2f-bc28-3e6b70fb26e5" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_19-42-50" src="https://github.com/user-attachments/assets/3bae3e34-51ac-4298-84e1-3d863a70b09b" />

### Collections on Modern Details Page
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_19-31-34" src="https://github.com/user-attachments/assets/e3df2c7b-9e87-4d68-9a4c-94050eeb011c" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
