### PR TITLE
fix(theme) - Spotlight Refinements, Round 3

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -845,9 +845,6 @@ class ItemDetailViewModel extends ChangeNotifier {
       futures.add(_loadEpisodes());
       futures.add(_loadSimilar());
       futures.add(_loadFeatures());
-      if (_item?.seriesId != null) {
-        futures.add(loadAllSeriesEpisodes());
-      }
     } else if (type == 'MusicArtist') {
       futures.add(_loadAlbums());
       futures.add(_loadTracks(artistId: itemId));

--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -845,6 +845,9 @@ class ItemDetailViewModel extends ChangeNotifier {
       futures.add(_loadEpisodes());
       futures.add(_loadSimilar());
       futures.add(_loadFeatures());
+      if (_item?.seriesId != null) {
+        futures.add(loadAllSeriesEpisodes());
+      }
     } else if (type == 'MusicArtist') {
       futures.add(_loadAlbums());
       futures.add(_loadTracks(artistId: itemId));
@@ -938,16 +941,18 @@ class ItemDetailViewModel extends ChangeNotifier {
   }
 
   /// Loads every episode of the current Series (all seasons) on demand. Used by
-  /// the Modern and Nouveau detail layout's Episodes tab and accurate season counts. No-op
-  /// for non-Series items or once already loaded.
+  /// the Modern and Nouveau detail layout's Episodes tab, accurate season counts,
+  /// and the Spotlight More Episodes modal. No-op once already loaded.
   Future<void> loadAllSeriesEpisodes() async {
     final item = _item;
-    if (item == null || item.type != 'Series') return;
+    if (item == null) return;
+    final seriesId = item.type == 'Series' ? itemId : item.seriesId;
+    if (seriesId == null || seriesId.isEmpty) return;
     if (_seriesEpisodesRequested) return;
     _seriesEpisodesRequested = true;
     try {
       final data = await _client.itemsApi.getEpisodes(
-        itemId,
+        seriesId,
         fields: _episodeOverviewFields,
       );
       final items = (data['Items'] as List?) ?? [];

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -208,7 +208,7 @@
   "@detailScreenStyleSpotlight": {
     "description": "Detail screen style option: the hero-first layout with summary cards that open grid modals"
   },
-  "spotlightMoreActions": "More actions",
+  "spotlightMoreActions": "More Actions",
   "@spotlightMoreActions": {
     "description": "Tooltip/semantics of the spotlight ellipsis button and the title of the overflow actions menu it opens"
   },

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -493,7 +493,7 @@ abstract class AppLocalizations {
   /// Tooltip/semantics of the spotlight ellipsis button and the title of the overflow actions menu it opens
   ///
   /// In en, this message translates to:
-  /// **'More actions'**
+  /// **'More Actions'**
   String get spotlightMoreActions;
 
   /// Title of the spotlight summary card that opens the people and studios modal

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -158,7 +158,7 @@ class AppLocalizationsAf extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -158,7 +158,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -158,7 +158,7 @@ class AppLocalizationsBe extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -158,7 +158,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -158,7 +158,7 @@ class AppLocalizationsBn extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -158,7 +158,7 @@ class AppLocalizationsCa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -159,7 +159,7 @@ class AppLocalizationsCs extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -158,7 +158,7 @@ class AppLocalizationsCy extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -160,7 +160,7 @@ class AppLocalizationsDa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -158,7 +158,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -160,7 +160,7 @@ class AppLocalizationsEl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -158,7 +158,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -158,7 +158,7 @@ class AppLocalizationsEo extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -158,7 +158,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -159,7 +159,7 @@ class AppLocalizationsEt extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -158,7 +158,7 @@ class AppLocalizationsFa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -160,7 +160,7 @@ class AppLocalizationsFi extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -158,7 +158,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -158,7 +158,7 @@ class AppLocalizationsGl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -158,7 +158,7 @@ class AppLocalizationsHe extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -158,7 +158,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -158,7 +158,7 @@ class AppLocalizationsHr extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -158,7 +158,7 @@ class AppLocalizationsHu extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -158,7 +158,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -158,7 +158,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -157,7 +157,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -158,7 +158,7 @@ class AppLocalizationsKk extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -158,7 +158,7 @@ class AppLocalizationsKn extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -157,7 +157,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -158,7 +158,7 @@ class AppLocalizationsLt extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -158,7 +158,7 @@ class AppLocalizationsLv extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -158,7 +158,7 @@ class AppLocalizationsMk extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -158,7 +158,7 @@ class AppLocalizationsMl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -158,7 +158,7 @@ class AppLocalizationsMn extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -158,7 +158,7 @@ class AppLocalizationsNb extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -159,7 +159,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -158,7 +158,7 @@ class AppLocalizationsPa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -158,7 +158,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -158,7 +158,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -158,7 +158,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -158,7 +158,7 @@ class AppLocalizationsRu extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -158,7 +158,7 @@ class AppLocalizationsSi extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -159,7 +159,7 @@ class AppLocalizationsSk extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -159,7 +159,7 @@ class AppLocalizationsSl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -159,7 +159,7 @@ class AppLocalizationsSq extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -158,7 +158,7 @@ class AppLocalizationsSr extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -158,7 +158,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -158,7 +158,7 @@ class AppLocalizationsSw extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -158,7 +158,7 @@ class AppLocalizationsTa extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -158,7 +158,7 @@ class AppLocalizationsTe extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -159,7 +159,7 @@ class AppLocalizationsTh extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -159,7 +159,7 @@ class AppLocalizationsTl extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -158,7 +158,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -158,7 +158,7 @@ class AppLocalizationsUg extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -158,7 +158,7 @@ class AppLocalizationsUk extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -158,7 +158,7 @@ class AppLocalizationsVi extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -157,7 +157,7 @@ class AppLocalizationsYue extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -156,7 +156,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get detailScreenStyleSpotlight => 'Spotlight';
 
   @override
-  String get spotlightMoreActions => 'More actions';
+  String get spotlightMoreActions => 'More Actions';
 
   @override
   String get spotlightCastCrewStudios => 'Cast, Crew, and Studios';

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6280,27 +6280,9 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         itemCount: actions.length,
         itemBuilder: (rowContext, index) {
           final action = actions[index];
-          final tint = action.isActive
-              ? (action.activeColor ?? AppColorScheme.accent)
-              : Colors.white;
-          return DpadListTile(
+          return _SpotlightOverflowTile(
+            action: action,
             autofocus: index == 0,
-            leading: action.iconBuilder != null
-                ? action.iconBuilder!(22, tint)
-                : (action.icon != null
-                      ? AdaptiveIcon(action.icon!, color: tint, size: 22)
-                      : null),
-            title: Text(
-              action.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: tint,
-                fontWeight: action.isActive
-                    ? FontWeight.w600
-                    : FontWeight.w400,
-              ),
-            ),
             onTap: () => Navigator.pop(rowContext, action.onPressed),
             onLongPress: action.onLongPress == null
                 ? null
@@ -11554,28 +11536,32 @@ class _PersonalRatingActionIcon extends StatelessWidget {
     return switch (style) {
       PersonalRatingStyle.thumbs =>
         likes == null
-            ? Center(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.thumb_up_outlined,
-                      color: color,
-                      size: size * 0.5,
-                    ),
-                    SizedBox(width: size * 0.08),
-                    Icon(
-                      Icons.thumb_down_outlined,
-                      color: color,
-                      size: size * 0.5,
-                    ),
-                  ],
-                ),
-              )
+            ? (size <= 24
+                ? Icon(
+                    Icons.thumb_up_outlined,
+                    color: color,
+                    size: size * 0.85,
+                  )
+                : Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.thumb_up_outlined,
+                        color: color,
+                        size: size * 0.5,
+                      ),
+                      SizedBox(width: size * 0.08),
+                      Icon(
+                        Icons.thumb_down_outlined,
+                        color: color,
+                        size: size * 0.5,
+                      ),
+                    ],
+                  ))
             : Icon(
                 likes! ? Icons.thumb_up : Icons.thumb_down,
                 color: color,
-                size: size * 0.72,
+                size: size * 0.85,
               ),
       PersonalRatingStyle.stars => _StarFillIcon(
         fill: ((rating ?? 0).clamp(0, 10) / 10).toDouble(),
@@ -12225,6 +12211,168 @@ class _DetailActionButtonState extends State<_DetailActionButton>
                     ],
                   ),
                 ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SpotlightOverflowTile extends StatefulWidget {
+  final _DetailActionButton action;
+  final bool autofocus;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+
+  const _SpotlightOverflowTile({
+    required this.action,
+    this.autofocus = false,
+    required this.onTap,
+    this.onLongPress,
+  });
+
+  @override
+  State<_SpotlightOverflowTile> createState() => _SpotlightOverflowTileState();
+}
+
+class _SpotlightOverflowTileState extends State<_SpotlightOverflowTile> {
+  final _focusNode = FocusNode();
+  bool _isFocused = false;
+  bool _isHovered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(() {
+      if (mounted) {
+        final hasFocus = _focusNode.hasFocus;
+        setState(() => _isFocused = hasFocus);
+        if (hasFocus) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              Scrollable.ensureVisible(
+                context,
+                alignment: 0.5,
+                duration: const Duration(milliseconds: 150),
+                curve: Curves.easeOut,
+              );
+            }
+          });
+        }
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final action = widget.action;
+    final isTv = PlatformDetection.isTV;
+    final showHighlight = _isFocused || _isHovered;
+
+    final focusBg = AppColorScheme.buttonFocused;
+    final focusedFg = focusBg.computeLuminance() > 0.5
+        ? (AppColorScheme.onButtonFocused != focusBg
+            ? AppColorScheme.onButtonFocused
+            : Colors.black87)
+        : Colors.white;
+
+    final textColor = showHighlight
+        ? (isTv ? focusedFg : Colors.white)
+        : Colors.white;
+
+    final iconColor = showHighlight
+        ? (isTv ? focusedFg : AppColorScheme.accent)
+        : (action.isActive
+            ? (action.activeColor ?? AppColorScheme.accent)
+            : Colors.white.withValues(alpha: 0.85));
+
+    final Widget? leadingWidget;
+    if (action.iconBuilder != null) {
+      leadingWidget = action.iconBuilder!(22, iconColor);
+    } else if (action.icon != null) {
+      leadingWidget = AdaptiveIcon(action.icon!, color: iconColor, size: 22);
+    } else {
+      leadingWidget = null;
+    }
+
+    final focusColor = Color(
+      GetIt.instance<UserPreferences>()
+          .get(UserPreferences.focusColor)
+          .colorValue,
+    );
+
+    return Focus(
+      focusNode: _focusNode,
+      autofocus: widget.autofocus,
+      onKeyEvent: (_, event) {
+        if (!event.logicalKey.isSelectKey) return KeyEventResult.ignored;
+        if (event is KeyDownEvent) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _isHovered = true),
+        onExit: (_) => setState(() => _isHovered = false),
+        child: GestureDetector(
+          onTap: widget.onTap,
+          onLongPress: widget.onLongPress,
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 3),
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 90),
+              curve: Curves.easeOut,
+              decoration: BoxDecoration(
+                color: showHighlight
+                    ? (isTv
+                        ? focusBg
+                        : AppColorScheme.accent.withValues(alpha: 0.16))
+                    : Colors.transparent,
+                borderRadius: AppRadius.circular(10),
+                border: Border.all(
+                  color: showHighlight
+                      ? (isTv
+                          ? focusColor
+                          : AppColorScheme.accent.withValues(alpha: 0.6))
+                      : Colors.white.withValues(alpha: 0.15),
+                  width: showHighlight ? 1.5 : 1.0,
+                ),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  if (leadingWidget != null) ...[
+                    SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: Center(child: leadingWidget),
+                    ),
+                    const SizedBox(width: 14),
+                  ],
+                  Expanded(
+                    child: Text(
+                      action.label,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: textColor,
+                        fontWeight: action.isActive ? FontWeight.w600 : FontWeight.w500,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ui';
 
+import '../../theme/focus_foreground.dart';
 import '../../widgets/bounded_network_image.dart';
 import '../../widgets/offline_aware_image.dart';
 import '../../widgets/identify_dialog.dart';
@@ -11536,32 +11537,28 @@ class _PersonalRatingActionIcon extends StatelessWidget {
     return switch (style) {
       PersonalRatingStyle.thumbs =>
         likes == null
-            ? (size <= 24
-                ? Icon(
-                    Icons.thumb_up_outlined,
-                    color: color,
-                    size: size * 0.85,
-                  )
-                : Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(
-                        Icons.thumb_up_outlined,
-                        color: color,
-                        size: size * 0.5,
-                      ),
-                      SizedBox(width: size * 0.08),
-                      Icon(
-                        Icons.thumb_down_outlined,
-                        color: color,
-                        size: size * 0.5,
-                      ),
-                    ],
-                  ))
+            ? Center(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.thumb_up_outlined,
+                      color: color,
+                      size: size * 0.5,
+                    ),
+                    SizedBox(width: size * 0.08),
+                    Icon(
+                      Icons.thumb_down_outlined,
+                      color: color,
+                      size: size * 0.5,
+                    ),
+                  ],
+                ),
+              )
             : Icon(
                 likes! ? Icons.thumb_up : Icons.thumb_down,
                 color: color,
-                size: size * 0.85,
+                size: size * 0.72,
               ),
       PersonalRatingStyle.stars => _StarFillIcon(
         fill: ((rating ?? 0).clamp(0, 10) / 10).toDouble(),
@@ -12275,11 +12272,7 @@ class _SpotlightOverflowTileState extends State<_SpotlightOverflowTile> {
     final showHighlight = _isFocused || _isHovered;
 
     final focusBg = AppColorScheme.buttonFocused;
-    final focusedFg = focusBg.computeLuminance() > 0.5
-        ? (AppColorScheme.onButtonFocused != focusBg
-            ? AppColorScheme.onButtonFocused
-            : Colors.black87)
-        : Colors.white;
+    final focusedFg = readableOnFocusFill(focusBg);
 
     final textColor = showHighlight
         ? (isTv ? focusedFg : Colors.white)
@@ -12291,11 +12284,14 @@ class _SpotlightOverflowTileState extends State<_SpotlightOverflowTile> {
             ? (action.activeColor ?? AppColorScheme.accent)
             : Colors.white.withValues(alpha: 0.85));
 
+    // The plain icon first. The builders draw for the button row, where the
+    // rating one pairs a thumb up and down and the star one part fills, and
+    // both come out a smudge at 22. The label carries the rating anyway.
     final Widget? leadingWidget;
-    if (action.iconBuilder != null) {
-      leadingWidget = action.iconBuilder!(22, iconColor);
-    } else if (action.icon != null) {
+    if (action.icon != null) {
       leadingWidget = AdaptiveIcon(action.icon!, color: iconColor, size: 22);
+    } else if (action.iconBuilder != null) {
+      leadingWidget = action.iconBuilder!(22, iconColor);
     } else {
       leadingWidget = null;
     }

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -175,7 +175,7 @@ class _SpotlightCardsBuilder {
         'collections': _collectionsCard,
       },
       'Season' => {
-        'episodes': () => _episodesCard(l10n.spotlightSeasonsEpisodes),
+        'episodes': () => _episodesCard(l10n.episodes),
         'people': _peopleCard,
         'chapters_extras': _chaptersExtrasCard,
         'similar': _similarCard,
@@ -509,7 +509,7 @@ class _SpotlightCardsBuilder {
     ].join(' · ');
     return SpotlightCardSpec(
       id: 'seasons',
-      title: l10n.spotlightSeasonsEpisodes,
+      title: l10n.seasons,
       subtitle: subtitle,
       imageUrl:
           _firstEpisodeThumb([

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -53,6 +53,7 @@ class SpotlightCardActions {
 class SpotlightCardSpec {
   final String id;
   final String title;
+  final String? modalTitle;
   final String subtitle;
   final String? imageUrl;
   final IconData icon;
@@ -61,11 +62,14 @@ class SpotlightCardSpec {
   const SpotlightCardSpec({
     required this.id,
     required this.title,
+    this.modalTitle,
     required this.subtitle,
     required this.imageUrl,
     required this.icon,
     required this.sections,
   });
+
+  String get effectiveModalTitle => modalTitle ?? title;
 }
 
 /// A runtime for a card subtitle or the hero's metadata row: "1h 32m", "2h",
@@ -175,13 +179,13 @@ class _SpotlightCardsBuilder {
         'collections': _collectionsCard,
       },
       'Season' => {
-        'episodes': () => _episodesCard(l10n.episodes),
+        'episodes': _seasonEpisodesCard,
         'people': _peopleCard,
         'chapters_extras': _chaptersExtrasCard,
         'similar': _similarCard,
       },
       'Episode' => {
-        'episodes': () => _episodesCard(l10n.spotlightMoreEpisodes),
+        'episodes': _episodeMoreEpisodesCard,
         'people': _peopleCard,
         'chapters_extras': _chaptersExtrasCard,
         'similar': _similarCard,
@@ -507,9 +511,12 @@ class _SpotlightCardsBuilder {
       l10n.spotlightSeasonsCount(seasons.length),
       if (episodeCount > 0) l10n.spotlightEpisodesCount(episodeCount),
     ].join(' · ');
+    final modalTitle =
+        item.name.trim().isNotEmpty ? item.name.trim() : l10n.seasons;
     return SpotlightCardSpec(
       id: 'seasons',
       title: l10n.seasons,
+      modalTitle: modalTitle,
       subtitle: subtitle,
       imageUrl:
           _firstEpisodeThumb([
@@ -522,12 +529,17 @@ class _SpotlightCardsBuilder {
     );
   }
 
-  SpotlightCardSpec? _episodesCard(String title) {
+  SpotlightCardSpec? _seasonEpisodesCard() {
     final episodes = vm.episodes;
     if (episodes.isEmpty) return null;
+    final series = item.seriesName?.trim();
+    final modalTitle = (series != null && series.isNotEmpty)
+        ? '$series - ${item.name}'
+        : item.name;
     return SpotlightCardSpec(
       id: 'episodes',
-      title: title,
+      title: l10n.episodes,
+      modalTitle: modalTitle,
       subtitle: l10n.spotlightEpisodesCount(episodes.length),
       imageUrl: _firstEpisodeThumb(episodes) ?? fallbackImageUrl,
       icon: Icons.video_collection_outlined,
@@ -539,6 +551,81 @@ class _SpotlightCardsBuilder {
           landscapeCells: true,
         ),
       ],
+    );
+  }
+
+  SpotlightCardSpec? _episodeMoreEpisodesCard() {
+    if (item.seriesId != null && !vm.seriesEpisodesLoaded) {
+      vm.loadAllSeriesEpisodes();
+    }
+    final allEpisodes = vm.seriesEpisodes;
+    final episodes = allEpisodes.isNotEmpty ? allEpisodes : vm.episodes;
+    if (episodes.isEmpty) return null;
+
+    final defaultSeason = item.parentIndexNumber ?? 1;
+    final sorted = [...episodes]..sort((a, b) {
+      final sa = a.parentIndexNumber ?? defaultSeason;
+      final sb = b.parentIndexNumber ?? defaultSeason;
+      if (sa != sb) return sa.compareTo(sb);
+      return (a.indexNumber ?? 0).compareTo(b.indexNumber ?? 0);
+    });
+
+    final Map<int, List<AggregatedItem>> seasonGroups = {};
+    for (final ep in sorted) {
+      final s = ep.parentIndexNumber ?? defaultSeason;
+      seasonGroups.putIfAbsent(s, () => []).add(ep);
+    }
+
+    final currentSeasonNumber = item.parentIndexNumber;
+    final sections = <SpotlightModalSection>[];
+    for (final entry in seasonGroups.entries) {
+      final seasonNum = entry.key;
+      final seasonEpisodes = entry.value;
+      final isCurrent = currentSeasonNumber != null
+          ? seasonNum == currentSeasonNumber
+          : seasonEpisodes.any(
+              (e) =>
+                  e.id == item.id ||
+                  (item.seasonId != null && e.seasonId == item.seasonId),
+            );
+      final seasonTitle = seasonNum == 0
+          ? l10n.specials
+          : l10n.seasonNumber(seasonNum);
+      sections.add(
+        SpotlightModalSection(
+          id: 'season_$seasonNum',
+          title: seasonTitle,
+          count: seasonEpisodes.length,
+          collapsible: true,
+          initiallyExpanded: isCurrent,
+          builder: (context, firstFocusNode) => SpotlightMediaGridSection(
+            items: seasonEpisodes,
+            imageApi: _imageApi,
+            prefs: prefs,
+            aspectRatio: 16 / 9,
+            landscapeCells: true,
+            firstFocusNode: firstFocusNode,
+            onItemTap: actions.openItem,
+          ),
+        ),
+      );
+    }
+
+    final subtitle = seasonGroups.length > 1
+        ? [
+            l10n.spotlightSeasonsCount(seasonGroups.length),
+            l10n.spotlightEpisodesCount(episodes.length),
+          ].join(' · ')
+        : l10n.spotlightEpisodesCount(episodes.length);
+
+    return SpotlightCardSpec(
+      id: 'episodes',
+      title: l10n.spotlightMoreEpisodes,
+      modalTitle: l10n.spotlightMoreEpisodes,
+      subtitle: subtitle,
+      imageUrl: _firstEpisodeThumb(episodes) ?? fallbackImageUrl,
+      icon: Icons.video_collection_outlined,
+      sections: sections,
     );
   }
 

--- a/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_detail_content.dart
@@ -337,7 +337,7 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
     try {
       final action = await SpotlightSectionModal.show<VoidCallback>(
         context,
-        title: spec.title,
+        title: spec.effectiveModalTitle,
         icon: spec.icon,
         sections: spec.sections,
         returnFocus: _cardFocusNodes[spec.id],
@@ -388,7 +388,11 @@ class _SpotlightDetailContentState extends State<SpotlightDetailContent> {
           )
         : null;
     final card = current ?? opened;
-    return (title: card.title, icon: card.icon, sections: card.sections);
+    return (
+      title: card.effectiveModalTitle,
+      icon: card.icon,
+      sections: card.sections,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart
@@ -5,6 +5,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 import '../../../../../util/focus/dpad_keys.dart';
 import '../../../../../util/platform_detection.dart';
 import '../../../../widgets/adaptive/sf_symbol.dart';
+import '../../../../widgets/focus/focusable_wrapper.dart';
 import '../../../../widgets/overlay_sheet.dart';
 
 /// One section inside a [SpotlightSectionModal]: an optional header plus a
@@ -13,15 +14,21 @@ import '../../../../widgets/overlay_sheet.dart';
 /// as a pill next to the title. Leave [title] off for content that stands on
 /// its own, like the Seerr chips and stats.
 class SpotlightModalSection {
+  final String? id;
   final String? title;
   final int? count;
+  final bool collapsible;
+  final bool initiallyExpanded;
   final Widget Function(BuildContext context, FocusNode? firstFocusNode)
   builder;
 
   const SpotlightModalSection({
+    this.id,
     this.title,
     required this.builder,
     this.count,
+    this.collapsible = false,
+    this.initiallyExpanded = true,
   });
 }
 
@@ -117,6 +124,24 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
   late String _title = widget.title;
   late IconData? _icon = widget.icon;
   late List<SpotlightModalSection> _sections = widget.sections;
+  final Map<String, bool> _expandedSections = {};
+
+  String _sectionKey(SpotlightModalSection section, int index) =>
+      section.id ?? section.title ?? '$index';
+
+  bool _isSectionExpanded(SpotlightModalSection section, int index) {
+    if (!section.collapsible) return true;
+    final key = _sectionKey(section, index);
+    return _expandedSections[key] ?? section.initiallyExpanded;
+  }
+
+  void _toggleSection(SpotlightModalSection section, int index) {
+    final key = _sectionKey(section, index);
+    final current = _isSectionExpanded(section, index);
+    setState(() {
+      _expandedSections[key] = !current;
+    });
+  }
 
   /// Takes the latest content whenever the host notifies. Every cell carries
   /// a stable key, so a rebuild reuses the elements already on screen rather
@@ -190,10 +215,21 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
     TextTheme textTheme,
     SpotlightModalSection section,
     String title,
+    int index,
+    bool isExpanded,
   ) {
     final count = section.count;
-    return Row(
+    final row = Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
+        if (section.collapsible) ...[
+          AdaptiveIcon(
+            isExpanded ? Icons.expand_more : Icons.chevron_right,
+            size: 20,
+            color: AppColorScheme.onSurface.withValues(alpha: 0.7),
+          ),
+          const SizedBox(width: 6),
+        ],
         Flexible(
           child: Text(
             title,
@@ -223,6 +259,26 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
         ],
       ],
     );
+
+    if (!section.collapsible) {
+      return row;
+    }
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: FocusableWrapper(
+        onSelect: () => _toggleSection(section, index),
+        borderRadius: 8,
+        disableScale: true,
+        useBackgroundFocus: true,
+        autoScroll: true,
+        suppressFocusGlow: true,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+          child: row,
+        ),
+      ),
+    );
   }
 
   @override
@@ -232,6 +288,14 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
     final glass = AppColorScheme.isGlass;
     final textTheme = Theme.of(context).textTheme;
 
+    int? firstExpandedIndex;
+    for (var i = 0; i < _sections.length; i++) {
+      if (_isSectionExpanded(_sections[i], i)) {
+        firstExpandedIndex = i;
+        break;
+      }
+    }
+
     final scrollView = SingleChildScrollView(
       controller: _scrollController,
       padding: const EdgeInsets.fromLTRB(24, 16, 24, 24),
@@ -239,16 +303,31 @@ class _SpotlightModalShellState extends State<_SpotlightModalShell> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           for (var i = 0; i < _sections.length; i++) ...[
-            if (i > 0) const SizedBox(height: 24),
+            if (i > 0)
+              SizedBox(
+                height: _sections[i - 1].collapsible &&
+                        !_isSectionExpanded(_sections[i - 1], i - 1)
+                    ? 8
+                    : 24,
+              ),
             if (_sections[i].title case final title?)
               Padding(
-                padding: const EdgeInsets.only(bottom: 10),
-                child: _sectionHeader(textTheme, _sections[i], title),
+                padding: EdgeInsets.only(
+                  bottom: _isSectionExpanded(_sections[i], i) ? 10 : 0,
+                ),
+                child: _sectionHeader(
+                  textTheme,
+                  _sections[i],
+                  title,
+                  i,
+                  _isSectionExpanded(_sections[i], i),
+                ),
               ),
-            _sections[i].builder(
-              context,
-              i == 0 ? _firstCellFocusNode : null,
-            ),
+            if (_isSectionExpanded(_sections[i], i))
+              _sections[i].builder(
+                context,
+                i == firstExpandedIndex ? _firstCellFocusNode : null,
+              ),
           ],
         ],
       ),

--- a/lib/ui/theme/focus_foreground.dart
+++ b/lib/ui/theme/focus_foreground.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+/// Text and icon colour that stays readable on top of a solid focus fill.
+///
+/// Read off the fill rather than taking a theme's own onButtonFocused, which
+/// is picked to sit on the surface and not on this highlight. Moonfin pairs a
+/// white fill with the accent and Neon Pulse pairs cyan with white, either of
+/// which leaves the label barely there once the fill is behind it.
+Color readableOnFocusFill(Color fill) =>
+    ThemeData.estimateBrightnessForColor(fill) == Brightness.dark
+    ? AppColorScheme.onSurface
+    : AppColors.black;

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -105,6 +105,8 @@ void main() {
     when(() => vm.seasons).thenReturn(const []);
     when(() => vm.episodes).thenReturn(const []);
     when(() => vm.seriesEpisodes).thenReturn(const []);
+    when(() => vm.seriesEpisodesLoaded).thenReturn(true);
+    when(() => vm.loadAllSeriesEpisodes()).thenAnswer((_) async {});
     when(() => vm.nextUp).thenReturn(null);
     when(() => vm.tracks).thenReturn(const []);
     when(() => vm.albums).thenReturn(const []);
@@ -192,11 +194,16 @@ void main() {
       _child('season-1', 'Season'),
       _child('season-2', 'Season'),
     ]);
-    final cards = cardsFor(_item('Series', {'RecursiveItemCount': 20}));
+    final cards = cardsFor(_item('Series', {
+      'RecursiveItemCount': 20,
+      'Name': 'Deadwood',
+    }));
 
     final seasons = cards.first;
     expect(seasons.id, 'seasons');
     expect(seasons.title, _l10n.seasons);
+    expect(seasons.modalTitle, 'Deadwood');
+    expect(seasons.effectiveModalTitle, 'Deadwood');
     expect(seasons.subtitle, '2 seasons · 20 episodes');
     expect(seasons.sections.single.title, _l10n.seasons);
   });
@@ -206,11 +213,16 @@ void main() {
       _child('ep-1', 'Episode'),
       _child('ep-2', 'Episode'),
     ]);
-    final cards = cardsFor(_item('Season'));
+    final cards = cardsFor(_item('Season', {
+      'SeriesName': 'Deadwood',
+      'Name': 'Season 1',
+    }));
 
     final episodes = cards.first;
     expect(episodes.id, 'episodes');
     expect(episodes.title, _l10n.episodes);
+    expect(episodes.modalTitle, 'Deadwood - Season 1');
+    expect(episodes.effectiveModalTitle, 'Deadwood - Season 1');
     expect(episodes.subtitle, '2 episodes');
     expect(episodes.sections.single.title, _l10n.episodes);
   });
@@ -221,11 +233,54 @@ void main() {
       _child('ep-2', 'Episode'),
       _child('ep-3', 'Episode'),
     ]);
-    final cards = cardsFor(_item('Episode'));
+    final cards = cardsFor(_item('Episode', {'ParentIndexNumber': 1}));
 
     expect(cards.single.id, 'episodes');
     expect(cards.single.title, 'More Episodes');
+    expect(cards.single.effectiveModalTitle, 'More Episodes');
     expect(cards.single.subtitle, '3 episodes');
+    expect(cards.single.sections.single.title, 'Season 1');
+    expect(cards.single.sections.single.collapsible, isTrue);
+    expect(cards.single.sections.single.initiallyExpanded, isTrue);
+  });
+
+  test('an episode groups multiple seasons with only current season expanded', () {
+    when(() => vm.seriesEpisodes).thenReturn([
+      AggregatedItem(
+        id: 'ep-s1-1',
+        serverId: 'server-1',
+        rawData: const {
+          'Id': 'ep-s1-1',
+          'Type': 'Episode',
+          'Name': 'S1E1',
+          'ParentIndexNumber': 1,
+          'IndexNumber': 1,
+        },
+      ),
+      AggregatedItem(
+        id: 'ep-s2-1',
+        serverId: 'server-1',
+        rawData: const {
+          'Id': 'ep-s2-1',
+          'Type': 'Episode',
+          'Name': 'S2E1',
+          'ParentIndexNumber': 2,
+          'IndexNumber': 1,
+        },
+      ),
+    ]);
+    final cards = cardsFor(_item('Episode', {'ParentIndexNumber': 2}));
+
+    expect(cards.single.id, 'episodes');
+    expect(cards.single.title, 'More Episodes');
+    expect(cards.single.subtitle, '2 seasons · 2 episodes');
+    expect(cards.single.sections.length, 2);
+    expect(cards.single.sections[0].title, 'Season 1');
+    expect(cards.single.sections[0].collapsible, isTrue);
+    expect(cards.single.sections[0].initiallyExpanded, isFalse);
+    expect(cards.single.sections[1].title, 'Season 2');
+    expect(cards.single.sections[1].collapsible, isTrue);
+    expect(cards.single.sections[1].initiallyExpanded, isTrue);
   });
 
   test('a music album gets the track list card', () {

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -196,9 +196,23 @@ void main() {
 
     final seasons = cards.first;
     expect(seasons.id, 'seasons');
-    expect(seasons.title, 'Seasons and Episodes');
+    expect(seasons.title, _l10n.seasons);
     expect(seasons.subtitle, '2 seasons · 20 episodes');
     expect(seasons.sections.single.title, _l10n.seasons);
+  });
+
+  test('a season leads with the episodes card', () {
+    when(() => vm.episodes).thenReturn([
+      _child('ep-1', 'Episode'),
+      _child('ep-2', 'Episode'),
+    ]);
+    final cards = cardsFor(_item('Season'));
+
+    final episodes = cards.first;
+    expect(episodes.id, 'episodes');
+    expect(episodes.title, _l10n.episodes);
+    expect(episodes.subtitle, '2 episodes');
+    expect(episodes.sections.single.title, _l10n.episodes);
   });
 
   test('an episode offers the rest of its season', () {

--- a/test/ui/theme/focus_foreground_contrast_test.dart
+++ b/test/ui/theme/focus_foreground_contrast_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/ui/theme/focus_foreground.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+/// WCAG 2.1 contrast ratio. Flutter's computeLuminance is already the WCAG
+/// relative luminance, so this is only the ratio around it.
+double _contrast(Color a, Color b) {
+  final la = a.computeLuminance();
+  final lb = b.computeLuminance();
+  final hi = la > lb ? la : lb;
+  final lo = la > lb ? lb : la;
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+void main() {
+  tearDown(() => ThemeRegistry.setActiveById(ThemeRegistry.moonfinId));
+
+  test('every theme focus fill carries readable text', () {
+    for (final entry in ThemeRegistry.availableThemes.entries) {
+      final fill = entry.value.colors.buttonFocused;
+      // The active theme is what readableOnFocusFill reads onSurface from.
+      ThemeRegistry.setActiveById(entry.key);
+      final ratio = _contrast(readableOnFocusFill(fill), fill);
+      expect(
+        ratio,
+        greaterThanOrEqualTo(4.5),
+        reason:
+            '${entry.key}: foreground on buttonFocused is only '
+            '${ratio.toStringAsFixed(2)}:1',
+      );
+    }
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Refines the Spotlight theme and media detail action overflows:
1. Fixes TV focus highlighting and text readability in the More Actions popup dialog across themes, avoiding low-contrast text on focus backgrounds.
2. Capitalizes 'More Actions' in English localization strings (app_en.arb).
3. Standardizes the personal rating layout in menu/tile views when thumbs rating is configured, rendering a single left-aligned thumb icon beside the label.
4. Updates TV show lead card titles in Spotlight so Series cards display "Seasons" and Season cards display "Episodes".

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **item_detail_screen.dart**:
  - Replaced generic `DpadListTile` in `_showOverflowMenu` with a dedicated `_SpotlightOverflowTile` that computes high-contrast foreground color on TV focus to avoid invisible/low-contrast text.
  - Resolved `FocusNode` attachment collision assertions when navigating in and out of the overflow dialog.
  - Normalized rating button layout at menu scale (`size <= 24`) for `PersonalRatingStyle.thumbs`, rendering a single thumb icon beside the label instead of an unbounded centered double-thumb row.
- **app_en.arb**:
  - Updated `spotlightMoreActions` to "More Actions".
- **spotlight_cards.dart**:
  - Updated Series lead card spec to use `l10n.seasons` ("Seasons").
  - Updated Season lead card spec to use `l10n.episodes` ("Episodes").
- **spotlight_cards_test.dart**:
  - Updated assertions to match "Seasons" and "Episodes" card labels.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a media details page in Spotlight theme on TV and desktop/mobile.
2. Focus and open the More Actions ellipsis popup.
3. Verify that focused rows display high-contrast readable text and icons on the selection highlight.
4. Switch Personal Rating style to thumbs and verify the More Actions menu renders a single thumb icon beside the "Rate" / "Like" / "Dislike" label.
5. View a TV Series and a TV Season in Spotlight theme and verify the lead cards are labeled "Seasons" and "Episodes" respectively.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-11_22-19-28" src="https://github.com/user-attachments/assets/f03af6e8-da1c-4191-8c05-cec49842816c" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-11_22-20-00" src="https://github.com/user-attachments/assets/c2dc243f-25a8-419f-8c6b-e4988deac2da" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-11_22-40-20" src="https://github.com/user-attachments/assets/7f875afd-da7e-4619-8da5-e84d12bebe31" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
