### PR TITLE
bugfix-ui - Restore season watched indicator badges on Modern details pages

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -865,7 +865,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     try {
       final data = await _client.itemsApi.getSeasons(
         itemId,
-        fields: 'ChildCount',
+        fields: 'ChildCount,UserData',
       );
       final items = (data['Items'] as List?) ?? [];
       _seasons = _mapItems(items);

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1131,9 +1131,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final showPosterUrl = _imageUrl(item);
     final watchedBehavior =
         widget.prefs.get(UserPreferences.watchedIndicatorBehavior);
-    final showWatchedIndicator =
-        watchedBehavior != WatchedIndicatorBehavior.never &&
-        watchedBehavior != WatchedIndicatorBehavior.episodesOnly;
+    final showPlayedIndicator =
+        watchedBehavior == WatchedIndicatorBehavior.always ||
+        watchedBehavior == WatchedIndicatorBehavior.hideUnwatched;
+    final showUnwatchedIndicator =
+        watchedBehavior == WatchedIndicatorBehavior.always;
     // Determine which season contains the "next up" episode, mirroring the
     // episode-card logic: prefer _vm.nextUp.seasonId, fall back to the first
     // unplayed episode's seasonId so the cyan border always renders correctly.
@@ -1158,10 +1160,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             (season.indexNumber != null &&
                 e.parentIndexNumber == season.indexNumber),
       );
