### PR TITLE
feat-ui - Tab Stabilization for the Modern Detail Screen

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -264,11 +264,28 @@ class ItemDetailViewModel extends ChangeNotifier {
   List<AggregatedItem> _seasons = const [];
   List<AggregatedItem> get seasons => _seasons;
 
+  bool _seasonsLoaded = false;
+
+  /// Whether the seasons fetch has finished, however it went. An empty
+  /// [seasons] says nothing on its own until this is true, so callers can tell
+  /// a load still in flight from a series that really has none.
+  bool get seasonsLoaded => _seasonsLoaded;
+
   List<AggregatedItem> _episodes = const [];
   List<AggregatedItem> get episodes => _episodes;
 
+  bool _episodesLoaded = false;
+
+  /// The [seasonsLoaded] contract, for [episodes].
+  bool get episodesLoaded => _episodesLoaded;
+
   List<AggregatedItem> _seriesEpisodes = const [];
   bool _seriesEpisodesRequested = false;
+  bool _seriesEpisodesLoaded = false;
+
+  /// Whether [seriesEpisodes] has arrived. Unlike [seasonsLoaded] this only
+  /// turns true on a fetch that worked, because a failed one is tried again.
+  bool get seriesEpisodesLoaded => _seriesEpisodesLoaded;
 
   /// All episodes of a Series across every season, in the server's
   /// season/episode order. Empty until [loadAllSeriesEpisodes] completes.
@@ -622,6 +639,7 @@ class ItemDetailViewModel extends ChangeNotifier {
     // Seerr owns the seasons here, so nothing goes looking for them on a server
     // that has never heard of this title.
     _seasons = _seerrSeasons(state);
+    _seasonsLoaded = true;
     _state = ItemDetailState.ready;
     notifyListeners();
 
@@ -869,8 +887,11 @@ class ItemDetailViewModel extends ChangeNotifier {
       );
       final items = (data['Items'] as List?) ?? [];
       _seasons = _mapItems(items);
+    } catch (_) {
+    } finally {
+      _seasonsLoaded = true;
       notifyListeners();
-    } catch (_) {}
+    }
   }
 
   Future<void> _loadEpisodes() async {
@@ -909,8 +930,11 @@ class ItemDetailViewModel extends ChangeNotifier {
 
       _resolvedEpisodesSeasonId = seasonId;
       _episodes = episodes;
+    } catch (_) {
+    } finally {
+      _episodesLoaded = true;
       notifyListeners();
-    } catch (_) {}
+    }
   }
 
   /// Loads every episode of the current Series (all seasons) on demand. Used by
@@ -928,14 +952,19 @@ class ItemDetailViewModel extends ChangeNotifier {
       );
       final items = (data['Items'] as List?) ?? [];
       _seriesEpisodes = _mapItems(items);
+      _seriesEpisodesLoaded = true;
       notifyListeners();
     } catch (_) {
+      // Left unloaded and silent on purpose. The Modern layout calls this from
+      // build, so the next rebuild gets another go, and notifying here would
+      // turn that into a loop against a server that is down.
       _seriesEpisodesRequested = false;
     }
   }
 
   Future<void> refreshSeriesEpisodes() {
     _seriesEpisodesRequested = false;
+    _seriesEpisodesLoaded = false;
     return loadAllSeriesEpisodes();
   }
 

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -1171,28 +1171,61 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
   }
 
