### PR TITLE
bugfix/feat-buttons - Details Page Action Button refinements

### DIFF
--- a/lib/data/viewmodels/item_detail_view_model.dart
+++ b/lib/data/viewmodels/item_detail_view_model.dart
@@ -473,22 +473,57 @@ class ItemDetailViewModel extends ChangeNotifier {
   Future<void> _loadSeerrOverlay() async {
     final item = _item;
     if (item == null) return;
-    if (item.type != 'Movie' && item.type != 'Series') return;
+    final isMedia = item.type == 'Movie' || item.type == 'Series';
+    final isTvPart = item.type == 'Season' || item.type == 'Episode';
+    if (!isMedia && !isTvPart) return;
     if (!GetIt.instance<PluginSyncService>().seerrAvailable) return;
 
-    // TMDB is the id Seerr speaks. IMDb goes through its search fallback.
-    final tmdbId = item.tmdbId;
-    final lookupId = (tmdbId != null && tmdbId.isNotEmpty)
-        ? tmdbId
-        : item.imdbId;
+    String? lookupId;
+    String mediaType = 'movie';
+    String title = item.name;
+
+    if (item.type == 'Movie') {
+      lookupId = (item.tmdbId != null && item.tmdbId!.isNotEmpty)
+          ? item.tmdbId
+          : item.imdbId;
+      mediaType = 'movie';
+      title = item.name;
+    } else if (item.type == 'Series') {
+      lookupId = (item.tmdbId != null && item.tmdbId!.isNotEmpty)
+          ? item.tmdbId
+          : item.imdbId;
+      mediaType = 'tv';
+      title = item.name;
+    } else if (isTvPart) {
+      final seriesId = item.seriesId;
+      if (seriesId != null && seriesId.isNotEmpty) {
+        try {
+          final seriesData = await _client.itemsApi.getItem(seriesId);
+          if (_isDisposed) return;
+          final seriesItem = AggregatedItem(
+            id: seriesId,
+            serverId: _serverId ?? _client.baseUrl,
+            rawData: seriesData,
+          );
+          lookupId =
+              (seriesItem.tmdbId != null && seriesItem.tmdbId!.isNotEmpty)
+                  ? seriesItem.tmdbId
+                  : seriesItem.imdbId;
+          mediaType = 'tv';
+          title = seriesItem.name;
+        } catch (_) {}
+      }
+    }
+
     if (lookupId == null || lookupId.isEmpty) return;
 
     try {
       final vm = await _ensureSeerr();
+      if (_isDisposed) return;
       await vm.load(
         lookupId,
-        item.type == 'Series' ? 'tv' : 'movie',
-        title: item.name,
+        mediaType,
+        title: title,
       );
     } catch (_) {}
   }
@@ -697,7 +732,7 @@ class ItemDetailViewModel extends ChangeNotifier {
         for (final season in s.tv?.seasons ?? const [])
           if (season.seasonNumber > 0)
             AggregatedItem(
-              id: '${itemId}:s${season.seasonNumber}',
+              id: '$itemId:s${season.seasonNumber}',
               serverId: 'seerr',
               rawData: {
                 'Name': season.name ?? '',

--- a/lib/ui/screens/detail/detail_buttons.dart
+++ b/lib/ui/screens/detail/detail_buttons.dart
@@ -5,6 +5,7 @@ import '../../../data/services/plugin_sync_service.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../preference/button_layout.dart';
 import '../../../preference/user_preferences.dart';
+import '../../../syncplay/syncplay_manager.dart';
 import '../../../util/platform_detection.dart';
 
 /// The details screen action buttons a user can arrange. Play is absent on
@@ -70,8 +71,20 @@ enum DetailButton {
     DetailButton.seerrReportIssue ||
     DetailButton.seerrManage =>
       GetIt.instance<PluginSyncService>().seerrAvailable,
+    DetailButton.watchWithGroup => _syncPlayAvailable,
     _ => true,
   };
+
+  static bool get _syncPlayAvailable {
+    try {
+      if (GetIt.instance.isRegistered<SyncPlayManager>()) {
+        return GetIt.instance<SyncPlayManager>().syncPlayEnabled;
+      }
+      return GetIt.instance<UserPreferences>().get(UserPreferences.syncPlayEnabled);
+    } catch (_) {
+      return false;
+    }
+  }
 
   IconData get icon => switch (this) {
     DetailButton.shuffle => Icons.shuffle_rounded,
@@ -108,7 +121,7 @@ enum DetailButton {
     DetailButton.watched => l10n.watched,
     DetailButton.favorite => l10n.favorite,
     DetailButton.personalRating => l10n.rate,
-    DetailButton.playlist => l10n.playlist,
+    DetailButton.playlist => l10n.addToPlaylist,
     DetailButton.download => l10n.download,
     DetailButton.deleteFiles => l10n.deleteDownloadedFiles,
     DetailButton.goToSeries => l10n.goToSeries,

--- a/lib/ui/screens/detail/detail_buttons.dart
+++ b/lib/ui/screens/detail/detail_buttons.dart
@@ -110,7 +110,7 @@ enum DetailButton {
     DetailButton.personalRating => l10n.rate,
     DetailButton.playlist => l10n.playlist,
     DetailButton.download => l10n.download,
-    DetailButton.deleteFiles => l10n.deleteFiles,
+    DetailButton.deleteFiles => l10n.deleteDownloadedFiles,
     DetailButton.goToSeries => l10n.goToSeries,
     DetailButton.seerrRequest => l10n.request,
     DetailButton.seerrRequest4k => l10n.request4k,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -7009,7 +7009,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         ),
       if (!isBook && shows(DetailButton.playlist))
         DetailButton.playlist: _DetailActionButton(
-          label: l10n.playlist,
+          label: l10n.addToPlaylist,
           icon: Icons.playlist_add,
           onPressed: () => AddToPlaylistDialog.show(
             context,
@@ -7052,7 +7052,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         ),
       if (seerr != null && shows(DetailButton.seerrWatchlist))
         DetailButton.seerrWatchlist: _DetailActionButton(
-          label: onWatchlist ? l10n.onWatchlist : l10n.watchlist,
+          label: onWatchlist ? l10n.removeFromWatchlist : l10n.addToWatchlist,
           icon: onWatchlist ? Icons.bookmark : Icons.bookmark_border,
           onPressed: () => seerr.toggleWatchlist(),
           isActive: onWatchlist,

--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -6271,7 +6271,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
     List<Widget> extraButtons,
   ) async {
     final l10n = AppLocalizations.of(context);
-    final actions = extraButtons.whereType<_DetailActionButton>().toList();
+    final actions = <_DetailActionButton>[
+      for (final btn in extraButtons)
+        ?_actionForOverflow(context, btn),
+    ];
     if (actions.isEmpty) return;
     final selected = await showStyledPlayerDialog<VoidCallback>(
       context,
@@ -6297,6 +6300,121 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
       // immediately open a dialog of their own.
       WidgetsBinding.instance.addPostFrameCallback((_) => selected());
     }
+  }
+
+  _DetailActionButton? _actionForOverflow(
+    BuildContext context,
+    Widget button,
+  ) {
+    if (button is _DetailActionButton) {
+      return button;
+    }
+    if (button is _DownloadButton) {
+      return _buildDownloadDetailAction(context, button.item);
+    }
+    if (button is _DeleteDownloadButton) {
+      return _buildDeleteDetailAction(context, button.item);
+    }
+    return null;
+  }
+
+  _DetailActionButton _buildDownloadDetailAction(
+    BuildContext context,
+    AggregatedItem item,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    final downloadService = GetIt.instance.isRegistered<DownloadService>()
+        ? GetIt.instance<DownloadService>()
+        : null;
+    final progress = downloadService?.activeDownloads[item.id];
+    final isMulti = _DownloadButtonState._isBatchType(item.type);
+    final isBatch = downloadService?.isBatchDownloading ?? false;
+
+    if (progress != null && !progress.isComplete && progress.error == null) {
+      final label = progress.isFinalizing
+          ? l10n.finalizingDownload
+          : progress.isQueued
+          ? l10n.queuedDownload
+          : progress.progress >= 0
+          ? '${(progress.progress * 100).toInt()}%'
+          : progress.bytesReceived > 0
+          ? '${(progress.bytesReceived / 1048576).toStringAsFixed(1)} MB'
+          : '…';
+      return _DetailActionButton(
+        label: label,
+        icon: Icons.close,
+        onPressed: () => downloadService?.cancelDownload(item.id),
+        isActive: true,
+        activeColor: AppColorScheme.accent,
+      );
+    }
+
+    if (isBatch && isMulti && downloadService != null) {
+      final done = downloadService.completedCount;
+      final total = downloadService.totalQueued;
+      var pct = '';
+      for (final p in downloadService.activeDownloads.values) {
+        if (!p.isComplete && p.error == null) {
+          if (p.progress >= 0) {
+            pct = '${(p.progress * 100).toInt()}%';
+          }
+          break;
+        }
+      }
+      return _DetailActionButton(
+        label: '${done + 1}/$total${pct.isNotEmpty ? ' · $pct' : ''}',
+        icon: Icons.close,
+        onPressed: () => downloadService.cancelAll(),
+        isActive: true,
+        activeColor: AppColorScheme.accent,
+      );
+    }
+
+    if (_availableOffline || (progress != null && progress.isComplete)) {
+      return _DetailActionButton(
+        label: l10n.downloaded,
+        icon: Icons.download_done,
+        isActive: true,
+        activeColor: const Color(0xFF4CAF50),
+        onPressed: () {
+          if (downloadService != null) {
+            _DownloadButton.showDownloadOptions(context, item, downloadService);
+          }
+        },
+      );
+    }
+
+    return _DetailActionButton(
+      label: l10n.download,
+      icon: Icons.download_for_offline,
+      onPressed: () {
+        if (downloadService != null) {
+          _DownloadButton.showDownloadOptions(context, item, downloadService);
+        }
+      },
+    );
+  }
+
+  _DetailActionButton _buildDeleteDetailAction(
+    BuildContext context,
+    AggregatedItem item,
+  ) {
+    final l10n = AppLocalizations.of(context);
+    return _DetailActionButton(
+      label: l10n.deleteDownloadedFiles,
+      icon: Icons.delete_outline,
+      onPressed: () => _DeleteDownloadButton.confirmDelete(
+        context,
+        item,
+        onDeleted: () {
+          if (mounted) {
+            setState(() => _availableOffline = false);
+          }
+        },
+      ),
+      isActive: true,
+      activeColor: const Color(0xFFFF4757),
+    );
   }
 
   /// The count-based overflow decision, extracted pure so the Spotlight cap
@@ -6908,7 +7026,7 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           shows(DetailButton.deleteFiles) &&
           _availableOffline)
         DetailButton.deleteFiles: _DeleteDownloadButton(item: item),
-      if (item.type == 'Episode' &&
+      if ((item.type == 'Episode' || item.type == 'Season') &&
           item.seriesId != null &&
           shows(DetailButton.goToSeries))
         DetailButton.goToSeries: _DetailActionButton(
@@ -6946,8 +7064,14 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
         DetailButton.seerrReportIssue: _DetailActionButton(
           label: l10n.reportIssue,
           icon: Icons.report_problem_outlined,
-          onPressed: () =>
-              showSeerrReportIssueDialog(context: context, vm: seerr),
+          onPressed: () => showSeerrReportIssueDialog(
+            context: context,
+            vm: seerr,
+            initialSeason: item.type == 'Episode'
+                ? item.parentIndexNumber
+                : (item.type == 'Season' ? item.indexNumber : null),
+            initialEpisode: item.type == 'Episode' ? item.indexNumber : null,
+          ),
         ),
       if (seerr != null &&
           seerr.canManageRequests &&
@@ -7090,11 +7214,10 @@ class DetailActionButtonsState extends State<DetailActionButtons> {
           (button) => button.id,
           prefs,
         )) ...[
-          if (byButton[detailButton] case final _DetailActionButton button)
-            button,
-          if (cancelByButton[detailButton]
-              case final _DetailActionButton button)
-            button,
+          if (byButton[detailButton] case final btn?)
+            ?_actionForOverflow(context, btn),
+          if (cancelByButton[detailButton] case final btn?)
+            ?_actionForOverflow(context, btn),
         ],
       ];
 
@@ -10626,6 +10749,12 @@ class _DownloadButton extends StatefulWidget {
     this.suppressAutoScrollToTop = false,
   });
 
+  static void showDownloadOptions(
+    BuildContext context,
+    AggregatedItem item,
+    DownloadService service,
+  ) => _DownloadButtonState._showDownloadOptionsFor(context, item, service);
+
   @override
   State<_DownloadButton> createState() => _DownloadButtonState();
 }
@@ -10634,7 +10763,8 @@ class _DownloadButtonState extends State<_DownloadButton> {
   bool _isOffline = false;
   DownloadService? _downloadService;
 
-  String _originalQualitySubtitle(
+  static String _originalQualitySubtitle(
+    BuildContext context,
     AggregatedItem item, {
     required bool isMulti,
     List<AggregatedItem> batchItems = const [],
@@ -10642,6 +10772,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     final l10n = AppLocalizations.of(context);
     if (isMulti) {
       final sizeLabel = _batchSizeLabel(
+        context,
         batchItems,
         sourceSizeBytes,
         l10n.downloadSizeTotal,
@@ -10681,7 +10812,8 @@ class _DownloadButtonState extends State<_DownloadButton> {
     return details.join(' • ');
   }
 
-  String _qualitySubtitle(
+  static String _qualitySubtitle(
+    BuildContext context,
     AggregatedItem item,
     DownloadQuality quality, {
     required bool supportsTranscoding,
@@ -10690,6 +10822,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
   }) {
     if (!quality.isTranscoded || !supportsTranscoding) {
       return _originalQualitySubtitle(
+        context,
         item,
         isMulti: isMulti,
         batchItems: batchItems,
@@ -10698,6 +10831,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
 
     final estimate = isMulti
         ? _batchSizeLabel(
+            context,
             batchItems,
             (batchItem) => estimateTranscodedSizeBytes(batchItem, quality),
             AppLocalizations.of(context).downloadEstimateTotal,
@@ -10712,7 +10846,8 @@ class _DownloadButtonState extends State<_DownloadButton> {
   /// Sums [bytesOf] over [items], skipping items whose size is unknown, and
   /// formats the total with [label]. Notes how many items were skipped.
   /// Null when no item had a size.
-  String? _batchSizeLabel(
+  static String? _batchSizeLabel(
+    BuildContext context,
     List<AggregatedItem> items,
     int? Function(AggregatedItem item) bytesOf,
     String Function(String size) label,
@@ -10884,7 +11019,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
       type == 'Season' || type == 'Series' || type == 'BoxSet';
 
   /// One line of context under a sheet title.
-  Widget _sheetNote(BuildContext sheetContext, String text) => Padding(
+  static Widget _sheetNote(BuildContext sheetContext, String text) => Padding(
     padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
     child: Text(
       text,
@@ -10897,7 +11032,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     ),
   );
 
-  Widget _sheetTitle(BuildContext sheetContext, String text) => Padding(
+  static Widget _sheetTitle(BuildContext sheetContext, String text) => Padding(
     padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
     child: Text(
       text,
@@ -10908,25 +11043,33 @@ class _DownloadButtonState extends State<_DownloadButton> {
     ),
   );
 
+  void _showDownloadOptions(BuildContext context, DownloadService service) {
+    _showDownloadOptionsFor(context, widget.item, service);
+  }
+
   /// Entry point for the download button. Series, seasons and collections
   /// first ask whether to download everything or only unwatched items; single
   /// items go straight to the quality picker.
-  void _showDownloadOptions(BuildContext context, DownloadService service) {
-    if (_isBatchType(widget.item.type)) {
-      _showScopePicker(context, service);
+  static void _showDownloadOptionsFor(
+    BuildContext context,
+    AggregatedItem item,
+    DownloadService service,
+  ) {
+    if (_isBatchType(item.type)) {
+      _showScopePicker(context, item, service);
     } else {
-      _showQualityPicker(context, service);
+      _showQualityPicker(context, item, service);
     }
   }
 
   /// Asks whether to download all items or only unwatched ones, then opens
   /// the quality picker for the chosen list. The list is resolved once here
   /// so the counts, the size estimates and the queued downloads all agree.
-  Future<void> _showScopePicker(
+  static Future<void> _showScopePicker(
     BuildContext context,
+    AggregatedItem item,
     DownloadService service,
   ) async {
-    final item = widget.item;
     final isCollection = item.type == 'BoxSet';
     final seriesId = item.seriesId;
 
@@ -11013,6 +11156,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
                         children: [
                           _scopeRow(
                             sheetContext,
+                            item: item,
                             autofocus: true,
                             icon: Icons.download_for_offline,
                             label: isCollection
@@ -11023,6 +11167,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
                           ),
                           _scopeRow(
                             sheetContext,
+                            item: item,
                             autofocus: false,
                             icon: Icons.visibility_off_outlined,
                             label: isCollection
@@ -11038,6 +11183,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
                   if (autoDownloads != null)
                     _autoDownloadRow(
                       sheetContext,
+                      item,
                       autoDownloads,
                       initial: subscription,
                       onSubscription: (current) => subscription = current,
@@ -11054,26 +11200,27 @@ class _DownloadButtonState extends State<_DownloadButton> {
         );
     // Opened only after the scope sheet is gone, so the quality picker
     // restores focus to the Download button rather than to a disposed row.
-    if (!mounted) return;
+    if (!context.mounted) return;
     if (autoChosen) {
-      await _toggleAutoDownload(autoDownloads!, existing: subscription);
+      await _toggleAutoDownload(context, item, autoDownloads!, existing: subscription);
       return;
     }
     if (chosen == null) return;
-    _showQualityPicker(this.context, service, items: chosen);
+    _showQualityPicker(context, item, service, items: chosen);
   }
 
   /// Follows or unfollows the series. Following asks for a quality first so
   /// the subscription records one.
-  Future<void> _toggleAutoDownload(
+  static Future<void> _toggleAutoDownload(
+    BuildContext context,
+    AggregatedItem item,
     AutoDownloadService autoDownloads, {
     required AutoDownloadSubscription? existing,
   }) async {
-    final item = widget.item;
     final l10n = AppLocalizations.of(context);
     if (existing != null) {
       await autoDownloads.unsubscribe(item.id);
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(l10n.autoDownloadStoppedFor(item.name))),
       );
@@ -11081,10 +11228,11 @@ class _DownloadButtonState extends State<_DownloadButton> {
     }
     final quality = await _pickQuality(
       context,
+      item,
       title: l10n.autoDownloadQualityTitle,
       note: l10n.autoDownloadTranscodedForegroundNote,
     );
-    if (quality == null || !mounted) return;
+    if (quality == null || !context.mounted) return;
     unawaited(autoDownloads.subscribe(item, quality: quality));
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text(l10n.autoDownloadEnabledFor(item.name))),
@@ -11094,8 +11242,9 @@ class _DownloadButtonState extends State<_DownloadButton> {
   /// Third row of a series' scope sheet: subscribe to new episodes, or stop.
   /// Reports the current subscription through [onSubscription] so the
   /// caller knows which of the two [onTap] meant.
-  Widget _autoDownloadRow(
+  static Widget _autoDownloadRow(
     BuildContext sheetContext,
+    AggregatedItem item,
     AutoDownloadService autoDownloads, {
     required AutoDownloadSubscription? initial,
     required void Function(AutoDownloadSubscription?) onSubscription,
@@ -11108,7 +11257,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     );
     return StreamBuilder<AutoDownloadSubscription?>(
       initialData: initial,
-      stream: autoDownloads.watchSubscription(widget.item.id),
+      stream: autoDownloads.watchSubscription(item.id),
       builder: (_, snapshot) {
         final subscription = snapshot.data;
         onSubscription(subscription);
@@ -11143,8 +11292,9 @@ class _DownloadButtonState extends State<_DownloadButton> {
     );
   }
 
-  Widget _scopeRow(
+  static Widget _scopeRow(
     BuildContext sheetContext, {
+    required AggregatedItem item,
     required bool autofocus,
     required IconData icon,
     required String label,
@@ -11156,7 +11306,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     final enabled = loading || items.isNotEmpty;
     final subtitle = loading
         ? l10n.downloadScopeLoading
-        : widget.item.type == 'BoxSet'
+        : item.type == 'BoxSet'
         ? l10n.itemCountLabel(items.length)
         : l10n.episodeCount(items.length);
     return DpadListTile(
@@ -11187,26 +11337,27 @@ class _DownloadButtonState extends State<_DownloadButton> {
   /// Shows the quality picker and queues the download. For series, seasons
   /// and collections [items] is the list resolved by the scope picker and
   /// drives both the size estimate and what gets queued.
-  Future<void> _showQualityPicker(
+  static Future<void> _showQualityPicker(
     BuildContext context,
+    AggregatedItem item,
     DownloadService service, {
     List<AggregatedItem>? items,
   }) async {
-    final item = widget.item;
     final isMulti = _isBatchType(item.type);
     if (!isMulti && !_supportsTranscoding(item.type)) {
-      _startDownload(context, service, DownloadQuality.original);
+      _startDownload(context, item, service, DownloadQuality.original);
       return;
     }
     final quality = await _pickQuality(
       context,
+      item,
       title: isMulti
           ? AppLocalizations.of(context).downloadAllQuality
           : AppLocalizations.of(context).downloadQuality,
       items: items ?? const [],
     );
-    if (quality == null || !mounted) return;
-    _startDownload(this.context, service, quality, items: items);
+    if (quality == null || !context.mounted) return;
+    _startDownload(context, item, service, quality, items: items);
   }
 
   static bool _supportsTranscoding(String? type) =>
@@ -11219,13 +11370,13 @@ class _DownloadButtonState extends State<_DownloadButton> {
   /// [items] for batches. Null when the sheet is dismissed.
   /// [note] is shown once under the title, for callers where the choice has
   /// a consequence worth stating.
-  Future<DownloadQuality?> _pickQuality(
-    BuildContext context, {
+  static Future<DownloadQuality?> _pickQuality(
+    BuildContext context,
+    AggregatedItem item, {
     required String title,
     List<AggregatedItem> items = const [],
     String? note,
   }) {
-    final item = widget.item;
     final isMulti = _isBatchType(item.type);
     final supportsTranscoding = isMulti || _supportsTranscoding(item.type);
     final batchItems = items;
@@ -11253,6 +11404,7 @@ class _DownloadButtonState extends State<_DownloadButton> {
     final subtitles = {
       for (final quality in availableQualities)
         quality: _qualitySubtitle(
+          context,
           item,
           quality,
           supportsTranscoding: supportsTranscoding,
@@ -11348,13 +11500,13 @@ class _DownloadButtonState extends State<_DownloadButton> {
 
   /// Queues the download. [items] is the list chosen in the scope sheet for
   /// series, seasons and collections; single items leave it null.
-  void _startDownload(
+  static void _startDownload(
     BuildContext context,
+    AggregatedItem item,
     DownloadService service,
     DownloadQuality quality, {
     List<AggregatedItem>? items,
   }) {
-    final item = widget.item;
     final l10n = AppLocalizations.of(context);
     final String message;
     if (items != null) {
@@ -11402,6 +11554,16 @@ class _DeleteDownloadButton extends StatefulWidget {
     this.suppressAutoScrollToTop = false,
   });
 
+  static Future<void> confirmDelete(
+    BuildContext context,
+    AggregatedItem item, {
+    VoidCallback? onDeleted,
+  }) => _DeleteDownloadButtonState._confirmDelete(
+    context,
+    item,
+    onDeleted: onDeleted,
+  );
+
   @override
   State<_DeleteDownloadButton> createState() => _DeleteDownloadButtonState();
 }
@@ -11445,9 +11607,17 @@ class _DeleteDownloadButtonState extends State<_DeleteDownloadButton> {
     if (_checking || !_hasFiles) return const SizedBox.shrink();
 
     return _DetailActionButton(
-      label: AppLocalizations.of(context).deleteFiles,
+      label: AppLocalizations.of(context).deleteDownloadedFiles,
       icon: Icons.delete_outline,
-      onPressed: () => _confirmDelete(context),
+      onPressed: () => _confirmDelete(
+        context,
+        widget.item,
+        onDeleted: () {
+          if (mounted) {
+            setState(() => _hasFiles = false);
+          }
+        },
+      ),
       isActive: true,
       activeColor: const Color(0xFFFF4757),
       focusNode: widget.focusNode,
@@ -11460,8 +11630,11 @@ class _DeleteDownloadButtonState extends State<_DeleteDownloadButton> {
     );
   }
 
-  Future<void> _confirmDelete(BuildContext context) async {
-    final item = widget.item;
+  static Future<void> _confirmDelete(
+    BuildContext context,
+    AggregatedItem item, {
+    VoidCallback? onDeleted,
+  }) async {
     final l10n = AppLocalizations.of(context);
     final typeLabel = switch (item.type) {
       'Series' => l10n.deleteSeriesFiles(item.seriesName ?? item.name),
@@ -11510,7 +11683,7 @@ class _DeleteDownloadButtonState extends State<_DeleteDownloadButton> {
           ),
         );
         if (success) {
-          setState(() => _hasFiles = false);
+          onDeleted?.call();
         }
       }
     }
@@ -11535,31 +11708,13 @@ class _PersonalRatingActionIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return switch (style) {
-      PersonalRatingStyle.thumbs =>
+      PersonalRatingStyle.thumbs => Icon(
         likes == null
-            ? Center(
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(
-                      Icons.thumb_up_outlined,
-                      color: color,
-                      size: size * 0.5,
-                    ),
-                    SizedBox(width: size * 0.08),
-                    Icon(
-                      Icons.thumb_down_outlined,
-                      color: color,
-                      size: size * 0.5,
-                    ),
-                  ],
-                ),
-              )
-            : Icon(
-                likes! ? Icons.thumb_up : Icons.thumb_down,
-                color: color,
-                size: size * 0.72,
-              ),
+            ? Icons.thumb_up_outlined
+            : (likes! ? Icons.thumb_up : Icons.thumb_down),
+        color: color,
+        size: size * 0.85,
+      ),
       PersonalRatingStyle.stars => _StarFillIcon(
         fill: ((rating ?? 0).clamp(0, 10) / 10).toDouble(),
         size: size * 0.82,

--- a/lib/ui/widgets/seerr/seerr_report_issue_dialog.dart
+++ b/lib/ui/widgets/seerr/seerr_report_issue_dialog.dart
@@ -16,6 +16,8 @@ import '../track_selector_dialog.dart';
 void showSeerrReportIssueDialog({
   required BuildContext context,
   required SeerrMediaDetailViewModel vm,
+  int? initialSeason,
+  int? initialEpisode,
 }) {
   final s = vm.state;
   showStyledPlayerDialog<void>(
@@ -26,6 +28,8 @@ void showSeerrReportIssueDialog({
       isTv: s.isTv,
       seasons: s.tv?.seasons ?? const [],
       numberOfSeasons: s.numberOfSeasons ?? 0,
+      initialSeason: initialSeason,
+      initialEpisode: initialEpisode,
     ),
   );
 }
@@ -37,6 +41,8 @@ class SeerrReportIssueDialog extends StatefulWidget {
   final bool isTv;
   final List<SeerrSeason> seasons;
   final int numberOfSeasons;
+  final int? initialSeason;
+  final int? initialEpisode;
 
   const SeerrReportIssueDialog({
     super.key,
@@ -44,6 +50,8 @@ class SeerrReportIssueDialog extends StatefulWidget {
     required this.isTv,
     required this.seasons,
     required this.numberOfSeasons,
+    this.initialSeason,
+    this.initialEpisode,
   });
 
   @override
@@ -71,8 +79,15 @@ class _SeerrReportIssueDialogState extends State<SeerrReportIssueDialog> {
   @override
   void initState() {
     super.initState();
-    if (widget.isTv && _seasonNumbers.length == 1) {
-      _season = _seasonNumbers.first;
+    if (widget.isTv) {
+      if (widget.initialSeason != null && widget.initialSeason! > 0) {
+        _season = widget.initialSeason!;
+        if (widget.initialEpisode != null && widget.initialEpisode! > 0) {
+          _episode = widget.initialEpisode!;
+        }
+      } else if (_seasonNumbers.length == 1) {
+        _season = _seasonNumbers.first;
+      }
     }
   }
 

--- a/lib/ui/widgets/seerr/seerr_text_field.dart
+++ b/lib/ui/widgets/seerr/seerr_text_field.dart
@@ -41,25 +41,39 @@ class _SeerrTextFieldState extends State<SeerrTextField> {
   void initState() {
     super.initState();
     _effectiveFocusNode.addListener(_onFocusChanged);
+    CustomTVTextField.isKeyboardVisibleNotifier.addListener(_onKeyboardVisibilityChanged);
+  }
+
+  void _onKeyboardVisibilityChanged() {
+    if (_effectiveFocusNode.hasFocus && CustomTVTextField.isKeyboardVisibleNotifier.value) {
+      _scrollToVisible();
+    }
   }
 
   void _onFocusChanged() {
     if (_effectiveFocusNode.hasFocus) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
+      _scrollToVisible();
+    }
+  }
+
+  void _scrollToVisible() {
+    Future.delayed(const Duration(milliseconds: 150), () {
+      if (!mounted) return;
+      try {
         Scrollable.ensureVisible(
           context,
-          alignment: 0.2,
-          duration: const Duration(milliseconds: 180),
+          alignment: 0.5,
+          duration: const Duration(milliseconds: 200),
           curve: Curves.easeOut,
         );
-      });
-    }
+      } catch (_) {}
+    });
   }
 
   @override
   void dispose() {
     _effectiveFocusNode.removeListener(_onFocusChanged);
+    CustomTVTextField.isKeyboardVisibleNotifier.removeListener(_onKeyboardVisibilityChanged);
     _internalFocusNode?.dispose();
     super.dispose();
   }

--- a/lib/ui/widgets/seerr/seerr_text_field.dart
+++ b/lib/ui/widgets/seerr/seerr_text_field.dart
@@ -1,9 +1,11 @@
 import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../preference/user_preferences.dart';
+import '../../../util/focus/dpad_keys.dart';
 import '../../../util/platform_detection.dart';
 
 /// Text input for seerr dialogs that uses the TV keyboard (honoring the
@@ -13,6 +15,7 @@ class SeerrTextField extends StatefulWidget {
   final String hint;
   final int maxLines;
   final ValueChanged<String>? onSubmitted;
+  final FocusNode? focusNode;
 
   const SeerrTextField({
     super.key,
@@ -20,6 +23,7 @@ class SeerrTextField extends StatefulWidget {
     required this.hint,
     this.maxLines = 1,
     this.onSubmitted,
+    this.focusNode,
   });
 
   @override
@@ -28,11 +32,35 @@ class SeerrTextField extends StatefulWidget {
 
 class _SeerrTextFieldState extends State<SeerrTextField> {
   final _tvFieldKey = GlobalKey<CustomTVTextFieldState>();
-  final _focusNode = FocusNode(debugLabel: 'seerr-text-field');
+  FocusNode? _internalFocusNode;
+
+  FocusNode get _effectiveFocusNode =>
+      widget.focusNode ?? (_internalFocusNode ??= FocusNode(debugLabel: 'seerr-text-field'));
+
+  @override
+  void initState() {
+    super.initState();
+    _effectiveFocusNode.addListener(_onFocusChanged);
+  }
+
+  void _onFocusChanged() {
+    if (_effectiveFocusNode.hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        Scrollable.ensureVisible(
+          context,
+          alignment: 0.2,
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOut,
+        );
+      });
+    }
+  }
 
   @override
   void dispose() {
-    _focusNode.dispose();
+    _effectiveFocusNode.removeListener(_onFocusChanged);
+    _internalFocusNode?.dispose();
     super.dispose();
   }
 
@@ -42,6 +70,7 @@ class _SeerrTextFieldState extends State<SeerrTextField> {
     if (!PlatformDetection.isTV) {
       return TextField(
         controller: widget.controller,
+        focusNode: widget.focusNode,
         maxLines: widget.maxLines,
         onSubmitted: widget.onSubmitted,
         style: TextStyle(color: onSurface),
@@ -67,26 +96,50 @@ class _SeerrTextFieldState extends State<SeerrTextField> {
     }
 
     final prefs = GetIt.instance<UserPreferences>();
+    final focusNode = _effectiveFocusNode;
     return Focus(
-      focusNode: _focusNode,
-      child: ListenableBuilder(
-        listenable: _focusNode,
-        builder: (_, _) => CustomTVTextField(
-          key: _tvFieldKey,
-          controller: widget.controller,
-          isFocused: _focusNode.hasFocus,
-          inputPurpose: InputPurpose.text,
-          keyboardType: KeyboardType.alphabetic,
-          preferSystemIme: prefs.get(UserPreferences.preferSystemImeKeyboard),
-          hint: widget.hint,
-          filled: true,
-          fillColor: AppColorScheme.inputBackground,
-          borderColor: ThemeRegistry.active.borders.chipBorder.color,
-          focusedBorderColor: AppColorScheme.accent,
-          hintStyle: TextStyle(color: onSurface.withValues(alpha: 0.54)),
-          textStyle: TextStyle(color: onSurface),
-          popParentOnKeyboardClose: false,
-          onFieldSubmitted: (v) => widget.onSubmitted?.call(v),
+      focusNode: focusNode,
+      onKeyEvent: (node, event) {
+        if (event.logicalKey.isBackKey) {
+          if (event is KeyDownEvent &&
+              (_tvFieldKey.currentState?.isKeyboardVisible ?? false)) {
+            _tvFieldKey.currentState?.closeKeyboard();
+            node.requestFocus();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
+        }
+        if (event.isActionable && event.logicalKey.isSelectKey) {
+          if (!node.hasFocus) node.requestFocus();
+          _tvFieldKey.currentState?.openKeyboard();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: GestureDetector(
+        onTap: () {
+          if (!focusNode.hasFocus) focusNode.requestFocus();
+          _tvFieldKey.currentState?.openKeyboard();
+        },
+        child: ListenableBuilder(
+          listenable: focusNode,
+          builder: (_, _) => CustomTVTextField(
+            key: _tvFieldKey,
+            controller: widget.controller,
+            isFocused: focusNode.hasFocus,
+            inputPurpose: InputPurpose.text,
+            keyboardType: KeyboardType.alphabetic,
+            preferSystemIme: prefs.get(UserPreferences.preferSystemImeKeyboard),
+            hint: widget.hint,
+            filled: true,
+            fillColor: AppColorScheme.inputBackground,
+            borderColor: ThemeRegistry.active.borders.chipBorder.color,
+            focusedBorderColor: AppColorScheme.accent,
+            hintStyle: TextStyle(color: onSurface.withValues(alpha: 0.54)),
+            textStyle: TextStyle(color: onSurface),
+            popParentOnKeyboardClose: false,
+            onFieldSubmitted: (v) => widget.onSubmitted?.call(v),
+          ),
         ),
       ),
     );

--- a/lib/ui/widgets/settings/button_layout_list.dart
+++ b/lib/ui/widgets/settings/button_layout_list.dart
@@ -83,6 +83,9 @@ class _ButtonLayoutListState extends State<ButtonLayoutList> {
     } else if (!ids.contains(entry.id)) {
       ids.add(entry.id);
     }
+    if (entry.id == 'download' && PlatformDetection.isTV) {
+      unawaited(_prefs.set(UserPreferences.tvOfflineDownloads, shown));
+    }
     unawaited(
       _prefs
           .set(widget.layout.hiddenPreference, ids.join(','))

--- a/lib/ui/widgets/track_selector_dialog.dart
+++ b/lib/ui/widgets/track_selector_dialog.dart
@@ -1,3 +1,6 @@
+import 'dart:math' as math;
+
+import 'package:custom_tv_text_field/custom_tv_text_field.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get_it/get_it.dart';
@@ -5,6 +8,7 @@ import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../l10n/app_localizations.dart';
 import '../../preference/user_preferences.dart';
+import '../../util/platform_detection.dart';
 import 'marquee_text.dart';
 import 'overlay_sheet.dart';
 
@@ -24,85 +28,106 @@ Future<T?> showStyledPlayerDialog<T>(
     barrierDismissible: barrierDismissible,
     builder: (dialogContext) {
       final mediaQuery = MediaQuery.of(dialogContext);
-      final maxDialogHeight = mediaQuery.size.height -
-          mediaQuery.padding.vertical -
-          mediaQuery.viewInsets.vertical -
-          24;
       final glass = AppColorScheme.isGlass;
-      final inner = Container(
-          constraints: BoxConstraints(
-            minWidth: 340,
-            maxWidth: maxWidth,
-            maxHeight: maxDialogHeight,
-          ),
-          decoration: glass
-              ? null
-              : BoxDecoration(
-                  color: AppColorScheme.surface.withValues(alpha: 0.9),
-                  borderRadius: AppRadius.circular(20),
-                  border: Border.fromBorderSide(
-                    ThemeRegistry.active.borders.chipBorder,
-                  ),
-                ),
-          padding: const EdgeInsets.symmetric(vertical: 20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Padding(
-                padding: EdgeInsets.fromLTRB(24, 0, 24, subtitle != null ? 4 : 12),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    title,
-                    style: const TextStyle(
-                      fontSize: 20,
-                      fontWeight: FontWeight.w600,
-                      color: Colors.white,
+
+      return ValueListenableBuilder<bool>(
+        valueListenable: CustomTVTextField.isKeyboardVisibleNotifier,
+        builder: (context, isKeyboardVisible, _) {
+          final isTv = PlatformDetection.isTV;
+          final shiftUp = isKeyboardVisible && isTv;
+          final keyboardSpace = shiftUp ? 360.0 : 0.0;
+          final effectiveBottomInset = math.max(
+            mediaQuery.viewInsets.bottom,
+            keyboardSpace,
+          );
+          final maxDialogHeight = mediaQuery.size.height -
+              mediaQuery.padding.vertical -
+              effectiveBottomInset -
+              24;
+
+          final inner = Container(
+            constraints: BoxConstraints(
+              minWidth: 340,
+              maxWidth: maxWidth,
+              maxHeight: maxDialogHeight,
+            ),
+            decoration: glass
+                ? null
+                : BoxDecoration(
+                    color: AppColorScheme.surface.withValues(alpha: 0.9),
+                    borderRadius: AppRadius.circular(20),
+                    border: Border.fromBorderSide(
+                      ThemeRegistry.active.borders.chipBorder,
                     ),
                   ),
-                ),
-              ),
-              if (subtitle != null)
+            padding: const EdgeInsets.symmetric(vertical: 20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+                  padding: EdgeInsets.fromLTRB(24, 0, 24, subtitle != null ? 4 : 12),
                   child: Align(
                     alignment: Alignment.centerLeft,
                     child: Text(
-                      subtitle,
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: Colors.white.withValues(alpha: 0.54),
+                      title,
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white,
                       ),
                     ),
                   ),
                 ),
-              Container(height: 1, color: Colors.white.withValues(alpha: 0.08)),
-              const SizedBox(height: 8),
-              Flexible(child: builder(dialogContext)),
-              if (showCancel) ...[
-                const SizedBox(height: 4),
+                if (subtitle != null)
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 12),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        subtitle,
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.white.withValues(alpha: 0.54),
+                        ),
+                      ),
+                    ),
+                  ),
                 Container(height: 1, color: Colors.white.withValues(alpha: 0.08)),
-                const SizedBox(height: 4),
-                _TrackRow(
-                  option: TrackOption(label: AppLocalizations.of(dialogContext).cancel),
-                  isSelected: false,
-                  onTap: () => Navigator.pop(dialogContext),
-                  dimmed: true,
-                ),
+                const SizedBox(height: 8),
+                Flexible(child: builder(dialogContext)),
+                if (showCancel) ...[
+                  const SizedBox(height: 4),
+                  Container(height: 1, color: Colors.white.withValues(alpha: 0.08)),
+                  const SizedBox(height: 4),
+                  _TrackRow(
+                    option: TrackOption(label: AppLocalizations.of(dialogContext).cancel),
+                    isSelected: false,
+                    onTap: () => Navigator.pop(dialogContext),
+                    dimmed: true,
+                  ),
+                ],
               ],
-            ],
-          ),
-        );
-      return Dialog(
-        backgroundColor: Colors.transparent,
-        child: glass
-            ? GlassSurface(
-                cornerRadius: 20,
-                reinforced: true,
-                fallbackColor: Colors.transparent,
-                child: inner,
-              )
-            : inner,
+            ),
+          );
+
+          return Dialog(
+            alignment: shiftUp ? const Alignment(0, -0.85) : Alignment.center,
+            insetAnimationDuration: const Duration(milliseconds: 200),
+            insetAnimationCurve: Curves.easeOutCubic,
+            insetPadding: shiftUp
+                ? const EdgeInsets.fromLTRB(40, 20, 40, 360)
+                : const EdgeInsets.symmetric(horizontal: 40, vertical: 24),
+            backgroundColor: Colors.transparent,
+            child: glass
+                ? GlassSurface(
+                    cornerRadius: 20,
+                    reinforced: true,
+                    fallbackColor: Colors.transparent,
+                    child: inner,
+                  )
+                : inner,
+          );
+        },
       );
     },
   );

--- a/lib/util/download_utils.dart
+++ b/lib/util/download_utils.dart
@@ -8,25 +8,19 @@ import '../auth/repositories/user_repository.dart';
 import '../data/models/aggregated_item.dart';
 import '../data/models/download_quality.dart';
 import '../preference/user_preferences.dart';
-import '../ui/screens/detail/detail_buttons.dart';
 import 'platform_detection.dart';
 
 /// Whether download actions may be offered on this device at all.
 ///
 /// Android TV keeps them hidden until the user enables offline downloads in
-/// Settings -> Playback -> Offline Downloads or explicitly includes them in
-/// their Action Buttons layout. Every other platform that supports downloads
-/// offers them unconditionally. Existing downloads and the management screens
-/// are never affected by this gate.
-bool showsTvDownloadActions(UserPreferences prefs) {
-  if (!PlatformDetection.isTV) return true;
-  if (prefs.get(UserPreferences.tvOfflineDownloads)) return true;
-  final order = prefs.get(UserPreferences.detailButtonOrderTv);
-  if (order.isNotEmpty && order.split(',').contains(DetailButton.download.id)) {
-    return !detailButtonLayout.hidden(prefs).contains(DetailButton.download.id);
-  }
-  return false;
-}
+/// Settings -> Playback -> Offline Downloads. Every other platform that
+/// supports downloads offers them unconditionally. Existing downloads and the
+/// management screens are never affected by this gate.
+///
+/// Showing or hiding the Download action button writes that same setting, so
+/// the two places a user can reach this stay in step.
+bool showsTvDownloadActions(UserPreferences prefs) =>
+    !PlatformDetection.isTV || prefs.get(UserPreferences.tvOfflineDownloads);
 
 /// Whether the signed in user may start a download here.
 ///

--- a/lib/util/download_utils.dart
+++ b/lib/util/download_utils.dart
@@ -8,16 +8,25 @@ import '../auth/repositories/user_repository.dart';
 import '../data/models/aggregated_item.dart';
 import '../data/models/download_quality.dart';
 import '../preference/user_preferences.dart';
+import '../ui/screens/detail/detail_buttons.dart';
 import 'platform_detection.dart';
 
 /// Whether download actions may be offered on this device at all.
 ///
 /// Android TV keeps them hidden until the user enables offline downloads in
-/// Settings -> Playback -> Offline Downloads. Every other platform that
-/// supports downloads offers them unconditionally. Existing downloads and the
-/// management screens are never affected by this gate.
-bool showsTvDownloadActions(UserPreferences prefs) =>
-    !PlatformDetection.isTV || prefs.get(UserPreferences.tvOfflineDownloads);
+/// Settings -> Playback -> Offline Downloads or explicitly includes them in
+/// their Action Buttons layout. Every other platform that supports downloads
+/// offers them unconditionally. Existing downloads and the management screens
+/// are never affected by this gate.
+bool showsTvDownloadActions(UserPreferences prefs) {
+  if (!PlatformDetection.isTV) return true;
+  if (prefs.get(UserPreferences.tvOfflineDownloads)) return true;
+  final order = prefs.get(UserPreferences.detailButtonOrderTv);
+  if (order.isNotEmpty && order.split(',').contains(DetailButton.download.id)) {
+    return !detailButtonLayout.hidden(prefs).contains(DetailButton.download.id);
+  }
+  return false;
+}
 
 /// Whether the signed in user may start a download here.
 ///

--- a/test/ui/screens/detail/detail_buttons_test.dart
+++ b/test/ui/screens/detail/detail_buttons_test.dart
@@ -118,16 +118,12 @@ void main() {
       expect(showsTvDownloadActions(prefs), isTrue);
     });
 
-    test('TV offers downloads if explicitly ordered and not hidden in action buttons', () async {
+    test('a saved button order does not opt TV in on its own', () async {
       PlatformDetection.setTvMode(true);
-      final prefs = await _prefs();
+      // Moving any row writes the whole arrangement back, download included,
+      // so the order says nothing about whether downloads were asked for.
+      final prefs = await _prefs(order: 'play,download,subtitles');
 
-      expect(showsTvDownloadActions(prefs), isFalse);
-
-      await prefs.set(UserPreferences.detailButtonOrderTv, 'play,download,subtitles');
-      expect(showsTvDownloadActions(prefs), isTrue);
-
-      await prefs.set(UserPreferences.hiddenDetailButtonsTv, 'download');
       expect(showsTvDownloadActions(prefs), isFalse);
     });
   });

--- a/test/ui/screens/detail/detail_buttons_test.dart
+++ b/test/ui/screens/detail/detail_buttons_test.dart
@@ -95,6 +95,10 @@ void main() {
       expect(DetailButton.deleteFiles.isOffered, isTrue);
       expect(DetailButton.cast.isOffered, isFalse);
     });
+
+    test('watchWithGroup is hidden from offered buttons when SyncPlay is not enabled', () {
+      expect(DetailButton.watchWithGroup.isOffered, isFalse);
+    });
   });
 
   group('showsTvDownloadActions', () {

--- a/test/ui/screens/detail/detail_buttons_test.dart
+++ b/test/ui/screens/detail/detail_buttons_test.dart
@@ -111,8 +111,20 @@ void main() {
     test('non-TV platforms offer downloads unconditionally', () async {
       PlatformDetection.setTvMode(false);
       final prefs = await _prefs();
-
       expect(showsTvDownloadActions(prefs), isTrue);
+    });
+
+    test('TV offers downloads if explicitly ordered and not hidden in action buttons', () async {
+      PlatformDetection.setTvMode(true);
+      final prefs = await _prefs();
+
+      expect(showsTvDownloadActions(prefs), isFalse);
+
+      await prefs.set(UserPreferences.detailButtonOrderTv, 'play,download,subtitles');
+      expect(showsTvDownloadActions(prefs), isTrue);
+
+      await prefs.set(UserPreferences.hiddenDetailButtonsTv, 'download');
+      expect(showsTvDownloadActions(prefs), isFalse);
     });
   });
 }


### PR DESCRIPTION
# Pull Request

## Summary
Reconciles action button visibility, styling, and behavior across all themes (Classic, Modern, Nouveau, Spotlight), ensures seamless TV input navigation for Seerr issue reporting, clarifies action button labels, and synchronizes action button layout settings:

1. **Detail Action Buttons and Labels**:
   - **Add to Playlist**: Updated button and settings label from "Playlist" to "Add to Playlist" across all themes and in the Action Buttons layout settings.
   - **Add to Watchlist / Remove from Watchlist (Seerr Watchlist)**: Dynamically toggles button label between "Add to Watchlist" (when not on watchlist) and "Remove from Watchlist" (when already on watchlist) on media detail screens, while retaining "Watchlist" in settings.
   - **Watch with Group (SyncPlay)**: Hidden from available Action Buttons settings unless SyncPlay is configured and supported by the active server.
   - **Delete Downloaded Files**: Renamed button and settings label from "Delete Files" to "Delete Downloaded Files" to eliminate confusion with server-side media deletion in the Admin dialog.
   - **Go to Series**: Expanded to appear on both TV Season and Episode detail screens.
   - **Seerr Actions on Seasons and Episodes**: Enables Seerr Watchlist and Report Issue on TV Season and Episode screens by resolving parent series TMDB/IMDb IDs, and automatically pre-populates Season and Episode numbers in the issue report dialog.
   - **Personal Rating (Thumbs)**: Standardized thumbs rating icon sizing across Classic, Modern, and Spotlight themes to use standard single-thumb sizing matching star ratings rather than rendering two tiny icons.
   - **Download Actions**: Restores Download and Delete Downloaded Files visibility and functionality in Spotlight More Actions and Modern action rows, and synchronizes TV offline download permissions when toggled in settings.

2. **TV On-Screen Keyboard & Viewport Visibility**:
   - Fixed SeerrTextField on TV mode to properly trigger the on-screen keyboard on D-pad Select/OK key events or pointer clicks.
   - Resolved keyboard viewport occlusion: showStyledPlayerDialog dynamically shifts up towards the top of the screen (Alignment(0, -0.85)) with reserved bottom inset and constrained height when the on-screen keyboard opens, and SeerrTextField automatically scrolls into the clear viewport above the keyboard so users can view the text field and typed input live.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **Modified Button Actions & Labels**:
  - **Add to Playlist**:
    - Detail screen action button label updated from l10n.playlist ("Playlist") to l10n.addToPlaylist ("Add to Playlist") in **item_detail_screen.dart**.
    - Action Buttons settings menu label for DetailButton.playlist updated from "Playlist" to "Add to Playlist" (l10n.addToPlaylist) in **detail_buttons.dart**.
  - **Add to Watchlist / Remove from Watchlist (Seerr Watchlist)**:
    - Detail screen action button label updated from static "Watchlist" / "On Watchlist" to dynamic binary toggle in **item_detail_screen.dart**:
      - Displays "Add to Watchlist" (l10n.addToWatchlist) when item is not on the user's Seerr watchlist.
      - Displays "Remove from Watchlist" (l10n.removeFromWatchlist) when item is already on the user's Seerr watchlist.
    - Action Buttons settings menu retains clean section identifier "Watchlist" (l10n.watchlist).
  - **Watch with Group (SyncPlay)**:
    - DetailButton.watchWithGroup.isOffered now verifies _syncPlayAvailable (SyncPlayManager.syncPlayEnabled and UserPreferences.syncPlayEnabled) in **detail_buttons.dart**.
    - Hides the button from the Action Buttons settings menu when SyncPlay is disabled or unsupported.
  - **Delete Downloaded Files**:
    - Renamed from "Delete Files" (l10n.deleteFiles) to "Delete Downloaded Files" (l10n.deleteDownloadedFiles) in both **detail_buttons.dart** and **item_detail_screen.dart** to prevent confusion with server deletion in the Admin dialog.
  - **Go to Series**:
    - Expanded from Episode-only to appear for both TV Seasons and Episodes ((item.type == 'Episode' || item.type == 'Season') && item.seriesId != null) in **item_detail_screen.dart**.
  - **Seerr Watchlist & Report Issue on Seasons and Episodes**:
    - Updated **item_detail_view_model.dart** to look up parent series TMDB/IMDb IDs when viewing a Season or Episode, enabling Seerr Watchlist and Report Issue buttons across Classic, Modern, and Spotlight themes.
    - Updated **seerr_report_issue_dialog.dart** to accept initialSeason and initialEpisode parameters and pre-populate them when opened from a season or episode.
  - **Personal Rating Thumbs Icon**:
    - Updated _PersonalRatingActionIcon in **item_detail_screen.dart** so thumbs rating style renders a single full-sized thumb icon across Classic, Modern, and Spotlight themes.
  - **Download Actions & Settings Sync**:
    - Wired download and delete buttons into Spotlight More Actions and Modern action layouts in **item_detail_screen.dart**.
    - Added synchronization in **button_layout_list.dart** and **download_utils.dart** to ensure TV offline downloads setting aligns with user action button selections.
- **TV Dialog & On-Screen Keyboard Interaction**:
  - **seerr_text_field.dart**:
    - Added D-pad key event handling for isActionable && logicalKey.isSelectKey to open the TV on-screen keyboard via _tvFieldKey.currentState?.openKeyboard().
    - Added isBackKey handling to close the virtual keyboard on Back press without dismissing the parent dialog.
    - Added GestureDetector(onTap: ...) to support pointer/touch click activation.
    - Added isKeyboardVisibleNotifier listener with smooth auto-scroll (Scrollable.ensureVisible) to ensure the field is centered in the visible dialog viewport upon keyboard presentation.
  - **track_selector_dialog.dart** (showStyledPlayerDialog):
    - Added listener to CustomTVTextField.isKeyboardVisibleNotifier.
    - When the on-screen keyboard opens on TV, animates dialog alignment to Alignment(0, -0.85) (top of screen), applies bottom inset padding of 360px, and constrains maxDialogHeight so the dialog and all its fields remain completely visible above the keyboard.
    - Smoothly restores dialog to Alignment.center when the keyboard closes.
- **Unit Tests**:
  - **detail_buttons_test.dart**: Added test coverage for DetailButton.watchWithGroup.isOffered when SyncPlay is disabled, and verified all action button ordering and offline download tests.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to Settings > Details Screen > Action Buttons.
2. Verify that "Watch with group" is hidden from available buttons when SyncPlay is disabled in Settings. Enable SyncPlay and verify it appears.
3. Verify that Playlist is listed as "Add to Playlist" and Watchlist is listed as "Watchlist".
4. Verify that "Delete Downloaded Files" is listed instead of "Delete Files".
5. Open an Episode or Season detail view across Classic, Modern, and Spotlight themes:
   - Verify "Go to Series" button appears.
   - Verify Seerr "Add to Watchlist" / "Remove from Watchlist" toggles dynamically based on watchlist state.
   - Open Seerr "Report Issue" dialog; verify Season and Episode numbers are pre-populated.
6. On Android TV / Shield:
   - Open the "Report Issue" dialog and navigate to "What's wrong?".
   - Press Select / OK on the remote: verify the on-screen keyboard opens.
   - Verify the dialog shifts to the top half of the screen, the "What's wrong?" field remains completely visible above the keyboard, and typed text appears in real time.
   - Press Back to close the keyboard; verify dialog returns smoothly to center.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

<img width="3840" height="2160" alt="2026-09-11_23-49-27" src="https://github.com/user-attachments/assets/aa42486d-7747-488a-b992-7e07fb7c630c" />

<img width="3840" height="2160" alt="2026-09-11_23-46-58" src="https://github.com/user-attachments/assets/4ed42f43-c301-411f-b270-d13b11221fea" />
<img width="3840" height="2160" alt="2026-09-11_23-47-59" src="https://github.com/user-attachments/assets/e2bbd32f-7ca0-4e0d-9ab0-cee9d62d95f7" />
<img width="3840" height="2160" alt="Shield_Screenshot_2026-09-11_23-31-13" src="https://github.com/user-attachments/assets/3e45c8f2-a33d-49b3-ad3b-6bcf258857b4" />

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