-      final isPlayed = showWatchedIndicator &&
-          (season.isPlayed ||
-              (seasonEpisodes.isNotEmpty &&
-                  seasonEpisodes.every((e) => e.isPlayed)));
+      final isFullyPlayed = season.isPlayed ||
+          (seasonEpisodes.isNotEmpty &&
+              seasonEpisodes.every((e) => e.isPlayed));
+      final isPlayed = showPlayedIndicator && isFullyPlayed;
+      final int? unplayedCount;
+      if (isFullyPlayed || !showUnwatchedIndicator) {
+        unplayedCount = null;
+      } else if (seasonEpisodes.isNotEmpty) {
+        unplayedCount = seasonEpisodes.where((e) => !e.isPlayed).length;
+      } else {
+        unplayedCount = season.unplayedItemCount;
+      }
 
       return SeasonCard(
         seerrStatus: showAvailabilityBadges
@@ -1176,6 +1186,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         landscape: _landscape,
         isNextUp: season.id == nextUpSeasonId,
         isPlayed: isPlayed,
+        unplayedCount: unplayedCount,
         onNavigateUp: topRow ? _focusSelectedTab : null,
         focusNode: i == 0 ? _seasonsFirstFocusNode : null,
         width: width,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -24,6 +24,7 @@ import '../../../../util/detail_playback_info.dart';
 import '../../../../util/detail_track_highlight.dart';
 import '../../../../util/direct_play_reasons_formatter.dart';
 import '../../../../util/episode_playability.dart';
+import '../../../../util/item_watch_state.dart';
 import '../../../../util/overview_text.dart';
 import '../../../../util/playback_time_label.dart';
 import '../../../../util/platform_detection.dart';
@@ -1131,11 +1132,6 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final showPosterUrl = _imageUrl(item);
     final watchedBehavior =
         widget.prefs.get(UserPreferences.watchedIndicatorBehavior);
-    final showPlayedIndicator =
-        watchedBehavior == WatchedIndicatorBehavior.always ||
-        watchedBehavior == WatchedIndicatorBehavior.hideUnwatched;
-    final showUnwatchedIndicator =
-        watchedBehavior == WatchedIndicatorBehavior.always;
     // Determine which season contains the "next up" episode, mirroring the
     // episode-card logic: prefer _vm.nextUp.seasonId, fall back to the first
     // unplayed episode's seasonId so the cyan border always renders correctly.
@@ -1154,24 +1150,28 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       bool topRow = true,
     }) {
       final season = _vm.seasons[i];
-      final seasonEpisodes = _vm.seriesEpisodes.where(
-        (e) =>
-            e.seasonId == season.id ||
-            (season.indexNumber != null &&
-                e.parentIndexNumber == season.indexNumber),
+      final seasonEpisodes = _vm.seriesEpisodes
+          .where(
+            (e) =>
+                e.seasonId == season.id ||
+                (season.indexNumber != null &&
+                    e.parentIndexNumber == season.indexNumber),
+          )
+          .toList(growable: false);
+      final unplayed = seasonEpisodes.where((e) => !e.isPlayed).length;
+      final isFullyPlayed =
+          season.isPlayed || (seasonEpisodes.isNotEmpty && unplayed == 0);
+      final remaining = isFullyPlayed
+          ? 0
+          : (seasonEpisodes.isNotEmpty
+              ? unplayed
+              : (season.unplayedItemCount ?? 0));
+      final showsIndicator = showsWatchedIndicator(
+        behavior: watchedBehavior,
+        isPlayed: isFullyPlayed,
+        itemType: 'Season',
+        unplayedCount: remaining,
       );
-      final isFullyPlayed = season.isPlayed ||
-          (seasonEpisodes.isNotEmpty &&
-              seasonEpisodes.every((e) => e.isPlayed));
-      final isPlayed = showPlayedIndicator && isFullyPlayed;
-      final int? unplayedCount;
-      if (isFullyPlayed || !showUnwatchedIndicator) {
-        unplayedCount = null;
-      } else if (seasonEpisodes.isNotEmpty) {
-        unplayedCount = seasonEpisodes.where((e) => !e.isPlayed).length;
-      } else {
-        unplayedCount = season.unplayedItemCount;
-      }
 
       return SeasonCard(
         seerrStatus: showAvailabilityBadges
@@ -1185,8 +1185,8 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         isFallbackImage: _imageUrl(season) == null,
         landscape: _landscape,
         isNextUp: season.id == nextUpSeasonId,
-        isPlayed: isPlayed,
-        unplayedCount: unplayedCount,
+        isPlayed: showsIndicator && isFullyPlayed,
+        unplayedCount: showsIndicator && !isFullyPlayed ? remaining : null,
         onNavigateUp: topRow ? _focusSelectedTab : null,
         focusNode: i == 0 ? _seasonsFirstFocusNode : null,
         width: width,

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1129,6 +1129,11 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final textTheme = Theme.of(context).textTheme;
     final counts = _episodeCountsBySeason();
     final showPosterUrl = _imageUrl(item);
+    final watchedBehavior =
+        widget.prefs.get(UserPreferences.watchedIndicatorBehavior);
+    final showWatchedIndicator =
+        watchedBehavior != WatchedIndicatorBehavior.never &&
+        watchedBehavior != WatchedIndicatorBehavior.episodesOnly;
     // Determine which season contains the "next up" episode, mirroring the
     // episode-card logic: prefer _vm.nextUp.seasonId, fall back to the first
     // unplayed episode's seasonId so the cyan border always renders correctly.
@@ -1145,39 +1150,53 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       double? width,
       double? height,
       bool topRow = true,
-    }) =>
-        SeasonCard(
-          seerrStatus: showAvailabilityBadges
-              ? seerrSeasonStatus[_vm.seasons[i].indexNumber]
-              : null,
-          title: _vm.seasons[i].name,
-          subtitle: l10n.episodeCount(
-            counts[_vm.seasons[i].id] ?? _vm.seasons[i].childCount ?? 0,
-          ),
-          imageUrl: _imageUrl(_vm.seasons[i]) ?? showPosterUrl,
-          isFallbackImage: _imageUrl(_vm.seasons[i]) == null,
-          landscape: _landscape,
-          isNextUp: _vm.seasons[i].id == nextUpSeasonId,
-          onNavigateUp: topRow ? _focusSelectedTab : null,
-          focusNode: i == 0 ? _seasonsFirstFocusNode : null,
-          width: width,
-          height: height,
-          autoScroll: true,
-          onTap: () => seerrOnlyVm != null
-              ? showSeerrRequestDialog(
-                  context: context,
-                  vm: seerrOnlyVm,
-                  is4k: false,
-                  qualityToggle: true,
-                  season: _vm.seasons[i].indexNumber,
-                )
-              : context.push(
-                  Destinations.item(
-                    _vm.seasons[i].id,
-                    serverId: _vm.seasons[i].serverId,
-                  ),
+    }) {
+      final season = _vm.seasons[i];
+      final seasonEpisodes = _vm.seriesEpisodes.where(
+        (e) =>
+            e.seasonId == season.id ||
+            (season.indexNumber != null &&
+                e.parentIndexNumber == season.indexNumber),
+      );
+      final isPlayed = showWatchedIndicator &&
+          (season.isPlayed ||
+              (seasonEpisodes.isNotEmpty &&
+                  seasonEpisodes.every((e) => e.isPlayed)));
+
+      return SeasonCard(
+        seerrStatus: showAvailabilityBadges
+            ? seerrSeasonStatus[season.indexNumber]
+            : null,
+        title: season.name,
+        subtitle: l10n.episodeCount(
+          counts[season.id] ?? season.childCount ?? 0,
+        ),
+        imageUrl: _imageUrl(season) ?? showPosterUrl,
+        isFallbackImage: _imageUrl(season) == null,
+        landscape: _landscape,
+        isNextUp: season.id == nextUpSeasonId,
+        isPlayed: isPlayed,
+        onNavigateUp: topRow ? _focusSelectedTab : null,
+        focusNode: i == 0 ? _seasonsFirstFocusNode : null,
+        width: width,
+        height: height,
+        autoScroll: true,
+        onTap: () => seerrOnlyVm != null
+            ? showSeerrRequestDialog(
+                context: context,
+                vm: seerrOnlyVm,
+                is4k: false,
+                qualityToggle: true,
+                season: season.indexNumber,
+              )
+            : context.push(
+                Destinations.item(
+                  season.id,
+                  serverId: season.serverId,
                 ),
-        );
+              ),
+      );
+    }
     final seasonLabelStyle = textTheme.labelMedium?.copyWith(
       color: Colors.white70,
       fontWeight: FontWeight.bold,

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -33,6 +33,9 @@ class SeasonCard extends StatelessWidget {
   /// Seerr's status for this season, when Seerr has one.
   final int? seerrStatus;
 
+  /// Whether this season is fully watched.
+  final bool isPlayed;
+
   const SeasonCard({
     super.key,
     required this.title,
@@ -49,6 +52,7 @@ class SeasonCard extends StatelessWidget {
     this.height,
     this.autoScroll = false,
     this.seerrStatus,
+    this.isPlayed = false,
   });
 
   @override
@@ -108,6 +112,25 @@ class SeasonCard extends StatelessWidget {
                   top: 6,
                   left: 6,
                   child: SeerrStatusDot(status: seerrStatus, size: 18),
+                ),
+              if (isPlayed)
+                Positioned(
+                  top: 6,
+                  right: 6,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: AppColorScheme.accent,
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Padding(
+                      padding: EdgeInsets.all(3),
+                      child: Icon(
+                        Icons.check,
+                        color: Colors.white,
+                        size: 14,
+                      ),
+                    ),
+                  ),
                 ),
               Positioned(
                 left: 8,

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -36,6 +36,9 @@ class SeasonCard extends StatelessWidget {
   /// Whether this season is fully watched.
   final bool isPlayed;
 
+  /// Count of unplayed episodes in this season, if partially watched or unwatched.
+  final int? unplayedCount;
+
   const SeasonCard({
     super.key,
     required this.title,
@@ -53,6 +56,7 @@ class SeasonCard extends StatelessWidget {
     this.autoScroll = false,
     this.seerrStatus,
     this.isPlayed = false,
+    this.unplayedCount,
   });
 
   @override
@@ -119,15 +123,38 @@ class SeasonCard extends StatelessWidget {
                   right: 6,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: AppColorScheme.accent,
+                      color: AppColorScheme.badgeWatched,
                       shape: BoxShape.circle,
                     ),
-                    child: const Padding(
-                      padding: EdgeInsets.all(3),
+                    child: Padding(
+                      padding: const EdgeInsets.all(3),
                       child: Icon(
                         Icons.check,
-                        color: Colors.white,
-                        size: 14,
+                        color: AppColorScheme.onBadge,
+                        size: 13,
+                      ),
+                    ),
+                  ),
+                )
+              else if (unplayedCount != null && unplayedCount! > 0)
+                Positioned(
+                  top: 6,
+                  right: 6,
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 5,
+                      vertical: 1,
+                    ),
+                    decoration: BoxDecoration(
+                      color: AppColorScheme.badgeUnplayed,
+                      borderRadius: AppRadius.circular(8),
+                    ),
+                    child: Text(
+                      '$unplayedCount',
+                      style: TextStyle(
+                        color: AppColorScheme.onBadge,
+                        fontSize: 10,
+                        fontWeight: FontWeight.bold,
                       ),
                     ),
                   ),

--- a/packages/server_emby/lib/src/api/emby_items_api.dart
+++ b/packages/server_emby/lib/src/api/emby_items_api.dart
@@ -364,7 +364,10 @@ class EmbyItemsApi implements ItemsApi {
   }) async {
     final response = await _dio.get(
       '/Shows/$seriesId/Seasons',
-      queryParameters: {'Fields': ?_knownFields(fields)},
+      queryParameters: {
+        'Fields': ?_knownFields(fields),
+        'UserId': _getUserId(),
+      },
     );
     return response.data as Map<String, dynamic>;
   }

--- a/packages/server_emby/test/emby_items_api_test.dart
+++ b/packages/server_emby/test/emby_items_api_test.dart
@@ -159,6 +159,7 @@ void main() {
 
     expect(request()?.path, '/Shows/series-1/Seasons');
     expect(request()?.queryParameters['Fields'], 'ChildCount');
+    expect(request()?.queryParameters['UserId'], 'user-1');
   });
 
   test('seasons send no Fields when none are asked for', () async {
@@ -167,5 +168,6 @@ void main() {
     await EmbyItemsApi(dio, () => 'user-1').getSeasons('series-1');
 
     expect(request()?.queryParameters.containsKey('Fields'), isFalse);
+    expect(request()?.queryParameters['UserId'], 'user-1');
   });
 }

--- a/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
+++ b/packages/server_jellyfin/lib/src/api/jellyfin_items_api.dart
@@ -330,7 +330,7 @@ class JellyfinItemsApi implements ItemsApi {
   }) async {
     final response = await _dio.get(
       '/Shows/$seriesId/Seasons',
-      queryParameters: {'Fields': ?fields},
+      queryParameters: {'Fields': ?fields, 'UserId': _getUserId()},
     );
     return response.data as Map<String, dynamic>;
   }