+  /// Body for a reserved tab with nothing in it yet: the placeholder row while
+  /// the fetch is out, then the message once it has come back empty, since a
+  /// shimmer that outlives the fetch reads as a row still on its way. Up goes
+  /// back to the tab bar so neither one is a focus dead end.
+  Widget _reservedTabBody({
+    required FocusNode focusNode,
+    required bool loaded,
+    required String emptyMessage,
+    required double cardWidth,
+    required double heightRatio,
+  }) {
+    return Focus(
+      focusNode: focusNode,
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+          _focusSelectedTab();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: loaded
+          ? Padding(
+              padding: const EdgeInsets.symmetric(vertical: 32),
+              child: Center(
+                child: Text(
+                  emptyMessage,
+                  style: Theme.of(context)
+                      .textTheme
+                      .bodyMedium
+                      ?.copyWith(color: Colors.white70),
+                ),
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.only(top: 8, bottom: 24),
+              child: SkeletonHomeRow(
+                cardWidth: cardWidth,
+                imageHeight: cardWidth * heightRatio,
+                isModern: true,
+              ),
+            ),
+    );
+  }
+
   Widget _seasonsTab(BuildContext context, AggregatedItem item) {
+    final l10n = AppLocalizations.of(context);
     if (_vm.seasons.isEmpty) {
-      return Focus(
+      return _reservedTabBody(
         focusNode: _seasonsFirstFocusNode,
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: Padding(
-          padding: const EdgeInsets.only(top: 8, bottom: 24),
-          child: SkeletonHomeRow(
-            cardWidth: _landscape ? 150.0 : 120.0,
-            imageHeight: (_landscape ? 150.0 : 120.0) * 1.5,
-            isModern: true,
-          ),
-        ),
+        loaded: _vm.seasonsLoaded,
+        emptyMessage: l10n.noItemsLoaded(l10n.seasons),
+        cardWidth: _landscape ? 150.0 : 120.0,
+        heightRatio: 1.5,
       );
     }
-    final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     final counts = _episodeCountsBySeason();
     final showPosterUrl = _imageUrl(item);
@@ -1348,24 +1381,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _episodeListTab(BuildContext context, AggregatedItem item) {
+    final l10n = AppLocalizations.of(context);
     if (_vm.episodes.isEmpty) {
-      return Focus(
+      return _reservedTabBody(
         focusNode: _episodesFirstFocusNode,
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: Padding(
-          padding: const EdgeInsets.only(top: 8, bottom: 24),
-          child: SkeletonHomeRow(
-            cardWidth: _landscape ? 240.0 : 180.0,
-            imageHeight: (_landscape ? 240.0 : 180.0) * (9 / 16),
-            isModern: true,
-          ),
-        ),
+        loaded: _vm.episodesLoaded,
+        emptyMessage: l10n.noEpisodesLoaded,
+        cardWidth: _landscape ? 240.0 : 180.0,
+        heightRatio: 9 / 16,
       );
     }
     // For Season pages _vm.nextUp is null (the API call uses seriesId which
@@ -1430,23 +1453,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final l10n = AppLocalizations.of(context);
     final episodes = _vm.seriesEpisodes;
     if (episodes.isEmpty) {
-      return Focus(
+      return _reservedTabBody(
         focusNode: _episodesFirstFocusNode,
-        onKeyEvent: (node, event) {
-          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
-            _focusSelectedTab();
-            return KeyEventResult.handled;
-          }
-          return KeyEventResult.ignored;
-        },
-        child: Padding(
-          padding: const EdgeInsets.only(top: 8, bottom: 24),
-          child: SkeletonHomeRow(
-            cardWidth: _landscape ? 240.0 : 180.0,
-            imageHeight: (_landscape ? 240.0 : 180.0) * (9 / 16),
-            isModern: true,
-          ),
-        ),
+        loaded: _vm.seriesEpisodesLoaded,
+        emptyMessage: l10n.noEpisodesLoaded,
+        cardWidth: _landscape ? 240.0 : 180.0,
+        heightRatio: 9 / 16,
       );
     }
     final sorted = [...episodes]..sort((a, b) {

--- a/lib/ui/screens/detail/modern/modern_detail_content.dart
+++ b/lib/ui/screens/detail/modern/modern_detail_content.dart
@@ -42,6 +42,7 @@ import '../../../widgets/focus/focusable_toolbar_button.dart';
 import '../../../widgets/navigation_layout.dart';
 import '../../../widgets/quick_return_wrapper.dart';
 import '../../../widgets/top_toolbar.dart';
+import '../../../widgets/skeleton/skeleton_home_row.dart';
 import '../../../../data/repositories/seerr_repository.dart';
 import '../../../../data/repositories/tmdb_repository.dart';
 import '../../../../data/services/seerr/seerr_api_models.dart';
@@ -184,6 +185,8 @@ class ModernDetailContent extends StatefulWidget {
 
 class _ModernDetailContentState extends State<ModernDetailContent> {
   int _selectedTab = 0;
+  String? _selectedTabId;
+  String? _lastItemId;
   bool _landscape = true;
 
   /// Expanded Tabs preference: when on, tabs behave like the search pill, with
@@ -778,67 +781,81 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final l10n = AppLocalizations.of(context);
       final tabs = _tabsFor(_vm.item!, l10n);
       if (tabIndex >= 0 && tabIndex < tabs.length) {
-        final label = tabs[tabIndex].label;
-        String? extraCat;
-        for (final cat in extraCategoriesOrder) {
-          if (label == getExtraCategoryLabel(cat, l10n)) {
-            extraCat = cat;
-            break;
-          }
-        }
-        if (extraCat != null) {
-          _featuresFirstFocusNodes[extraCat]?.requestFocus();
-        } else if (label == l10n.castMembers) {
-          _castFirstFocusNode.requestFocus();
-        } else if (label == l10n.crewSection) {
-          _crewFirstFocusNode.requestFocus();
-        } else if (label == l10n.studios) {
-          _studiosFirstFocusNode.requestFocus();
-        } else if (label == l10n.chapters) {
-          _chaptersFirstFocusNode.requestFocus();
-        } else if (label == l10n.details) {
-          _detailsTabFocusNode.requestFocus();
-        } else if (label == l10n.similar) {
-          _similarFirstFocusNode.requestFocus();
-        } else if (label == l10n.collections) {
-          if (_vm.parentCollections.length == 1) {
-            _collectionFirstFocusNode.requestFocus();
-          } else if (_vm.parentCollections.isNotEmpty) {
-            _collectionRowFocusNodeFor(_vm.parentCollections.first.id).requestFocus();
-          }
-        } else if (label == l10n.seasons) {
-          _seasonsFirstFocusNode.requestFocus();
-        } else if (label == l10n.episodes) {
-          _episodesFirstFocusNode.requestFocus();
-        } else if (label == l10n.movies) {
-          if (_vm.item?.type == 'BoxSet') {
-            _moviesFirstFocusNode.requestFocus();
-          } else {
-            _personMoviesFirstFocusNode.requestFocus();
-          }
-        } else if (label == l10n.series) {
-          if (_vm.item?.type == 'BoxSet') {
-            _seriesFirstFocusNode.requestFocus();
-          } else {
-            _personSeriesFirstFocusNode.requestFocus();
-          }
-        } else if (label ==
-            GetIt.instance<SeerrPreferences>().labelOrDefault(l10n.seerr)) {
-          final state = seerrItemTabState(_vm);
-          if (state != null) _seerrTabChain(state).firstOrNull?.requestFocus();
-        } else if (label == l10n.appearancesSeerr) {
-          _personSeerrAppearancesFirstFocusNode.requestFocus();
-        } else if (label == l10n.crewContributionsSeerr) {
-          _personSeerrCrewCreditsFirstFocusNode.requestFocus();
-        } else if (label == l10n.albums || label == l10n.items || label == l10n.appearances) {
-          _gridFirstFocusNode.requestFocus();
-        } else if (label == l10n.trackList) {
-          _focusFirstTrack();
-        } else if (label == l10n.playlist) {
-          if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
-            _collectionSortFocusNode.requestFocus();
-          } else {
-            _focusFirstTrack();
+        final tab = tabs[tabIndex];
+        if (tab.id.startsWith('extra_')) {
+          final cat = tab.id.substring('extra_'.length);
+          _featuresFirstFocusNodes[cat]?.requestFocus();
+        } else {
+          switch (tab.id) {
+            case 'cast':
+              _castFirstFocusNode.requestFocus();
+              break;
+            case 'crew':
+              _crewFirstFocusNode.requestFocus();
+              break;
+            case 'studios':
+              _studiosFirstFocusNode.requestFocus();
+              break;
+            case 'chapters':
+              _chaptersFirstFocusNode.requestFocus();
+              break;
+            case 'details':
+              _detailsTabFocusNode.requestFocus();
+              break;
+            case 'similar':
+              _similarFirstFocusNode.requestFocus();
+              break;
+            case 'collections':
+              if (_vm.parentCollections.length == 1) {
+                _collectionFirstFocusNode.requestFocus();
+              } else if (_vm.parentCollections.isNotEmpty) {
+                _collectionRowFocusNodeFor(_vm.parentCollections.first.id).requestFocus();
+              }
+              break;
+            case 'seasons':
+              _seasonsFirstFocusNode.requestFocus();
+              break;
+            case 'episodes':
+              _episodesFirstFocusNode.requestFocus();
+              break;
+            case 'movies':
+              if (_vm.item?.type == 'BoxSet') {
+                _moviesFirstFocusNode.requestFocus();
+              } else {
+                _personMoviesFirstFocusNode.requestFocus();
+              }
+              break;
+            case 'series':
+              if (_vm.item?.type == 'BoxSet') {
+                _seriesFirstFocusNode.requestFocus();
+              } else {
+                _personSeriesFirstFocusNode.requestFocus();
+              }
+              break;
+            case 'seerr':
+              final state = seerrItemTabState(_vm);
+              if (state != null) _seerrTabChain(state).firstOrNull?.requestFocus();
+              break;
+            case 'seerrAppearances':
+              _personSeerrAppearancesFirstFocusNode.requestFocus();
+              break;
+            case 'seerrCrewContributions':
+              _personSeerrCrewCreditsFirstFocusNode.requestFocus();
+              break;
+            case 'albums':
+            case 'appearances':
+              _gridFirstFocusNode.requestFocus();
+              break;
+            case 'tracks':
+              _focusFirstTrack();
+              break;
+            case 'playlist':
+              if (_vm.item?.type == 'BoxSet' && _vm.playlistItems.isNotEmpty) {
+                _collectionSortFocusNode.requestFocus();
+              } else {
+                _focusFirstTrack();
+              }
+              break;
           }
         }
       }
@@ -887,11 +904,12 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
   List<_ModernTab> _tabsFor(AggregatedItem item, AppLocalizations l10n) {
     final hasCast = _vm.actors.isNotEmpty;
-    final cast = _ModernTab(l10n.castMembers, _castTab);
+    final cast = _ModernTab('cast', l10n.castMembers, _castTab);
     final seerrState = seerrItemTabState(_vm);
     final seerrTab = seerrState == null
         ? null
         : _ModernTab(
+            'seerr',
             GetIt.instance<SeerrPreferences>().labelOrDefault(l10n.seerr),
             (context, item) => _seerrTab(context, seerrState),
           );
@@ -917,23 +935,24 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       final items = groupedFeatures[cat];
       if (items != null && items.isNotEmpty) {
         extraTabs.add(_ModernTab(
+          'extra_$cat',
           getExtraCategoryLabel(cat, l10n),
           (context, item) => _extrasTab(context, item, items, _featuresFirstFocusNodes[cat]),
         ));
       }
     }
 
-    final crew = _ModernTab(l10n.crewSection, _crewTab);
-    final studios = _ModernTab(l10n.studios, _studiosTab);
-    final chapters = _ModernTab(l10n.chapters, _chaptersTab);
-    final details = _ModernTab(l10n.details, _detailsTab);
-    final similar = _ModernTab(l10n.similar, (_, _) => _similarTab(context, _vm.similar));
+    final crew = _ModernTab('crew', l10n.crewSection, _crewTab);
+    final studios = _ModernTab('studios', l10n.studios, _studiosTab);
+    final chapters = _ModernTab('chapters', l10n.chapters, _chaptersTab);
+    final details = _ModernTab('details', l10n.details, _detailsTab);
+    final similar = _ModernTab('similar', l10n.similar, (_, _) => _similarTab(context, _vm.similar));
 
     switch (item.type) {
       case 'Series':
         return [
-          if (_vm.seasons.isNotEmpty) _ModernTab(l10n.seasons, _seasonsTab),
-          _ModernTab(l10n.episodes, _seriesEpisodesTab),
+          _ModernTab('seasons', l10n.seasons, _seasonsTab),
+          _ModernTab('episodes', l10n.episodes, _seriesEpisodesTab),
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
@@ -941,6 +960,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ...extraTabs,
           if (_vm.parentCollections.isNotEmpty)
             _ModernTab(
+              'collections',
               l10n.collections,
               (context, item) => _collectionsTab(context, item),
             ),
@@ -949,8 +969,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ];
       case 'Season':
         return [
-          if (_vm.episodes.isNotEmpty)
-            _ModernTab(l10n.episodes, _episodeListTab),
+          _ModernTab('episodes', l10n.episodes, _episodeListTab),
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
@@ -959,8 +978,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
         ];
       case 'Episode':
         return [
-          if (_vm.episodes.isNotEmpty)
-            _ModernTab(l10n.episodes, _episodeListTab),
+          _ModernTab('episodes', l10n.episodes, _episodeListTab),
           if (hasCast) cast,
           if (hasCrew) crew,
           if (hasStudios) studios,
@@ -973,14 +991,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
       case 'Playlist':
       case 'AudioBook':
         return [
-          if (_vm.tracks.isNotEmpty) _ModernTab(l10n.trackList, _tracksTab),
+          if (_vm.tracks.isNotEmpty) _ModernTab('tracks', l10n.trackList, _tracksTab),
           details,
           if (hasSimilar) similar,
         ];
       case 'MusicArtist':
         return [
           if (_vm.albums.isNotEmpty)
-            _ModernTab(l10n.albums, (_, _) => _itemGrid(_vm.albums, aspectRatio: 1.0)),
+            _ModernTab('albums', l10n.albums, (_, _) => _itemGrid(_vm.albums, aspectRatio: 1.0)),
           if (hasSimilar) similar,
         ];
       case 'Person':
@@ -993,15 +1011,15 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
         return [
           if (movies.isNotEmpty)
-            _ModernTab(l10n.movies, (context, item) => _moviesTab(context, movies)),
+            _ModernTab('movies', l10n.movies, (context, item) => _moviesTab(context, movies)),
           if (series.isNotEmpty)
-            _ModernTab(l10n.series, (context, item) => _seriesTab(context, series)),
+            _ModernTab('series', l10n.series, (context, item) => _seriesTab(context, series)),
           if (sortedSeerrAppearances.isNotEmpty)
-            _ModernTab(l10n.appearancesSeerr, (context, item) => _seerrAppearancesTab(context, sortedSeerrAppearances)),
+            _ModernTab('seerrAppearances', l10n.appearancesSeerr, (context, item) => _seerrAppearancesTab(context, sortedSeerrAppearances)),
           if (sortedSeerrCrewCredits.isNotEmpty)
-            _ModernTab(l10n.crewContributionsSeerr, (context, item) => _seerrCrewCreditsTab(context, sortedSeerrCrewCredits)),
+            _ModernTab('seerrCrewContributions', l10n.crewContributionsSeerr, (context, item) => _seerrCrewCreditsTab(context, sortedSeerrCrewCredits)),
           if (movies.isEmpty && series.isEmpty && sortedSeerrAppearances.isEmpty && sortedSeerrCrewCredits.isEmpty && _vm.filmography.isNotEmpty)
-            _ModernTab(l10n.appearances, (_, _) => _itemGrid(_sortJellyfinItems(_vm.filmography))),
+            _ModernTab('appearances', l10n.appearances, (_, _) => _itemGrid(_sortJellyfinItems(_vm.filmography))),
         ];
       case 'BoxSet':
         final showMissing = widget.prefs.get(
@@ -1037,17 +1055,18 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
         return [
           if (moviesList.isNotEmpty)
-            _ModernTab(l10n.movies, (context, item) => _mediaGrid(context, moviesList, firstFocusNode: _moviesFirstFocusNode)),
+            _ModernTab('movies', l10n.movies, (context, item) => _mediaGrid(context, moviesList, firstFocusNode: _moviesFirstFocusNode)),
           if (seriesList.isNotEmpty)
-            _ModernTab(l10n.series, (context, item) => _mediaGrid(context, seriesList, firstFocusNode: _seriesFirstFocusNode)),
-          if (hasCast) _ModernTab(l10n.castMembers, _boxSetCastTab),
-          if (hasCrew) _ModernTab(l10n.crewSection, _boxSetCrewTab),
+            _ModernTab('series', l10n.series, (context, item) => _mediaGrid(context, seriesList, firstFocusNode: _seriesFirstFocusNode)),
+          if (hasCast) _ModernTab('cast', l10n.castMembers, _boxSetCastTab),
+          if (hasCrew) _ModernTab('crew', l10n.crewSection, _boxSetCrewTab),
           if (hasStudios) studios,
           // Show the Playlist tab while the index is building (spinner) OR
           // once items are available (the list). Placed last so simple
           // movie-only collections land on Movies by default.
           if (_vm.playlistItems.isNotEmpty || _vm.playlistIndexBuilding)
             _ModernTab(
+              'playlist',
               l10n.playlist,
               (context, item) {
                 // Phase 1: flat ID index still building — show full spinner.
@@ -1142,6 +1161,7 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
           ...extraTabs,
           if (_vm.parentCollections.isNotEmpty)
             _ModernTab(
+              'collections',
               l10n.collections,
               (context, item) => _collectionsTab(context, item),
             ),
@@ -1152,6 +1172,26 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _seasonsTab(BuildContext context, AggregatedItem item) {
+    if (_vm.seasons.isEmpty) {
+      return Focus(
+        focusNode: _seasonsFirstFocusNode,
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 24),
+          child: SkeletonHomeRow(
+            cardWidth: _landscape ? 150.0 : 120.0,
+            imageHeight: (_landscape ? 150.0 : 120.0) * 1.5,
+            isModern: true,
+          ),
+        ),
+      );
+    }
     final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     final counts = _episodeCountsBySeason();
@@ -1308,6 +1348,26 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
   }
 
   Widget _episodeListTab(BuildContext context, AggregatedItem item) {
+    if (_vm.episodes.isEmpty) {
+      return Focus(
+        focusNode: _episodesFirstFocusNode,
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 24),
+          child: SkeletonHomeRow(
+            cardWidth: _landscape ? 240.0 : 180.0,
+            imageHeight: (_landscape ? 240.0 : 180.0) * (9 / 16),
+            isModern: true,
+          ),
+        ),
+      );
+    }
     // For Season pages _vm.nextUp is null (the API call uses seriesId which
     // on a Season item resolves to nothing). Fall back to the first unplayed
     // episode so the cyan "next up" border still renders correctly.
@@ -1370,9 +1430,23 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     final l10n = AppLocalizations.of(context);
     final episodes = _vm.seriesEpisodes;
     if (episodes.isEmpty) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 32),
-        child: Center(child: CircularProgressIndicator()),
+      return Focus(
+        focusNode: _episodesFirstFocusNode,
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent && event.logicalKey == LogicalKeyboardKey.arrowUp) {
+            _focusSelectedTab();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        },
+        child: Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 24),
+          child: SkeletonHomeRow(
+            cardWidth: _landscape ? 240.0 : 180.0,
+            imageHeight: (_landscape ? 240.0 : 180.0) * (9 / 16),
+            isModern: true,
+          ),
+        ),
       );
     }
     final sorted = [...episodes]..sort((a, b) {
@@ -4819,7 +4893,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     if (index == _selectedTab) {
       // With Expanded Tabs on, reselecting the current tab never collapses.
       if (!_expandedTabs) {
-        setState(() => _selectedTab = -1);
+        setState(() {
+          _selectedTab = -1;
+          _selectedTabId = null;
+        });
         if (_scrollController.hasClients) {
           _scrollController.animateTo(
             0.0,
@@ -4832,6 +4909,14 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
     }
 
     final wasCollapsed = _selectedTab < 0;
+    final item = _vm.item;
+    if (item != null) {
+      final l10n = AppLocalizations.of(context);
+      final tabs = _tabsFor(item, l10n);
+      if (index >= 0 && index < tabs.length) {
+        _selectedTabId = tabs[index].id;
+      }
+    }
     setState(() => _selectedTab = index);
     if (index >= 0 && !_expandedTabs && wasCollapsed) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -4868,13 +4953,41 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 
     final tabs = _tabsFor(item, l10n);
     final isMusicAlbumOrPlaylist = item.type == 'Playlist' || item.type == 'MusicAlbum';
-    if (isMusicAlbumOrPlaylist) {
-      _selectedTab = 0;
-    } else if (_selectedTab >= tabs.length) {
-      _selectedTab = _expandedTabs ? 0 : -1;
+
+    // Reset tab selection if the item changed completely.
+    if (_lastItemId != item.id) {
+      _lastItemId = item.id;
+      _selectedTab = (isMusicAlbumOrPlaylist || _expandedTabs || item.type == 'Season') ? 0 : -1;
+      _selectedTabId = (_selectedTab == 0 && tabs.isNotEmpty) ? tabs[0].id : null;
     }
 
-    if (tabs.isNotEmpty && _selectedTab >= 0 && _selectedTab < tabs.length && tabs[_selectedTab].label == l10n.details) {
+    if (isMusicAlbumOrPlaylist) {
+      _selectedTab = 0;
+      _selectedTabId = tabs.isNotEmpty ? tabs[0].id : null;
+    } else if (tabs.isEmpty) {
+      _selectedTab = -1;
+      _selectedTabId = null;
+    } else {
+      // Identity-aware resolution: anchor to _selectedTabId across dynamic tab insertions/prepending
+      if (_selectedTabId != null) {
+        final foundIndex = tabs.indexWhere((t) => t.id == _selectedTabId);
+        if (foundIndex != -1) {
+          _selectedTab = foundIndex;
+        } else if (_selectedTab >= tabs.length) {
+          _selectedTab = _expandedTabs ? 0 : -1;
+          _selectedTabId = _selectedTab >= 0 ? tabs[_selectedTab].id : null;
+        }
+      } else if (_selectedTab >= 0 && _selectedTab < tabs.length) {
+        _selectedTabId = tabs[_selectedTab].id;
+      } else if (_expandedTabs || item.type == 'Season') {
+        _selectedTab = 0;
+        _selectedTabId = tabs[0].id;
+      } else {
+        _selectedTab = -1;
+      }
+    }
+
+    if (tabs.isNotEmpty && _selectedTab >= 0 && _selectedTab < tabs.length && tabs[_selectedTab].id == 'details') {
       final targetItem = _getRelevantEpisode(item) ?? item;
       final isPlayable = targetItem.type != 'Series' && targetItem.type != 'Season' && targetItem.type != 'Person';
       if (isPlayable) {
@@ -5095,9 +5208,10 @@ class _ModernDetailContentState extends State<ModernDetailContent> {
 }
 
 class _ModernTab {
+  final String id;
   final String label;
   final Widget Function(BuildContext, AggregatedItem) builder;
-  const _ModernTab(this.label, this.builder);
+  const _ModernTab(this.id, this.label, this.builder);
 }
 
 class _DetailsContainer extends StatefulWidget {

--- a/test/ui/screens/detail/modern_details_stable_tabs_test.dart
+++ b/test/ui/screens/detail/modern_details_stable_tabs_test.dart
@@ -13,6 +13,7 @@ import 'package:moonfin/preference/preference_constants.dart';
 import 'package:moonfin/preference/seerr_preferences.dart';
 import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/ui/screens/detail/modern/modern_detail_content.dart';
+import 'package:moonfin/ui/screens/detail/modern/widgets/details_tab_bar.dart';
 import 'package:moonfin/ui/widgets/skeleton/skeleton_home_row.dart';
 import 'package:moonfin/util/platform_detection.dart';
 import 'package:server_core/server_core.dart';
@@ -101,6 +102,9 @@ void main() {
     when(() => vm.seasons).thenReturn([]);
     when(() => vm.episodes).thenReturn([]);
     when(() => vm.seriesEpisodes).thenReturn([]);
+    when(() => vm.seasonsLoaded).thenReturn(false);
+    when(() => vm.episodesLoaded).thenReturn(false);
+    when(() => vm.seriesEpisodesLoaded).thenReturn(false);
     when(() => vm.similar).thenReturn([]);
     when(() => vm.collectionItems).thenReturn([]);
     when(() => vm.missingCollectionItems).thenReturn([]);
@@ -144,6 +148,17 @@ void main() {
     return GetIt.instance.reset();
   });
 
+  String selectedTabLabel(WidgetTester tester) {
+    final bar = tester.widget<DetailsTabBar>(find.byType(DetailsTabBar));
+    return bar.labels[bar.selectedIndex];
+  }
+
+  AggregatedItem seriesItem() => AggregatedItem(
+        id: 'series-1',
+        serverId: 'server-1',
+        rawData: const {'Id': 'series-1', 'Name': 'Arcane', 'Type': 'Series'},
+      );
+
   Widget buildTestWidget() {
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -162,17 +177,7 @@ void main() {
   }
 
   testWidgets('Series reserves Seasons tab at index 0 and renders SkeletonHomeRow while seasons are empty', (tester) async {
-    final seriesItem = AggregatedItem(
-      id: 'series-1',
-      serverId: 'server-1',
-      rawData: const {
-        'Id': 'series-1',
-        'Name': 'Arcane',
-        'Type': 'Series',
-      },
-    );
-
-    when(() => vm.item).thenReturn(seriesItem);
+    when(() => vm.item).thenReturn(seriesItem());
     when(() => vm.seasons).thenReturn([]);
 
     await tester.pumpWidget(buildTestWidget());
@@ -186,53 +191,64 @@ void main() {
     expect(find.byType(SkeletonHomeRow), findsOneWidget);
   });
 
-  testWidgets('Selecting a tab anchors by ID so subsequent content loading preserves selection', (tester) async {
-    final seriesItem = AggregatedItem(
-      id: 'series-1',
-      serverId: 'server-1',
-      rawData: const {
-        'Id': 'series-1',
-        'Name': 'Arcane',
-        'Type': 'Series',
-      },
-    );
+  testWidgets('a tab arriving ahead of the selected one leaves the selection where it was', (tester) async {
+    when(() => vm.item).thenReturn(seriesItem());
+    when(() => vm.similar).thenReturn([
+      AggregatedItem(
+        id: 'similar-1',
+        serverId: 'server-1',
+        rawData: const {'Id': 'similar-1', 'Name': 'Vi', 'Type': 'Series'},
+      ),
+    ]);
 
-    when(() => vm.item).thenReturn(seriesItem);
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Seasons, Episodes, Similar. No Cast tab yet, the server has not sent one.
+    expect(selectedTabLabel(tester), 'Seasons');
+    await tester.tap(find.text('Similar'));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(selectedTabLabel(tester), 'Similar');
+
+    // The cast lands, which puts a new tab in front of the selected one.
+    when(() => vm.actors).thenReturn([
+      <String, dynamic>{'Id': 'p1', 'Name': 'Hailee Steinfeld', 'Type': 'Actor'},
+    ]);
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Cast'), findsOneWidget);
+    expect(selectedTabLabel(tester), 'Similar');
+  });
+
+  testWidgets('a Series with no seasons says so once the fetch is done', (tester) async {
+    when(() => vm.item).thenReturn(seriesItem());
     when(() => vm.seasons).thenReturn([]);
+    when(() => vm.seasonsLoaded).thenReturn(true);
 
     await tester.pumpWidget(buildTestWidget());
-    await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    // Both Seasons and Episodes tabs are present
-    expect(find.text('Seasons'), findsOneWidget);
-    expect(find.text('Episodes'), findsOneWidget);
+    expect(find.byType(SkeletonHomeRow), findsNothing);
+    expect(find.text('No Seasons loaded'), findsOneWidget);
+  });
 
-    // Click on the Episodes tab
-    await tester.tap(find.text('Episodes'));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 100));
-
-    // Now simulate similar items or seasons loading in
-    final season1 = AggregatedItem(
-      id: 'season-1',
-      serverId: 'server-1',
-      rawData: const {
-        'Id': 'season-1',
-        'Name': 'Season 1',
-        'Type': 'Season',
-        'IndexNumber': 1,
-      },
+  testWidgets('a Season with no episodes says so once the fetch is done', (tester) async {
+    when(() => vm.item).thenReturn(
+      AggregatedItem(
+        id: 'season-1',
+        serverId: 'server-1',
+        rawData: const {'Id': 'season-1', 'Name': 'Season 1', 'Type': 'Season'},
+      ),
     );
-    when(() => vm.seasons).thenReturn([season1]);
+    when(() => vm.episodes).thenReturn([]);
+    when(() => vm.episodesLoaded).thenReturn(true);
 
-    // Rebuild widget
     await tester.pumpWidget(buildTestWidget());
-    await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    // Episodes tab should still be present and actively selected
-    expect(find.text('Episodes'), findsOneWidget);
+    expect(find.byType(SkeletonHomeRow), findsNothing);
+    expect(find.text('No episodes loaded'), findsOneWidget);
   });
 
   testWidgets('Season reserves Episodes tab at index 0 and renders SkeletonHomeRow while episodes are empty', (tester) async {

--- a/test/ui/screens/detail/modern_details_stable_tabs_test.dart
+++ b/test/ui/screens/detail/modern_details_stable_tabs_test.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:jellyfin_preference/jellyfin_preference.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:moonfin/auth/repositories/user_repository.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/data/repositories/offline_repository.dart';
+import 'package:moonfin/data/services/plugin_sync_service.dart';
+import 'package:moonfin/data/viewmodels/item_detail_view_model.dart';
+import 'package:moonfin/l10n/app_localizations.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/preference/seerr_preferences.dart';
+import 'package:moonfin/preference/user_preferences.dart';
+import 'package:moonfin/ui/screens/detail/modern/modern_detail_content.dart';
+import 'package:moonfin/ui/widgets/skeleton/skeleton_home_row.dart';
+import 'package:moonfin/util/platform_detection.dart';
+import 'package:server_core/server_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:playback_core/playback_core.dart';
+
+class MockItemDetailViewModel extends Mock implements ItemDetailViewModel {}
+class MockPluginSyncService extends Mock implements PluginSyncService {}
+class MockSeerrPreferences extends Mock implements SeerrPreferences {}
+class MockMediaServerClient extends Mock implements MediaServerClient {}
+class MockImageApi extends Mock implements ImageApi {}
+class MockUserRepository extends Mock implements UserRepository {}
+class MockOfflineRepository extends Mock implements OfflineRepository {}
+class MockPlaybackManager extends Mock implements PlaybackManager {}
+class MockQueueService extends Mock implements QueueService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late UserPreferences prefs;
+  late MockItemDetailViewModel vm;
+  late MockPluginSyncService pluginSyncService;
+  late MockSeerrPreferences seerrPrefs;
+  late MockMediaServerClient mediaClient;
+  late MockImageApi imageApi;
+  late MockUserRepository userRepo;
+  late MockOfflineRepository offlineRepo;
+
+  setUp(() async {
+    await GetIt.instance.reset();
+    SharedPreferences.setMockInitialValues({});
+    final store = PreferenceStore();
+    await store.init();
+    prefs = UserPreferences(store);
+    await prefs.set(UserPreferences.detailScreenStyle, DetailScreenStyle.modern);
+    await prefs.set(UserPreferences.detailExpandedTabs, true);
+
+    GetIt.instance.registerSingleton<UserPreferences>(prefs);
+
+    pluginSyncService = MockPluginSyncService();
+    when(() => pluginSyncService.seerrAvailable).thenReturn(false);
+    when(() => pluginSyncService.pluginAvailable).thenReturn(false);
+    GetIt.instance.registerSingleton<PluginSyncService>(pluginSyncService);
+
+    seerrPrefs = MockSeerrPreferences();
+    when(() => seerrPrefs.labelOrDefault(any())).thenReturn('Discover');
+    when(() => seerrPrefs.showRequestStatus).thenReturn(false);
+    GetIt.instance.registerSingleton<SeerrPreferences>(seerrPrefs);
+
+    mediaClient = MockMediaServerClient();
+    when(() => mediaClient.serverType).thenReturn(ServerType.jellyfin);
+    imageApi = MockImageApi();
+    when(() => mediaClient.imageApi).thenReturn(imageApi);
+    when(
+      () => imageApi.getPrimaryImageUrl(
+        any(),
+        maxWidth: any(named: 'maxWidth'),
+        maxHeight: any(named: 'maxHeight'),
+        tag: any(named: 'tag'),
+      ),
+    ).thenReturn('http://server/img');
+    GetIt.instance.registerSingleton<MediaServerClient>(mediaClient);
+
+    userRepo = MockUserRepository();
+    when(() => userRepo.currentUserStream).thenAnswer((_) => const Stream.empty());
+    when(() => userRepo.currentUser).thenReturn(null);
+    GetIt.instance.registerSingleton<UserRepository>(userRepo);
+
+    offlineRepo = MockOfflineRepository();
+    when(() => offlineRepo.getSeriesEpisodes(any())).thenAnswer((_) async => []);
+    when(() => offlineRepo.getSeasonEpisodes(any())).thenAnswer((_) async => []);
+    when(() => offlineRepo.getItem(any())).thenAnswer((_) async => null);
+    GetIt.instance.registerSingleton<OfflineRepository>(offlineRepo);
+
+    final playbackManager = MockPlaybackManager();
+    final queueService = MockQueueService();
+    when(() => playbackManager.queueService).thenReturn(queueService);
+    when(() => queueService.currentItem).thenReturn(null);
+    when(() => playbackManager.currentResolution).thenReturn(null);
+    GetIt.instance.registerSingleton<PlaybackManager>(playbackManager);
+
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.desktop);
+
+    vm = MockItemDetailViewModel();
+    when(() => vm.seasons).thenReturn([]);
+    when(() => vm.episodes).thenReturn([]);
+    when(() => vm.seriesEpisodes).thenReturn([]);
+    when(() => vm.similar).thenReturn([]);
+    when(() => vm.collectionItems).thenReturn([]);
+    when(() => vm.missingCollectionItems).thenReturn([]);
+    when(() => vm.parentCollections).thenReturn([]);
+    when(() => vm.parentCollectionItems).thenReturn([]);
+    when(() => vm.parentCollectionName).thenReturn(null);
+    when(() => vm.playlistItems).thenReturn([]);
+    when(() => vm.playlistIndexBuilding).thenReturn(false);
+    when(() => vm.tracks).thenReturn([]);
+    when(() => vm.albums).thenReturn([]);
+    when(() => vm.filmography).thenReturn([]);
+    when(() => vm.features).thenReturn([]);
+    when(() => vm.seerr).thenReturn(null);
+    when(() => vm.state).thenReturn(ItemDetailState.ready);
+    when(() => vm.errorMessage).thenReturn(null);
+    when(() => vm.effectiveSeasonId).thenReturn(null);
+    when(() => vm.selectedAudioIndex).thenReturn(null);
+    when(() => vm.selectedSubtitleIndex).thenReturn(null);
+    when(() => vm.actors).thenReturn([]);
+    when(() => vm.directors).thenReturn([]);
+    when(() => vm.writers).thenReturn([]);
+    when(() => vm.isSeerrOnly).thenReturn(false);
+    when(() => vm.localPersonId).thenReturn(null);
+    when(() => vm.nextUp).thenReturn(null);
+    when(() => vm.loadAllSeriesEpisodes()).thenAnswer((_) async {});
+    when(() => vm.addListener(any())).thenReturn(null);
+    when(() => vm.removeListener(any())).thenReturn(null);
+    when(() => vm.ratings).thenReturn({});
+    when(() => vm.imageApi).thenReturn(imageApi);
+    when(() => vm.canManagePlaylistTracks).thenReturn(false);
+    when(() => vm.playlistLoadingMore).thenReturn(false);
+    when(() => vm.filmographyMovies).thenReturn([]);
+    when(() => vm.filmographySeries).thenReturn([]);
+    when(() => vm.supportsNumericUserRatings).thenReturn(false);
+    when(() => vm.isRatingMutationInProgress).thenReturn(false);
+    when(() => vm.contextSeasonId).thenReturn(null);
+  });
+
+  tearDown(() {
+    PlatformDetection.setInterfaceLayout(InterfaceLayout.automatic);
+    return GetIt.instance.reset();
+  });
+
+  Widget buildTestWidget() {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: Scaffold(
+        body: ModernDetailContent(
+          viewModel: vm,
+          prefs: prefs,
+          backdropUrl: ValueNotifier<String?>(null),
+          onSelectedMediaSourceChanged: (_) {},
+          actionsExpanded: false,
+          onActionsExpandedChanged: (_) {},
+        ),
+      ),
+    );
+  }
+
+  testWidgets('Series reserves Seasons tab at index 0 and renders SkeletonHomeRow while seasons are empty', (tester) async {
+    final seriesItem = AggregatedItem(
+      id: 'series-1',
+      serverId: 'server-1',
+      rawData: const {
+        'Id': 'series-1',
+        'Name': 'Arcane',
+        'Type': 'Series',
+      },
+    );
+
+    when(() => vm.item).thenReturn(seriesItem);
+    when(() => vm.seasons).thenReturn([]);
+
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // The Seasons tab label should be present even though seasons is empty
+    expect(find.text('Seasons'), findsOneWidget);
+
+    // SkeletonHomeRow should be rendered in the tab body
+    expect(find.byType(SkeletonHomeRow), findsOneWidget);
+  });
+
+  testWidgets('Selecting a tab anchors by ID so subsequent content loading preserves selection', (tester) async {
+    final seriesItem = AggregatedItem(
+      id: 'series-1',
+      serverId: 'server-1',
+      rawData: const {
+        'Id': 'series-1',
+        'Name': 'Arcane',
+        'Type': 'Series',
+      },
+    );
+
+    when(() => vm.item).thenReturn(seriesItem);
+    when(() => vm.seasons).thenReturn([]);
+
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Both Seasons and Episodes tabs are present
+    expect(find.text('Seasons'), findsOneWidget);
+    expect(find.text('Episodes'), findsOneWidget);
+
+    // Click on the Episodes tab
+    await tester.tap(find.text('Episodes'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Now simulate similar items or seasons loading in
+    final season1 = AggregatedItem(
+      id: 'season-1',
+      serverId: 'server-1',
+      rawData: const {
+        'Id': 'season-1',
+        'Name': 'Season 1',
+        'Type': 'Season',
+        'IndexNumber': 1,
+      },
+    );
+    when(() => vm.seasons).thenReturn([season1]);
+
+    // Rebuild widget
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // Episodes tab should still be present and actively selected
+    expect(find.text('Episodes'), findsOneWidget);
+  });
+
+  testWidgets('Season reserves Episodes tab at index 0 and renders SkeletonHomeRow while episodes are empty', (tester) async {
+    final seasonItem = AggregatedItem(
+      id: 'season-1',
+      serverId: 'server-1',
+      rawData: const {
+        'Id': 'season-1',
+        'Name': 'Season 1',
+        'Type': 'Season',
+      },
+    );
+
+    when(() => vm.item).thenReturn(seasonItem);
+    when(() => vm.episodes).thenReturn([]);
+
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // The Episodes tab label should be present even though episodes is empty
+    expect(find.text('Episodes'), findsOneWidget);
+
+    // SkeletonHomeRow should be rendered in the tab body
+    expect(find.byType(SkeletonHomeRow), findsOneWidget);
+  });
+
+  testWidgets('Episode reserves Episodes tab at index 0 and renders SkeletonHomeRow while episodes are empty', (tester) async {
+    final episodeItem = AggregatedItem(
+      id: 'episode-1',
+      serverId: 'server-1',
+      rawData: const {
+        'Id': 'episode-1',
+        'Name': 'Episode 1',
+        'Type': 'Episode',
+      },
+    );
+
+    when(() => vm.item).thenReturn(episodeItem);
+    when(() => vm.episodes).thenReturn([]);
+
+    await tester.pumpWidget(buildTestWidget());
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // The Episodes tab label should be present even though episodes is empty
+    expect(find.text('Episodes'), findsOneWidget);
+
+    // SkeletonHomeRow should be rendered in the tab body
+    expect(find.byType(SkeletonHomeRow), findsOneWidget);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Stabilizes modern detail screen tab positions and anchors active tab navigation by stable tab ID instead of an integer index. For Series, Season, and Episode items, the primary tabs (Seasons and Episodes) are unconditionally reserved at index 0 and display a `SkeletonHomeRow` while content loads asynchronously from the server, preventing layout shifts, tab popping, and focus loss.

Note: This builds off of the "skeleton" PR #1501 so that should be reviewed first.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #1501 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Stable Tab Reservation**: Unconditionally reserved the `Seasons` tab at index 0 for `Series` items, and the `Episodes` tab at index 0 for `Season` and `Episode` items in **modern_detail_content.dart**.
- **Skeleton Fallback During Async Load**: Rendered a `SkeletonHomeRow` with proper Up-arrow focus redirection in `_seasonsTab`, `_episodeListTab`, and `_seriesEpisodesTab` when item collections are empty during server fetch, eliminating tab popping.
- **Identity-Anchored Tab Tracking**: Updated `_ModernTab` to carry a unique string identifier. Replaced index-only `_selectedTab` tracking with `_selectedTabId` resolution so that later-arriving tabs (e.g. Collections, Similar, Seerr) prepending or inserting into the tab list never displace the active tab or reset the user's cursor.
- **Directional Focus Refactor**: Refactored tab bar downward navigation to switch on `tab.id` instead of fragile localized label strings.
- **Item Transition Reset**: Tracked `_lastItemId` to cleanly re-initialize tab state when navigating between different media items.
- **Automated Tests**: Added comprehensive widget tests in **modern_details_stable_tabs_test.dart** verifying unconditional tab reservations, skeleton row rendering, and tab identity anchoring.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Launch Moonfin on Windows with Modern Detail Screen style enabled.
2. Open a Series detail page; observe the `Seasons` tab is immediately present at index 0 with a skeleton row during fetch, smoothly populating seasons without shifting tabs.
3. Open a Season or Episode page; observe the `Episodes` tab is immediately present at index 0 with skeleton row fallback.
4. Select a tab (such as Cast, Details, or Similar); observe that subsequent asynchronous arrivals of Collections or Seerr tabs preserve the active tab selection and cursor position.
5. Ran automated test suite `flutter test test/ui/screens/detail/` (99/99 passed).
6. Ran static analysis `dart analyze lib/ui/screens/detail/modern/ test/ui/screens/detail/` (0 issues).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

https://github.com/user-attachments/assets/72d59f5c-2ce6-443f-a032-5d59ceadc614

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
