### PR TITLE
feat(ui) - Giving Core a Backbone (adding skeleton loading placeholders to stabilize layout shifts)

### DIFF
--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -23,6 +23,7 @@ import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/quick_return_wrapper.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -401,9 +402,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
 
   Widget _buildBody() {
     if (_isLoading) {
-      return Center(
-        child: CircularProgressIndicator(color: AppColorScheme.accent),
-      );
+      return const SkeletonLibraryGrid(aspectRatio: 16 / 9);
     }
 
     if (_genres.isEmpty) {

--- a/lib/ui/screens/browse/book_browse_screen.dart
+++ b/lib/ui/screens/browse/book_browse_screen.dart
@@ -24,6 +24,7 @@ import '../../widgets/book/book_stats_band.dart';
 import '../../widgets/book/discover/book_discover_tab.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/focusable_wrapper.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../widgets/focus/locked_focus_row.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/navigation_layout.dart';
@@ -211,8 +212,9 @@ class _BookBrowseScreenState extends State<BookBrowseScreen> {
       body: NavigationLayout(
         showBackButton: true,
         child: _vm.isLoading
-            ? Center(
-                child: CircularProgressIndicator(color: AppColorScheme.accent),
+            ? const SkeletonLibraryGrid(
+                cardWidth: 160,
+                aspectRatio: 2 / 3,
               )
             : RefreshIndicator(
                 onRefresh: _vm.refresh,

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -27,6 +27,7 @@ import '../../widgets/overlay_sheet.dart';
 import '../../widgets/quick_return_wrapper.dart';
 import '../../widgets/rating_display.dart';
 import '../../widgets/sliding_pill_tabs.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -417,9 +418,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
 
   Widget _buildBody() {
     return switch (_vm.state) {
-      FavoritesState.loading => Center(
-        child: CircularProgressIndicator(color: AppColorScheme.accent),
-      ),
+      FavoritesState.loading => const SkeletonLibraryGrid(),
       FavoritesState.error => Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/browse/favorites_screen.dart
+++ b/lib/ui/screens/browse/favorites_screen.dart
@@ -418,7 +418,10 @@ class _FavoritesScreenState extends State<FavoritesScreen> with GridFocusNodeMix
 
   Widget _buildBody() {
     return switch (_vm.state) {
-      FavoritesState.loading => const SkeletonLibraryGrid(),
+      FavoritesState.loading => SkeletonLibraryGrid(
+        cardWidth: _cardWidth(),
+        aspectRatio: _gridBaseAspectRatio(),
+      ),
       FavoritesState.error => Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/browse/folder_browse_screen.dart
+++ b/lib/ui/screens/browse/folder_browse_screen.dart
@@ -14,6 +14,7 @@ import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/media_card.dart';
 import '../../widgets/navigation_layout.dart';
 import '../../widgets/quick_return_wrapper.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../../l10n/app_localizations.dart';
 
 class FolderBrowseScreen extends StatefulWidget {
@@ -298,7 +299,7 @@ class _FolderBrowseScreenState extends State<FolderBrowseScreen> {
   Widget _buildBody() {
     switch (_vm.state) {
       case FolderBrowseState.loading:
-        return const Center(child: CircularProgressIndicator());
+        return const SkeletonLibraryGrid();
       case FolderBrowseState.error:
         return Center(
           child: Text(

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -35,6 +35,7 @@ import '../../widgets/quick_return_wrapper.dart';
 import '../../widgets/rating_display.dart';
 import '../detail/item_detail_screen.dart';
 import '../../widgets/local_search_field.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -1001,7 +1002,6 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
   }
 
   Widget _buildBody() {
-    final spinnerColor = _vm.isBookLibrary ? const Color(0xFFD97706) : _jellyfinBlue;
     final showHorizChevrons =
         _horizontalGridIsScrollable &&
         _vm.state == LibraryBrowseState.ready &&
@@ -1040,8 +1040,11 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
           ),
         Expanded(
           child: switch (_vm.state) {
-            LibraryBrowseState.loading => Center(
-                child: CircularProgressIndicator(color: spinnerColor),
+            LibraryBrowseState.loading => SkeletonLibraryGrid(
+                cardWidth: _cardWidth(),
+                aspectRatio: _gridBaseAspectRatio(),
+                isSongs: _isSongsBrowse,
+                isHorizontal: _vm.scrollDirection == LibraryScrollDirection.horizontal,
               ),
             LibraryBrowseState.error => Center(
                 child: Column(

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -18,6 +18,7 @@ import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../widgets/genre_grid_card.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../../l10n/app_localizations.dart';
 
 Color get _navyBackground => AppColorScheme.background;
@@ -377,9 +378,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
   Widget _buildBody() {
     if (_isLoading) {
-      return Center(
-        child: CircularProgressIndicator(color: AppColorScheme.accent),
-      );
+      return const SkeletonLibraryGrid(aspectRatio: 16 / 9);
     }
 
     if (_genres.isEmpty) {

--- a/lib/ui/screens/browse/music_browse_screen.dart
+++ b/lib/ui/screens/browse/music_browse_screen.dart
@@ -24,6 +24,7 @@ import '../../widgets/fullscreen_backdrop_switcher.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../util/home_row_title_localizer.dart';
 import '../../widgets/overlay_sheet.dart';
+import '../../widgets/skeleton/skeleton_music_browse.dart';
 
 Color get _navyBackground => AppColorScheme.background;
 
@@ -250,11 +251,7 @@ class _MusicBrowseScreenState extends State<MusicBrowseScreen> {
               const SizedBox(height: 10),
               Expanded(
                 child: _vm.isLoading
-                    ? Center(
-                        child: CircularProgressIndicator(
-                          color: AppColorScheme.accent,
-                        ),
-                      )
+                    ? const SkeletonMusicBrowse()
                     : RefreshIndicator(
                         onRefresh: _vm.refresh,
                         child: LayoutBuilder(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -661,6 +661,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
     return switch (_viewModel.state) {
       ItemDetailState.loading => DetailScreenSkeleton(
         style: _prefs.get(UserPreferences.detailScreenStyle),
+        prefs: _prefs,
       ),
       ItemDetailState.error => Center(
         child: Column(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -660,8 +660,7 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
   Widget _buildBody(BuildContext context) {
     return switch (_viewModel.state) {
       ItemDetailState.loading => DetailScreenSkeleton(
-        isModern: _prefs.get(UserPreferences.detailScreenStyle) ==
-            DetailScreenStyle.modern,
+        style: _prefs.get(UserPreferences.detailScreenStyle),
       ),
       ItemDetailState.error => Center(
         child: Column(

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -41,6 +41,8 @@ import 'nouveau/nouveau_detail_content.dart';
 import 'nouveau/hero/nouveau_action_buttons.dart';
 import 'modern/modern_detail_content.dart';
 import 'spotlight/spotlight_detail_content.dart';
+import '../../widgets/skeleton/skeleton_detail_screen.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 import '../../../data/repositories/seerr_repository.dart';
 import '../../../data/services/seerr/seerr_api_models.dart';
 import '../../../l10n/app_localizations.dart';
@@ -91,7 +93,6 @@ import '../../widgets/focus/dpad_list_tile.dart';
 import '../../widgets/focus/focusable_button.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/overlay_sheet.dart';
-import '../../widgets/playback/player_loading_overlay.dart';
 import '../../../playback/hdr_stream_capability.dart';
 import '../../../playback/known_defects.dart';
 import '../../../syncplay/syncplay_manager.dart';
@@ -658,8 +659,9 @@ class _ItemDetailScreenState extends State<ItemDetailScreen>
 
   Widget _buildBody(BuildContext context) {
     return switch (_viewModel.state) {
-      ItemDetailState.loading => const Center(
-        child: PlayerLoadingOverlay(customSize: 120),
+      ItemDetailState.loading => DetailScreenSkeleton(
+        isModern: _prefs.get(UserPreferences.detailScreenStyle) ==
+            DetailScreenStyle.modern,
       ),
       ItemDetailState.error => Center(
         child: Column(
@@ -5253,8 +5255,11 @@ class _BookAuthorDetailScreenState extends State<_BookAuthorDetailScreen> {
       ),
       body: SafeArea(
         child: _loading && data == null
-            ? const Center(
-                child: CircularProgressIndicator(color: Color(0xFF32B9E8)),
+            ? _buildSkeleton(
+                context,
+                horizontalPadding,
+                crossAxisCount,
+                gridSpacing,
               )
             : data == null
             ? Center(
@@ -5339,6 +5344,105 @@ class _BookAuthorDetailScreenState extends State<_BookAuthorDetailScreen> {
                   ],
                 ),
               ),
+      ),
+    );
+  }
+
+  Widget _buildSkeleton(
+    BuildContext context,
+    double horizontalPadding,
+    int crossAxisCount,
+    double gridSpacing,
+  ) {
+    return SkeletonShimmer(
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(
+          horizontalPadding,
+          8,
+          horizontalPadding,
+          24,
+        ),
+        physics: const NeverScrollableScrollPhysics(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                SkeletonBox(
+                  width: 84,
+                  height: 84,
+                  borderRadius: BorderRadius.circular(42),
+                ),
+                const SizedBox(width: 20),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      SkeletonBox(
+                        width: 200,
+                        height: 24,
+                        borderRadius: BorderRadius.all(Radius.circular(4)),
+                      ),
+                      SizedBox(height: 8),
+                      SkeletonBox(
+                        width: 110,
+                        height: 14,
+                        borderRadius: BorderRadius.all(Radius.circular(4)),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            const SkeletonBox(
+              width: 100,
+              height: 18,
+              borderRadius: BorderRadius.all(Radius.circular(4)),
+            ),
+            const SizedBox(height: 10),
+            const SkeletonBox(
+              width: double.infinity,
+              height: 13,
+              borderRadius: BorderRadius.all(Radius.circular(4)),
+            ),
+            const SizedBox(height: 6),
+            const SkeletonBox(
+              width: double.infinity,
+              height: 13,
+              borderRadius: BorderRadius.all(Radius.circular(4)),
+            ),
+            const SizedBox(height: 6),
+            const SkeletonBox(
+              width: 240,
+              height: 13,
+              borderRadius: BorderRadius.all(Radius.circular(4)),
+            ),
+            const SizedBox(height: 32),
+            const SkeletonBox(
+              width: 80,
+              height: 18,
+              borderRadius: BorderRadius.all(Radius.circular(4)),
+            ),
+            const SizedBox(height: 12),
+            GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: crossAxisCount,
+                crossAxisSpacing: gridSpacing,
+                mainAxisSpacing: gridSpacing,
+                childAspectRatio: 2 / 3,
+              ),
+              itemCount: crossAxisCount * 2,
+              itemBuilder: (_, _) => const SkeletonBox(
+                width: double.infinity,
+                height: double.infinity,
+                borderRadius: BorderRadius.all(Radius.circular(8)),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -544,6 +544,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       });
       NavigationLayout.focusDetailsPlayButtonNotifier.value = widget.initialFocusNode;
     }
+    final initialItem = _vm.item;
+    if (initialItem != null && initialItem.type == 'Episode') {
+      if (initialItem.seriesLogoImageTag != null && initialItem.seriesId != null) {
+        _seriesLogoTag = initialItem.seriesLogoImageTag;
+        _seriesLogoId = initialItem.seriesId;
+      }
+    }
     _loadSeriesLogo();
     _loadStudioLogos();
     _loadSeerrAppearances().then((_) {
@@ -599,6 +606,13 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       if (_vm.item?.type == 'BoxSet' &&
           (_vm.state == ItemDetailState.loading || _vm.playlistItems.isEmpty)) {
         _boxSetLastTriggerMaxExtent = -1;
+      }
+      final currentItem = _vm.item;
+      if (currentItem != null && currentItem.type == 'Episode' && _seriesLogoTag == null) {
+        if (currentItem.seriesLogoImageTag != null && currentItem.seriesId != null) {
+          _seriesLogoTag = currentItem.seriesLogoImageTag;
+          _seriesLogoId = currentItem.seriesId;
+        }
       }
       setState(() {});
       _loadSeriesLogo();
@@ -4075,6 +4089,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final showTech = widget.prefs.get(UserPreferences.detailShowTechnicalDetails);
     final techRow = showTech ? _buildTechnicalDetailsRow(context, item, selectedSource) : null;
 
+    final seriesLogoHeight = (_landscape ? 90.0 : 64.0) * logoScaleFactor;
+    final seriesLogoWidth = (_landscape ? 360.0 : 260.0) * logoScaleFactor;
+    final itemLogoHeight = (_landscape ? 75.0 : 64.0) * logoScaleFactor;
+    final itemLogoWidth = (_landscape ? 300.0 : 260.0) * logoScaleFactor;
+    final effectiveSeriesLogoTag = _seriesLogoTag ?? item.seriesLogoImageTag;
+    final effectiveSeriesLogoId = _seriesLogoId ?? item.seriesId;
+    final hasSeriesLogo = effectiveSeriesLogoTag != null && effectiveSeriesLogoId != null;
+
     final Column childrenCol = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: hasUpNext ? MainAxisSize.max : MainAxisSize.min,
@@ -4101,28 +4123,34 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
               ],
             ),
           ] else if (isEpisode) ...[
-            if (_seriesLogoTag != null && _seriesLogoId != null) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: LogoView(
-                  imageUrl: _vm.imageApi
-                      .getLogoImageUrl(_seriesLogoId!, maxWidth: 350, tag: _seriesLogoTag),
-                  maxHeight: (_landscape ? 90 : 64) * logoScaleFactor,
-                  maxWidth: (_landscape ? 360 : 260) * logoScaleFactor,
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: SizedBox(
+                height: seriesLogoHeight,
+                child: Align(
+                  alignment: Alignment.bottomLeft,
+                  child: hasSeriesLogo
+                      ? LogoView(
+                          imageUrl: _vm.imageApi.getLogoImageUrl(
+                            effectiveSeriesLogoId,
+                            maxWidth: 350,
+                            tag: effectiveSeriesLogoTag,
+                          ),
+                          maxHeight: seriesLogoHeight,
+                          maxWidth: seriesLogoWidth,
+                        )
+                      : (item.seriesName != null
+                          ? Text(
+                              item.seriesName!,
+                              style: textTheme.labelLarge?.copyWith(
+                                color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                                letterSpacing: 1.2,
+                              ),
+                            )
+                          : const SizedBox.shrink()),
                 ),
               ),
-            ] else if (item.seriesName != null) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4),
-                child: Text(
-                  item.seriesName!,
-                  style: textTheme.labelLarge?.copyWith(
-                    color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-                    letterSpacing: 1.2,
-                  ),
-                ),
-              ),
-            ],
+            ),
             Text(
               item.name,
               style: (_landscape
@@ -4133,41 +4161,44 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ] else if (logoTag != null && logoId != null) ...[
             Padding(
               padding: const EdgeInsets.only(bottom: 4),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  LogoView(
-                    imageUrl: _vm.imageApi
-                        .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                    maxHeight: (_landscape ? 75 : 64) * logoScaleFactor,
-                    maxWidth: (_landscape ? 300 : 260) * logoScaleFactor,
-                  ),
-                  if (item.mediaSources.length > 1) ...[
-                    const SizedBox(width: 16),
-                    () {
-                      final versionName = selectedSource?['Name'] as String? ?? 'Default';
-                      return Container(
-                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: AppColorScheme.accent.withValues(alpha: 0.15),
-                          borderRadius: AppRadius.circular(4),
-                          border: Border.all(
-                            color: AppColorScheme.accent.withValues(alpha: 0.4),
-                            width: 1,
+              child: SizedBox(
+                height: itemLogoHeight,
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    LogoView(
+                      imageUrl: _vm.imageApi
+                          .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                      maxHeight: itemLogoHeight,
+                      maxWidth: itemLogoWidth,
+                    ),
+                    if (item.mediaSources.length > 1) ...[
+                      const SizedBox(width: 16),
+                      () {
+                        final versionName = selectedSource?['Name'] as String? ?? 'Default';
+                        return Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: AppColorScheme.accent.withValues(alpha: 0.15),
+                            borderRadius: AppRadius.circular(4),
+                            border: Border.all(
+                              color: AppColorScheme.accent.withValues(alpha: 0.4),
+                              width: 1,
+                            ),
                           ),
-                        ),
-                        child: Text(
-                          versionName,
-                          style: textTheme.bodySmall?.copyWith(
-                            color: AppColorScheme.accent,
-                            fontWeight: FontWeight.bold,
+                          child: Text(
+                            versionName,
+                            style: textTheme.bodySmall?.copyWith(
+                              color: AppColorScheme.accent,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                      );
-                    }(),
+                        );
+                      }(),
+                    ],
                   ],
-                ],
+                ),
               ),
             ),
           ] else ...[
@@ -4930,44 +4961,47 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
             children: [
               const SizedBox(height: 24),
               if (logoTag != null && logoId != null) ...[
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    LogoView(
-                      imageUrl: _vm.imageApi
-                          .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
-                      maxHeight: 75 * logoScaleFactor,
-                      maxWidth: 300 * logoScaleFactor,
-                    ),
-                    if (item.mediaSources.length > 1) ...[
-                      const SizedBox(width: 16),
-                      // The logo keeps the width it needs, so a narrow window
-                      // shortens the version name instead of overflowing the row.
-                      Flexible(
-                        child: Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
-                          decoration: BoxDecoration(
-                            color: AppColorScheme.accent.withValues(alpha: 0.15),
-                            borderRadius: AppRadius.circular(4),
-                            border: Border.all(
-                              color: AppColorScheme.accent.withValues(alpha: 0.4),
-                              width: 1,
+                SizedBox(
+                  height: 75 * logoScaleFactor,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      LogoView(
+                        imageUrl: _vm.imageApi
+                            .getLogoImageUrl(logoId, maxWidth: 350, tag: logoTag),
+                        maxHeight: 75 * logoScaleFactor,
+                        maxWidth: 300 * logoScaleFactor,
+                      ),
+                      if (item.mediaSources.length > 1) ...[
+                        const SizedBox(width: 16),
+                        // The logo keeps the width it needs, so a narrow window
+                        // shortens the version name instead of overflowing the row.
+                        Flexible(
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: AppColorScheme.accent.withValues(alpha: 0.15),
+                              borderRadius: AppRadius.circular(4),
+                              border: Border.all(
+                                color: AppColorScheme.accent.withValues(alpha: 0.4),
+                                width: 1,
+                              ),
                             ),
-                          ),
-                          child: Text(
-                            selectedSource?['Name'] as String? ?? 'Default',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: textTheme.bodySmall?.copyWith(
-                              color: AppColorScheme.accent,
-                              fontWeight: FontWeight.bold,
+                            child: Text(
+                              selectedSource?['Name'] as String? ?? 'Default',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: textTheme.bodySmall?.copyWith(
+                                color: AppColorScheme.accent,
+                                fontWeight: FontWeight.bold,
+                              ),
                             ),
                           ),
                         ),
-                      ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
                 const SizedBox(height: 6),
               ] else ...[

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -559,34 +559,42 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
     );
 
     if (isEpisode) {
+      final seriesLogoHeight = (_landscape ? 90.0 : 64.0) * logoScaleFactor;
+      final seriesLogoWidth = (_landscape ? 360.0 : 260.0) * logoScaleFactor;
+      final hasSeriesLogo = logoTag != null && logoId != null;
+
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (logoTag != null && logoId != null)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: LogoView(
-                imageUrl: _vm.imageApi.getLogoImageUrl(
-                  logoId,
-                  maxWidth: 350,
-                  tag: logoTag,
-                ),
-                maxHeight: (_landscape ? 90 : 64) * logoScaleFactor,
-                maxWidth: (_landscape ? 360 : 260) * logoScaleFactor,
-              ),
-            )
-          else if (item.seriesName != null)
-            Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: Text(
-                item.seriesName!,
-                style: textTheme.labelLarge?.copyWith(
-                  color: AppColorScheme.onSurface.withValues(alpha: 0.7),
-                  letterSpacing: 1.2,
-                ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: SizedBox(
+              height: seriesLogoHeight,
+              child: Align(
+                alignment: Alignment.bottomLeft,
+                child: hasSeriesLogo
+                    ? LogoView(
+                        imageUrl: _vm.imageApi.getLogoImageUrl(
+                          logoId,
+                          maxWidth: 350,
+                          tag: logoTag,
+                        ),
+                        maxHeight: seriesLogoHeight,
+                        maxWidth: seriesLogoWidth,
+                      )
+                    : (item.seriesName != null
+                        ? Text(
+                            item.seriesName!,
+                            style: textTheme.labelLarge?.copyWith(
+                              color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+                              letterSpacing: 1.2,
+                            ),
+                          )
+                        : const SizedBox.shrink()),
               ),
             ),
+          ),
           titleText,
         ],
       );

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -77,6 +77,8 @@ import '../../util/home_row_title_localizer.dart';
 import '../../../util/game_library.dart';
 import 'home_view_model.dart';
 import '../../widgets/seerr/seerr_genre_label.dart';
+import '../../widgets/skeleton/skeleton_home_row.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 
 Color get _homeBackground => AppColorScheme.background;
 
@@ -3955,6 +3957,70 @@ class _ContentRowsState extends State<_ContentRows>
     return null;
   }
 
+  Widget _buildHomeInitialLoadingSkeleton({
+    required BuildContext context,
+    required UserPreferences prefs,
+    required PosterSize posterSize,
+  }) {
+    final safeTop = MediaQuery.of(context).padding.top;
+    final desktopScale = _desktopUiScaleFactor();
+    final isRowsV2 = _isHomeRowsStyleV2();
+    final navbarIsTop =
+        prefs.get(UserPreferences.navbarPosition) == NavbarPosition.top;
+    final tvTopNavbarInset =
+        navbarIsTop && PlatformDetection.isTV && !PlatformDetection.useMobileUi
+            ? 48.0
+            : 0.0;
+    final navbarLeftInset = navbarIsTop ? 16.0 + tvTopNavbarInset : 56.0;
+    final platformScale = PlatformDetection.isTV
+        ? 1.0
+        : (PlatformDetection.useMobileUi ? 1.0 : desktopScale);
+    final v2ImageHeight =
+        posterSize.portraitHeight.toDouble() * platformScale * 2;
+    final v2PortraitWidth = v2ImageHeight * (2 / 3);
+    final cardWidth = isRowsV2
+        ? v2PortraitWidth
+        : (posterSize.portraitHeight.toDouble() * platformScale * (2 / 3));
+    final imageHeight = isRowsV2
+        ? v2ImageHeight
+        : (posterSize.portraitHeight.toDouble() * platformScale);
+
+    return SkeletonShimmer(
+      child: ListView(
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.only(
+          top: safeTop + (navbarIsTop ? 70.0 : 24.0),
+          bottom: 48.0,
+        ),
+        children: [
+          for (int i = 0; i < 4; i++) ...[
+            Padding(
+              padding: EdgeInsets.only(
+                left: navbarLeftInset + (isRowsV2 ? _kHomeRowLabelInset : 0),
+                bottom: 8.0,
+                top: i == 0 ? 0 : 24.0,
+              ),
+              child: SkeletonBox(
+                width: 140.0 + (i * 24),
+                height: 18,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+            SkeletonHomeRow(
+              cardWidth: cardWidth,
+              imageHeight: imageHeight,
+              leadingPadding:
+                  navbarLeftInset + (isRowsV2 ? _kHomeRowLabelInset : 0),
+              itemSpacing: 14.0,
+              isModern: isRowsV2,
+              count: 8,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final rows = widget.viewModel.rows;
@@ -3975,7 +4041,11 @@ class _ContentRowsState extends State<_ContentRows>
     final useSeriesThumbs = prefs.get(UserPreferences.seriesThumbnailsEnabled);
 
     if (widget.viewModel.isLoading && rows.isEmpty) {
-      return const Center(child: CircularProgressIndicator());
+      return _buildHomeInitialLoadingSkeleton(
+        context: context,
+        prefs: prefs,
+        posterSize: posterSize,
+      );
     }
 
     _updateOffsets();
@@ -4646,13 +4716,36 @@ class _ContentRowsState extends State<_ContentRows>
 
     final subtitle = _rowSubtitle(row, l10n);
     final hasSubtitle = subtitle != null && subtitle.isNotEmpty;
+    final rowTotalHeight =
+        maxCardHeight + (10 * metadataScale) + (hasSubtitle ? 18.0 : 0.0);
+
+    if (row.isLoading && row.items.isEmpty) {
+      return _buildTitledRow(
+        key: _rowContainerKey(rowIndex),
+        title: _localizedRowTitle(row, l10n),
+        subtitle: subtitle,
+        rowIndex: rowIndex,
+        hasItems: false,
+        height: rowTotalHeight,
+        child: SkeletonHomeRow(
+          cardWidth: firstCardWidth,
+          imageHeight: isRowsV2
+              ? v2ImageHeight
+              : (posterSize.portraitHeight.toDouble() * platformScale),
+          itemSpacing: _rowItemSpacing(firstCardWidth, cardExpansion),
+          leadingPadding: isRowsV2 ? _kHomeRowLabelInset : 0,
+          isModern: isRowsV2,
+        ),
+      );
+    }
+
     return _buildTitledRow(
       key: _rowContainerKey(rowIndex),
       title: _localizedRowTitle(row, l10n),
       subtitle: subtitle,
       rowIndex: rowIndex,
       hasItems: row.items.isNotEmpty,
-      height: maxCardHeight + (10 * metadataScale) + (hasSubtitle ? 18.0 : 0.0),
+      height: rowTotalHeight,
       child: LockedFocusRow<AggregatedItem>(
         key: _rowKey(rowIndex),
         items: row.items,

--- a/lib/ui/screens/search/search_screen.dart
+++ b/lib/ui/screens/search/search_screen.dart
@@ -33,6 +33,7 @@ import '../../widgets/navigation_layout.dart';
 import '../../widgets/focus/context_menu_sheet.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/sliding_pill_tabs.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 
 class SearchScreen extends StatefulWidget {
   final String? initialQuery;
@@ -962,7 +963,10 @@ class _SearchScreenState extends State<SearchScreen> with GridFocusNodeMixin {
         return const SizedBox.shrink();
       case SearchState.loading:
         if (_vm.results.isEmpty) {
-          return const Center(child: CircularProgressIndicator());
+          return const SkeletonLibraryGrid(
+            aspectRatio: 2 / 3,
+            itemCount: 18,
+          );
         }
         return _buildResults();
       case SearchState.ready

--- a/lib/ui/screens/seerr/seerr_browse_screen.dart
+++ b/lib/ui/screens/seerr/seerr_browse_screen.dart
@@ -20,6 +20,7 @@ import '../../widgets/overlay_sheet.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/quick_return_wrapper.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w342';
 Color get _navyBackground => AppColorScheme.background;
@@ -171,9 +172,12 @@ class _SeerrBrowseScreenState extends State<SeerrBrowseScreen> {
   Widget _buildBody() {
     final l10n = AppLocalizations.of(context);
     final vm = _vm;
-    if (_initializing || vm == null || vm.state.isLoading) {
-      return Center(
-        child: CircularProgressIndicator(color: _seerrAccent),
+    if (_initializing || vm == null || (vm.state.isLoading && vm.state.items.isEmpty)) {
+      final cardWidth =
+          _prefs.resolveLibraryPosterSize().portraitHeight * (2 / 3);
+      return SkeletonLibraryGrid(
+        cardWidth: cardWidth,
+        aspectRatio: 2 / 3,
       );
     }
 

--- a/lib/ui/screens/seerr/seerr_collection_screen.dart
+++ b/lib/ui/screens/seerr/seerr_collection_screen.dart
@@ -22,6 +22,8 @@ import '../../widgets/seerr/seerr_tv_controls.dart';
 import '../../widgets/track_selector_dialog.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
+import '../../widgets/skeleton/skeleton_home_row.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w342';
 const _tmdbBackdropBase = 'https://image.tmdb.org/t/p/w1280';
@@ -97,14 +99,11 @@ class _SeerrCollectionScreenState extends State<SeerrCollectionScreen> {
   Widget _buildBody() {
     final l10n = AppLocalizations.of(context);
     final vm = _vm;
-    if (_initializing || vm == null) {
-      return const Center(child: CircularProgressIndicator());
+    if (_initializing || vm == null || (vm.state.isLoading && vm.state.collection == null)) {
+      return _buildSkeleton(context);
     }
 
     final s = vm.state;
-    if (s.isLoading && s.collection == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
 
     if (s.error != null && s.collection == null) {
       return Center(
@@ -175,6 +174,62 @@ class _SeerrCollectionScreenState extends State<SeerrCollectionScreen> {
           ),
         ),
       ],
+    );
+  }
+
+  Widget _buildSkeleton(BuildContext context) {
+    final topPad = MediaQuery.of(context).padding.top;
+    return SkeletonShimmer(
+      child: SingleChildScrollView(
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.only(top: topPad + 56, bottom: 48),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: EdgeInsets.fromLTRB(_leftInset, 0, 24, 0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SkeletonBox(
+                    width: 120,
+                    height: 180,
+                    borderRadius: BorderRadius.all(Radius.circular(10)),
+                  ),
+                  const SizedBox(width: 20),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: const [
+                        SkeletonBox(width: 200, height: 26, borderRadius: BorderRadius.all(Radius.circular(4))),
+                        SizedBox(height: 10),
+                        SkeletonBox(width: 120, height: 16, borderRadius: BorderRadius.all(Radius.circular(4))),
+                        SizedBox(height: 14),
+                        SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+                        SizedBox(height: 8),
+                        SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+                        SizedBox(height: 8),
+                        SkeletonBox(width: 260, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 32),
+            Padding(
+              padding: EdgeInsets.fromLTRB(_leftInset, 0, 24, 12),
+              child: const SkeletonBox(width: 160, height: 20, borderRadius: BorderRadius.all(Radius.circular(4))),
+            ),
+            SkeletonHomeRow(
+              cardWidth: 130,
+              imageHeight: 195,
+              leadingPadding: _leftInset,
+              count: 6,
+            ),
+          ],
+        ),
+      ),
     );
   }
 

--- a/lib/ui/screens/seerr/seerr_discover_screen.dart
+++ b/lib/ui/screens/seerr/seerr_discover_screen.dart
@@ -30,6 +30,8 @@ import '../../widgets/horizontal_scroll_section.dart';
 import '../../widgets/quick_return_wrapper.dart';
 import '../../../util/seerr_genre_art.dart';
 import '../../widgets/seerr/seerr_genre_label.dart';
+import '../../widgets/skeleton/skeleton_home_row.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w300';
 const _tmdbBackdropBase = 'https://image.tmdb.org/t/p/w1280';
@@ -380,11 +382,44 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
     );
   }
 
+  Widget _buildSkeleton({double rowLeftInset = 0.0}) {
+    final desktopScale = GetIt.instance<UserPreferences>()
+        .get(UserPreferences.desktopUiScale)
+        .scaleFactor;
+    final cardWidth = 130.0 * desktopScale;
+    final imageHeight = 195.0 * desktopScale;
+    return SkeletonShimmer(
+      child: ListView(
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.only(left: rowLeftInset, top: 16, bottom: 32),
+        children: [
+          for (int i = 0; i < 4; i++) ...[
+            Padding(
+              padding: EdgeInsets.fromLTRB(20 * desktopScale, 16, 20 * desktopScale, 8),
+              child: SkeletonBox(
+                width: 140.0 + (i * 25),
+                height: 18,
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+            SkeletonHomeRow(
+              cardWidth: cardWidth,
+              imageHeight: imageHeight,
+              leadingPadding: 20 * desktopScale,
+              itemSpacing: 12 * desktopScale,
+            ),
+            const SizedBox(height: 16),
+          ],
+        ],
+      ),
+    );
+  }
+
   Widget _buildContent({double rowLeftInset = 0.0}) {
     final l10n = AppLocalizations.of(context);
     final vm = _viewModel;
     if (vm == null) {
-      return const Center(child: CircularProgressIndicator());
+      return _buildSkeleton(rowLeftInset: rowLeftInset);
     }
 
     if (vm.error != null && vm.rows.isEmpty) {
@@ -410,7 +445,7 @@ class _SeerrDiscoverScreenState extends State<SeerrDiscoverScreen> {
 
     final rows = vm.rows;
     if (rows.isEmpty && vm.isLoading) {
-      return const Center(child: CircularProgressIndicator());
+      return _buildSkeleton(rowLeftInset: rowLeftInset);
     }
 
     _firstFocusableVisibleIndex = -1;

--- a/lib/ui/screens/seerr/seerr_person_screen.dart
+++ b/lib/ui/screens/seerr/seerr_person_screen.dart
@@ -19,6 +19,8 @@ import '../../../l10n/app_localizations.dart';
 import '../../widgets/focus/request_initial_focus.dart';
 import '../../widgets/focus/step_scroll.dart';
 import '../../widgets/quick_return_wrapper.dart';
+import '../../widgets/skeleton/skeleton_home_row.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 
 const _tmdbPosterBase = 'https://image.tmdb.org/t/p/w342';
 const _tmdbProfileLarge = 'https://image.tmdb.org/t/p/w500';
@@ -103,15 +105,11 @@ class _SeerrPersonScreenState extends State<SeerrPersonScreen> {
   Widget _buildBody() {
     final l10n = AppLocalizations.of(context);
     final vm = _vm;
-    if (_initializing || vm == null) {
-      return const Center(child: CircularProgressIndicator());
+    if (_initializing || vm == null || vm.state.isLoading) {
+      return _buildSkeleton(context);
     }
 
     final s = vm.state;
-
-    if (s.isLoading) {
-      return const Center(child: CircularProgressIndicator());
-    }
 
     if (s.error != null) {
       return Center(
@@ -135,6 +133,60 @@ class _SeerrPersonScreenState extends State<SeerrPersonScreen> {
     if (person == null) return const SizedBox.shrink();
 
     return _buildContent(person, s);
+  }
+
+  Widget _buildSkeleton(BuildContext context) {
+    final topPad = MediaQuery.of(context).padding.top;
+    return SkeletonShimmer(
+      child: SingleChildScrollView(
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.fromLTRB(32, topPad + 16, 32, 80),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SkeletonBox(
+                  width: 120,
+                  height: 120,
+                  borderRadius: BorderRadius.circular(60),
+                ),
+                const SizedBox(width: 20),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: const [
+                      SizedBox(height: 8),
+                      SkeletonBox(width: 220, height: 26, borderRadius: BorderRadius.all(Radius.circular(4))),
+                      SizedBox(height: 8),
+                      SkeletonBox(width: 120, height: 16, borderRadius: BorderRadius.all(Radius.circular(4))),
+                      SizedBox(height: 10),
+                      SkeletonBox(width: 180, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+            const SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+            const SizedBox(height: 8),
+            const SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+            const SizedBox(height: 8),
+            const SkeletonBox(width: 240, height: 14, borderRadius: BorderRadius.all(Radius.circular(4))),
+            const SizedBox(height: 32),
+            const SkeletonBox(width: 140, height: 20, borderRadius: BorderRadius.all(Radius.circular(4))),
+            const SizedBox(height: 16),
+            const SkeletonHomeRow(
+              cardWidth: 120,
+              imageHeight: 180,
+              leadingPadding: 0,
+              count: 6,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   Widget _buildContent(SeerrPersonDetails person, SeerrPersonState s) {

--- a/lib/ui/screens/seerr/seerr_requests_screen.dart
+++ b/lib/ui/screens/seerr/seerr_requests_screen.dart
@@ -28,6 +28,7 @@ import '../../widgets/seerr_download_progress_bar.dart';
 import '../../widgets/seerr/seerr_media_type_badge.dart';
 import '../../widgets/seerr/seerr_request_tile_caption.dart';
 import '../../widgets/seerr/seerr_text_field.dart';
+import '../../widgets/skeleton/skeleton_library_grid.dart';
 import '../../widgets/seerr/seerr_tv_controls.dart';
 import '../../widgets/track_selector_dialog.dart';
 import '../../../l10n/app_localizations.dart';
@@ -219,7 +220,7 @@ class _SeerrRequestsScreenState extends State<SeerrRequestsScreen>
   Widget _buildBody() {
     final l10n = AppLocalizations.of(context);
     if (_initializing || _requestsVm == null || _issuesVm == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const SkeletonLibraryGrid(aspectRatio: 16 / 9);
     }
 
     final prefs = GetIt.instance<UserPreferences>();

--- a/lib/ui/screens/settings/home_sections_screen.dart
+++ b/lib/ui/screens/settings/home_sections_screen.dart
@@ -23,7 +23,7 @@ import '../../../util/platform_detection.dart';
 import '../../navigation/route_lifecycle_observer.dart';
 import '../../widgets/overlay_sheet.dart';
 import '../../widgets/poster_size_settings_dialog.dart';
-import '../../widgets/playback/player_loading_overlay.dart';
+import '../../widgets/skeleton/skeleton_shimmer.dart';
 import '../../widgets/settings/clean_settings_typography.dart';
 import '../../widgets/settings/preference_tiles.dart';
 import '../../../l10n/app_localizations.dart';
@@ -1715,10 +1715,11 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
 
   Widget _buildLoadingOverlay(BuildContext context) {
     final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     return Positioned.fill(
       child: AnimatedOpacity(
         opacity: _isLoading ? 1.0 : 0.0,
-        duration: const Duration(milliseconds: 300),
+        duration: const Duration(milliseconds: 250),
         curve: Curves.easeInOut,
         onEnd: () {
           if (!_isLoading && mounted) {
@@ -1728,9 +1729,111 @@ class _HomeSectionsScreenState extends State<HomeSectionsScreen>
           }
         },
         child: Container(
-          color: theme.colorScheme.surface,
-          alignment: Alignment.center,
-          child: const PlayerLoadingOverlay(customSize: 80, labelSpacing: 20),
+          color: theme.scaffoldBackgroundColor,
+          child: SkeletonShimmer(
+            child: ListView(
+              physics: const NeverScrollableScrollPhysics(),
+              padding: const EdgeInsets.only(top: 8, bottom: 32),
+              children: [
+                if (widget.showGeneralOptions)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                    child: Container(
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: colorScheme.surfaceContainerLow.withValues(alpha: 0.5),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Column(
+                        children: const [
+                          Row(
+                            children: [
+                              SkeletonBox(width: 24, height: 24, borderRadius: BorderRadius.all(Radius.circular(6))),
+                              SizedBox(width: 16),
+                              Expanded(
+                                child: SkeletonBox(width: 180, height: 16, borderRadius: BorderRadius.all(Radius.circular(4))),
+                              ),
+                              SkeletonBox(width: 44, height: 24, borderRadius: BorderRadius.all(Radius.circular(12))),
+                            ],
+                          ),
+                          SizedBox(height: 16),
+                          Row(
+                            children: [
+                              SkeletonBox(width: 24, height: 24, borderRadius: BorderRadius.all(Radius.circular(6))),
+                              SizedBox(width: 16),
+                              Expanded(
+                                child: SkeletonBox(width: 160, height: 16, borderRadius: BorderRadius.all(Radius.circular(4))),
+                              ),
+                              SkeletonBox(width: 44, height: 24, borderRadius: BorderRadius.all(Radius.circular(12))),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                for (int i = 0; i < 9; i++)
+                  Padding(
+                    padding: _kHomeSectionTileOuterPadding,
+                    child: Container(
+                      height: 64,
+                      padding: _kHomeSectionTileContentPadding,
+                      decoration: _homeSectionTileDecoration(
+                        context,
+                        focused: false,
+                      ),
+                      child: Row(
+                        children: [
+                          const SkeletonBox(
+                            width: 32,
+                            height: 32,
+                            borderRadius: BorderRadius.all(Radius.circular(8)),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                SkeletonBox(
+                                  width: 120.0 + ((i * 17) % 80),
+                                  height: 15,
+                                  borderRadius: const BorderRadius.all(Radius.circular(4)),
+                                ),
+                                if (i % 3 != 0) ...[
+                                  const SizedBox(height: 6),
+                                  SkeletonBox(
+                                    width: 80.0 + ((i * 13) % 50),
+                                    height: 11,
+                                    borderRadius: const BorderRadius.all(Radius.circular(4)),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                          const SkeletonBox(
+                            width: 28,
+                            height: 28,
+                            borderRadius: BorderRadius.all(Radius.circular(14)),
+                          ),
+                          const SizedBox(width: 8),
+                          const SkeletonBox(
+                            width: 28,
+                            height: 28,
+                            borderRadius: BorderRadius.all(Radius.circular(14)),
+                          ),
+                          const SizedBox(width: 12),
+                          const SkeletonBox(
+                            width: 44,
+                            height: 24,
+                            borderRadius: BorderRadius.all(Radius.circular(12)),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
+++ b/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
@@ -1,21 +1,33 @@
 import 'package:flutter/material.dart';
 
+import '../../../preference/preference_constants.dart';
 import 'skeleton_shimmer.dart';
 
 /// Skeleton placeholder screen displayed while an item detail page is loading.
-/// Supports both Modern and Classic layout structures.
+/// Supports Classic, Modern, Spotlight, and Nouveau layout structures.
 class DetailScreenSkeleton extends StatelessWidget {
-  final bool isModern;
+  final DetailScreenStyle style;
 
   const DetailScreenSkeleton({
     super.key,
-    required this.isModern,
-  });
+    DetailScreenStyle? style,
+    bool? isModern,
+  }) : style = style ??
+            (isModern != null
+                ? (isModern ? DetailScreenStyle.modern : DetailScreenStyle.classic)
+                : DetailScreenStyle.modern);
+
+  bool get isModern => style == DetailScreenStyle.modern;
 
   @override
   Widget build(BuildContext context) {
     return SkeletonShimmer(
-      child: isModern ? _buildModern(context) : _buildClassic(context),
+      child: switch (style) {
+        DetailScreenStyle.classic => _buildClassic(context),
+        DetailScreenStyle.modern => _buildModern(context),
+        DetailScreenStyle.spotlight => _buildSpotlight(context),
+        DetailScreenStyle.nouveau => _buildNouveau(context),
+      },
     );
   }
 
@@ -47,8 +59,9 @@ class DetailScreenSkeleton extends StatelessWidget {
         ),
         // Content
         Positioned.fill(
-          child: Padding(
-            padding: EdgeInsets.fromLTRB(leftPadding, topInset + 10, 40, 0),
+          child: SingleChildScrollView(
+            physics: const ClampingScrollPhysics(),
+            padding: EdgeInsets.fromLTRB(leftPadding, topInset + 10, 40, 20),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -123,9 +136,403 @@ class DetailScreenSkeleton extends StatelessWidget {
     );
   }
 
+  Widget _buildSpotlight(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width >= size.height;
+    final topInset = isLandscape ? 60.0 : 40.0;
+    final horizontalPadding = isLandscape ? 40.0 : 20.0;
+    final heroWidth = isLandscape
+        ? (size.width * 0.85).clamp(450.0, 1100.0)
+        : double.infinity;
+
+    return Stack(
+      children: [
+        // Cinematic backdrop gradient
+        Positioned.fill(
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: isLandscape ? Alignment.centerRight : Alignment.topCenter,
+                end: isLandscape ? Alignment.centerLeft : Alignment.bottomCenter,
+                colors: [
+                  Colors.white.withAlpha(25),
+                  Colors.white.withAlpha(8),
+                  Colors.transparent,
+                ],
+                stops: const [0.0, 0.45, 1.0],
+              ),
+            ),
+          ),
+        ),
+        // Content
+        Positioned.fill(
+          child: SingleChildScrollView(
+            physics: const ClampingScrollPhysics(),
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              topInset,
+              horizontalPadding,
+              30,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: heroWidth,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Tagline placeholder
+                      SkeletonBox(
+                        width: 140,
+                        height: 14,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 10),
+                      // Title / Logo placeholder
+                      SkeletonBox(
+                        width: isLandscape ? 320 : size.width * 0.65,
+                        height: isLandscape ? 64 : 48,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      const SizedBox(height: 12),
+                      // Metadata dot-separated row
+                      Row(
+                        children: [
+                          SkeletonBox(width: 50, height: 18, borderRadius: BorderRadius.circular(4)),
+                          const SizedBox(width: 8),
+                          SkeletonBox(width: 42, height: 18, borderRadius: BorderRadius.circular(4)),
+                          const SizedBox(width: 8),
+                          SkeletonBox(width: 60, height: 18, borderRadius: BorderRadius.circular(4)),
+                          const SizedBox(width: 8),
+                          SkeletonBox(width: 75, height: 18, borderRadius: BorderRadius.circular(4)),
+                        ],
+                      ),
+                      const SizedBox(height: 10),
+                      // Tech badges row
+                      Row(
+                        children: [
+                          SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
+                          const SizedBox(width: 8),
+                          SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
+                          const SizedBox(width: 8),
+                          SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
+                        ],
+                      ),
+                      const SizedBox(height: 14),
+                      // Overview lines
+                      SkeletonBox(
+                        width: isLandscape ? 680 : double.infinity,
+                        height: 14,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 8),
+                      SkeletonBox(
+                        width: isLandscape ? 620 : size.width * 0.85,
+                        height: 14,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 8),
+                      SkeletonBox(
+                        width: isLandscape ? 450 : size.width * 0.55,
+                        height: 14,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 20),
+                      // Action buttons row (Play pill + circular action buttons)
+                      Row(
+                        children: [
+                          SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
+                          const SizedBox(width: 14),
+                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                          const SizedBox(width: 14),
+                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                          const SizedBox(width: 14),
+                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                          const SizedBox(width: 14),
+                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 28),
+                // Bottom Spotlight summary cards band
+                if (isLandscape)
+                  Row(
+                    children: List.generate(4, (index) {
+                      return Expanded(
+                        child: Padding(
+                          padding: EdgeInsets.only(right: index < 3 ? 16.0 : 0.0),
+                          child: _buildSpotlightSummaryCard(),
+                        ),
+                      );
+                    }),
+                  )
+                else
+                  SizedBox(
+                    height: 120,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      physics: const ClampingScrollPhysics(),
+                      itemCount: 4,
+                      separatorBuilder: (_, _) => const SizedBox(width: 12),
+                      itemBuilder: (_, _) => SizedBox(
+                        width: 220,
+                        child: _buildSpotlightSummaryCard(),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSpotlightSummaryCard() {
+    return Container(
+      height: 135,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white.withAlpha(12),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: Colors.white.withAlpha(20),
+          width: 1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Align(
+            alignment: Alignment.topRight,
+            child: SkeletonBox(
+              width: 22,
+              height: 22,
+              borderRadius: BorderRadius.circular(6),
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SkeletonBox(
+                width: 80,
+                height: 14,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              const SizedBox(height: 6),
+              SkeletonBox(
+                width: 50,
+                height: 10,
+                borderRadius: BorderRadius.circular(3),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNouveau(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final isLandscape = size.width >= size.height;
+    final topInset = isLandscape ? 60.0 : 40.0;
+    final horizontalPadding = isLandscape ? 56.0 : 20.0;
+
+    return Stack(
+      children: [
+        // Backdrop placeholder
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          height: size.height * 0.60,
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.white.withAlpha(30),
+                  Colors.transparent,
+                ],
+              ),
+            ),
+          ),
+        ),
+        // Content with stacked sections
+        Positioned.fill(
+          child: SingleChildScrollView(
+            physics: const ClampingScrollPhysics(),
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              topInset,
+              horizontalPadding,
+              40,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Top genres text placeholder
+                SkeletonBox(
+                  width: 160,
+                  height: 13,
+                  borderRadius: BorderRadius.circular(3),
+                ),
+                const SizedBox(height: 14),
+                // Title / Logo
+                SkeletonBox(
+                  width: isLandscape ? 320 : size.width * 0.7,
+                  height: isLandscape ? 64 : 48,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                const SizedBox(height: 16),
+                // Badges row: Status badge + Seerr pill
+                Row(
+                  children: [
+                    SkeletonBox(width: 64, height: 22, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 76, height: 22, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                // Metadata row
+                Row(
+                  children: [
+                    SkeletonBox(width: 52, height: 18, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 44, height: 18, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 64, height: 18, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 70, height: 18, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                // Technical details badges
+                Row(
+                  children: [
+                    SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                // Overview description (3 lines)
+                SkeletonBox(
+                  width: isLandscape ? 700 : double.infinity,
+                  height: 14,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 8),
+                SkeletonBox(
+                  width: isLandscape ? 640 : size.width * 0.85,
+                  height: 14,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 8),
+                SkeletonBox(
+                  width: isLandscape ? 460 : size.width * 0.55,
+                  height: 14,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 22),
+                // Action buttons row (Play pill + circular buttons)
+                Row(
+                  children: [
+                    SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                  ],
+                ),
+                const SizedBox(height: 36),
+                // Stacked Section 1: Episodes / Media row
+                SkeletonBox(
+                  width: 140,
+                  height: 22,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 14),
+                SizedBox(
+                  height: 150,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    physics: const ClampingScrollPhysics(),
+                    itemCount: 6,
+                    separatorBuilder: (_, _) => const SizedBox(width: 14),
+                    itemBuilder: (_, _) => Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SkeletonBox(
+                          width: 200,
+                          height: 116,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        const SizedBox(height: 8),
+                        SkeletonBox(
+                          width: 120,
+                          height: 12,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 28),
+                // Stacked Section 2: Cast & Crew
+                SkeletonBox(
+                  width: 120,
+                  height: 22,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 14),
+                SizedBox(
+                  height: 96,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    physics: const ClampingScrollPhysics(),
+                    itemCount: 8,
+                    separatorBuilder: (_, _) => const SizedBox(width: 18),
+                    itemBuilder: (_, _) => Column(
+                      children: [
+                        SkeletonBox(
+                          width: 64,
+                          height: 64,
+                          borderRadius: BorderRadius.circular(32),
+                        ),
+                        const SizedBox(height: 8),
+                        SkeletonBox(
+                          width: 54,
+                          height: 10,
+                          borderRadius: BorderRadius.circular(3),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _buildClassic(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
-    return Padding(
+    return SingleChildScrollView(
+      physics: const ClampingScrollPhysics(),
       padding: const EdgeInsets.symmetric(horizontal: 48.0, vertical: 40.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -183,26 +590,30 @@ class DetailScreenSkeleton extends StatelessWidget {
                 // People / Cast row placeholder
                 SkeletonBox(width: 120, height: 24, borderRadius: BorderRadius.circular(6)),
                 const SizedBox(height: 16),
-                Row(
-                  children: List.generate(
-                    6,
-                    (_) => Padding(
-                      padding: const EdgeInsets.only(right: 20.0),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          SkeletonBox(
-                            width: 72,
-                            height: 72,
-                            borderRadius: BorderRadius.circular(36),
-                          ),
-                          const SizedBox(height: 8),
-                          SkeletonBox(
-                            width: 60,
-                            height: 12,
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                        ],
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const ClampingScrollPhysics(),
+                  child: Row(
+                    children: List.generate(
+                      6,
+                      (_) => Padding(
+                        padding: const EdgeInsets.only(right: 20.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SkeletonBox(
+                              width: 72,
+                              height: 72,
+                              borderRadius: BorderRadius.circular(36),
+                            ),
+                            const SizedBox(height: 8),
+                            SkeletonBox(
+                              width: 60,
+                              height: 12,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                   ),

--- a/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
+++ b/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
@@ -1,16 +1,25 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 
 import '../../../preference/preference_constants.dart';
+import '../../../preference/user_preferences.dart';
+import '../../../util/platform_detection.dart';
+import '../top_toolbar.dart';
 import 'skeleton_shimmer.dart';
 
 /// Skeleton placeholder screen displayed while an item detail page is loading.
-/// Supports Classic, Modern, Spotlight, and Nouveau layout structures.
+/// Respects active user preferences (detail style, desktop UI scale, navbar position,
+/// and metadata display settings) so placeholders align with actual content.
 class DetailScreenSkeleton extends StatelessWidget {
   final DetailScreenStyle style;
+  final UserPreferences? prefs;
 
   const DetailScreenSkeleton({
     super.key,
     DetailScreenStyle? style,
+    this.prefs,
     bool? isModern,
   }) : style = style ??
             (isModern != null
@@ -18,6 +27,12 @@ class DetailScreenSkeleton extends StatelessWidget {
                 : DetailScreenStyle.modern);
 
   bool get isModern => style == DetailScreenStyle.modern;
+
+  UserPreferences? get _effectivePrefs =>
+      prefs ??
+      (GetIt.instance.isRegistered<UserPreferences>()
+          ? GetIt.instance<UserPreferences>()
+          : null);
 
   @override
   Widget build(BuildContext context) {
@@ -33,8 +48,13 @@ class DetailScreenSkeleton extends StatelessWidget {
 
   Widget _buildModern(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
-    final topInset = 70.0;
-    final leftPadding = 40.0;
+    final userPrefs = _effectivePrefs;
+    final scale = userPrefs?.get(UserPreferences.desktopUiScale).scaleFactor ?? 1.0;
+    final hasLeftSidebar =
+        userPrefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    final leftPadding = hasLeftSidebar ? 120.0 : 40.0;
+    final baseTopInset = TopToolbar.baseHeightFor(context);
+    final topInset = (baseTopInset - 12) / scale + (10 / scale);
 
     return Stack(
       children: [
@@ -61,72 +81,80 @@ class DetailScreenSkeleton extends StatelessWidget {
         Positioned.fill(
           child: SingleChildScrollView(
             physics: const ClampingScrollPhysics(),
-            padding: EdgeInsets.fromLTRB(leftPadding, topInset + 10, 40, 20),
+            padding: EdgeInsets.fromLTRB(leftPadding, topInset, 40, 20),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 // Logo placeholder (reserved space to eliminate layout shift)
                 SkeletonBox(
-                  width: 240,
-                  height: 64,
+                  width: 240 * scale,
+                  height: 64 * scale,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                const SizedBox(height: 10),
+                SizedBox(height: 10 * scale),
                 // Title placeholder
                 SkeletonBox(
                   width: size.width * 0.35,
-                  height: 40,
+                  height: 40 * scale,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                const SizedBox(height: 12),
+                SizedBox(height: 12 * scale),
                 // Metadata pills
-                Row(
-                  children: [
-                    SkeletonBox(width: 56, height: 20, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 72, height: 20, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 60, height: 20, borderRadius: BorderRadius.circular(4)),
-                  ],
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const ClampingScrollPhysics(),
+                  child: Row(
+                    children: [
+                      SkeletonBox(width: 56 * scale, height: 20 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 72 * scale, height: 20 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 48 * scale, height: 20 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 60 * scale, height: 20 * scale, borderRadius: BorderRadius.circular(4)),
+                    ],
+                  ),
                 ),
-                const SizedBox(height: 14),
+                SizedBox(height: 14 * scale),
                 // Rating badge placeholder
                 SkeletonBox(
-                  width: 52,
-                  height: 24,
+                  width: 52 * scale,
+                  height: 24 * scale,
                   borderRadius: BorderRadius.circular(4),
                 ),
-                const SizedBox(height: 18),
+                SizedBox(height: 18 * scale),
                 // Action buttons row (Play button pill + circular action buttons)
                 Row(
                   children: [
-                    SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    SkeletonBox(width: 120 * scale, height: 46 * scale, borderRadius: BorderRadius.circular(23 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 46 * scale, height: 46 * scale, borderRadius: BorderRadius.circular(23 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 46 * scale, height: 46 * scale, borderRadius: BorderRadius.circular(23 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 46 * scale, height: 46 * scale, borderRadius: BorderRadius.circular(23 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 46 * scale, height: 46 * scale, borderRadius: BorderRadius.circular(23 * scale)),
                   ],
                 ),
-                const SizedBox(height: 28),
+                SizedBox(height: 28 * scale),
                 // Bottom tabs row
-                Row(
-                  children: [
-                    SkeletonBox(width: 90, height: 32, borderRadius: BorderRadius.circular(16)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 70, height: 32, borderRadius: BorderRadius.circular(16)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 70, height: 32, borderRadius: BorderRadius.circular(16)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 85, height: 32, borderRadius: BorderRadius.circular(16)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 75, height: 32, borderRadius: BorderRadius.circular(16)),
-                  ],
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const ClampingScrollPhysics(),
+                  child: Row(
+                    children: [
+                      SkeletonBox(width: 90 * scale, height: 32 * scale, borderRadius: BorderRadius.circular(16 * scale)),
+                      SizedBox(width: 14 * scale),
+                      SkeletonBox(width: 70 * scale, height: 32 * scale, borderRadius: BorderRadius.circular(16 * scale)),
+                      SizedBox(width: 14 * scale),
+                      SkeletonBox(width: 70 * scale, height: 32 * scale, borderRadius: BorderRadius.circular(16 * scale)),
+                      SizedBox(width: 14 * scale),
+                      SkeletonBox(width: 85 * scale, height: 32 * scale, borderRadius: BorderRadius.circular(16 * scale)),
+                      SizedBox(width: 14 * scale),
+                      SkeletonBox(width: 75 * scale, height: 32 * scale, borderRadius: BorderRadius.circular(16 * scale)),
+                    ],
+                  ),
                 ),
               ],
             ),
@@ -139,11 +167,26 @@ class DetailScreenSkeleton extends StatelessWidget {
   Widget _buildSpotlight(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
     final isLandscape = size.width >= size.height;
-    final topInset = isLandscape ? 60.0 : 40.0;
-    final horizontalPadding = isLandscape ? 40.0 : 20.0;
+    final userPrefs = _effectivePrefs;
+    final scale = userPrefs?.get(UserPreferences.desktopUiScale).scaleFactor ?? 1.0;
+    final hasLeftSidebar =
+        userPrefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    final leftPadding = isLandscape ? (hasLeftSidebar ? 120.0 : 40.0) : 20.0;
+    final baseTopInset = TopToolbar.baseHeightFor(context);
+    // Matches SpotlightLandscapeLayout padding calculations
+    final topInset = isLandscape
+        ? (baseTopInset - 12) / scale + (10 / scale)
+        : (size.height * 0.26 + baseTopInset);
+
     final heroWidth = isLandscape
         ? (size.width * 0.85).clamp(450.0, 1100.0)
         : double.infinity;
+    final cardHeight = isLandscape
+        ? math.min(
+            200.0 * scale,
+            math.max(120.0, size.height * 0.28),
+          )
+        : 140.0;
 
     return Stack(
       children: [
@@ -169,9 +212,9 @@ class DetailScreenSkeleton extends StatelessWidget {
           child: SingleChildScrollView(
             physics: const ClampingScrollPhysics(),
             padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
+              leftPadding,
               topInset,
-              horizontalPadding,
+              isLandscape ? 40.0 : 20.0,
               30,
             ),
             child: Column(
@@ -182,104 +225,97 @@ class DetailScreenSkeleton extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      // Tagline placeholder
+                      // Tagline placeholder (e.g. A DOUBLE FEATURE THAT'LL TEAR YOU IN TWO!)
                       SkeletonBox(
-                        width: 140,
-                        height: 14,
-                        borderRadius: BorderRadius.circular(4),
+                        width: 240 * scale,
+                        height: 12 * scale,
+                        borderRadius: BorderRadius.circular(3),
                       ),
-                      const SizedBox(height: 10),
+                      SizedBox(height: 8 * scale),
                       // Title / Logo placeholder
                       SkeletonBox(
-                        width: isLandscape ? 320 : size.width * 0.65,
-                        height: isLandscape ? 64 : 48,
+                        width: isLandscape ? 280 * scale : size.width * 0.65,
+                        height: isLandscape ? 48 * scale : 40 * scale,
                         borderRadius: BorderRadius.circular(8),
                       ),
-                      const SizedBox(height: 12),
-                      // Metadata dot-separated row
+                      SizedBox(height: 8 * scale),
+                      // Metadata row (year · rating · runtime · genres)
+                      SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        physics: const ClampingScrollPhysics(),
+                        child: Row(
+                          children: [
+                            SkeletonBox(width: 40 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 24 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 54 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 140 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                          ],
+                        ),
+                      ),
+                      SizedBox(height: 8 * scale),
+                      // Ratings badges row (IMDb, TMDb, Community, Critic badges)
+                      SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        physics: const ClampingScrollPhysics(),
+                        child: Row(
+                          children: [
+                            SkeletonBox(width: 48 * scale, height: 22 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 44 * scale, height: 22 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 44 * scale, height: 22 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 58 * scale, height: 22 * scale, borderRadius: BorderRadius.circular(4)),
+                            SizedBox(width: 8 * scale),
+                            SkeletonBox(width: 44 * scale, height: 22 * scale, borderRadius: BorderRadius.circular(4)),
+                          ],
+                        ),
+                      ),
+                      SizedBox(height: 16 * scale),
+                      // Action buttons: All 5 actions (including Play) are circular buttons in Spotlight
                       Row(
                         children: [
-                          SkeletonBox(width: 50, height: 18, borderRadius: BorderRadius.circular(4)),
-                          const SizedBox(width: 8),
-                          SkeletonBox(width: 42, height: 18, borderRadius: BorderRadius.circular(4)),
-                          const SizedBox(width: 8),
-                          SkeletonBox(width: 60, height: 18, borderRadius: BorderRadius.circular(4)),
-                          const SizedBox(width: 8),
-                          SkeletonBox(width: 75, height: 18, borderRadius: BorderRadius.circular(4)),
-                        ],
-                      ),
-                      const SizedBox(height: 10),
-                      // Tech badges row
-                      Row(
-                        children: [
-                          SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
-                          const SizedBox(width: 8),
-                          SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
-                          const SizedBox(width: 8),
-                          SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
-                        ],
-                      ),
-                      const SizedBox(height: 14),
-                      // Overview lines
-                      SkeletonBox(
-                        width: isLandscape ? 680 : double.infinity,
-                        height: 14,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      const SizedBox(height: 8),
-                      SkeletonBox(
-                        width: isLandscape ? 620 : size.width * 0.85,
-                        height: 14,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      const SizedBox(height: 8),
-                      SkeletonBox(
-                        width: isLandscape ? 450 : size.width * 0.55,
-                        height: 14,
-                        borderRadius: BorderRadius.circular(4),
-                      ),
-                      const SizedBox(height: 20),
-                      // Action buttons row (Play pill + circular action buttons)
-                      Row(
-                        children: [
-                          SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
-                          const SizedBox(width: 14),
-                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                          const SizedBox(width: 14),
-                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                          const SizedBox(width: 14),
-                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                          const SizedBox(width: 14),
-                          SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                          SkeletonBox(width: 52 * scale, height: 52 * scale, borderRadius: BorderRadius.circular(26 * scale)),
+                          SizedBox(width: 12 * scale),
+                          SkeletonBox(width: 52 * scale, height: 52 * scale, borderRadius: BorderRadius.circular(26 * scale)),
+                          SizedBox(width: 12 * scale),
+                          SkeletonBox(width: 52 * scale, height: 52 * scale, borderRadius: BorderRadius.circular(26 * scale)),
+                          SizedBox(width: 12 * scale),
+                          SkeletonBox(width: 52 * scale, height: 52 * scale, borderRadius: BorderRadius.circular(26 * scale)),
+                          SizedBox(width: 12 * scale),
+                          SkeletonBox(width: 52 * scale, height: 52 * scale, borderRadius: BorderRadius.circular(26 * scale)),
                         ],
                       ),
                     ],
                   ),
                 ),
-                const SizedBox(height: 28),
-                // Bottom Spotlight summary cards band
+                SizedBox(height: 20 / scale),
+                // Bottom Spotlight summary cards band: 3 prominent cards matching Spotlight's layout
                 if (isLandscape)
                   Row(
-                    children: List.generate(4, (index) {
+                    children: List.generate(3, (index) {
                       return Expanded(
                         child: Padding(
-                          padding: EdgeInsets.only(right: index < 3 ? 16.0 : 0.0),
-                          child: _buildSpotlightSummaryCard(),
+                          padding: EdgeInsets.only(right: index < 2 ? 16.0 : 0.0),
+                          child: _buildSpotlightSummaryCard(cardHeight, scale),
                         ),
                       );
                     }),
                   )
                 else
                   SizedBox(
-                    height: 120,
+                    height: cardHeight,
                     child: ListView.separated(
                       scrollDirection: Axis.horizontal,
                       physics: const ClampingScrollPhysics(),
-                      itemCount: 4,
-                      separatorBuilder: (_, _) => const SizedBox(width: 12),
+                      itemCount: 3,
+                      separatorBuilder: (_, _) => const SizedBox(width: 14),
                       itemBuilder: (_, _) => SizedBox(
-                        width: 220,
-                        child: _buildSpotlightSummaryCard(),
+                        width: 260,
+                        child: _buildSpotlightSummaryCard(cardHeight, scale),
                       ),
                     ),
                   ),
@@ -291,10 +327,10 @@ class DetailScreenSkeleton extends StatelessWidget {
     );
   }
 
-  Widget _buildSpotlightSummaryCard() {
+  Widget _buildSpotlightSummaryCard(double height, double scale) {
     return Container(
-      height: 135,
-      padding: const EdgeInsets.all(14),
+      height: height,
+      padding: EdgeInsets.all(16 * scale),
       decoration: BoxDecoration(
         color: Colors.white.withAlpha(12),
         borderRadius: BorderRadius.circular(12),
@@ -307,27 +343,38 @@ class DetailScreenSkeleton extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Align(
-            alignment: Alignment.topRight,
-            child: SkeletonBox(
-              width: 22,
-              height: 22,
-              borderRadius: BorderRadius.circular(6),
-            ),
+          // Top icon placeholder
+          SkeletonBox(
+            width: 22 * scale,
+            height: 22 * scale,
+            borderRadius: BorderRadius.circular(6),
           ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          // Bottom title, subtitle, and trailing arrow
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              SkeletonBox(
-                width: 80,
-                height: 14,
-                borderRadius: BorderRadius.circular(4),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SkeletonBox(
+                    width: 120 * scale,
+                    height: 14 * scale,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  SizedBox(height: 6 * scale),
+                  SkeletonBox(
+                    width: 70 * scale,
+                    height: 10 * scale,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                ],
               ),
-              const SizedBox(height: 6),
               SkeletonBox(
-                width: 50,
-                height: 10,
-                borderRadius: BorderRadius.circular(3),
+                width: 14 * scale,
+                height: 14 * scale,
+                borderRadius: BorderRadius.circular(4),
               ),
             ],
           ),
@@ -339,8 +386,32 @@ class DetailScreenSkeleton extends StatelessWidget {
   Widget _buildNouveau(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
     final isLandscape = size.width >= size.height;
-    final topInset = isLandscape ? 60.0 : 40.0;
-    final horizontalPadding = isLandscape ? 56.0 : 20.0;
+    final userPrefs = _effectivePrefs;
+    final navbarIsTop =
+        userPrefs?.get(UserPreferences.navbarPosition) != NavbarPosition.left;
+
+    final safePadding = MediaQuery.paddingOf(context);
+    final scale = (size.width / 1920.0).clamp(0.90, 1.08);
+
+    // Exact formula from NouveauDetailContent._nouveauLandscapeContentInsets()
+    final heroTop = navbarIsTop
+        ? (212.0 * scale).clamp(190.0, 232.0)
+        : (152.0 * scale).clamp(136.0, 166.0);
+
+    final horizontalInset = PlatformDetection.isTV
+        ? 56.0
+        : (size.width * 0.046).clamp(56.0, 96.0);
+
+    final horizontalSafePadding = PlatformDetection.isTV
+        ? EdgeInsets.zero
+        : safePadding;
+
+    final leftPadding = isLandscape
+        ? (horizontalInset + horizontalSafePadding.left)
+        : 20.0;
+    final topPadding = isLandscape
+        ? (heroTop + safePadding.top)
+        : (safePadding.top + 80);
 
     return Stack(
       children: [
@@ -368,154 +439,90 @@ class DetailScreenSkeleton extends StatelessWidget {
           child: SingleChildScrollView(
             physics: const ClampingScrollPhysics(),
             padding: EdgeInsets.fromLTRB(
-              horizontalPadding,
-              topInset,
-              horizontalPadding,
+              leftPadding,
+              topPadding,
+              isLandscape ? (horizontalInset + horizontalSafePadding.right) : 20.0,
               40,
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // Top genres text placeholder
+                // Top genres text placeholder (e.g. THRILLER · ACTION & ADVENTURE · HORROR)
                 SkeletonBox(
-                  width: 160,
-                  height: 13,
+                  width: 200 * scale,
+                  height: 12 * scale,
                   borderRadius: BorderRadius.circular(3),
                 ),
-                const SizedBox(height: 14),
-                // Title / Logo
+                SizedBox(height: 16 * scale),
+                // Title / Logo (e.g. GRINDHOUSE)
                 SkeletonBox(
-                  width: isLandscape ? 320 : size.width * 0.7,
-                  height: isLandscape ? 64 : 48,
+                  width: isLandscape ? 280 * scale : size.width * 0.7,
+                  height: isLandscape ? 48 * scale : 40 * scale,
                   borderRadius: BorderRadius.circular(8),
                 ),
-                const SizedBox(height: 16),
-                // Badges row: Status badge + Seerr pill
+                SizedBox(height: 14 * scale),
+                // Metadata row (e.g. 2007 · R · 3h 11m · 7.0 · 84%)
+                SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  physics: const ClampingScrollPhysics(),
+                  child: Row(
+                    children: [
+                      SkeletonBox(width: 42 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 24 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 56 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 48 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                      SizedBox(width: 8 * scale),
+                      SkeletonBox(width: 42 * scale, height: 16 * scale, borderRadius: BorderRadius.circular(4)),
+                    ],
+                  ),
+                ),
+                SizedBox(height: 20 * scale),
+                // Action buttons row: Play button pill + circular buttons
                 Row(
                   children: [
-                    SkeletonBox(width: 64, height: 22, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 76, height: 22, borderRadius: BorderRadius.circular(4)),
+                    SkeletonBox(width: 110 * scale, height: 48 * scale, borderRadius: BorderRadius.circular(24 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 48 * scale, height: 48 * scale, borderRadius: BorderRadius.circular(24 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 48 * scale, height: 48 * scale, borderRadius: BorderRadius.circular(24 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 48 * scale, height: 48 * scale, borderRadius: BorderRadius.circular(24 * scale)),
+                    SizedBox(width: 14 * scale),
+                    SkeletonBox(width: 48 * scale, height: 48 * scale, borderRadius: BorderRadius.circular(24 * scale)),
                   ],
                 ),
-                const SizedBox(height: 12),
-                // Metadata row
-                Row(
-                  children: [
-                    SkeletonBox(width: 52, height: 18, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 44, height: 18, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 64, height: 18, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 70, height: 18, borderRadius: BorderRadius.circular(4)),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                // Technical details badges
-                Row(
-                  children: [
-                    SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
-                    const SizedBox(width: 8),
-                    SkeletonBox(width: 44, height: 20, borderRadius: BorderRadius.circular(4)),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                // Overview description (3 lines)
+                SizedBox(height: 36 * scale),
+                // Stacked Section: Section header (e.g. "Chapters" / "Episodes")
                 SkeletonBox(
-                  width: isLandscape ? 700 : double.infinity,
-                  height: 14,
+                  width: 90 * scale,
+                  height: 20 * scale,
                   borderRadius: BorderRadius.circular(4),
                 ),
-                const SizedBox(height: 8),
-                SkeletonBox(
-                  width: isLandscape ? 640 : size.width * 0.85,
-                  height: 14,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                const SizedBox(height: 8),
-                SkeletonBox(
-                  width: isLandscape ? 460 : size.width * 0.55,
-                  height: 14,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                const SizedBox(height: 22),
-                // Action buttons row (Play pill + circular buttons)
-                Row(
-                  children: [
-                    SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                    const SizedBox(width: 14),
-                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
-                  ],
-                ),
-                const SizedBox(height: 36),
-                // Stacked Section 1: Episodes / Media row
-                SkeletonBox(
-                  width: 140,
-                  height: 22,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                const SizedBox(height: 14),
+                SizedBox(height: 16 * scale),
+                // Horizontal 16:9 chapter/episode thumbnail cards with title and timestamp underneath
                 SizedBox(
-                  height: 150,
+                  height: 180 * scale,
                   child: ListView.separated(
                     scrollDirection: Axis.horizontal,
                     physics: const ClampingScrollPhysics(),
-                    itemCount: 6,
-                    separatorBuilder: (_, _) => const SizedBox(width: 14),
+                    itemCount: 5,
+                    separatorBuilder: (_, _) => SizedBox(width: 16 * scale),
                     itemBuilder: (_, _) => Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         SkeletonBox(
-                          width: 200,
-                          height: 116,
-                          borderRadius: BorderRadius.circular(8),
+                          width: 240 * scale,
+                          height: 135 * scale,
+                          borderRadius: BorderRadius.circular(10),
                         ),
-                        const SizedBox(height: 8),
+                        SizedBox(height: 8 * scale),
                         SkeletonBox(
-                          width: 120,
-                          height: 12,
+                          width: 140 * scale,
+                          height: 12 * scale,
                           borderRadius: BorderRadius.circular(4),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 28),
-                // Stacked Section 2: Cast & Crew
-                SkeletonBox(
-                  width: 120,
-                  height: 22,
-                  borderRadius: BorderRadius.circular(4),
-                ),
-                const SizedBox(height: 14),
-                SizedBox(
-                  height: 96,
-                  child: ListView.separated(
-                    scrollDirection: Axis.horizontal,
-                    physics: const ClampingScrollPhysics(),
-                    itemCount: 8,
-                    separatorBuilder: (_, _) => const SizedBox(width: 18),
-                    itemBuilder: (_, _) => Column(
-                      children: [
-                        SkeletonBox(
-                          width: 64,
-                          height: 64,
-                          borderRadius: BorderRadius.circular(32),
-                        ),
-                        const SizedBox(height: 8),
-                        SkeletonBox(
-                          width: 54,
-                          height: 10,
-                          borderRadius: BorderRadius.circular(3),
                         ),
                       ],
                     ),
@@ -531,9 +538,14 @@ class DetailScreenSkeleton extends StatelessWidget {
 
   Widget _buildClassic(BuildContext context) {
     final size = MediaQuery.sizeOf(context);
+    final userPrefs = _effectivePrefs;
+    final hasLeftSidebar =
+        userPrefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    final leftPadding = hasLeftSidebar ? 120.0 : 48.0;
+
     return SingleChildScrollView(
       physics: const ClampingScrollPhysics(),
-      padding: const EdgeInsets.symmetric(horizontal: 48.0, vertical: 40.0),
+      padding: EdgeInsets.symmetric(horizontal: leftPadding, vertical: 40.0),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
+++ b/lib/ui/widgets/skeleton/skeleton_detail_screen.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+
+import 'skeleton_shimmer.dart';
+
+/// Skeleton placeholder screen displayed while an item detail page is loading.
+/// Supports both Modern and Classic layout structures.
+class DetailScreenSkeleton extends StatelessWidget {
+  final bool isModern;
+
+  const DetailScreenSkeleton({
+    super.key,
+    required this.isModern,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: isModern ? _buildModern(context) : _buildClassic(context),
+    );
+  }
+
+  Widget _buildModern(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    final topInset = 70.0;
+    final leftPadding = 40.0;
+
+    return Stack(
+      children: [
+        // Hero backdrop placeholder
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          height: size.height * 0.55,
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors: [
+                  Colors.white.withAlpha(25),
+                  Colors.transparent,
+                ],
+              ),
+            ),
+          ),
+        ),
+        // Content
+        Positioned.fill(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(leftPadding, topInset + 10, 40, 0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Logo placeholder (reserved space to eliminate layout shift)
+                SkeletonBox(
+                  width: 240,
+                  height: 64,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                const SizedBox(height: 10),
+                // Title placeholder
+                SkeletonBox(
+                  width: size.width * 0.35,
+                  height: 40,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                const SizedBox(height: 12),
+                // Metadata pills
+                Row(
+                  children: [
+                    SkeletonBox(width: 56, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 72, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 48, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 8),
+                    SkeletonBox(width: 60, height: 20, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+                const SizedBox(height: 14),
+                // Rating badge placeholder
+                SkeletonBox(
+                  width: 52,
+                  height: 24,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 18),
+                // Action buttons row (Play button pill + circular action buttons)
+                Row(
+                  children: [
+                    SkeletonBox(width: 120, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 46, height: 46, borderRadius: BorderRadius.circular(23)),
+                  ],
+                ),
+                const SizedBox(height: 28),
+                // Bottom tabs row
+                Row(
+                  children: [
+                    SkeletonBox(width: 90, height: 32, borderRadius: BorderRadius.circular(16)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 70, height: 32, borderRadius: BorderRadius.circular(16)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 70, height: 32, borderRadius: BorderRadius.circular(16)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 85, height: 32, borderRadius: BorderRadius.circular(16)),
+                    const SizedBox(width: 14),
+                    SkeletonBox(width: 75, height: 32, borderRadius: BorderRadius.circular(16)),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildClassic(BuildContext context) {
+    final size = MediaQuery.sizeOf(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 48.0, vertical: 40.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Left Poster card
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SkeletonBox(
+                width: 240,
+                height: 360,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              const SizedBox(height: 20),
+              SkeletonBox(
+                width: 240,
+                height: 48,
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ],
+          ),
+          const SizedBox(width: 48),
+          // Right metadata
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 16),
+                // Title
+                SkeletonBox(
+                  width: size.width * 0.45,
+                  height: 40,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                const SizedBox(height: 16),
+                // Subtitle / tags
+                Row(
+                  children: [
+                    SkeletonBox(width: 60, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 12),
+                    SkeletonBox(width: 80, height: 20, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(width: 12),
+                    SkeletonBox(width: 50, height: 20, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+                const SizedBox(height: 28),
+                // Overview paragraph
+                SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.circular(4)),
+                const SizedBox(height: 10),
+                SkeletonBox(width: double.infinity, height: 14, borderRadius: BorderRadius.circular(4)),
+                const SizedBox(height: 10),
+                SkeletonBox(width: size.width * 0.4, height: 14, borderRadius: BorderRadius.circular(4)),
+                const SizedBox(height: 40),
+                // People / Cast row placeholder
+                SkeletonBox(width: 120, height: 24, borderRadius: BorderRadius.circular(6)),
+                const SizedBox(height: 16),
+                Row(
+                  children: List.generate(
+                    6,
+                    (_) => Padding(
+                      padding: const EdgeInsets.only(right: 20.0),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          SkeletonBox(
+                            width: 72,
+                            height: 72,
+                            borderRadius: BorderRadius.circular(36),
+                          ),
+                          const SizedBox(height: 8),
+                          SkeletonBox(
+                            width: 60,
+                            height: 12,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/skeleton/skeleton_home_row.dart
+++ b/lib/ui/widgets/skeleton/skeleton_home_row.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'skeleton_shimmer.dart';
+
+/// Renders a row of skeleton card placeholders while home sections are fetching.
+class SkeletonHomeRow extends StatelessWidget {
+  final double cardWidth;
+  final double imageHeight;
+  final double itemSpacing;
+  final double leadingPadding;
+  final bool isModern;
+  final int count;
+
+  const SkeletonHomeRow({
+    super.key,
+    required this.cardWidth,
+    required this.imageHeight,
+    this.itemSpacing = 16.0,
+    this.leadingPadding = 16.0,
+    this.isModern = false,
+    this.count = 8,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SkeletonShimmer(
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.only(left: leadingPadding, right: 20),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: List.generate(count, (index) {
+            return Padding(
+              padding: EdgeInsets.only(right: itemSpacing),
+              child: SizedBox(
+                width: cardWidth,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    SkeletonBox(
+                      width: cardWidth,
+                      height: imageHeight,
+                      borderRadius: BorderRadius.circular(isModern ? 12 : 8),
+                    ),
+                    const SizedBox(height: 8),
+                    SkeletonBox(
+                      width: cardWidth * 0.75,
+                      height: 14,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    if (isModern) ...[
+                      const SizedBox(height: 6),
+                      SkeletonBox(
+                        width: cardWidth * 0.5,
+                        height: 11,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            );
+          }),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/skeleton/skeleton_library_grid.dart
+++ b/lib/ui/widgets/skeleton/skeleton_library_grid.dart
@@ -75,7 +75,10 @@ class SkeletonLibraryGrid extends StatelessWidget {
             : null;
         final hasLeftSidebar = prefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
         final horizontalPadding = hasLeftSidebar ? 120.0 : 40.0;
-        final targetWidth = cardWidth ?? 150.0;
+        final scale = (prefs?.get(UserPreferences.desktopUiScale) ?? DesktopUiScale.medium).scaleFactor;
+        final posterSize = prefs?.get(UserPreferences.posterSize) ?? PosterSize.medium;
+        final defaultWidth = (posterSize.portraitHeight * aspectRatio) * scale;
+        final targetWidth = cardWidth ?? defaultWidth;
         const spacing = 16.0;
 
         final crossAxisCount = ((constraints.maxWidth - horizontalPadding * 2 + spacing) /
@@ -141,7 +144,10 @@ class SkeletonLibraryGrid extends StatelessWidget {
             : null;
         final hasLeftSidebar = prefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
         final horizontalPadding = hasLeftSidebar ? 120.0 : 40.0;
-        final targetWidth = cardWidth ?? 150.0;
+        final scale = (prefs?.get(UserPreferences.desktopUiScale) ?? DesktopUiScale.medium).scaleFactor;
+        final posterSize = prefs?.get(UserPreferences.posterSize) ?? PosterSize.medium;
+        final defaultWidth = (posterSize.portraitHeight * aspectRatio) * scale;
+        final targetWidth = cardWidth ?? defaultWidth;
         final imageHeight = targetWidth / aspectRatio;
 
         return ListView.builder(

--- a/lib/ui/widgets/skeleton/skeleton_library_grid.dart
+++ b/lib/ui/widgets/skeleton/skeleton_library_grid.dart
@@ -1,0 +1,190 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../preference/preference_constants.dart';
+import '../../../preference/user_preferences.dart';
+import 'skeleton_shimmer.dart';
+
+/// Skeleton placeholder grid displayed while a media library or collection is loading.
+class SkeletonLibraryGrid extends StatelessWidget {
+  final double? cardWidth;
+  final double aspectRatio;
+  final int itemCount;
+  final bool isSongs;
+  final bool isHorizontal;
+
+  const SkeletonLibraryGrid({
+    super.key,
+    this.cardWidth,
+    this.aspectRatio = 2 / 3,
+    this.itemCount = 20,
+    this.isSongs = false,
+    this.isHorizontal = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final content = isSongs
+        ? _buildSongsSkeleton(context)
+        : (isHorizontal ? _buildHorizontalSkeleton(context) : _buildVerticalSkeleton(context));
+    return SkeletonShimmer(child: content);
+  }
+
+  Widget _buildSongsSkeleton(BuildContext context) {
+    final prefs = GetIt.instance.isRegistered<UserPreferences>()
+        ? GetIt.instance<UserPreferences>()
+        : null;
+    final hasLeftSidebar = prefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+    final hPad = hasLeftSidebar ? 120.0 : 40.0;
+
+    return ListView.builder(
+      padding: EdgeInsets.fromLTRB(hPad, 8, hPad, 32),
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: 14,
+      itemBuilder: (context, index) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 6),
+          child: Row(
+            children: [
+              SkeletonBox(width: 44, height: 44, borderRadius: BorderRadius.circular(6)),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SkeletonBox(width: 220, height: 14, borderRadius: BorderRadius.circular(4)),
+                    const SizedBox(height: 6),
+                    SkeletonBox(width: 140, height: 12, borderRadius: BorderRadius.circular(4)),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+              SkeletonBox(width: 50, height: 12, borderRadius: BorderRadius.circular(4)),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildVerticalSkeleton(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final prefs = GetIt.instance.isRegistered<UserPreferences>()
+            ? GetIt.instance<UserPreferences>()
+            : null;
+        final hasLeftSidebar = prefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+        final horizontalPadding = hasLeftSidebar ? 120.0 : 40.0;
+        final targetWidth = cardWidth ?? 150.0;
+        const spacing = 16.0;
+
+        final crossAxisCount = ((constraints.maxWidth - horizontalPadding * 2 + spacing) /
+                (targetWidth + spacing))
+            .floor()
+            .clamp(2, 20);
+
+        final cellWidth = (constraints.maxWidth -
+                horizontalPadding * 2 -
+                (crossAxisCount - 1) * spacing) /
+            crossAxisCount;
+        final imageHeight = cellWidth / aspectRatio;
+        const textHeight = 36.0;
+        final cellHeight = imageHeight + textHeight;
+        final childAspectRatio = cellWidth / cellHeight;
+
+        return GridView.builder(
+          padding: EdgeInsets.fromLTRB(horizontalPadding, 16, horizontalPadding, 32),
+          physics: const NeverScrollableScrollPhysics(),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            mainAxisSpacing: spacing,
+            crossAxisSpacing: spacing,
+            childAspectRatio: childAspectRatio,
+          ),
+          itemCount: itemCount,
+          itemBuilder: (context, index) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: SkeletonBox(
+                    width: double.infinity,
+                    height: double.infinity,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SkeletonBox(
+                  width: cellWidth * 0.75,
+                  height: 14,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                const SizedBox(height: 4),
+                SkeletonBox(
+                  width: cellWidth * 0.45,
+                  height: 12,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildHorizontalSkeleton(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final prefs = GetIt.instance.isRegistered<UserPreferences>()
+            ? GetIt.instance<UserPreferences>()
+            : null;
+        final hasLeftSidebar = prefs?.get(UserPreferences.navbarPosition) == NavbarPosition.left;
+        final horizontalPadding = hasLeftSidebar ? 120.0 : 40.0;
+        final targetWidth = cardWidth ?? 150.0;
+        final imageHeight = targetWidth / aspectRatio;
+
+        return ListView.builder(
+          padding: EdgeInsets.fromLTRB(horizontalPadding, 16, horizontalPadding, 32),
+          scrollDirection: Axis.horizontal,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: 10,
+          itemBuilder: (context, index) {
+            return Padding(
+              padding: const EdgeInsets.only(right: 16),
+              child: SizedBox(
+                width: targetWidth,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      width: targetWidth,
+                      height: imageHeight,
+                      child: SkeletonBox(
+                        width: double.infinity,
+                        height: double.infinity,
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    SkeletonBox(
+                      width: targetWidth * 0.75,
+                      height: 14,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    const SizedBox(height: 4),
+                    SkeletonBox(
+                      width: targetWidth * 0.45,
+                      height: 12,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/ui/widgets/skeleton/skeleton_music_browse.dart
+++ b/lib/ui/widgets/skeleton/skeleton_music_browse.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+
+import '../../../util/platform_detection.dart';
+import 'skeleton_shimmer.dart';
+
+/// Skeleton placeholder screen for the music / audio browse landing page.
+class SkeletonMusicBrowse extends StatelessWidget {
+  const SkeletonMusicBrowse({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final isMobile = PlatformDetection.useMobileUi;
+    final isDesktop = PlatformDetection.useDesktopUi;
+    final isTV = PlatformDetection.isTV;
+
+    final horizontalPadding = isMobile ? 20.0 : 60.0;
+    final cardSize = isMobile ? 112.0 : (isTV ? 168.0 : 148.0);
+    const cardSpacing = 12.0;
+    final heroHeight = isMobile ? 108.0 : (isTV ? 220.0 : 168.0);
+
+    return SkeletonShimmer(
+      child: ListView(
+        padding: const EdgeInsets.only(top: 24, bottom: 120),
+        physics: const NeverScrollableScrollPhysics(),
+      children: [
+        // 1. Hero banner placeholder
+        Padding(
+          padding: EdgeInsets.fromLTRB(
+            horizontalPadding,
+            isMobile ? 4 : 8,
+            horizontalPadding,
+            isMobile ? 8 : 12,
+          ),
+          child: Container(
+            height: heroHeight,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Colors.white.withAlpha(15),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Row(
+              children: [
+                SkeletonBox(
+                  width: heroHeight - 32,
+                  height: heroHeight - 32,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                const SizedBox(width: 20),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SkeletonBox(
+                        width: 220,
+                        height: 22,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 10),
+                      SkeletonBox(
+                        width: 140,
+                        height: 14,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      const SizedBox(height: 8),
+                      SkeletonBox(
+                        width: 80,
+                        height: 12,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // 2. Category chips bar (mobile/TV)
+        if (!isDesktop)
+          SizedBox(
+            height: 56,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              physics: const NeverScrollableScrollPhysics(),
+              padding: EdgeInsets.fromLTRB(horizontalPadding, 6, horizontalPadding, 8),
+              itemCount: 5,
+              separatorBuilder: (_, _) => const SizedBox(width: 10),
+              itemBuilder: (context, index) => SkeletonBox(
+                width: 96,
+                height: 38,
+                borderRadius: BorderRadius.circular(20),
+              ),
+            ),
+          ),
+
+        // 3. Music rows (horizontal strips of square cards)
+        for (int r = 0; r < 3; r++) ...[
+          Padding(
+            padding: EdgeInsets.fromLTRB(
+              horizontalPadding,
+              16,
+              horizontalPadding,
+              8,
+            ),
+            child: SkeletonBox(
+              width: 140.0 + (r * 20),
+              height: 18,
+              borderRadius: BorderRadius.circular(4),
+            ),
+          ),
+          SizedBox(
+            height: cardSize + 72,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              physics: const NeverScrollableScrollPhysics(),
+              padding: EdgeInsets.fromLTRB(horizontalPadding, 6, horizontalPadding, 12),
+              itemCount: 8,
+              separatorBuilder: (_, _) => const SizedBox(width: cardSpacing),
+              itemBuilder: (context, index) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  SkeletonBox(
+                    width: cardSize,
+                    height: cardSize,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  const SizedBox(height: 8),
+                  SkeletonBox(
+                    width: cardSize * 0.75,
+                    height: 14,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  const SizedBox(height: 6),
+                  SkeletonBox(
+                    width: cardSize * 0.5,
+                    height: 11,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ],
+    ),
+  );
+}
+}

--- a/lib/ui/widgets/skeleton/skeleton_shimmer.dart
+++ b/lib/ui/widgets/skeleton/skeleton_shimmer.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+/// Shimmer / breathing opacity wrapper for skeleton placeholder UI elements.
+class SkeletonShimmer extends StatefulWidget {
+  final Widget child;
+
+  const SkeletonShimmer({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  State<SkeletonShimmer> createState() => _SkeletonShimmerState();
+}
+
+class _SkeletonShimmerState extends State<SkeletonShimmer>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1300),
+    )..repeat(reverse: true);
+    _animation = Tween<double>(begin: 0.45, end: 1.0).animate(
+      CurvedAnimation(
+        parent: _controller,
+        curve: Curves.easeInOut,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _animation,
+      child: widget.child,
+    );
+  }
+}
+
+/// A standard rounded placeholder box styled for skeleton loading layouts.
+class SkeletonBox extends StatelessWidget {
+  final double? width;
+  final double? height;
+  final BorderRadiusGeometry? borderRadius;
+  final Color? color;
+
+  const SkeletonBox({
+    super.key,
+    this.width,
+    this.height,
+    this.borderRadius,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveRadius = borderRadius ?? BorderRadius.circular(8);
+    final onSurface = Theme.of(context).colorScheme.onSurface;
+    final baseColor = color ??
+        (ThemeRegistry.active.isGlass
+            ? Colors.white.withValues(alpha: 0.16)
+            : onSurface.withValues(alpha: 0.14));
+
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: baseColor,
+        borderRadius: effectiveRadius,
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/skeleton/skeleton_shimmer.dart
+++ b/lib/ui/widgets/skeleton/skeleton_shimmer.dart
@@ -1,8 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+class _ShimmerScope extends InheritedWidget {
+  const _ShimmerScope({required super.child});
+
+  @override
+  bool updateShouldNotify(_ShimmerScope oldWidget) => false;
+}
+
 /// Shimmer / breathing opacity wrapper for skeleton placeholder UI elements.
-class SkeletonShimmer extends StatefulWidget {
+///
+/// A screen usually wraps its whole skeleton, and the pieces it is built from
+/// wrap themselves so they still breathe when used alone. Nesting two of these
+/// multiplies their opacities and lets the two animations drift apart, so the
+/// inner one passes its child straight through.
+class SkeletonShimmer extends StatelessWidget {
   final Widget child;
 
   const SkeletonShimmer({
@@ -11,10 +23,24 @@ class SkeletonShimmer extends StatefulWidget {
   });
 
   @override
-  State<SkeletonShimmer> createState() => _SkeletonShimmerState();
+  Widget build(BuildContext context) {
+    if (context.getInheritedWidgetOfExactType<_ShimmerScope>() != null) {
+      return child;
+    }
+    return _ShimmerScope(child: _ShimmerAnimation(child: child));
+  }
 }
 
-class _SkeletonShimmerState extends State<SkeletonShimmer>
+class _ShimmerAnimation extends StatefulWidget {
+  final Widget child;
+
+  const _ShimmerAnimation({required this.child});
+
+  @override
+  State<_ShimmerAnimation> createState() => _ShimmerAnimationState();
+}
+
+class _ShimmerAnimationState extends State<_ShimmerAnimation>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _animation;

--- a/test/skeleton/skeleton_widgets_test.dart
+++ b/test/skeleton/skeleton_widgets_test.dart
@@ -160,5 +160,41 @@ void main() {
       expect(find.byType(SkeletonMusicBrowse), findsOneWidget);
       expect(find.byType(SkeletonBox), findsWidgets);
     });
+
+    // MaterialApp draws fade transitions of its own for the route, so these
+    // count only the ones inside the shimmer.
+    Finder shimmerFades() => find.descendant(
+      of: find.byType(SkeletonShimmer).first,
+      matching: find.byType(FadeTransition),
+    );
+
+    testWidgets('a shimmer on its own breathes', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonShimmer(child: SkeletonBox(width: 10, height: 10)),
+          ),
+        ),
+      );
+
+      expect(shimmerFades(), findsOneWidget);
+    });
+
+    testWidgets('a nested shimmer stands aside', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonShimmer(
+              child: SkeletonShimmer(
+                child: SkeletonBox(width: 10, height: 10),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(shimmerFades(), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsOneWidget);
+    });
   });
 }

--- a/test/skeleton/skeleton_widgets_test.dart
+++ b/test/skeleton/skeleton_widgets_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/preference/preference_constants.dart';
 import 'package:moonfin/ui/widgets/skeleton/skeleton_detail_screen.dart';
 import 'package:moonfin/ui/widgets/skeleton/skeleton_home_row.dart';
 import 'package:moonfin/ui/widgets/skeleton/skeleton_library_grid.dart';
@@ -50,15 +51,59 @@ void main() {
       expect(find.byType(SkeletonBox), findsWidgets);
     });
 
-    testWidgets('DetailScreenSkeleton renders without overflow', (tester) async {
+    testWidgets('DetailScreenSkeleton renders all variants without overflow', (tester) async {
+      // 1. Classic layout
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: DetailScreenSkeleton(isModern: true),
+            body: DetailScreenSkeleton(style: DetailScreenStyle.classic),
           ),
         ),
       );
+      expect(find.byType(DetailScreenSkeleton), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
 
+      // 2. Modern layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DetailScreenSkeleton(style: DetailScreenStyle.modern),
+          ),
+        ),
+      );
+      expect(find.byType(DetailScreenSkeleton), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+
+      // 3. Spotlight layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DetailScreenSkeleton(style: DetailScreenStyle.spotlight),
+          ),
+        ),
+      );
+      expect(find.byType(DetailScreenSkeleton), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+
+      // 4. Nouveau layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DetailScreenSkeleton(style: DetailScreenStyle.nouveau),
+          ),
+        ),
+      );
+      expect(find.byType(DetailScreenSkeleton), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+
+      // 5. Legacy backward compatibility (isModern flag)
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DetailScreenSkeleton(isModern: false),
+          ),
+        ),
+      );
       expect(find.byType(DetailScreenSkeleton), findsOneWidget);
       expect(find.byType(SkeletonBox), findsWidgets);
     });

--- a/test/skeleton/skeleton_widgets_test.dart
+++ b/test/skeleton/skeleton_widgets_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_detail_screen.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_home_row.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_library_grid.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_music_browse.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_shimmer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Skeleton UI Widgets', () {
+    testWidgets('SkeletonHomeRow renders both classic and modern variants', (tester) async {
+      // 1. Classic layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonHomeRow(
+              cardWidth: 150,
+              imageHeight: 225,
+              leadingPadding: 16,
+              itemSpacing: 14,
+              isModern: false,
+              count: 6,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SkeletonHomeRow), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+
+      // 2. Modern layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonHomeRow(
+              cardWidth: 260,
+              imageHeight: 390,
+              leadingPadding: 32,
+              itemSpacing: 18,
+              isModern: true,
+              count: 6,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SkeletonHomeRow), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+    });
+
+    testWidgets('DetailScreenSkeleton renders without overflow', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DetailScreenSkeleton(isModern: true),
+          ),
+        ),
+      );
+
+      expect(find.byType(DetailScreenSkeleton), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+    });
+
+    testWidgets('SkeletonLibraryGrid renders vertical, horizontal, and song layouts without overflow', (tester) async {
+      // 1. Vertical grid layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLibraryGrid(
+              cardWidth: 150,
+              aspectRatio: 2 / 3,
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(SkeletonLibraryGrid), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+
+      // 2. Horizontal row layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLibraryGrid(
+              isHorizontal: true,
+              cardWidth: 150,
+              aspectRatio: 2 / 3,
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(SkeletonLibraryGrid), findsOneWidget);
+
+      // 3. Audio/Songs list layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonLibraryGrid(
+              isSongs: true,
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(SkeletonLibraryGrid), findsOneWidget);
+
+      // 4. Music browse landing page layout
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: SkeletonMusicBrowse(),
+          ),
+        ),
+      );
+      expect(find.byType(SkeletonMusicBrowse), findsOneWidget);
+      expect(find.byType(SkeletonBox), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Implements smooth skeleton loading placeholders across Moonfin-Core to eliminate abrupt empty content jumps and layout shifts during initial data fetches, tab changes, and route transitions. Replaces blank loading states and isolated spinners with breathing shimmer placeholders matching exact card/row geometry, and fixes the modern media details layout shift caused by dynamic logo sizing. Note: This PR is separate but related to the upcoming animation-focused PR - specifically, there is a new settings that adjusts the "fade" duration between page transitions. The longer the fade, the less the user will see the skeletons (and vice versa).

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

### Skeleton Component Primitives
- Added **skeleton_box.dart** and **skeleton_shimmer.dart** providing animated breathing opacity gradients aligned with Moonfin's dark surface colors.
- Added **skeleton_home_row.dart** supporting both classic and modern V2 card aspect ratios and heights.
- Added **skeleton_library_grid.dart** supporting vertical poster grids, horizontal episode/season rows, and song list layouts.
- Added **detail_screen_skeleton.dart** matching media detail action buttons, backdrop, summary blocks, and carousel cards.
- Added **skeleton_music_browse.dart** for music artist, album, and track placeholder grids.

### Screen Integrations
- **home_screen.dart**: Integrated multi-row skeleton layout during initial app startup and skeleton placeholders for dynamically loading row sections.
- **library_screen.dart**, **favorite_items_screen.dart**, **folder_browse_screen.dart**, **genre_list_screen.dart**, **all_genres_screen.dart**, **music_browse_screen.dart**, **books_browse_screen.dart**: Replaced blank loading screens with adaptive skeleton grids.
- **search_screen.dart**: Integrated skeleton grid for asynchronous search queries.
- **author_details_screen.dart** & **detail_screen.dart**: Added skeleton placeholders while item metadata loads.
- **seerr_browse_screen.dart**, **seerr_details_screen.dart**, **seerr_search_screen.dart**: Added skeleton loaders for seerr discovery and detail pages.
- **home_sections_screen.dart**: Embedded row skeletons in section reordering previews.

### Layout Shift Stabilization
- **detail_screen.dart**: Stabilized the modern media details screen by reserving a dedicated fixed-height container for the series/movie clearart logo slot. Prevents metadata and action buttons from jumping vertically when the image finishes loading.

### Testing
- Added comprehensive widget test suite in **skeleton_widgets_test.dart** validating classic/modern home rows, detail screen skeletons, and library grids across aspect ratios.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch application on Windows / Android / TV client.
2. Observe home screen during initial server metadata fetch: verified smooth breathing skeleton placeholders render with correct card dimensions before populating with library rows.
3. Navigate to Movies, TV Shows, Music, Books, and Collections libraries: verified library grid skeletons match view aspect ratios and eliminate empty-state flashing.
4. Navigate to a series/movie details page: verified detail skeleton placeholder smoothly transitions into content with zero vertical jump when the series logo loads.
5. Executed `flutter test test/skeleton/skeleton_widgets_test.dart` and `dart analyze lib test`: all tests pass with zero warnings or errors.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Previous Structure - Black screen, layout not protected.

On a library:

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-11_11-01-40" src="https://github.com/user-attachments/assets/05720b0d-adaa-4b85-94ea-227f213ce1a6" />

On a Show Page (key note is the vertical displacement after the logo shows up):

<img width="2112" height="1421" alt="2026-09-11_10-39-35_PotPlayer64" src="https://github.com/user-attachments/assets/c5774d6b-939c-49da-9d67-478597263901" />

<img width="2112" height="1421" alt="2026-09-11_10-39-46_PotPlayer64" src="https://github.com/user-attachments/assets/58be50c1-8776-4289-a7bd-4b3993232f3a" />

### Skeletons Applied

Loading a Library:

https://github.com/user-attachments/assets/a1312d02-97ae-4f65-919b-93ef1171d7c7

Loading a Details Page:

https://github.com/user-attachments/assets/8b309b22-0d5c-4809-90b0-339a48ab984b

Loading the Music Library (slowest library on my server):

https://github.com/user-attachments/assets/73e714b8-7b84-4156-a1f2-53ff0f521644

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