--- a/packages/server_jellyfin/test/jellyfin_items_api_test.dart
+++ b/packages/server_jellyfin/test/jellyfin_items_api_test.dart
@@ -131,6 +131,7 @@ void main() {
 
     expect(request?.path, '/Shows/series-1/Seasons');
     expect(request?.queryParameters['Fields'], 'ChildCount');
+    expect(request?.queryParameters['UserId'], 'user-1');
   });
 
   test('seasons send no Fields when none are asked for', () async {
@@ -148,5 +149,6 @@ void main() {
     await JellyfinItemsApi(dio, () => 'user-1').getSeasons('series-1');
 
     expect(request?.queryParameters.containsKey('Fields'), isFalse);
+    expect(request?.queryParameters['UserId'], 'user-1');
   });
 }


### PR DESCRIPTION
# Pull Request

## Summary
Restores watched indicator checkmark badges on TV show season cards in Moonfin-Core. Season cards previously omitted watched checkmarks in Modern detail views because `SeasonCard` lacked an indicator widget and the items API omitted `UserId` and `UserData` during season fetches.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **jellyfin_items_api.dart**: Passed `'UserId': _getUserId()` in `getSeasons` queries so user data is returned.
- **emby_items_api.dart**: Passed `'UserId': _getUserId()` in `getSeasons` queries so user data is returned.
- **item_detail_view_model.dart**: Included `UserData` in `fields: 'ChildCount,UserData'` within `_loadSeasons()` so `season.isPlayed` is populated.
- **season_card.dart**: Added `isPlayed` parameter and a top-right accent circular checkmark badge matching episode cards.
- **modern_detail_content.dart**: Evaluated `watchedIndicatorBehavior` and computed `isPlayed` based on `season.isPlayed` and series episodes completion.
- Updated API unit test suites in **packages/server_jellyfin** and **packages/server_emby**.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a Series detail screen with fully watched and partially watched seasons in Modern view.
2. Verify that fully watched seasons display the circular accent checkmark in the top-right corner of the season card.
3. Verify unplayed or partially watched seasons do not display the checkmark badge.
4. Verify watched indicators respect user preferences for `watchedIndicatorBehavior`.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### No indicators
<img width="1300" height="865" alt="2026-09-10_21-35-12_moonfin" src="https://github.com/user-attachments/assets/73d6f857-eaef-4b7d-bce0-6c3e928e7026" />

### They're back!
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_22-55-14" src="https://github.com/user-attachments/assets/24abe785-686f-4dac-9642-03b122830c72" />

### Commit 2 - And now with episode counts!
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-10_23-19-03" src="https://github.com/user-attachments/assets/c57d8079-5a60-47c0-8492-ac032b799e33" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
