### PR TITLE
Fix intermittent HLS playback stall while transcoding on Android

### DIFF
--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -71,6 +71,8 @@ import androidx.media3.exoplayer.RendererCapabilities
 import androidx.media3.exoplayer.mediacodec.MediaCodecAdapter
 import androidx.media3.exoplayer.mediacodec.MediaCodecInfo
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+import androidx.media3.exoplayer.hls.DefaultHlsExtractorFactory
+import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.video.MediaCodecVideoRenderer
@@ -771,6 +773,7 @@ class Media3VideoView(
     private var currentUrl: String? = null
     private var currentHeaders: Map<String, String> = emptyMap()
     private lateinit var httpDataSourceFactory: DefaultHttpDataSource.Factory
+    private lateinit var hlsMediaSourceFactory: HlsMediaSource.Factory
     private var requestedSubtitleRendererMode: SubtitleRendererMode = SubtitleRendererMode.NATIVE
     private var activeSubtitleRendererMode: SubtitleRendererMode = SubtitleRendererMode.NATIVE
     private var selectedSubtitleCodec: String? = null
@@ -1625,6 +1628,15 @@ class Media3VideoView(
             AssSubtitleParserFactory(assHandler),
             assHandler,
         )
+
+        hlsMediaSourceFactory = HlsMediaSource.Factory(bootDataSourceFactory)
+            .setExtractorFactory(
+                DefaultHlsExtractorFactory(
+                    DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES,
+                    true,
+                ),
+            )
+            .setSubtitleParserFactory(assParserFactory)
         val bootMediaSourceFactory = DefaultMediaSourceFactory(
             bootDataSourceFactory,
             // The DoVi wrapper sits outermost so it sees the extractors every
@@ -3256,6 +3268,20 @@ class Media3VideoView(
         }
     }
 
+    private fun setPlayerMediaItem(
+        mediaItem: MediaItem,
+        startPositionMs: Long,
+    ) {
+        if (mediaItem.localConfiguration?.mimeType == MimeTypes.APPLICATION_M3U8) {
+            player.setMediaSource(
+                hlsMediaSourceFactory.createMediaSource(mediaItem),
+                startPositionMs,
+            )
+        } else {
+            player.setMediaItem(mediaItem, startPositionMs)
+        }
+    }
+
     private fun setMediaItem(startPositionMs: Long, playWhenReady: Boolean) {
         val url = currentUrl ?: return
 
@@ -3269,7 +3295,7 @@ class Media3VideoView(
             mediaItemBuilder.setMimeType(mimeType)
         }
         val mediaItem = mediaItemBuilder.build()
-        player.setMediaItem(mediaItem, startPositionMs)
+        setPlayerMediaItem(mediaItem, startPositionMs)
         player.prepare()
         if (playWhenReady) {
             player.playWhenReady = true
@@ -3484,7 +3510,7 @@ class Media3VideoView(
         Media3Bridge.emitEvent(
             mapOf("event" to "tunnelingDisabledOnAudioTrackFailure"),
         )
-        player.setMediaItem(mediaItem, retryPositionMs)
+        setPlayerMediaItem(mediaItem, retryPositionMs)
         player.prepare()
         player.playWhenReady = playWhenReady
         return true
@@ -3507,7 +3533,7 @@ class Media3VideoView(
 
         audioOffloadDisabled = true
         applyTrackSelectorForCurrentSource()
-        player.setMediaItem(mediaItem, retryPositionMs)
+        setPlayerMediaItem(mediaItem, retryPositionMs)
         player.prepare()
         player.playWhenReady = playWhenReady
         return true
@@ -3538,7 +3564,7 @@ class Media3VideoView(
         // instead of failing the AudioTrack init again.
         deviceRequiresStereoDownmix = true
         applyStereoDownmix(true)
-        player.setMediaItem(mediaItem, retryPositionMs)
+        setPlayerMediaItem(mediaItem, retryPositionMs)
         player.prepare()
         player.playWhenReady = playWhenReady
         return true
@@ -3568,7 +3594,7 @@ class Media3VideoView(
         val retryPositionMs = player.currentPosition.coerceAtLeast(0L)
         val playWhenReady = wasPlayingBeforeDisplayModeSwitch || player.playWhenReady
 
-        player.setMediaItem(mediaItem, retryPositionMs)
+        setPlayerMediaItem(mediaItem, retryPositionMs)
         player.prepare()
         player.playWhenReady = playWhenReady
         return true


### PR DESCRIPTION
## Summary

Fix an intermittent HLS playback stall that occurs **while transcoding certain files on some Android (phone/tablet) devices**.

When an affected file requires transcoding, the HLS playlist loads successfully and the first `.ts` segment plays normally, including rendering the initial video frame. Playback then stalls and enters buffering when advancing past the first segment, even though FFmpeg continues transcoding and generating HLS segments normally.

## Related Issues

- Fixes #1411

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- Configure `DefaultHlsExtractorFactory` with `FLAG_ALLOW_NON_IDR_KEYFRAMES`, similar to how `FLAG_ALLOW_NON_IDR_KEYFRAMES` is already configured for the progressive TS extractor.
- Route HLS `.m3u8` playback through the configured `HlsMediaSource.Factory`.
- Keep the change limited to the HLS playback path.

## Root Cause

Moonfin was already enabling `FLAG_ALLOW_NON_IDR_KEYFRAMES` for its progressive TS extractor, but the HLS-specific extractor used by `HlsMediaSource` was not configured with the same flag.

This could cause certain MPEG-TS HLS streams to stall when advancing from the initial segment.

## Investigation

I looked at the Moonfin playback logs along with the Nginx Proxy Manager access logs and the FFmpeg transcode logs to determine where the failure was occurring.

- Moonfin showed that the video and audio decoders initialized correctly and the first HLS segment played before playback stalled.
- Nginx showed the HLS playlist and initial `.ts` segment being served successfully.
- FFmpeg continued generating HLS segments normally while playback was stuck, with no transcoding errors.
- The HLS output was using MPEG-TS segments with a roughly 3-second segment duration, which matched the point where playback was getting stuck.
- The issue occurred with some files but not all HLS transcodes.
- Testing with the official Jellyfin Android client also showed that the problem was specific to the Moonfin playback path rather than the server or transcoder.

Looking through the Media3 implementation revealed that Moonfin was already enabling `FLAG_ALLOW_NON_IDR_KEYFRAMES` for its progressive TS extractor, but the HLS-specific extractor used by `HlsMediaSource` was not configured with the same flag.

## File-specific Behavior

The stall was only seen with certain transcoded HLS streams. The available logs don't establish exactly what differs between the affected and unaffected streams. One possibility is that certain keyframe or segment-boundary structures expose a limitation in the default Media3 HLS extractor.

## Platform

- [x] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing

- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps

1. Start playback of a file that requires transcoding in Moonfin.
2. Observe the HLS playback stall after the initial segment.
3. Test the same playback with the patched build.
4. Confirm playback continues past the previous stall point and continues buffering normally.

I built a patched Android version based directly on the official **Moonfin 2.5.1** tag and tested it against the affected type of playback.

With the patch, playback successfully passed the point where it previously stalled and continued buffering normally. I tested multiple transcoded files and was able to play past the previous failure point without the HLS buffering stall.

## Screenshots (if applicable)

Not applicable.

## AI-Assisted Development

AI was used as a development aid during the investigation to help analyze the logs, understand the Media3 HLS implementation, and review the proposed change. The issue was reproduced and investigated manually, the relevant source code was inspected, and the resulting build was tested against the affected playback scenario.

## Scope

This is a small, targeted change to the HLS playback path. The branch is based on the official **Moonfin 2.5.1** tag and contains only this HLS extractor change.

## Checklist

- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced