### PR TITLE
feat-ui - Add Show Seerr Availability Badges setting

### DIFF
--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -316,6 +316,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('showDescriptionOnPause', UserPreferences.showDescriptionOnPause, SyncCodec.boolean),
   SyncedField('showLoadingAnimationText', UserPreferences.showLoadingAnimationText, SyncCodec.boolean),
   SyncedField('showMediaDetailsOnLibraryPage', UserPreferences.showMediaDetailsOnLibraryPage, SyncCodec.boolean),
+  SyncedField('showSeerrAvailabilityBadges', UserPreferences.showSeerrAvailabilityBadges, SyncCodec.boolean),
   SyncedField('showSeerrButton', UserPreferences.showSeerrButton, SyncCodec.boolean),
   SyncedField('showServerMessagesButton', UserPreferences.showServerMessagesButton, SyncCodec.boolean),
   SyncedField('sinceYouWatched1Enabled', UserPreferences.sinceYouWatched1Enabled, SyncCodec.boolean),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5889,6 +5889,14 @@
   "@showMissingCollectionItemsDesc": {
     "description": "Setting subtitle explaining that missing items will be included on Collection pages"
   },
+  "showSeerrAvailabilityBadges": "Show Seerr Availability Badges",
+  "@showSeerrAvailabilityBadges": {
+    "description": "Setting title for showing Seerr availability badges on media details pages"
+  },
+  "showSeerrAvailabilityBadgesDescription": "Show season availability badges on media details pages",
+  "@showSeerrAvailabilityBadgesDescription": {
+    "description": "Setting description for showing Seerr availability badges on media details pages"
+  },
   "seerrNotificationsSection": "Notifications",
   "@seerrNotificationsSection": {
     "description": "Header for the Seerr notifications settings section"

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -7900,6 +7900,18 @@ abstract class AppLocalizations {
   /// **'Include missing items on Collection pages'**
   String get showMissingCollectionItemsDesc;
 
+  /// Setting title for showing Seerr availability badges on media details pages
+  ///
+  /// In en, this message translates to:
+  /// **'Show Seerr Availability Badges'**
+  String get showSeerrAvailabilityBadges;
+
+  /// Setting description for showing Seerr availability badges on media details pages
+  ///
+  /// In en, this message translates to:
+  /// **'Show season availability badges on media details pages'**
+  String get showSeerrAvailabilityBadgesDescription;
+
   /// Header for the Seerr notifications settings section
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -4452,6 +4452,13 @@ class AppLocalizationsAf extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Kennisgewings';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -4454,6 +4454,13 @@ class AppLocalizationsAr extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'الإشعارات';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -4467,6 +4467,13 @@ class AppLocalizationsBe extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Апавяшчэнні';
 
   @override

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -4469,6 +4469,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Известия';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -4438,6 +4438,13 @@ class AppLocalizationsBn extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'বিজ্ঞপ্তি';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -4502,6 +4502,13 @@ class AppLocalizationsCa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notificacions';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -4457,6 +4457,13 @@ class AppLocalizationsCs extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Oznámení';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -4472,6 +4472,13 @@ class AppLocalizationsCy extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Hysbysiadau';
 
   @override

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -4445,6 +4445,13 @@ class AppLocalizationsDa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notifikationer';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -4551,6 +4551,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Benachrichtigungen';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -4493,6 +4493,13 @@ class AppLocalizationsEl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Ειδοποιήσεις';
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -4426,6 +4426,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notifications';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -4444,6 +4444,13 @@ class AppLocalizationsEo extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Sciigoj';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -4476,6 +4476,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notificaciones';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -4451,6 +4451,13 @@ class AppLocalizationsEt extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Teavitused';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -4425,6 +4425,13 @@ class AppLocalizationsFa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'اعلان‌ها';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -4466,6 +4466,13 @@ class AppLocalizationsFi extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Ilmoitukset';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -4497,6 +4497,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notifications';
 
   @override

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -4491,6 +4491,13 @@ class AppLocalizationsGl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notificacións';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -4410,6 +4410,13 @@ class AppLocalizationsHe extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'התראות';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -4437,6 +4437,13 @@ class AppLocalizationsHi extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'सूचनाएँ';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4568,6 +4568,13 @@ class AppLocalizationsHr extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Obavijesti';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -4477,6 +4477,13 @@ class AppLocalizationsHu extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Értesítések';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -4450,6 +4450,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notifikasi';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -4471,6 +4471,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notifiche';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -4360,6 +4360,13 @@ class AppLocalizationsJa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => '通知';
 
   @override

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -4465,6 +4465,13 @@ class AppLocalizationsKk extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Хабарландырулар';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -4469,6 +4469,13 @@ class AppLocalizationsKn extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'ಅಧಿಸೂಚನೆಗಳು';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -4343,6 +4343,13 @@ class AppLocalizationsKo extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => '알림';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -4468,6 +4468,13 @@ class AppLocalizationsLt extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Pranešimai';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -4466,6 +4466,13 @@ class AppLocalizationsLv extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Paziņojumi';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -4467,6 +4467,13 @@ class AppLocalizationsMk extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Известувања';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -4473,6 +4473,13 @@ class AppLocalizationsMl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'അറിയിപ്പുകൾ';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -4457,6 +4457,13 @@ class AppLocalizationsMn extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Мэдэгдэл';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -4442,6 +4442,13 @@ class AppLocalizationsNb extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Varsler';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -4469,6 +4469,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Meldingen';
 
   @override

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -4435,6 +4435,13 @@ class AppLocalizationsPa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'ਸੂਚਨਾਵਾਂ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4597,6 +4597,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Powiadomienia';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -4468,6 +4468,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notificações';
 
   @override

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -4478,6 +4478,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Notificări';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -4478,6 +4478,13 @@ class AppLocalizationsRu extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Уведомления';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -4447,6 +4447,13 @@ class AppLocalizationsSi extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'දැනුම්දීම්';
 
   @override

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -4470,6 +4470,13 @@ class AppLocalizationsSk extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Upozornenia';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -4473,6 +4473,13 @@ class AppLocalizationsSl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Obvestila';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -4478,6 +4478,13 @@ class AppLocalizationsSq extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Njoftimet';
 
   @override

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4570,6 +4570,13 @@ class AppLocalizationsSr extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Обавештења';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -4451,6 +4451,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Aviseringar';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -4474,6 +4474,13 @@ class AppLocalizationsSw extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Arifa';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -4477,6 +4477,13 @@ class AppLocalizationsTa extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'அறிவிப்புகள்';
 
   @override

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -4468,6 +4468,13 @@ class AppLocalizationsTe extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'నోటిఫికేషన్‌లు';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -4419,6 +4419,13 @@ class AppLocalizationsTh extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'การแจ้งเตือน';
 
   @override

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -4482,6 +4482,13 @@ class AppLocalizationsTl extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Mga Notification';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -4457,6 +4457,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Bildirimler';
 
   @override

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -4454,6 +4454,13 @@ class AppLocalizationsUg extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'ئۇقتۇرۇشلار';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -4472,6 +4472,13 @@ class AppLocalizationsUk extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Сповіщення';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -4453,6 +4453,13 @@ class AppLocalizationsVi extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => 'Thông báo';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -4326,6 +4326,13 @@ class AppLocalizationsYue extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => '通知';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -4296,6 +4296,13 @@ class AppLocalizationsZh extends AppLocalizations {
       'Include missing items on Collection pages';
 
   @override
+  String get showSeerrAvailabilityBadges => 'Show Seerr Availability Badges';
+
+  @override
+  String get showSeerrAvailabilityBadgesDescription =>
+      'Show season availability badges on media details pages';
+
+  @override
   String get seerrNotificationsSection => '通知';
 
   @override

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -441,6 +441,7 @@ class UserPreferences extends ChangeNotifier {
     'poster_size_playlist',
     'pref_home_rows_fullscreen',
     'pref_show_seerr_button',
+    'pref_show_seerr_availability_badges',
     'pref_show_server_messages_button',
     'pref_show_media_details_on_library_page',
     'pref_use_detailed_sub_headings',
@@ -1472,6 +1473,11 @@ class UserPreferences extends ChangeNotifier {
 
   static final showSeerrButton = Preference(
     key: 'pref_show_seerr_button',
+    defaultValue: true,
+  );
+
+  static final showSeerrAvailabilityBadges = Preference(
+    key: 'pref_show_seerr_availability_badges',
     defaultValue: true,
   );
 

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -13342,8 +13342,11 @@ class DetailSeasonsRow extends StatelessWidget {
             SizedBox(width: isMobile ? 8 : 12 * desktopScale),
         itemBuilder: (context, index) {
           final season = seasons[index];
+          final showAvailabilityBadges =
+              prefs.get(UserPreferences.showSeerrAvailabilityBadges);
           final seerrStatus = seerrSeasonStatus?[season.indexNumber];
-          final hasSeerrDot = SeerrMediaStatus.hasDot(seerrStatus);
+          final hasSeerrDot =
+              showAvailabilityBadges && SeerrMediaStatus.hasDot(seerrStatus);
           return MediaCard(
             title: season.name,
             subtitle: _progressText(season),

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1144,6 +1144,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     // unplayed episode's seasonId so the cyan border always renders correctly.
     final nextUpSeasonId = _vm.nextUp?.seasonId ??
         _vm.seriesEpisodes.firstWhereOrNull((e) => !e.isPlayed)?.seasonId;
+    final showAvailabilityBadges =
+        widget.prefs.get(UserPreferences.showSeerrAvailabilityBadges);
     final seerrSeasonStatus = seerrItemSeasonStatus(_vm);
     // Set only for a series with no season to open, where the card offers to
     // request that season instead.
@@ -1155,7 +1157,9 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       bool topRow = true,
     }) =>
         SeasonCard(
-          seerrStatus: seerrSeasonStatus[_vm.seasons[i].indexNumber],
+          seerrStatus: showAvailabilityBadges
+              ? seerrSeasonStatus[_vm.seasons[i].indexNumber]
+              : null,
           title: _vm.seasons[i].name,
           subtitle: l10n.episodeCount(
             counts[_vm.seasons[i].id] ?? _vm.seasons[i].childCount ?? 0,

--- a/lib/ui/screens/settings/seerr_config_screen.dart
+++ b/lib/ui/screens/settings/seerr_config_screen.dart
@@ -44,6 +44,7 @@ class SeerrConfigScreen extends StatefulWidget {
 class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
   late final PluginSyncService _syncService;
   late final SeerrPreferences _seerrPrefs;
+  late final UserPreferences _userPreferences;
 
   MoonfinStatusResponse? _seerrStatus;
   bool _statusLoading = false;
@@ -60,6 +61,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     super.initState();
     _syncService = GetIt.instance<PluginSyncService>();
     _seerrPrefs = GetIt.instance<SeerrPreferences>();
+    _userPreferences = GetIt.instance<UserPreferences>();
     _rows = List.of(_seerrPrefs.rowsConfig)..sort((a, b) => a.order.compareTo(b.order));
     final beforeTypes = _rows.map((r) => r.type).toList();
     _sortRowsEnabledAboveDisabled();
@@ -267,6 +269,16 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
     // Pushed even after a quick back-navigation, or the next pull would
     // quietly undo the change.
     await _pushSync();
+  }
+
+  Future<void> _setShowAvailabilityBadges(bool value) async {
+    await _userPreferences.set(
+      UserPreferences.showSeerrAvailabilityBadges,
+      value,
+    );
+    await _pushSync();
+    if (!mounted) return;
+    setState(() {});
   }
 
   Future<void> _setNotifyOnNewRequests(bool value) async {
@@ -531,7 +543,7 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
               onChanged: _setBlockNsfw,
             ),
           ),
-        if (showSeerrSettings)
+        if (showSeerrSettings) ...[
           TvFocusHighlight(
             builder: (context, focused) => SwitchListTile.adaptive(
               secondary: Icon(
@@ -563,6 +575,38 @@ class _SeerrConfigScreenState extends State<SeerrConfigScreen> {
               onChanged: _setShowMissingCollectionItems,
             ),
           ),
+          TvFocusHighlight(
+            builder: (context, focused) => SwitchListTile.adaptive(
+              secondary: Icon(
+                Icons.check_circle_outline,
+                color: focused ? AppColors.black.withValues(alpha: 0.54) : null,
+              ),
+              title: Text(
+                l10n.showSeerrAvailabilityBadges,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.87)
+                      : AppColorScheme.onSurface,
+                ),
+              ),
+              subtitle: Text(
+                l10n.showSeerrAvailabilityBadgesDescription,
+                style: TextStyle(
+                  fontSize: 12,
+                  color: focused
+                      ? AppColors.black.withValues(alpha: 0.54)
+                      : AppColorScheme.onSurface.withValues(alpha: 0.7),
+                ),
+              ),
+              value: _userPreferences.get(
+                UserPreferences.showSeerrAvailabilityBadges,
+              ),
+              onChanged: _setShowAvailabilityBadges,
+            ),
+          ),
+        ],
         if (showSeerrSettings) ...[
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -225,6 +225,7 @@ void main() {
     'showLibrariesInToolbar',
     'showLoadingAnimationText',
     'showMediaDetailsOnLibraryPage',
+    'showSeerrAvailabilityBadges',
     'showSeerrButton',
     'showServerMessagesButton',
     'showShuffleButton',


### PR DESCRIPTION
# Pull Request

## Summary
Adds a user preference toggle "Show Seerr Availability Badges" (showSeerrAvailabilityBadges, default true) under Seerr Settings. When enabled (default), behavior is unchanged and season availability indicator checkmark dots display on media detail pages. When disabled, the availability badges on season detail screens are hidden, while leaving Seerr Discovery page cards unaffected.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to # https://github.com/Moonfin-Client/Plugin/pull/283

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Registered showSeerrAvailabilityBadges in **user_preferences.dart** scoped preferences with default true.
- Added showSeerrAvailabilityBadges to **synced_fields.dart** and updated unit tests in **synced_fields_test.dart**.
- Added localized strings to **app_en.arb** and regenerated all locale files via flutter gen-l10n.
- Added switch tile for "Show Seerr Availability Badges" directly beneath the NSFW filter in **seerr_config_screen.dart**.
- Gated season availability badge dots on media detail pages in **modern_detail_content.dart** and **item_detail_screen.dart**.


## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings -> Integrations -> Seerr Settings.
2. Verify "Show Seerr Availability Badges" toggle appears below the NSFW filter toggle and defaults to ON.
3. Open TV show media details page with available seasons; verify green checkmark dots appear on seasons.
4. Toggle "Show Seerr Availability Badges" OFF.
5. Return to TV show media details page; verify availability dots are hidden.
6. Verify Seerr Discovery page cards remain unaffected and still display badges normally.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Setting
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_22-02-41" src="https://github.com/user-attachments/assets/02032868-36bf-4d21-963c-685acb9aa5bd" />

### Badges Shown
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_22-02-19" src="https://github.com/user-attachments/assets/14bbbe6f-f7fa-4d7c-8999-26ad4bc0c986" />

### Badges Hidden
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_22-02-55" src="https://github.com/user-attachments/assets/01036abd-85f5-4c02-808a-8b82aec6b382" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
