### PR TITLE
add a Live TV button to the navigation

### DIFF
--- a/lib/data/services/synced_fields.dart
+++ b/lib/data/services/synced_fields.dart
@@ -139,6 +139,7 @@ final List<SyncedField> syncedFields = <SyncedField>[
   SyncedField('showShuffleButton', UserPreferences.showShuffleButton, SyncCodec.boolean),
   SyncedField('showGenresButton', UserPreferences.showGenresButton, SyncCodec.boolean),
   SyncedField('showFavoritesButton', UserPreferences.showFavoritesButton, SyncCodec.boolean),
+  SyncedField('showLiveTvButton', UserPreferences.showLiveTvButton, SyncCodec.boolean),
   SyncedField('showSyncPlayButton', UserPreferences.showSyncPlayButton, SyncCodec.boolean),
   SyncedField('showDownloadsButton', UserPreferences.showDownloadsButton, SyncCodec.boolean),
   SyncedField('showLibrariesInToolbar', UserPreferences.showLibrariesInToolbar, SyncCodec.boolean),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5191,6 +5191,10 @@
   "@showFavoritesButton": {
     "description": "Setting for showing favorites button"
   },
+  "showLiveTvButton": "Show Live TV Button",
+  "@showLiveTvButton": {
+    "description": "Setting for showing live TV button"
+  },
   "showDownloadsButton": "Show Downloads Button",
   "@showDownloadsButton": {
     "description": "Setting for showing downloads button"
@@ -9146,6 +9150,7 @@
   "settingsShowShuffleButtonInNavigation": "Show the shuffle button in the navigation bar",
   "settingsShowGenresButtonInNavigation": "Show the genres button in the navigation bar",
   "settingsShowFavoritesButtonInNavigation": "Show the favorites button in the navigation bar",
+  "settingsShowLiveTvButtonInNavigation": "Show the Live TV button in the navigation bar when the server has a Live TV library",
   "settingsShowLibrariesButtonInNavigation": "Show the libraries button in the navigation bar",
   "settingsShowSeerrButtonInNavigation": "Show the Seerr button in the navigation bar",
   "settingsAlwaysExpandNavbarLabels": "Always show text labels in the top navigation bar",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -6892,6 +6892,12 @@ abstract class AppLocalizations {
   /// **'Show Favorites Button'**
   String get showFavoritesButton;
 
+  /// Setting for showing live TV button
+  ///
+  /// In en, this message translates to:
+  /// **'Show Live TV Button'**
+  String get showLiveTvButton;
+
   /// Setting for showing downloads button
   ///
   /// In en, this message translates to:
@@ -16833,6 +16839,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Show the favorites button in the navigation bar'**
   String get settingsShowFavoritesButtonInNavigation;
+
+  /// No description provided for @settingsShowLiveTvButtonInNavigation.
+  ///
+  /// In en, this message translates to:
+  /// **'Show the Live TV button in the navigation bar when the server has a Live TV library'**
+  String get settingsShowLiveTvButtonInNavigation;
 
   /// No description provided for @settingsShowLibrariesButtonInNavigation.
   ///

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3903,6 +3903,9 @@ class AppLocalizationsAf extends AppLocalizations {
   String get showFavoritesButton => 'Wys gunstelinge-knoppie';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9504,6 +9507,10 @@ class AppLocalizationsAf extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Wys die gunstelinge-knoppie in die navigasiebalk';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3913,6 +3913,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get showFavoritesButton => 'إظهار زر المفضلة';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9484,6 +9487,10 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'إظهار زر المفضلة في شريط التنقل';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3917,6 +3917,9 @@ class AppLocalizationsBe extends AppLocalizations {
   String get showFavoritesButton => 'Паказаць кнопку \"Выбранае\".';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9545,6 +9548,10 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Паказаць кнопку абранага на панэлі навігацыі';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3917,6 +3917,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get showFavoritesButton => 'Показване на бутона за любими';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9585,6 +9588,10 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Показване на бутона за любими в лентата за навигация';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3892,6 +3892,9 @@ class AppLocalizationsBn extends AppLocalizations {
   String get showFavoritesButton => 'ফেভারিট বোতাম দেখান';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9483,6 +9486,10 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'নেভিগেশন বারে পছন্দের বোতামটি দেখান';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3943,6 +3943,9 @@ class AppLocalizationsCa extends AppLocalizations {
   String get showFavoritesButton => 'Mostra el botó de Preferits';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9646,6 +9649,10 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Mostra el botó de preferits a la barra de navegació';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3915,6 +3915,9 @@ class AppLocalizationsCs extends AppLocalizations {
   String get showFavoritesButton => 'Zobrazit tlačítko Oblíbené';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9530,6 +9533,10 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Zobrazit tlačítko oblíbených v navigační liště';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3927,6 +3927,9 @@ class AppLocalizationsCy extends AppLocalizations {
   String get showFavoritesButton => 'Dangos y Botwm Ffefrynnau';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9548,6 +9551,10 @@ class AppLocalizationsCy extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Dangoswch y botwm ffefrynnau yn y bar llywio';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3900,6 +3900,9 @@ class AppLocalizationsDa extends AppLocalizations {
   String get showFavoritesButton => 'Knappen Vis favoritter';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9495,6 +9498,10 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Vis knappen Favoritter i navigationslinjen';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3990,6 +3990,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showFavoritesButton => 'Favoriten-Schaltfläche anzeigen';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9645,6 +9648,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Zeigen Sie die Favoritenschaltfläche in der Navigationsleiste an.';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3937,6 +3937,9 @@ class AppLocalizationsEl extends AppLocalizations {
   String get showFavoritesButton => 'Εμφάνιση κουμπιού αγαπημένων';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9632,6 +9635,10 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Εμφάνιση του κουμπιού αγαπημένων στη γραμμή πλοήγησης';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3886,6 +3886,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showFavoritesButton => 'Show Favorites Button';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9429,6 +9432,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Show the favorites button in the navigation bar';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3898,6 +3898,9 @@ class AppLocalizationsEo extends AppLocalizations {
   String get showFavoritesButton => 'Montri Preferatajn Butonon';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9485,6 +9488,10 @@ class AppLocalizationsEo extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Montru la plej ŝatatajn butonon en la navigadbreto';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3920,6 +3920,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showFavoritesButton => 'Mostrar botón de favoritos';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9598,6 +9601,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Mostrar el botón de favoritos en la barra de navegación';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3910,6 +3910,9 @@ class AppLocalizationsEt extends AppLocalizations {
   String get showFavoritesButton => 'Kuva lemmikute nupp';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9508,6 +9511,10 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Kuvage navigeerimisribal lemmikute nupp';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3881,6 +3881,9 @@ class AppLocalizationsFa extends AppLocalizations {
   String get showFavoritesButton => 'دکمه نمایش موارد دلخواه';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9443,6 +9446,10 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'نمایش دکمه علاقه مندی ها در نوار ناوبری';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3916,6 +3916,9 @@ class AppLocalizationsFi extends AppLocalizations {
   String get showFavoritesButton => 'Näytä suosikit-painike';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Näytä latauspainike';
 
   @override
@@ -9532,6 +9535,10 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Näytä suosikit-painike navigointipalkissa';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3941,6 +3941,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showFavoritesButton => 'Afficher le bouton Favoris';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9615,6 +9618,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Afficher le bouton Favoris dans la barre de navigation';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3934,6 +3934,9 @@ class AppLocalizationsGl extends AppLocalizations {
   String get showFavoritesButton => 'Mostrar botón de favoritos';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9619,6 +9622,10 @@ class AppLocalizationsGl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Mostra o botón de favoritos na barra de navegación';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3878,6 +3878,9 @@ class AppLocalizationsHe extends AppLocalizations {
   String get showFavoritesButton => 'לחצן הצג מועדפים';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9382,6 +9385,10 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'הצג את לחצן המועדפים בסרגל הניווט';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3891,6 +3891,9 @@ class AppLocalizationsHi extends AppLocalizations {
   String get showFavoritesButton => 'पसंदीदा बटन दिखाएँ';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9474,6 +9477,10 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'नेविगेशन बार में पसंदीदा बटन दिखाएँ';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -4018,6 +4018,9 @@ class AppLocalizationsHr extends AppLocalizations {
   String get showFavoritesButton => 'Prikaži gumb Favoriti';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9713,6 +9716,10 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Prikaži gumb favorita na navigacijskoj traci';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3919,6 +3919,9 @@ class AppLocalizationsHu extends AppLocalizations {
   String get showFavoritesButton => 'Kedvencek gomb megjelenítése';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9580,6 +9583,10 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Kedvencek gomb megjelenítése a navigációs sávban';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3902,6 +3902,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get showFavoritesButton => 'Tampilkan Tombol Favorit';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9506,6 +9509,10 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Tampilkan tombol favorit di bilah navigasi';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3919,6 +3919,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get showFavoritesButton => 'Mostra Pulsante Preferiti';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9566,6 +9569,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Mostra il pulsante dei preferiti nella barra di navigazione';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -3837,6 +3837,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get showFavoritesButton => 'お気に入りボタンを表示';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9261,6 +9264,10 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'ナビゲーションバーにお気に入りボタンを表示する';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3910,6 +3910,9 @@ class AppLocalizationsKk extends AppLocalizations {
   String get showFavoritesButton => 'Таңдаулыларды көрсету түймесі';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9539,6 +9542,10 @@ class AppLocalizationsKk extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Навигация жолағында таңдаулылар түймесін көрсетіңіз';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3917,6 +3917,9 @@ class AppLocalizationsKn extends AppLocalizations {
   String get showFavoritesButton => 'ಮೆಚ್ಚಿನವುಗಳ ಬಟನ್ ತೋರಿಸಿ';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9559,6 +9562,10 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'ನ್ಯಾವಿಗೇಶನ್ ಬಾರ್‌ನಲ್ಲಿ ಮೆಚ್ಚಿನವುಗಳ ಬಟನ್ ಅನ್ನು ತೋರಿಸಿ';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -3824,6 +3824,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get showFavoritesButton => '즐겨찾기 버튼 표시';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9236,6 +9239,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get settingsShowFavoritesButtonInNavigation => '탐색 표시줄에 즐겨찾기 버튼 표시';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation => '탐색 모음에 라이브러리 버튼 표시';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3918,6 +3918,9 @@ class AppLocalizationsLt extends AppLocalizations {
   String get showFavoritesButton => 'Rodyti mėgstamiausių mygtuką';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9549,6 +9552,10 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Rodyti parankinių mygtuką naršymo juostoje';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3918,6 +3918,9 @@ class AppLocalizationsLv extends AppLocalizations {
   String get showFavoritesButton => 'Rādīt pogu Izlase';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9547,6 +9550,10 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Parādiet izlases pogu navigācijas joslā';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3917,6 +3917,9 @@ class AppLocalizationsMk extends AppLocalizations {
   String get showFavoritesButton => 'Копче за прикажување омилени';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9564,6 +9567,10 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Прикажи го копчето за омилени во лентата за навигација';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3920,6 +3920,9 @@ class AppLocalizationsMl extends AppLocalizations {
   String get showFavoritesButton => 'പ്രിയപ്പെട്ടവ ബട്ടൺ കാണിക്കുക';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9604,6 +9607,10 @@ class AppLocalizationsMl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'നാവിഗേഷൻ ബാറിൽ പ്രിയപ്പെട്ടവ ബട്ടൺ കാണിക്കുക';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3903,6 +3903,9 @@ class AppLocalizationsMn extends AppLocalizations {
   String get showFavoritesButton => 'Дуртайг харуулах товч';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9518,6 +9521,10 @@ class AppLocalizationsMn extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Навигацийн талбарт дуртай товчлууруудыг харуул';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3897,6 +3897,9 @@ class AppLocalizationsNb extends AppLocalizations {
   String get showFavoritesButton => 'Vis favoritter-knappen';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9493,6 +9496,10 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Vis favorittknappen i navigasjonslinjen';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3916,6 +3916,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get showFavoritesButton => 'Knop Favorieten tonen';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9547,6 +9550,10 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Toon de favorietenknop in de navigatiebalk';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3892,6 +3892,9 @@ class AppLocalizationsPa extends AppLocalizations {
   String get showFavoritesButton => 'ਮਨਪਸੰਦ ਬਟਨ ਦਿਖਾਓ';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9466,6 +9469,10 @@ class AppLocalizationsPa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'ਨੈਵੀਗੇਸ਼ਨ ਬਾਰ ਵਿੱਚ ਮਨਪਸੰਦ ਬਟਨ ਦਿਖਾਓ';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -4046,6 +4046,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get showFavoritesButton => 'Pokaż przycisk Ulubione';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9757,6 +9760,10 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Pokaż przycisk ulubionych na pasku nawigacyjnym';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3913,6 +3913,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get showFavoritesButton => 'Mostrar Botão de Favoritos';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9565,6 +9568,10 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Mostrar o botão de favoritos na barra de navegação';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3922,6 +3922,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get showFavoritesButton => 'Butonul Afișați Favorite';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9570,6 +9573,10 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Afișați butonul de favorite în bara de navigare';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3928,6 +3928,9 @@ class AppLocalizationsRu extends AppLocalizations {
   String get showFavoritesButton => 'Показать кнопку «Избранное»';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9569,6 +9572,10 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Показывать кнопку избранного на панели навигации';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3898,6 +3898,9 @@ class AppLocalizationsSi extends AppLocalizations {
   String get showFavoritesButton => 'ප්‍රියතම බොත්තම පෙන්වන්න';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9489,6 +9492,10 @@ class AppLocalizationsSi extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'සංචාලන තීරුවේ ප්‍රියතම බොත්තම පෙන්වන්න';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3922,6 +3922,9 @@ class AppLocalizationsSk extends AppLocalizations {
   String get showFavoritesButton => 'Zobraziť tlačidlo Obľúbené';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9555,6 +9558,10 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Zobraziť tlačidlo obľúbených na navigačnom paneli';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3925,6 +3925,9 @@ class AppLocalizationsSl extends AppLocalizations {
   String get showFavoritesButton => 'Prikaži gumb za priljubljene';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9550,6 +9553,10 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Pokažite gumb priljubljenih v navigacijski vrstici';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3923,6 +3923,9 @@ class AppLocalizationsSq extends AppLocalizations {
   String get showFavoritesButton => 'Shfaq butonin e të preferuarave';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9578,6 +9581,10 @@ class AppLocalizationsSq extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Shfaq butonin e të preferuarave në shiritin e navigimit';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -4019,6 +4019,9 @@ class AppLocalizationsSr extends AppLocalizations {
   String get showFavoritesButton => 'Прикажи дугме Фаворити';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9710,6 +9713,10 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Прикажите дугме фаворита на траци за навигацију';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3906,6 +3906,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get showFavoritesButton => 'Knappen Visa favoriter';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9509,6 +9512,10 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Visa favoritknappen i navigeringsfältet';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3921,6 +3921,9 @@ class AppLocalizationsSw extends AppLocalizations {
   String get showFavoritesButton => 'Onyesha Kitufe cha Vipendwa';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9567,6 +9570,10 @@ class AppLocalizationsSw extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Onyesha kitufe cha vipendwa kwenye upau wa kusogeza';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3922,6 +3922,9 @@ class AppLocalizationsTa extends AppLocalizations {
   String get showFavoritesButton => 'பிடித்தவை பட்டனைக் காட்டு';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9567,6 +9570,10 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'வழிசெலுத்தல் பட்டியில் பிடித்தவை பொத்தானைக் காட்டு';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3918,6 +3918,9 @@ class AppLocalizationsTe extends AppLocalizations {
   String get showFavoritesButton => 'ఇష్టమైనవి బటన్‌ను చూపించు';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9560,6 +9563,10 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'నావిగేషన్ బార్‌లో ఇష్టమైనవి బటన్‌ను చూపండి';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3881,6 +3881,9 @@ class AppLocalizationsTh extends AppLocalizations {
   String get showFavoritesButton => 'แสดงปุ่มรายการโปรด';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9440,6 +9443,10 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'แสดงปุ่มรายการโปรดในแถบนำทาง';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3924,6 +3924,9 @@ class AppLocalizationsTl extends AppLocalizations {
   String get showFavoritesButton => 'Button ng Ipakita ang Mga Paborito';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9593,6 +9596,10 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Ipakita ang pindutan ng mga paborito sa navigation bar';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3905,6 +3905,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get showFavoritesButton => 'Favoriler Butonunu Göster';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9507,6 +9510,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Gezinme çubuğunda favoriler butonunu göster';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3904,6 +3904,9 @@ class AppLocalizationsUg extends AppLocalizations {
   String get showFavoritesButton => 'ياقتۇرىدىغان كۇنۇپكىنى كۆرسەت';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9526,6 +9529,10 @@ class AppLocalizationsUg extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'يولباشچى ستونىدا ياقتۇرىدىغان كۇنۇپكىنى كۆرسىتىڭ';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3924,6 +3924,9 @@ class AppLocalizationsUk extends AppLocalizations {
   String get showFavoritesButton => 'Показати кнопку «Вибране».';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9569,6 +9572,10 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Показати кнопку вибраного на панелі навігації';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3904,6 +3904,9 @@ class AppLocalizationsVi extends AppLocalizations {
   String get showFavoritesButton => 'Hiển thị nút yêu thích';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9497,6 +9500,10 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get settingsShowFavoritesButtonInNavigation =>
       'Hiển thị nút yêu thích trên thanh điều hướng';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation =>

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -3810,6 +3810,9 @@ class AppLocalizationsYue extends AppLocalizations {
   String get showFavoritesButton => '顯示收藏夾按鈕';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => 'Show Downloads Button';
 
   @override
@@ -9202,6 +9205,10 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get settingsShowFavoritesButtonInNavigation => '在導覽列中顯示收藏夾按鈕';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation => '在導覽列中顯示庫按鈕';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -3783,6 +3783,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showFavoritesButton => '显示收藏按钮';
 
   @override
+  String get showLiveTvButton => 'Show Live TV Button';
+
+  @override
   String get showDownloadsButton => '显示下载按钮';
 
   @override
@@ -9164,6 +9167,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsShowFavoritesButtonInNavigation => '在导航栏中显示收藏按钮';
+
+  @override
+  String get settingsShowLiveTvButtonInNavigation =>
+      'Show the Live TV button in the navigation bar when the server has a Live TV library';
 
   @override
   String get settingsShowLibrariesButtonInNavigation => '在导航栏中显示媒体库按钮';

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -501,6 +501,7 @@ class UserPreferences extends ChangeNotifier {
     'pref_show_shuffle_button',
     'pref_show_genres_button',
     'pref_show_favorites_button',
+    'pref_show_live_tv_button',
     'pref_show_syncplay_button',
     'pref_show_downloads_button',
     'pref_show_libraries_in_toolbar',
@@ -1449,6 +1450,11 @@ class UserPreferences extends ChangeNotifier {
 
   static final showFavoritesButton = Preference(
     key: 'pref_show_favorites_button',
+    defaultValue: true,
+  );
+
+  static final showLiveTvButton = Preference(
+    key: 'pref_show_live_tv_button',
     defaultValue: true,
   );
 

--- a/lib/ui/screens/settings/navigation_settings_screen.dart
+++ b/lib/ui/screens/settings/navigation_settings_screen.dart
@@ -112,6 +112,12 @@ class _NavigationSettingsScreenState extends State<NavigationSettingsScreen> {
                   onChanged: _pushSync,
                 ),
                 SwitchPreferenceTile(
+                  preference: UserPreferences.showLiveTvButton,
+                  title: l10n.showLiveTvButton,
+                  icon: Icons.live_tv,
+                  onChanged: _pushSync,
+                ),
+                SwitchPreferenceTile(
                   preference: UserPreferences.showLibrariesInToolbar,
                   title: l10n.showLibrariesInToolbar,
                   iconBuilder: (size, color) => Image.asset(

--- a/lib/ui/screens/settings/panel/navigation_category_screen.dart
+++ b/lib/ui/screens/settings/panel/navigation_category_screen.dart
@@ -128,6 +128,13 @@ class _NavigationCategoryScreenState extends State<_NavigationCategoryScreen> {
                 onChanged: _pushPersonalizationSync,
               ),
               SwitchPreferenceTile(
+                preference: UserPreferences.showLiveTvButton,
+                title: l10n.showLiveTvButton,
+                subtitle: l10n.settingsShowLiveTvButtonInNavigation,
+                icon: Icons.live_tv,
+                onChanged: _pushPersonalizationSync,
+              ),
+              SwitchPreferenceTile(
                 preference: UserPreferences.showLibrariesInToolbar,
                 title: l10n.showLibrariesInToolbar,
                 subtitle: l10n.settingsShowLibrariesButtonInNavigation,

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -716,6 +716,12 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
       subtitle: l10n.settingsShowFavoritesButtonInNavigation,
     ),
     navigation.leaf(
+      'pref_show_live_tv_button',
+      l10n.showLiveTvButton,
+      subtitle: l10n.settingsShowLiveTvButtonInNavigation,
+      keywords: ['guide', 'channels'],
+    ),
+    navigation.leaf(
       'pref_show_libraries_in_toolbar',
       l10n.showLibrariesInToolbar,
       subtitle: l10n.settingsShowLibrariesButtonInNavigation,

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -21,6 +21,7 @@ import '../../l10n/app_localizations.dart';
 import '../../util/clock_format.dart';
 import '../../util/focus/dpad_keys.dart';
 import '../../util/game_library.dart';
+import '../../util/live_tv_library.dart';
 import '../../util/overlay_color_palette.dart';
 import '../../util/platform_detection.dart';
 import '../navigation/destinations.dart';
@@ -330,6 +331,13 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     }
     return true;
   }
+
+  bool get _showLiveTvButton =>
+      _prefs.get(UserPreferences.showLiveTvButton) &&
+      _libraries.any(isLiveTvLibrary);
+
+  List<AggregatedLibrary> get _navLibraries =>
+      librariesForNav(_libraries, _showLiveTvButton);
 
   Color _overlayColor() {
     return OverlayColorPalette.resolveColor(
@@ -839,12 +847,8 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     final showShuffle = _prefs.get(UserPreferences.showShuffleButton);
     final showGenres = _prefs.get(UserPreferences.showGenresButton);
     final showFavorites = _prefs.get(UserPreferences.showFavoritesButton);
-    // Only offered on a server that actually has a Live TV library, the same
-    // check the home screen's Live TV row makes. `_libraries` reloads on a
-    // server switch, so the button leaves with the server it belongs to.
-    final showLiveTv =
-        _prefs.get(UserPreferences.showLiveTvButton) &&
-        _libraries.any((lib) => lib.collectionType == 'livetv');
+    final showLiveTv = _showLiveTvButton;
+    final navLibraries = _navLibraries;
     final showLibraries = _prefs.get(UserPreferences.showLibrariesInToolbar);
     final showFolders = _prefs.get(UserPreferences.enableFolderView);
     final showSyncPlay =
@@ -1040,7 +1044,7 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                       context.navigateTopLevel(Destinations.seerrDiscover);
                     },
                   ),
-                if (showLibraries && _libraries.isNotEmpty) ...[
+                if (showLibraries && navLibraries.isNotEmpty) ...[
                   _SidebarItem(
                     key: const ValueKey('sidebar-libraries'),
                     baseColor: nextMainSidebarColor(),
@@ -1078,7 +1082,7 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                     curve: Curves.easeInOut,
                     child: _librariesExpanded
                         ? Column(
-                            children: _libraries
+                            children: navLibraries
                                 .map(
                                   (lib) => _SidebarLibraryItem(
                                     key: ObjectKey(lib.id),

--- a/lib/ui/widgets/left_sidebar.dart
+++ b/lib/ui/widgets/left_sidebar.dart
@@ -839,6 +839,12 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
     final showShuffle = _prefs.get(UserPreferences.showShuffleButton);
     final showGenres = _prefs.get(UserPreferences.showGenresButton);
     final showFavorites = _prefs.get(UserPreferences.showFavoritesButton);
+    // Only offered on a server that actually has a Live TV library, the same
+    // check the home screen's Live TV row makes. `_libraries` reloads on a
+    // server switch, so the button leaves with the server it belongs to.
+    final showLiveTv =
+        _prefs.get(UserPreferences.showLiveTvButton) &&
+        _libraries.any((lib) => lib.collectionType == 'livetv');
     final showLibraries = _prefs.get(UserPreferences.showLibrariesInToolbar);
     final showFolders = _prefs.get(UserPreferences.enableFolderView);
     final showSyncPlay =
@@ -961,6 +967,23 @@ class _LeftSidebarState extends State<LeftSidebar> with RouteAware {
                       }
                       _markNavigationAwayFromSidebar();
                       context.navigateTopLevel(Destinations.allFavorites);
+                    },
+                  ),
+                if (showLiveTv)
+                  _SidebarItem(
+                    key: const ValueKey('sidebar-livetv'),
+                    icon: Icons.live_tv_rounded,
+                    label: l10n.liveTv,
+                    baseColor: nextMainSidebarColor(),
+                    showLabel: _showLabels,
+                    onPressed: () {
+                      _onNavigate();
+                      if (_isActive(Destinations.liveTvGuide)) {
+                        _exitSidebarToContent();
+                        return;
+                      }
+                      _markNavigationAwayFromSidebar();
+                      context.navigateTopLevel(Destinations.liveTvGuide);
                     },
                   ),
                 if (showFolders)

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -17,6 +17,7 @@ import '../../preference/seerr_preferences.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/overlay_color_palette.dart';
 import '../../util/game_library.dart';
+import '../../util/live_tv_library.dart';
 import '../navigation/destinations.dart';
 import '../navigation/home_refresh_bus.dart';
 import '../screens/downloads/downloads_panel.dart';
@@ -169,6 +170,13 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
     return true;
   }
 
+  bool get _showLiveTvButton =>
+      _prefs.get(UserPreferences.showLiveTvButton) &&
+      _libraries.any(isLiveTvLibrary);
+
+  List<AggregatedLibrary> get _navLibraries =>
+      librariesForNav(_libraries, _showLiveTvButton);
+
   bool _isActive(String route) => widget.activeRoute == route;
 
   List<_BottomNavAction> _contentActions(
@@ -245,11 +253,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
       );
     }
 
-    // Only offered on a server that actually has a Live TV library, the same
-    // check the home screen's Live TV row makes. `_libraries` reloads on a
-    // server switch, so the button leaves with the server it belongs to.
-    if (_prefs.get(UserPreferences.showLiveTvButton) &&
-        _libraries.any((lib) => lib.collectionType == 'livetv')) {
+    if (_showLiveTvButton) {
       actions.add(
         _BottomNavAction(
           icon: Icons.live_tv_rounded,
@@ -312,7 +316,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
 
     final activeRoute = widget.activeRoute ?? '';
     if (_prefs.get(UserPreferences.showLibrariesInToolbar) &&
-        _libraries.isNotEmpty) {
+        _navLibraries.isNotEmpty) {
       actions.add(
         _BottomNavAction(
           iconBuilder: (size, color) => Image.asset(
@@ -510,7 +514,7 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
                     shrinkWrap: true,
                     padding: const EdgeInsets.only(bottom: 8),
                     children: [
-                      for (final lib in _libraries)
+                      for (final lib in _navLibraries)
                         ListTile(
                           leading: Image.asset(
                             'assets/icons/clapperboard.png',

--- a/lib/ui/widgets/mobile_bottom_nav_bar.dart
+++ b/lib/ui/widgets/mobile_bottom_nav_bar.dart
@@ -245,6 +245,24 @@ class _MobileBottomNavBarState extends State<MobileBottomNavBar> {
       );
     }
 
+    // Only offered on a server that actually has a Live TV library, the same
+    // check the home screen's Live TV row makes. `_libraries` reloads on a
+    // server switch, so the button leaves with the server it belongs to.
+    if (_prefs.get(UserPreferences.showLiveTvButton) &&
+        _libraries.any((lib) => lib.collectionType == 'livetv')) {
+      actions.add(
+        _BottomNavAction(
+          icon: Icons.live_tv_rounded,
+          label: l10n.liveTv,
+          isActive: _isActive(Destinations.liveTvGuide),
+          onTap: () {
+            if (_isActive(Destinations.liveTvGuide)) return;
+            context.navigateTopLevel(Destinations.liveTvGuide);
+          },
+        ),
+      );
+    }
+
     if (_prefs.get(UserPreferences.enableFolderView)) {
       actions.add(
         _BottomNavAction(

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -20,6 +20,7 @@ import '../../preference/seerr_preferences.dart';
 import '../../preference/user_preferences.dart';
 import '../../util/clock_format.dart';
 import '../../util/game_library.dart';
+import '../../util/live_tv_library.dart';
 import '../../util/overlay_color_palette.dart';
 import '../../util/platform_detection.dart';
 import '../navigation/destinations.dart';
@@ -361,6 +362,13 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     }
     return true;
   }
+
+  bool get _showLiveTvButton =>
+      _prefs.get(UserPreferences.showLiveTvButton) &&
+      _libraries.any(isLiveTvLibrary);
+
+  List<AggregatedLibrary> get _navLibraries =>
+      librariesForNav(_libraries, _showLiveTvButton);
 
   void _trackPreviousFocus() {
     final primary = FocusManager.instance.primaryFocus;
@@ -915,12 +923,8 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     final showShuffle = _prefs.get(UserPreferences.showShuffleButton);
     final showGenres = _prefs.get(UserPreferences.showGenresButton);
     final showFavorites = _prefs.get(UserPreferences.showFavoritesButton);
-    // Only offered on a server that actually has a Live TV library, the same
-    // check the home screen's Live TV row makes. `_libraries` reloads on a
-    // server switch, so the button leaves with the server it belongs to.
-    final showLiveTv =
-        _prefs.get(UserPreferences.showLiveTvButton) &&
-        _libraries.any((lib) => lib.collectionType == 'livetv');
+    final showLiveTv = _showLiveTvButton;
+    final navLibraries = _navLibraries;
     final showLibraries = _prefs.get(UserPreferences.showLibrariesInToolbar);
     final alwaysExpanded = _prefs.get(UserPreferences.navbarAlwaysExpanded);
     final showFolders = _prefs.get(UserPreferences.enableFolderView);
@@ -1118,7 +1122,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                   ),
                 ),
               ],
-              if (showLibraries && _libraries.isNotEmpty) ...[
+              if (showLibraries && navLibraries.isNotEmpty) ...[
                 _gap(),
                 _orderButton(
                   order: (order++).toDouble(),
@@ -1190,7 +1194,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                         event.logicalKey == inwardKey &&
                         useInlineLibraries &&
                         showLibraries &&
-                        _libraries.isNotEmpty) {
+                        navLibraries.isNotEmpty) {
                       _inlineLibrariesTriggerFocus.requestFocus();
                       return KeyEventResult.handled;
                     }
@@ -1251,7 +1255,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     return _LibrariesDropdown(
       key: const ValueKey('toolbar_libraries'),
       activeRoute: widget.activeRoute,
-      libraries: _libraries,
+      libraries: _navLibraries,
       surfaceColor: _toolbarSurfaceColor(),
       iconColor: iconColor,
       alwaysExpanded: alwaysExpanded,
@@ -1290,7 +1294,7 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     return _AndroidTvExpandableLibrariesButton(
       key: const ValueKey('toolbar_libraries_inline_tv'),
       activeRoute: widget.activeRoute,
-      libraries: _libraries,
+      libraries: _navLibraries,
       label: l10n.libraries,
       iconColor: iconColor,
       alwaysExpanded: alwaysExpanded,

--- a/lib/ui/widgets/top_toolbar.dart
+++ b/lib/ui/widgets/top_toolbar.dart
@@ -915,6 +915,12 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
     final showShuffle = _prefs.get(UserPreferences.showShuffleButton);
     final showGenres = _prefs.get(UserPreferences.showGenresButton);
     final showFavorites = _prefs.get(UserPreferences.showFavoritesButton);
+    // Only offered on a server that actually has a Live TV library, the same
+    // check the home screen's Live TV row makes. `_libraries` reloads on a
+    // server switch, so the button leaves with the server it belongs to.
+    final showLiveTv =
+        _prefs.get(UserPreferences.showLiveTvButton) &&
+        _libraries.any((lib) => lib.collectionType == 'livetv');
     final showLibraries = _prefs.get(UserPreferences.showLibrariesInToolbar);
     final alwaysExpanded = _prefs.get(UserPreferences.navbarAlwaysExpanded);
     final showFolders = _prefs.get(UserPreferences.enableFolderView);
@@ -1037,6 +1043,23 @@ class _TopToolbarState extends State<TopToolbar> with RouteAware {
                     onPressed: () {
                       if (_isActive(Destinations.allFavorites)) return;
                       context.navigateTopLevel(Destinations.allFavorites);
+                    },
+                  ),
+                ),
+              ],
+              if (showLiveTv) ...[
+                _gap(),
+                _orderButton(
+                  order: (order++).toDouble(),
+                  child: ExpandableIconButton(
+                    key: const ValueKey('toolbar_livetv'),
+                    forceExpanded: alwaysExpanded,
+                    icon: Icons.live_tv_rounded,
+                    label: l10n.liveTv,
+                    baseColor: nextNavColor(),
+                    onPressed: () {
+                      if (_isActive(Destinations.liveTvGuide)) return;
+                      context.navigateTopLevel(Destinations.liveTvGuide);
                     },
                   ),
                 ),

--- a/lib/util/live_tv_library.dart
+++ b/lib/util/live_tv_library.dart
@@ -1,0 +1,15 @@
+import '../data/models/aggregated_library.dart';
+
+/// Servers do not agree on how to spell the collection type, so it is
+/// lowercased before it is compared.
+bool isLiveTvLibrary(AggregatedLibrary library) =>
+    library.collectionType.toLowerCase() == 'livetv';
+
+/// The guide has a button of its own, so the library list drops Live TV rather
+/// than offering a second way to the same screen.
+List<AggregatedLibrary> librariesForNav(
+  List<AggregatedLibrary> libraries,
+  bool hasLiveTvButton,
+) => hasLiveTvButton
+    ? libraries.where((lib) => !isLiveTvLibrary(lib)).toList()
+    : libraries;

--- a/test/data/synced_fields_test.dart
+++ b/test/data/synced_fields_test.dart
@@ -224,6 +224,7 @@ void main() {
     'showFavoritesButton',
     'showGenresButton',
     'showLibrariesInToolbar',
+    'showLiveTvButton',
     'showLoadingAnimationText',
     'showMediaDetailsOnLibraryPage',
     'showSeerrAvailabilityBadges',


### PR DESCRIPTION
The guide already had a route, but the only ways in were the row on the home screen and the library tile. This puts a button in the top toolbar, the sidebar and the mobile bottom bar that goes straight to it.

It only shows up when the server actually has a Live TV library, checked against the libraries each nav widget already loads rather than a new API call, so switching to a server without Live TV hides it again. There is a Show Live TV Button toggle under Settings > Navigation to turn it off, on by default like the other optional nav buttons, and it syncs between clients the same way.

this is the core client version of https://github.com/Moonfin-Client/Smart-TV/pull/416

# Pull Request

## Summary
The Live TV view and its panel route already existed, but the only ways in were the row on the home screen and the library tile. This adds a button to both navigations that goes straight to the guide.

It only appears when the server actually has a Live TV library, checked against the libraries App.js has already fetched rather than a new API call, so switching to a server without Live TV hides it again. There's a Show Live TV Button toggle under Settings > Navigation to turn it off, defaulting to on like the other optional nav buttons.

The icon is the same glyph the guide draws for a channel, added to the shared nav icon table.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to https://github.com/Moonfin-Client/Smart-TV/pull/416

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

Added a Live TV button to top_toolbar.dart, left_sidebar.dart and mobile_bottom_nav_bar.dart that opens the guide (Destinations.liveTvGuide).

The button only shows when the server has a Live TV library. Each nav widget checks the libraries it has already loaded, so there is no extra API call and it updates when you switch servers.

Added a showLiveTvButton toggle under Settings > Navigation, on by default, matching the other optional nav buttons. It shows up in both navigation settings screens and in settings search.

The toggle syncs between clients like the other nav buttons, and is stored per server and user.

Used the built-in Icons.live_tv_rounded in the nav bars and Icons.live_tv in settings, so no new asset, and the button label reuses the existing liveTv string.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. enable live tv availability on server.
2. activate the navigation/show live tv icon toggle.
3. check that live tv icon shows in navbar, click through to EPG.
4. disactivate the navigation/show live tv icon toggle /disable live tv availability on server.
5. check that the live tv icon no longer shows.


## Screenshots (if applicable)
<img width="1719" height="977" alt="moonfinecorelivetvenabled" src="https://github.com/user-attachments/assets/afe14e43-8606-42fa-bf6d-ed4ed7daa407" />
<img width="1719" height="977" alt="moonfinecorelivetvdisabled" src="https://github.com/user-attachments/assets/14d0977b-afe8-47bd-bf99-c4563994b46c" />



## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
