### PR TITLE
Feat: live tv tuner status

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -11165,5 +11165,33 @@
   "pageTransitionFadeLong": "Long Fade",
   "@pageTransitionFadeLong": {
     "description": "Option label for long fade page transition"
+  },
+  "liveTvConnecting": "Connecting to channel…",
+  "@liveTvConnecting": {
+    "description": "Live TV player status while a channel is being tuned"
+  },
+  "liveTvTunerStillTrying": "The tuner is still trying to get this channel…",
+  "@liveTvTunerStillTrying": {
+    "description": "Live TV player status when the server has kept a channel request open for several seconds, meaning the tuner is retrying its source"
+  },
+  "liveTvReconnecting": "Signal lost. The tuner is reconnecting…",
+  "@liveTvReconnecting": {
+    "description": "Live TV player status when a playing channel stops receiving data"
+  },
+  "liveTvChannelUnavailableTitle": "Channel unavailable",
+  "@liveTvChannelUnavailableTitle": {
+    "description": "Title shown when a live TV channel could not be started"
+  },
+  "liveTvChannelUnavailableBody": "The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.",
+  "@liveTvChannelUnavailableBody": {
+    "description": "Explanation shown when a live TV channel could not be started"
+  },
+  "liveTvChannelLostTitle": "Channel lost",
+  "@liveTvChannelLostTitle": {
+    "description": "Title shown when a playing live TV channel stopped and did not recover"
+  },
+  "liveTvChannelLostBody": "The stream stopped and the tuner did not bring it back. Try again or pick another channel.",
+  "@liveTvChannelLostBody": {
+    "description": "Explanation shown when a playing live TV channel stopped and did not recover"
   }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -21580,6 +21580,48 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Long Fade'**
   String get pageTransitionFadeLong;
+
+  /// Live TV player status while a channel is being tuned
+  ///
+  /// In en, this message translates to:
+  /// **'Connecting to channel…'**
+  String get liveTvConnecting;
+
+  /// Live TV player status when the server has kept a channel request open for several seconds, meaning the tuner is retrying its source
+  ///
+  /// In en, this message translates to:
+  /// **'The tuner is still trying to get this channel…'**
+  String get liveTvTunerStillTrying;
+
+  /// Live TV player status when a playing channel stops receiving data
+  ///
+  /// In en, this message translates to:
+  /// **'Signal lost. The tuner is reconnecting…'**
+  String get liveTvReconnecting;
+
+  /// Title shown when a live TV channel could not be started
+  ///
+  /// In en, this message translates to:
+  /// **'Channel unavailable'**
+  String get liveTvChannelUnavailableTitle;
+
+  /// Explanation shown when a live TV channel could not be started
+  ///
+  /// In en, this message translates to:
+  /// **'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.'**
+  String get liveTvChannelUnavailableBody;
+
+  /// Title shown when a playing live TV channel stopped and did not recover
+  ///
+  /// In en, this message translates to:
+  /// **'Channel lost'**
+  String get liveTvChannelLostTitle;
+
+  /// Explanation shown when a playing live TV channel stopped and did not recover
+  ///
+  /// In en, this message translates to:
+  /// **'The stream stopped and the tuner did not bring it back. Try again or pick another channel.'**
+  String get liveTvChannelLostBody;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -12292,4 +12292,28 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -12269,4 +12269,28 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -12357,4 +12357,28 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -12395,4 +12395,28 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -12266,4 +12266,28 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -12472,4 +12472,28 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -12330,4 +12330,28 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -12347,4 +12347,28 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -12283,4 +12283,28 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -12469,4 +12469,28 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -12459,4 +12459,28 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -12203,6 +12203,30 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }
 
 /// The translations for English, as used in the United Kingdom (`en_GB`).

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -12278,4 +12278,28 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -12408,6 +12408,30 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }
 
 /// The translations for Spanish Castilian, as used in Latin America and the Caribbean (`es_419`).

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -12297,4 +12297,28 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -12224,4 +12224,28 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -12326,4 +12326,28 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -12434,4 +12434,28 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -12433,4 +12433,28 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -12145,4 +12145,28 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -12259,4 +12259,28 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -12512,4 +12512,28 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -12384,4 +12384,28 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -12288,4 +12288,28 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -12383,4 +12383,28 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -11972,4 +11972,28 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -12335,4 +12335,28 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -12358,4 +12358,28 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -11935,4 +11935,28 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -12351,4 +12351,28 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -12351,4 +12351,28 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -12366,4 +12366,28 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -12411,4 +12411,28 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -12308,4 +12308,28 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -12280,4 +12280,28 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -12350,4 +12350,28 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -12247,4 +12247,28 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -12582,4 +12582,28 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -12373,6 +12373,30 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -12379,4 +12379,28 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -12367,4 +12367,28 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -12279,4 +12279,28 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -12359,4 +12359,28 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -12353,4 +12353,28 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -12384,4 +12384,28 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -12502,4 +12502,28 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -12297,4 +12297,28 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -12372,4 +12372,28 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -12372,4 +12372,28 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -12359,4 +12359,28 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -12210,4 +12210,28 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -12403,4 +12403,28 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -12301,4 +12301,28 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -12321,4 +12321,28 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -12376,4 +12376,28 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -12291,4 +12291,28 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -11886,6 +11886,30 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }
 
 /// The translations for Yue Chinese Cantonese, as used in China (`yue_CN`).

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -11808,6 +11808,30 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get pageTransitionFadeLong => 'Long Fade';
+
+  @override
+  String get liveTvConnecting => 'Connecting to channel…';
+
+  @override
+  String get liveTvTunerStillTrying =>
+      'The tuner is still trying to get this channel…';
+
+  @override
+  String get liveTvReconnecting => 'Signal lost. The tuner is reconnecting…';
+
+  @override
+  String get liveTvChannelUnavailableTitle => 'Channel unavailable';
+
+  @override
+  String get liveTvChannelUnavailableBody =>
+      'The server could not get this channel from the tuner. The source may be down, or the tuner gave up after retrying.';
+
+  @override
+  String get liveTvChannelLostTitle => 'Channel lost';
+
+  @override
+  String get liveTvChannelLostBody =>
+      'The stream stopped and the tuner did not bring it back. Try again or pick another channel.';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/playback/aether_backend.dart
+++ b/lib/playback/aether_backend.dart
@@ -351,6 +351,9 @@ class AetherBackend implements PlayerBackend {
   Stream<bool> get bufferingStream => _bufferingStream.stream;
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => _completedStream.stream;
 
   @override

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -402,6 +402,9 @@ class AppleTvBackend implements PlayerBackend {
   Stream<bool> get bufferingStream => _bufferingStream.stream;
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => _completedStream.stream;
 
   @override
@@ -597,6 +600,16 @@ class AppleTvBackend implements PlayerBackend {
   /// when the subtitle arrived and the progress alert can just go away.
   Future<void> hideSubtitleProgress({String? message}) async {
     await _invoke<void>('hideSubtitleProgress', {'message': message});
+  }
+
+  /// A line of status over the picture. Unlike the progress alert it takes
+  /// no focus, so the remote's Menu press still leaves the player.
+  Future<void> showStatusMessage(String message) async {
+    await _invoke<void>('showStatusMessage', {'message': message});
+  }
+
+  Future<void> hideStatusMessage() async {
+    await _invoke<void>('hideStatusMessage');
   }
 
   Future<void> setThemeConfig({

--- a/lib/playback/live_tv_stream_status.dart
+++ b/lib/playback/live_tv_stream_status.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:get_it/get_it.dart';
 import 'package:playback_core/playback_core.dart';
+
+import '../data/services/log_service.dart';
 
 /// What the viewer should be told about a live channel right now.
 ///
@@ -111,7 +114,6 @@ class LiveTvStreamStatusTracker {
   DateTime? _readyAt;
   int? _sessionToken;
   bool _stopped = false;
-  bool _reachedReady = false;
   bool _everPlayed = false;
   bool _failed = false;
   bool _buffering = false;
@@ -120,6 +122,10 @@ class LiveTvStreamStatusTracker {
   DateTime? _lastAdvanceAt;
   DateTime? _cleanSince;
   DateTime? _troubleSince;
+  String? _lastBreakKind;
+  DateTime? _lastBreakAt;
+  bool _clockBroke = false;
+  bool _pictureShown = true;
 
   /// A single sample moving further than this is a jump to the live edge or
   /// a seek, not frames being shown.
@@ -127,7 +133,6 @@ class LiveTvStreamStatusTracker {
 
   void _resetPlayback() {
     _stopped = false;
-    _reachedReady = false;
     _readyAt = null;
     _everPlayed = false;
     _failed = false;
@@ -137,6 +142,22 @@ class LiveTvStreamStatusTracker {
     _lastAdvanceAt = null;
     _cleanSince = null;
     _troubleSince = null;
+    _lastBreakKind = null;
+    _lastBreakAt = null;
+    _clockBroke = false;
+    _pictureShown = true;
+  }
+
+  /// Whether there is a picture to see, from the manager: false while a
+  /// backend that can see its own picture reports none, or a black one.
+  /// ExoPlayer runs its clock on audio alone, and a tuner's failover
+  /// placeholder is a black video that decodes and renders like any
+  /// channel, so on such a backend the clock only counts once there is a
+  /// picture, and losing it is trouble like buffering is.
+  void onPictureShown(bool shown, DateTime now) {
+    if (shown == _pictureShown) return;
+    _pictureShown = shown;
+    if (!shown) _break(now, kind: 'picture black');
   }
 
   void onBringup(PlaybackBringupState state, DateTime now) {
@@ -162,7 +183,6 @@ class LiveTvStreamStatusTracker {
         // than unavailable. The next channel change starts clean.
         _stopped = true;
       case PlaybackBringupPhase.ready:
-        _reachedReady = true;
         _readyAt ??= now;
         _failed = false;
         if (token != null) _sessionToken = token;
@@ -183,7 +203,7 @@ class LiveTvStreamStatusTracker {
   /// what it still holds as a finished asset once the tuner stops feeding
   /// it, and the player runs that out and reports completion.
   void onEnded(DateTime now) {
-    if (_bringupStartedAt == null && !_reachedReady) return;
+    if (_bringupStartedAt == null && _readyAt == null) return;
     _bringupInProgress = false;
     _failed = true;
   }
@@ -191,18 +211,19 @@ class LiveTvStreamStatusTracker {
   void onBuffering(bool buffering, DateTime now) {
     if (buffering == _buffering) return;
     _buffering = buffering;
-    if (buffering) _break(now);
+    if (buffering) _break(now, kind: 'buffering');
   }
 
   /// Neither ready nor playing proves frames are moving. The tvOS player
   /// reports ready as soon as it is on screen, and playing as soon as its
   /// clock is told to run, both while still black. Playing only arms the
   /// clock check below. A pause is not trouble: the clock is meant to stand
-  /// still, so the run simply starts over on resume.
+  /// still, so the run simply starts over on resume. The last position is
+  /// kept across the change, so a clock that leaps while the player flaps
+  /// between buffering and playing is still seen to leap.
   void onPlaying(bool playing, DateTime now) {
     if (playing == _playing) return;
     _playing = playing;
-    _lastPosition = null;
     _lastAdvanceAt = null;
     _cleanSince = null;
   }
@@ -215,17 +236,24 @@ class LiveTvStreamStatusTracker {
   void onPosition(Duration position, DateTime now) {
     final last = _lastPosition;
     _lastPosition = position;
-    if (!_reachedReady || !_playing || last == null) return;
+    if (_readyAt == null || !_playing || last == null) return;
     final moved = position - last;
     final lastAdvance = _lastAdvanceAt;
     _lastAdvanceAt = now;
     if (moved <= Duration.zero || moved > _maxAdvance) {
-      _break(now);
+      _clockBroke = true;
+      _break(now, kind: moved <= Duration.zero ? 'clock stood still' : 'jump');
       return;
     }
     if (lastAdvance != null && now.difference(lastAdvance) > advanceGap) {
       // The clock stood still until this step: a freeze that just ended.
-      _break(now, since: lastAdvance);
+      _clockBroke = true;
+      _break(now, since: lastAdvance, kind: 'freeze');
+    }
+    // Steps over no picture prove nothing; the run starts with the picture.
+    if (!_pictureShown) {
+      _cleanSince = null;
+      return;
     }
     final cleanSince = _cleanSince ??= now;
     if (now.difference(cleanSince) >= playedAfter) {
@@ -236,9 +264,44 @@ class LiveTvStreamStatusTracker {
 
   /// Ends the current clean run and starts the trouble clock if it is not
   /// already running.
-  void _break(DateTime now, {DateTime? since}) {
+  void _break(DateTime now, {DateTime? since, required String kind}) {
     _cleanSince = null;
     _troubleSince ??= since ?? now;
+    _lastBreakKind = kind;
+    _lastBreakAt = now;
+  }
+
+  static String _seconds(Duration d) =>
+      '${(d.inMilliseconds / 1000).toStringAsFixed(1)}s';
+
+  /// One line of everything the verdict rests on, for the log when the
+  /// status changes: it says why playing came late or never came.
+  String describe(DateTime now) {
+    String ago(DateTime? t) =>
+        t == null ? 'never' : '${_seconds(now.difference(t))} ago';
+    final clock = _lastPosition;
+    final breakAt = _lastBreakAt;
+    final startedAt = _bringupStartedAt;
+    return [
+      'bringup ${_bringupInProgress ? 'in progress' : 'done'}',
+      'started ${ago(startedAt)}',
+      'ready ${ago(_readyAt)}',
+      'playing=$_playing',
+      'buffering=$_buffering',
+      'clock=${clock == null ? 'none' : _seconds(clock)}',
+      'last step ${ago(_lastAdvanceAt)}',
+      'clean since ${ago(_cleanSince)}',
+      'played=$_everPlayed',
+      'clock broke=$_clockBroke',
+      'picture ${_pictureShown ? 'shown' : 'none'}',
+      'trouble since ${ago(_troubleSince)}',
+      if (_lastBreakKind == null)
+        'last break: none'
+      else if (breakAt != null && startedAt != null)
+        'last break: $_lastBreakKind at +${_seconds(breakAt.difference(startedAt))}'
+      else
+        'last break: $_lastBreakKind',
+    ].join(', ');
   }
 
   /// When the stream stopped looking healthy, or null while it does. A clock
@@ -276,7 +339,8 @@ class LiveTvStreamStatusTracker {
           ? LiveTvStreamStatus.stillTrying
           : LiveTvStreamStatus.connecting;
     }
-    if (!_reachedReady) {
+    final readyAt = _readyAt;
+    if (readyAt == null) {
       return LiveTvStreamStatus.idle;
     }
     // On screen but no frame yet: still part of the channel change, and a
@@ -287,14 +351,15 @@ class LiveTvStreamStatusTracker {
       // the wait stops where the stepping began. A clock that leaps starts
       // over each time and still runs the wait out; one that froze after a
       // few steps is not stepping any more.
-      final lastStep = _lastAdvanceAt;
+      final cleanSince = _cleanSince;
       final stepping =
-          _cleanSince != null &&
-          lastStep != null &&
-          now.difference(lastStep) <= advanceGap;
-      final waited = (stepping ? _cleanSince! : now).difference(
-        _readyAt ?? startedAt ?? now,
-      );
+          cleanSince != null && now.difference(_lastAdvanceAt!) <= advanceGap;
+      // A clock that steps and has never misbehaved is frames on screen,
+      // and the viewer should not look at a spinner over them while the
+      // run is proven. A clock that has jumped or frozen once has to earn
+      // it: a tuner feeding broken timestamps creeps between leaps too.
+      if (stepping && !_clockBroke) return LiveTvStreamStatus.playing;
+      final waited = (stepping ? cleanSince : now).difference(readyAt);
       return waited >= stillTryingAfterReady
           ? LiveTvStreamStatus.stillTrying
           : LiveTvStreamStatus.connecting;
@@ -323,36 +388,30 @@ class LiveTvStreamStatusMonitor extends ValueNotifier<LiveTvStreamStatus> {
     final initial = _manager.bringupState;
     if (initial.phase != PlaybackBringupPhase.failed) {
       _tracker.onBringup(initial, now);
+      _tracker.onPictureShown(_manager.pictureShown, now);
       _tracker.onBuffering(_manager.state.isBuffering, now);
       _tracker.onPlaying(_manager.state.isPlaying, now);
       _tracker.onPosition(_manager.state.position, now);
     }
     _subs.addAll([
-      _manager.bringupStateStream.listen((state) {
-        final now = DateTime.now();
-        _tracker.onBringup(state, now);
-        _refresh(now);
-      }),
-      _manager.state.bufferingStream.listen((buffering) {
-        final now = DateTime.now();
-        _tracker.onBuffering(buffering, now);
-        _refresh(now);
-      }),
-      _manager.state.playingStream.listen((playing) {
-        final now = DateTime.now();
-        _tracker.onPlaying(playing, now);
-        _refresh(now);
-      }),
-      _manager.state.positionStream.listen((position) {
-        final now = DateTime.now();
-        _tracker.onPosition(position, now);
-        _refresh(now);
-      }),
-      _manager.sessionEndedStream.listen((_) {
-        final now = DateTime.now();
-        _tracker.onEnded(now);
-        _refresh(now);
-      }),
+      _manager.bringupStateStream.listen(
+        (state) => _feed((now) => _tracker.onBringup(state, now)),
+      ),
+      _manager.pictureShownStream.listen(
+        (shown) => _feed((now) => _tracker.onPictureShown(shown, now)),
+      ),
+      _manager.state.bufferingStream.listen(
+        (buffering) => _feed((now) => _tracker.onBuffering(buffering, now)),
+      ),
+      _manager.state.playingStream.listen(
+        (playing) => _feed((now) => _tracker.onPlaying(playing, now)),
+      ),
+      _manager.state.positionStream.listen(
+        (position) => _feed((now) => _tracker.onPosition(position, now)),
+      ),
+      _manager.sessionEndedStream.listen(
+        (_) => _feed((now) => _tracker.onEnded(now)),
+      ),
     ]);
     _refresh(now);
   }
@@ -362,9 +421,17 @@ class LiveTvStreamStatusMonitor extends ValueNotifier<LiveTvStreamStatus> {
   final _subs = <StreamSubscription<Object?>>[];
   Timer? _ticker;
 
+  void _feed(void Function(DateTime now) event) {
+    final now = DateTime.now();
+    event(now);
+    _refresh(now);
+  }
+
   void _refresh(DateTime now) {
     final status = _tracker.statusAt(now);
+    final previous = value;
     value = status;
+    if (status != previous) _log(previous, status, now);
     // Idle and the two failures only change on an event; everything else
     // has a threshold that time alone can cross.
     final needsClock = status != LiveTvStreamStatus.idle && !status.isFailure;
@@ -376,6 +443,18 @@ class LiveTvStreamStatusMonitor extends ValueNotifier<LiveTvStreamStatus> {
     } else {
       _ticker?.cancel();
       _ticker = null;
+    }
+  }
+
+  void _log(LiveTvStreamStatus from, LiveTvStreamStatus to, DateTime now) {
+    final line =
+        'Live TV status ${from.name} -> ${to.name}: ${_tracker.describe(now)}';
+    assert(() {
+      debugPrint(line);
+      return true;
+    }());
+    if (GetIt.instance.isRegistered<LogService>()) {
+      GetIt.instance<LogService>().playback(line, level: LogLevel.info);
     }
   }
 

--- a/lib/playback/live_tv_stream_status.dart
+++ b/lib/playback/live_tv_stream_status.dart
@@ -317,6 +317,14 @@ class LiveTvStreamStatusTracker {
     return null;
   }
 
+  /// The verdict for a channel change that ended without ever showing a
+  /// picture. The moment of "connecting" first is the same courtesy a refusal
+  /// gets: a Retry press is seen to do something before the card comes back.
+  LiveTvStreamStatus _neverCameUp(Duration sinceStart) =>
+      sinceStart < minimumConnecting
+      ? LiveTvStreamStatus.connecting
+      : LiveTvStreamStatus.unavailable;
+
   LiveTvStreamStatus statusAt(DateTime now) {
     final startedAt = _bringupStartedAt;
     final sinceStart = startedAt == null
@@ -332,6 +340,13 @@ class LiveTvStreamStatusTracker {
       return LiveTvStreamStatus.unavailable;
     }
     if (_stopped) {
+      // A channel stopped before it ever had a picture is one the tuner could
+      // not serve, and the viewer is owed the card rather than a black screen
+      // with nothing on it. One that did come up and was then stopped is the
+      // viewer leaving, which has nothing to report.
+      if (startedAt != null && _readyAt == null) {
+        return _neverCameUp(sinceStart);
+      }
       return LiveTvStreamStatus.idle;
     }
     if (_bringupInProgress) {

--- a/lib/playback/live_tv_stream_status.dart
+++ b/lib/playback/live_tv_stream_status.dart
@@ -350,6 +350,10 @@ class LiveTvStreamStatusTracker {
       return LiveTvStreamStatus.idle;
     }
     if (_bringupInProgress) {
+      // A bringup that never lands is the same wait as one that lands and
+      // never shows a frame. Without this a phase that hangs sits on still
+      // trying for as long as the screen is open.
+      if (sinceStart >= startTimeout) return LiveTvStreamStatus.unavailable;
       return sinceStart >= stillTryingAfter
           ? LiveTvStreamStatus.stillTrying
           : LiveTvStreamStatus.connecting;

--- a/lib/playback/live_tv_stream_status.dart
+++ b/lib/playback/live_tv_stream_status.dart
@@ -1,0 +1,390 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:playback_core/playback_core.dart';
+
+/// What the viewer should be told about a live channel right now.
+///
+/// The server never says whether the tuner is retrying or has given up, but
+/// the two look different from the client: a request still in flight means
+/// the tuner is still trying (it closes the connection only once its own
+/// retries are spent), and any failure means it has already given up. Time
+/// spent waiting separates a normal channel change from a tuner that is
+/// struggling, and a stream that stops mid-play from one that is gone.
+enum LiveTvStreamStatus {
+  /// Nothing to show: no channel is being brought up.
+  idle,
+
+  /// A channel change just started; the usual few seconds of tuning.
+  connecting,
+
+  /// The server has held the request open long enough that the tuner is
+  /// clearly retrying its upstream rather than just tuning.
+  stillTrying,
+
+  /// The channel is playing.
+  playing,
+
+  /// A short mid-play stall; only a spinner is warranted.
+  buffering,
+
+  /// Mid-play starvation long enough to mean the feed dropped and the tuner
+  /// is reconnecting.
+  reconnecting,
+
+  /// Bringup failed before the channel ever played: the tuner could not get
+  /// it.
+  unavailable,
+
+  /// The channel played and then died, or starved for so long the tuner is
+  /// not coming back with it.
+  lost,
+}
+
+extension LiveTvStreamStatusX on LiveTvStreamStatus {
+  /// The two states that stop playback and want a Retry / Back choice.
+  bool get isFailure =>
+      this == LiveTvStreamStatus.unavailable || this == LiveTvStreamStatus.lost;
+}
+
+extension LiveTvBringupStateX on PlaybackBringupState {
+  /// A bringup the tuner refused, which the status card already reports as
+  /// "channel unavailable"; the screens skip their generic failure snackbar
+  /// for it.
+  bool get isLiveChannelUnavailable =>
+      phase == PlaybackBringupPhase.failed &&
+      error == liveChannelUnavailableError;
+}
+
+/// Pure state machine behind [LiveTvStreamStatus]. Fed bringup and buffering
+/// changes with the time they happened, and asked for the status at a time.
+/// No timers, no streams, so it can be tested with a fixed clock.
+class LiveTvStreamStatusTracker {
+  /// How long the clock must run cleanly, one small step after another with
+  /// no jump, freeze or buffering report, before the channel counts as
+  /// showing frames. A tuner feeding broken timestamps makes the player
+  /// stall and leap to a new live edge every second, and between leaps the
+  /// clock does creep forward; only an unbroken run tells that from video.
+  static const playedAfter = Duration(seconds: 2);
+
+  /// The longest the clock may go without a step before it has frozen.
+  /// Every backend reports four times a second.
+  static const advanceGap = Duration(seconds: 1);
+
+  /// How long a fresh channel change shows as connecting even when the
+  /// server refuses it at once. A Retry that fails in a few hundred
+  /// milliseconds otherwise redraws the same card and looks like a press
+  /// that did nothing.
+  static const minimumConnecting = Duration(milliseconds: 1200);
+
+  /// How long a bringup may run before the tuner is said to be retrying.
+  /// A healthy channel change on a Jellyfin M3U or HDHomeRun tuner takes one
+  /// to four seconds, the open plus the server's three-second probe.
+  static const stillTryingAfter = Duration(seconds: 6);
+
+  /// How long a stream that is open may sit without its clock starting
+  /// before the tuner is said to be retrying. The tvOS engine reads the
+  /// source, cuts it into segments and waits for the player to buffer a few
+  /// of them before the first frame, several seconds on a healthy channel.
+  /// Once the clock has started stepping the wait stops counting, so a
+  /// channel that starts within this never shows the message even though
+  /// it is only proven to play [playedAfter] later.
+  static const stillTryingAfterReady = Duration(seconds: 8);
+
+  /// How long a channel may go without ever playing before it is given up
+  /// on. Covers the stream the server did open but the tuner dropped before
+  /// any data arrived: the transcode dies quietly, the manifest never fills,
+  /// and the player waits without ever raising an error. Past the tuner's
+  /// retry budget, which is about ten seconds on Dispatcharr's defaults.
+  static const startTimeout = Duration(seconds: 30);
+
+  /// How long a mid-play stall may last before it is called a dropped feed.
+  static const reconnectingAfter = Duration(seconds: 4);
+
+  /// How long a mid-play stall may last before the channel is given up on.
+  /// Well past the tuner's own retry budget, so a channel that recovers still
+  /// plays and one that does not stops spinning.
+  static const lostAfter = Duration(seconds: 45);
+
+  bool _bringupInProgress = false;
+  DateTime? _bringupStartedAt;
+  DateTime? _readyAt;
+  int? _sessionToken;
+  bool _stopped = false;
+  bool _reachedReady = false;
+  bool _everPlayed = false;
+  bool _failed = false;
+  bool _buffering = false;
+  bool _playing = false;
+  Duration? _lastPosition;
+  DateTime? _lastAdvanceAt;
+  DateTime? _cleanSince;
+  DateTime? _troubleSince;
+
+  /// A single sample moving further than this is a jump to the live edge or
+  /// a seek, not frames being shown.
+  static const _maxAdvance = Duration(seconds: 5);
+
+  void _resetPlayback() {
+    _stopped = false;
+    _reachedReady = false;
+    _readyAt = null;
+    _everPlayed = false;
+    _failed = false;
+    _buffering = false;
+    _playing = false;
+    _lastPosition = null;
+    _lastAdvanceAt = null;
+    _cleanSince = null;
+    _troubleSince = null;
+  }
+
+  void onBringup(PlaybackBringupState state, DateTime now) {
+    final token = state.sessionToken;
+    if (state.phase.isInProgress) {
+      final newSession =
+          !_bringupInProgress ||
+          (token != null && _sessionToken != null && token != _sessionToken);
+      if (newSession) {
+        _bringupInProgress = true;
+        _bringupStartedAt = now;
+        _resetPlayback();
+      }
+      if (token != null) _sessionToken = token;
+      return;
+    }
+    _bringupInProgress = false;
+    switch (state.phase) {
+      case PlaybackBringupPhase.idle:
+        // The player was stopped. What it had done stays on record, since
+        // the manager stops a stream that ran out on its own before it says
+        // so, and that word has to be able to turn this into lost rather
+        // than unavailable. The next channel change starts clean.
+        _stopped = true;
+      case PlaybackBringupPhase.ready:
+        _reachedReady = true;
+        _readyAt ??= now;
+        _failed = false;
+        if (token != null) _sessionToken = token;
+      case PlaybackBringupPhase.failed:
+        _failed = true;
+      case PlaybackBringupPhase.preparing:
+      case PlaybackBringupPhase.stoppingPrevious:
+      case PlaybackBringupPhase.resolving:
+      case PlaybackBringupPhase.opening:
+      case PlaybackBringupPhase.waitingForReady:
+      case PlaybackBringupPhase.seekingResume:
+        break;
+    }
+  }
+
+  /// The manager gave up on the channel by itself: the player reported the
+  /// end of a stream that, being live, has no end. The tvOS engine serves
+  /// what it still holds as a finished asset once the tuner stops feeding
+  /// it, and the player runs that out and reports completion.
+  void onEnded(DateTime now) {
+    if (_bringupStartedAt == null && !_reachedReady) return;
+    _bringupInProgress = false;
+    _failed = true;
+  }
+
+  void onBuffering(bool buffering, DateTime now) {
+    if (buffering == _buffering) return;
+    _buffering = buffering;
+    if (buffering) _break(now);
+  }
+
+  /// Neither ready nor playing proves frames are moving. The tvOS player
+  /// reports ready as soon as it is on screen, and playing as soon as its
+  /// clock is told to run, both while still black. Playing only arms the
+  /// clock check below. A pause is not trouble: the clock is meant to stand
+  /// still, so the run simply starts over on resume.
+  void onPlaying(bool playing, DateTime now) {
+    if (playing == _playing) return;
+    _playing = playing;
+    _lastPosition = null;
+    _lastAdvanceAt = null;
+    _cleanSince = null;
+  }
+
+  /// The position is the one thing that only moves once frames are shown:
+  /// every backend drives it from the decoder clock. A channel has played
+  /// once the clock has stepped forward for [playedAfter] without a jump,
+  /// a freeze or a buffering report in between, and it is in trouble again
+  /// from the first break until the next such run.
+  void onPosition(Duration position, DateTime now) {
+    final last = _lastPosition;
+    _lastPosition = position;
+    if (!_reachedReady || !_playing || last == null) return;
+    final moved = position - last;
+    final lastAdvance = _lastAdvanceAt;
+    _lastAdvanceAt = now;
+    if (moved <= Duration.zero || moved > _maxAdvance) {
+      _break(now);
+      return;
+    }
+    if (lastAdvance != null && now.difference(lastAdvance) > advanceGap) {
+      // The clock stood still until this step: a freeze that just ended.
+      _break(now, since: lastAdvance);
+    }
+    final cleanSince = _cleanSince ??= now;
+    if (now.difference(cleanSince) >= playedAfter) {
+      _everPlayed = true;
+      _troubleSince = null;
+    }
+  }
+
+  /// Ends the current clean run and starts the trouble clock if it is not
+  /// already running.
+  void _break(DateTime now, {DateTime? since}) {
+    _cleanSince = null;
+    _troubleSince ??= since ?? now;
+  }
+
+  /// When the stream stopped looking healthy, or null while it does. A clock
+  /// that has not stepped for [advanceGap] counts even though no event says
+  /// so: a frozen player reports nothing at all.
+  DateTime? _troubleStart(DateTime now) {
+    final since = _troubleSince;
+    if (since != null) return since;
+    final last = _lastAdvanceAt;
+    if (_playing && last != null && now.difference(last) > advanceGap) {
+      return last;
+    }
+    return null;
+  }
+
+  LiveTvStreamStatus statusAt(DateTime now) {
+    final startedAt = _bringupStartedAt;
+    final sinceStart = startedAt == null
+        ? Duration.zero
+        : now.difference(startedAt);
+    if (_failed) {
+      if (_everPlayed) return LiveTvStreamStatus.lost;
+      // An instant refusal still gets a moment of "connecting", so a Retry
+      // press is seen to do something before the card comes back.
+      if (startedAt != null && sinceStart < minimumConnecting) {
+        return LiveTvStreamStatus.connecting;
+      }
+      return LiveTvStreamStatus.unavailable;
+    }
+    if (_stopped) {
+      return LiveTvStreamStatus.idle;
+    }
+    if (_bringupInProgress) {
+      return sinceStart >= stillTryingAfter
+          ? LiveTvStreamStatus.stillTrying
+          : LiveTvStreamStatus.connecting;
+    }
+    if (!_reachedReady) {
+      return LiveTvStreamStatus.idle;
+    }
+    // On screen but no frame yet: still part of the channel change, and a
+    // change that never produces a frame is a channel the tuner lost.
+    if (!_everPlayed) {
+      if (sinceStart >= startTimeout) return LiveTvStreamStatus.unavailable;
+      // A clock that is stepping is frames on their way to being proven, so
+      // the wait stops where the stepping began. A clock that leaps starts
+      // over each time and still runs the wait out; one that froze after a
+      // few steps is not stepping any more.
+      final lastStep = _lastAdvanceAt;
+      final stepping =
+          _cleanSince != null &&
+          lastStep != null &&
+          now.difference(lastStep) <= advanceGap;
+      final waited = (stepping ? _cleanSince! : now).difference(
+        _readyAt ?? startedAt ?? now,
+      );
+      return waited >= stillTryingAfterReady
+          ? LiveTvStreamStatus.stillTrying
+          : LiveTvStreamStatus.connecting;
+    }
+    final trouble = _troubleStart(now);
+    if (trouble == null) return LiveTvStreamStatus.playing;
+    final stalled = now.difference(trouble);
+    if (stalled >= lostAfter) return LiveTvStreamStatus.lost;
+    if (stalled >= reconnectingAfter) return LiveTvStreamStatus.reconnecting;
+    // A short break only earns a spinner while the player itself says it
+    // is buffering; a brief clock hiccup over a moving picture shows nothing.
+    return _buffering
+        ? LiveTvStreamStatus.buffering
+        : LiveTvStreamStatus.playing;
+  }
+}
+
+/// Drives a [LiveTvStreamStatusTracker] from the playback manager and ticks
+/// it once a second while time can change the answer, so the thresholds fire
+/// without any event arriving.
+class LiveTvStreamStatusMonitor extends ValueNotifier<LiveTvStreamStatus> {
+  LiveTvStreamStatusMonitor(this._manager) : super(LiveTvStreamStatus.idle) {
+    final now = DateTime.now();
+    // A failure left over from whatever played before this screen is not
+    // this channel's failure; only a bringup that is live or done counts.
+    final initial = _manager.bringupState;
+    if (initial.phase != PlaybackBringupPhase.failed) {
+      _tracker.onBringup(initial, now);
+      _tracker.onBuffering(_manager.state.isBuffering, now);
+      _tracker.onPlaying(_manager.state.isPlaying, now);
+      _tracker.onPosition(_manager.state.position, now);
+    }
+    _subs.addAll([
+      _manager.bringupStateStream.listen((state) {
+        final now = DateTime.now();
+        _tracker.onBringup(state, now);
+        _refresh(now);
+      }),
+      _manager.state.bufferingStream.listen((buffering) {
+        final now = DateTime.now();
+        _tracker.onBuffering(buffering, now);
+        _refresh(now);
+      }),
+      _manager.state.playingStream.listen((playing) {
+        final now = DateTime.now();
+        _tracker.onPlaying(playing, now);
+        _refresh(now);
+      }),
+      _manager.state.positionStream.listen((position) {
+        final now = DateTime.now();
+        _tracker.onPosition(position, now);
+        _refresh(now);
+      }),
+      _manager.sessionEndedStream.listen((_) {
+        final now = DateTime.now();
+        _tracker.onEnded(now);
+        _refresh(now);
+      }),
+    ]);
+    _refresh(now);
+  }
+
+  final PlaybackManager _manager;
+  final _tracker = LiveTvStreamStatusTracker();
+  final _subs = <StreamSubscription<Object?>>[];
+  Timer? _ticker;
+
+  void _refresh(DateTime now) {
+    final status = _tracker.statusAt(now);
+    value = status;
+    // Idle and the two failures only change on an event; everything else
+    // has a threshold that time alone can cross.
+    final needsClock = status != LiveTvStreamStatus.idle && !status.isFailure;
+    if (needsClock) {
+      _ticker ??= Timer.periodic(
+        const Duration(seconds: 1),
+        (_) => _refresh(DateTime.now()),
+      );
+    } else {
+      _ticker?.cancel();
+      _ticker = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    for (final sub in _subs) {
+      sub.cancel();
+    }
+    _ticker?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -149,11 +149,16 @@ class Media3PlayerBackend extends PlayerBackend {
   final _bufferingStream = StreamController<bool>.broadcast();
   final _completedStream = StreamController<bool>.broadcast();
   final _errorStream = StreamController<Map<String, dynamic>>.broadcast();
+  final _pictureShownStream = StreamController<bool>.broadcast();
+  bool _pictureShown = false;
 
   int get volumeBoostLevel => _volumeBoostLevel;
 
   @override
   Stream<Map<String, dynamic>> get errorStream => _errorStream.stream;
+
+  @override
+  Stream<bool> get pictureShownStream => _pictureShownStream.stream;
 
   Future<T?> _invoke<T>(String method, [dynamic arguments]) async {
     if (_disposed) return null;
@@ -210,6 +215,16 @@ class Media3PlayerBackend extends PlayerBackend {
         if (completedNow != _completed) {
           _completed = completedNow;
           _completedStream.add(_completed);
+        }
+
+        // The view reads its own pixels once a frame is drawn: true while
+        // the picture is black, null where it cannot look, so a drawn frame
+        // is then taken on trust.
+        final pictureShown = _sawFirstFrame && map['pictureBlack'] != true;
+        if (pictureShown != _pictureShown) {
+          _pictureShown = pictureShown;
+          _diag('Media3: picture ${pictureShown ? 'shown' : 'none'}');
+          _pictureShownStream.add(pictureShown);
         }
 
         _positionStream.add(_position);
@@ -650,6 +665,7 @@ class Media3PlayerBackend extends PlayerBackend {
   void _resetPlaybackWatchdogs(String itemLabel) {
     _watchdogItemLabel = itemLabel;
     _sawFirstFrame = false;
+    _pictureShown = false;
     _firstFrameWarned = false;
     _stallWarned = false;
     _playStartedAtMs = 0;
@@ -1441,6 +1457,7 @@ class Media3PlayerBackend extends PlayerBackend {
     _bufferingStream.close();
     _completedStream.close();
     _errorStream.close();
+    _pictureShownStream.close();
     _tracksChangedController.close();
   }
 }

--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -30,6 +30,8 @@ import '../../../util/playback_time_label.dart';
 import '../../../util/system_ui.dart';
 import '../../widgets/adaptive/sf_symbol.dart';
 import '../../widgets/aether_video_view.dart';
+import '../../../playback/live_tv_stream_status.dart';
+import '../../widgets/playback/live_tv_stream_status_overlay.dart';
 import '../../widgets/playback/stream_info_dialog.dart';
 import '../../widgets/subtitle_preview.dart';
 import '../../widgets/track_selector_dialog.dart';
@@ -142,6 +144,13 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
   int _focusedControlIndex = 0;
   PlayerState get _state => _manager.state;
 
+  // Tells the viewer what the tuner is doing: tuning, still retrying, the
+  // feed dropped, or gone for good. Replaces the bare buffering spinner.
+  late final LiveTvStreamStatusMonitor _streamStatus;
+  bool get _streamFailed => _streamStatus.value.isFailure;
+  bool _wasStreamFailed = false;
+  final _retryFocus = FocusNode(debugLabel: 'LiveTvRetry');
+
   @override
   void initState() {
     super.initState();
@@ -150,6 +159,8 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
       _screensaverController.setPlaybackActive,
     );
     _currentIndex = widget.startIndex;
+    _streamStatus = LiveTvStreamStatusMonitor(_manager);
+    _streamStatus.addListener(_onStreamStatusChanged);
     _applyPlayerDisplayMode();
     _applySubtitleStyle();
     _backendSub = _manager.backendChangedStream.listen((backend) {
@@ -188,6 +199,8 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
   void dispose() {
     _screensaverPlayingSub?.cancel();
     _screensaverController.setPlaybackActive(false);
+    _streamStatus.removeListener(_onStreamStatusChanged);
+    _streamStatus.dispose();
     _hideTimer?.cancel();
     _programRefreshTimer?.cancel();
     _backendSub?.cancel();
@@ -224,6 +237,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
     _tvBitrateFocus.removeListener(_onControlFocusChanged);
     _tvPlaybackInfoFocus.removeListener(_onControlFocusChanged);
     _overlayFocus.dispose();
+    _retryFocus.dispose();
     _tvPlayPauseFocus.dispose();
     _tvChannelsFocus.dispose();
     _tvAudioFocus.dispose();
@@ -631,7 +645,10 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
         enableTranscoding: true,
       );
     } catch (e) {
-      if (mounted) {
+      // A channel the server refused is already on screen as "channel
+      // unavailable" with Retry and Back; a snackbar on top would just repeat
+      // it in vaguer words.
+      if (mounted && !_manager.bringupState.isLiveChannelUnavailable) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
@@ -643,6 +660,39 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
       return;
     }
     _fetchCurrentProgram();
+  }
+
+  /// Only the focus hand-off lives here; the overlay itself listens to the
+  /// monitor directly, so a status tick does not rebuild the whole player.
+  void _onStreamStatusChanged() {
+    // On the way out the manager's stop still reaches the tracker; nothing
+    // it says then is for this screen.
+    if (!mounted || _isStopping) return;
+    final failed = _streamFailed;
+    if (failed != _wasStreamFailed) {
+      _wasStreamFailed = failed;
+      // The card's Retry button has to be given focus by hand: the player's
+      // own focus node already owns the scope, so autofocus would lose. When
+      // the card goes away the player takes the remote back.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        if (_streamFailed) {
+          _retryFocus.requestFocus();
+        } else if (!_isGuidePickerOpen) {
+          _overlayFocus.requestFocus();
+        }
+      });
+    }
+  }
+
+  Future<void> _retryCurrentChannel() async {
+    if (_isSwitching) return;
+    _isSwitching = true;
+    try {
+      await _playCurrentChannel();
+    } finally {
+      _isSwitching = false;
+    }
   }
 
   Future<void> _switchChannel(int newIndex) async {
@@ -1365,6 +1415,12 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
       return KeyEventResult.ignored;
     }
 
+    // The channel failure card owns the remote too: its Retry and Back
+    // buttons take select and the arrows, and nothing behind it is usable.
+    if (_streamFailed) {
+      return KeyEventResult.ignored;
+    }
+
     switch (event.logicalKey) {
       case LogicalKeyboardKey.arrowUp:
       case LogicalKeyboardKey.arrowDown:
@@ -1439,6 +1495,12 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
           return;
         }
         if (_isBackNavigationSuppressed) return;
+        // With the channel failure card up there is nothing to watch, so Back
+        // leaves the player instead of just hiding the controls.
+        if (_streamFailed) {
+          _exitPlayback();
+          return;
+        }
         // Back dismisses the on-screen controls first; only exit the player once
         // the OSD is already hidden (e.g. after returning from the EPG overlay,
         // where a focused control otherwise keeps the OSD pinned open).
@@ -1478,7 +1540,7 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
                 fit: StackFit.expand,
                 children: [
                   _buildVideoSurface(),
-                  _buildBufferingIndicator(),
+                  _buildStreamStatusOverlay(),
                   if (PlatformDetection.isMobile) _buildBrightnessOverlay(),
                   if (PlatformDetection.isMobile) _buildVolumeOverlay(),
                   if (_isGuidePickerOpen) _buildGuideOverlay(),
@@ -1578,20 +1640,20 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
     );
   }
 
-  Widget _buildBufferingIndicator() {
+  Widget _buildStreamStatusOverlay() {
     return AnimatedPositioned.fromRect(
       rect: _videoRect(MediaQuery.sizeOf(context)),
       duration: _kGuideResizeDuration,
       curve: Curves.easeInOut,
-      child: StreamBuilder<bool>(
-        stream: _state.bufferingStream,
-        initialData: _state.isBuffering,
-        builder: (context, snap) {
-          if (snap.data != true) return const SizedBox.shrink();
-          return Center(
-            child: CircularProgressIndicator(color: AppColorScheme.accent),
-          );
-        },
+      child: ValueListenableBuilder<LiveTvStreamStatus>(
+        valueListenable: _streamStatus,
+        builder: (context, status, _) => LiveTvStreamStatusOverlay(
+          status: status,
+          compact: _isGuidePickerOpen,
+          retryFocusNode: _retryFocus,
+          onRetry: _retryCurrentChannel,
+          onExit: _exitPlayback,
+        ),
       ),
     );
   }

--- a/lib/ui/screens/livetv/live_tv_player_screen.dart
+++ b/lib/ui/screens/livetv/live_tv_player_screen.dart
@@ -1544,7 +1544,10 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
                   if (PlatformDetection.isMobile) _buildBrightnessOverlay(),
                   if (PlatformDetection.isMobile) _buildVolumeOverlay(),
                   if (_isGuidePickerOpen) _buildGuideOverlay(),
-                  if (_infoVisible && !_isGuidePickerOpen) ...[
+                  // The failure card takes the screen the way the guide does.
+                  // Controls left up would paint over it and give the arrows
+                  // somewhere else to land.
+                  if (_infoVisible && !_isGuidePickerOpen && !_streamFailed) ...[
                     _buildTopOverlay(),
                     _buildBottomOverlay(),
                   ],
@@ -1647,8 +1650,11 @@ class _LiveTvPlayerScreenState extends State<LiveTvPlayerScreen>
       curve: Curves.easeInOut,
       child: ValueListenableBuilder<LiveTvStreamStatus>(
         valueListenable: _streamStatus,
+        // Leaving stops the stream before the route goes, and a channel
+        // stopped before it came up reads as unavailable, so the card would
+        // show itself on the way out.
         builder: (context, status, _) => LiveTvStreamStatusOverlay(
-          status: status,
+          status: _isStopping ? LiveTvStreamStatus.idle : status,
           compact: _isGuidePickerOpen,
           retryFocusNode: _retryFocus,
           onRetry: _retryCurrentChannel,

--- a/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
@@ -13,9 +13,11 @@ import '../../../data/models/aggregated_item.dart';
 import '../../../data/viewmodels/live_tv_guide_view_model.dart';
 import '../../../playback/appletv_backend.dart';
 import '../../../playback/appletv_preview_player.dart';
+import '../../../playback/live_tv_stream_status.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../l10n/app_localizations.dart';
 import '../../../util/play_method_label.dart';
+import '../../widgets/playback/live_tv_stream_status_overlay.dart';
 import '../livetv/live_tv_guide_screen.dart';
 import '../../theme/app_theme_controller.dart';
 import 'osd_buttons.dart';
@@ -67,6 +69,14 @@ class _AppleTvLiveTvPlayerHostScreenState
   bool _sweepInFlight = false;
   AppThemeController? _themeController;
 
+  // The native player has no place for a status line, so while it is up
+  // tuner trouble is reported through its alert. Once the tuner has given
+  // up the native player comes down altogether: it would only sit there
+  // black, and this route's own surface has the Retry / Back card.
+  late final LiveTvStreamStatusMonitor _streamStatus;
+  LiveTvStreamStatus _shownStatus = LiveTvStreamStatus.idle;
+  final _retryFocus = FocusNode(debugLabel: 'LiveTvRetry');
+
   AppleTvBackend? get _backend {
     try {
       return GetIt.instance<AppleTvBackend>();
@@ -87,6 +97,8 @@ class _AppleTvLiveTvPlayerHostScreenState
       (_) => _onPlayerTracksChanged(),
     );
     _bringupSub = _manager.bringupStateStream.listen((_) => _pushMetadata());
+    _streamStatus = LiveTvStreamStatusMonitor(_manager);
+    _streamStatus.addListener(_onStreamStatusChanged);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _pushSubtitleStyle();
       _pushThemeConfig();
@@ -134,6 +146,9 @@ class _AppleTvLiveTvPlayerHostScreenState
     _exitSub?.cancel();
     _actionSub?.cancel();
     _bringupSub?.cancel();
+    _streamStatus.removeListener(_onStreamStatusChanged);
+    _streamStatus.dispose();
+    _retryFocus.dispose();
     _tracksChangedSub?.cancel();
     _programRefreshTimer?.cancel();
     _themeController?.removeListener(_onThemeChanged);
@@ -185,7 +200,9 @@ class _AppleTvLiveTvPlayerHostScreenState
         enableTranscoding: true,
       );
     } catch (_) {
-      if (mounted) {
+      // A channel the server refused is already reported by the status card
+      // as "channel unavailable"; a snackbar would only repeat it.
+      if (mounted && !_manager.bringupState.isLiveChannelUnavailable) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
@@ -198,6 +215,54 @@ class _AppleTvLiveTvPlayerHostScreenState
     }
     _pushMetadata();
     _fetchCurrentProgram();
+  }
+
+  /// Maps the tuner status onto the native player. Waiting states put up a
+  /// plain alert and take it down once the channel plays. The two failures
+  /// dismiss the native player, which leaves this route's card on screen
+  /// with Retry focused; a Retry then presents the player again.
+  void _onStreamStatusChanged() {
+    if (!mounted || _inGuide || _exiting) return;
+    final status = _streamStatus.value;
+    if (status == _shownStatus) return;
+    final backend = _backend;
+    if (backend == null) return;
+    final previous = _shownStatus;
+    _shownStatus = status;
+    if (status.isFailure) {
+      unawaited(_showFailureCard(backend));
+      return;
+    }
+    final message = _waitingMessage(status);
+    if (message != null) {
+      // The native side swaps an alert already up for the new one.
+      unawaited(backend.showSubtitleProgress(message));
+    } else if (_waitingMessage(previous) != null) {
+      unawaited(backend.hideSubtitleProgress());
+    }
+  }
+
+  String? _waitingMessage(LiveTvStreamStatus status) {
+    final l10n = AppLocalizations.of(context);
+    return switch (status) {
+      LiveTvStreamStatus.stillTrying => l10n.liveTvTunerStillTrying,
+      LiveTvStreamStatus.reconnecting => l10n.liveTvReconnecting,
+      _ => null,
+    };
+  }
+
+  /// Takes the native player down so the card behind it is what the viewer
+  /// sees. The native side only reports a user exit for its own Menu press,
+  /// so this dismissal leaves the route in place. Focus is put on Retry once
+  /// the card has had a frame to build.
+  Future<void> _showFailureCard(AppleTvBackend backend) async {
+    await backend.dismissPlayer();
+    if (!mounted || _exiting || !_streamStatus.value.isFailure) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _streamStatus.value.isFailure) {
+        _retryFocus.requestFocus();
+      }
+    });
   }
 
   Future<void> _switchChannel(String channelId) async {
@@ -758,11 +823,37 @@ class _AppleTvLiveTvPlayerHostScreenState
     }
   }
 
+  Future<void> _retryCurrentChannel() async {
+    if (_switching || _exiting) return;
+    _switching = true;
+    try {
+      await _playCurrentChannel();
+    } finally {
+      _switching = false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    // The native player is presented over this route only once a stream has
+    // opened. Until then, and again once a failed stream has been torn down,
+    // this Flutter surface is what is on screen, so the tuner status is
+    // drawn here: the spinner while connecting, and the Retry / Back card
+    // once the tuner has given up. While the native player is up this sits
+    // unseen behind it.
+    return Scaffold(
       backgroundColor: Colors.black,
-      body: SizedBox.expand(),
+      body: ValueListenableBuilder<LiveTvStreamStatus>(
+        valueListenable: _streamStatus,
+        builder: (context, status, _) {
+          return LiveTvStreamStatusOverlay(
+            status: status,
+            retryFocusNode: _retryFocus,
+            onRetry: _retryCurrentChannel,
+            onExit: _handleExit,
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
@@ -233,22 +233,22 @@ class _AppleTvLiveTvPlayerHostScreenState
       unawaited(_showFailureCard(backend));
       return;
     }
-    final message = _waitingMessage(status);
-    if (message != null) {
-      // The native side swaps an alert already up for the new one.
-      unawaited(backend.showSubtitleProgress(message));
-    } else if (_waitingMessage(previous) != null) {
-      unawaited(backend.hideSubtitleProgress());
+    if (_hasWaitingMessage(status)) {
+      unawaited(backend.showStatusMessage(_waitingMessage(status)));
+    } else if (_hasWaitingMessage(previous)) {
+      unawaited(backend.hideStatusMessage());
     }
   }
 
-  String? _waitingMessage(LiveTvStreamStatus status) {
+  static bool _hasWaitingMessage(LiveTvStreamStatus status) =>
+      status == LiveTvStreamStatus.stillTrying ||
+      status == LiveTvStreamStatus.reconnecting;
+
+  String _waitingMessage(LiveTvStreamStatus status) {
     final l10n = AppLocalizations.of(context);
-    return switch (status) {
-      LiveTvStreamStatus.stillTrying => l10n.liveTvTunerStillTrying,
-      LiveTvStreamStatus.reconnecting => l10n.liveTvReconnecting,
-      _ => null,
-    };
+    return status == LiveTvStreamStatus.stillTrying
+        ? l10n.liveTvTunerStillTrying
+        : l10n.liveTvReconnecting;
   }
 
   /// Takes the native player down so the card behind it is what the viewer

--- a/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
+++ b/lib/ui/screens/playback/appletv_livetv_player_host_screen.dart
@@ -333,6 +333,10 @@ class _AppleTvLiveTvPlayerHostScreenState
       await pip.dispose();
       _pipPlayer = null;
       _inGuide = false;
+      // A status that changed while the guide was up was turned away, and a
+      // notifier does not repeat itself, so it is read again here. Otherwise
+      // a channel that died behind the guide is never acted on.
+      _onStreamStatusChanged();
     }
 
     if (!mounted) return;
@@ -847,7 +851,10 @@ class _AppleTvLiveTvPlayerHostScreenState
         valueListenable: _streamStatus,
         builder: (context, status, _) {
           return LiveTvStreamStatusOverlay(
-            status: status,
+            // Leaving stops the stream before the route goes, and a channel
+            // stopped before it came up reads as unavailable, so the card
+            // would show itself on the way out.
+            status: _exiting ? LiveTvStreamStatus.idle : status,
             retryFocusNode: _retryFocus,
             onRetry: _retryCurrentChannel,
             onExit: _handleExit,

--- a/lib/ui/widgets/playback/live_tv_stream_status_overlay.dart
+++ b/lib/ui/widgets/playback/live_tv_stream_status_overlay.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../../../l10n/app_localizations.dart';
+import '../../../playback/live_tv_stream_status.dart';
+import '../focus/focusable_button.dart';
+
+/// What the live player shows over the video for a [LiveTvStreamStatus].
+///
+/// Waiting states get a spinner with a line under it that says what is
+/// being waited for. The two failure states get a card with Retry and Back,
+/// since by then the tuner has already given up and a spinner would only
+/// hide that. [compact] is for the mini-player box behind the in-player
+/// guide, where there is no room for the card.
+class LiveTvStreamStatusOverlay extends StatelessWidget {
+  const LiveTvStreamStatusOverlay({
+    super.key,
+    required this.status,
+    required this.onRetry,
+    required this.onExit,
+    required this.retryFocusNode,
+    this.compact = false,
+  });
+
+  final LiveTvStreamStatus status;
+  final VoidCallback onRetry;
+  final VoidCallback onExit;
+
+  /// The owning screen moves the remote's focus onto this node when the card
+  /// appears. Autofocus alone loses to whatever player control already holds
+  /// focus in the same scope.
+  final FocusNode retryFocusNode;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    switch (status) {
+      case LiveTvStreamStatus.idle:
+      case LiveTvStreamStatus.playing:
+        return const SizedBox.shrink();
+      case LiveTvStreamStatus.buffering:
+        return _spinner(null);
+      case LiveTvStreamStatus.connecting:
+        return _spinner(compact ? null : l10n.liveTvConnecting);
+      case LiveTvStreamStatus.stillTrying:
+        return _spinner(l10n.liveTvTunerStillTrying);
+      case LiveTvStreamStatus.reconnecting:
+        return _spinner(l10n.liveTvReconnecting);
+      case LiveTvStreamStatus.unavailable:
+        return _failure(
+          context,
+          title: l10n.liveTvChannelUnavailableTitle,
+          body: l10n.liveTvChannelUnavailableBody,
+        );
+      case LiveTvStreamStatus.lost:
+        return _failure(
+          context,
+          title: l10n.liveTvChannelLostTitle,
+          body: l10n.liveTvChannelLostBody,
+        );
+    }
+  }
+
+  Widget _spinner(String? label) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CircularProgressIndicator(color: AppColorScheme.accent),
+          if (label != null) ...[
+            const SizedBox(height: AppSpacing.spaceLg),
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.spaceLg,
+                vertical: AppSpacing.spaceSm,
+              ),
+              decoration: BoxDecoration(
+                color: Colors.black.withValues(alpha: 0.55),
+                borderRadius: AppRadius.circular(8),
+              ),
+              child: Text(
+                label,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: AppTypography.fontSizeMd,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _failure(
+    BuildContext context, {
+    required String title,
+    required String body,
+  }) {
+    return ColoredBox(
+      color: Colors.black.withValues(alpha: 0.7),
+      child: Center(
+        child: compact
+            ? Text(
+                title,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: AppTypography.fontSizeSm,
+                  fontWeight: FontWeight.w600,
+                ),
+              )
+            : _card(title: title, body: body),
+      ),
+    );
+  }
+
+  Widget _card({required String title, required String body}) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 420),
+      child: Container(
+        margin: const EdgeInsets.all(AppSpacing.spaceXl),
+        padding: const EdgeInsets.all(AppSpacing.spaceXl),
+        decoration: BoxDecoration(
+          color: AppColorScheme.surface,
+          borderRadius: AppRadius.circular(18),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Icon(
+              Icons.tv_off_rounded,
+              size: 40,
+              color: AppColorScheme.onSurface.withValues(alpha: 0.8),
+            ),
+            const SizedBox(height: AppSpacing.spaceMd),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColorScheme.onSurface,
+                fontSize: AppTypography.fontSizeXl,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.spaceSm),
+            Text(
+              body,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColorScheme.onSurface.withValues(alpha: 0.62),
+                fontSize: AppTypography.fontSizeSm,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.spaceXl),
+            _FailureActions(
+              retryFocusNode: retryFocusNode,
+              onRetry: onRetry,
+              onExit: onExit,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Retry over Back, on the app's own focusable buttons. Material buttons
+/// never fire from a TV remote here: the select key is consumed by the
+/// focus wrapper layer, so the buttons have to be that layer. Up and down
+/// move between the two, and the remote's back key leaves the player.
+class _FailureActions extends StatefulWidget {
+  const _FailureActions({
+    required this.retryFocusNode,
+    required this.onRetry,
+    required this.onExit,
+  });
+
+  final FocusNode retryFocusNode;
+  final VoidCallback onRetry;
+  final VoidCallback onExit;
+
+  @override
+  State<_FailureActions> createState() => _FailureActionsState();
+}
+
+class _FailureActionsState extends State<_FailureActions> {
+  final _backFocus = FocusNode(debugLabel: 'LiveTvBack');
+
+  @override
+  void dispose() {
+    _backFocus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final retryFocus = widget.retryFocusNode;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        FocusableButton(
+          focusNode: retryFocus,
+          borderRadius: 14,
+          padding: EdgeInsets.zero,
+          onPressed: widget.onRetry,
+          onNavigateDown: _backFocus.requestFocus,
+          onBack: widget.onExit,
+          semanticLabel: l10n.retry,
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 13),
+            decoration: BoxDecoration(
+              color: AppColorScheme.accent,
+              borderRadius: AppRadius.circular(14),
+            ),
+            child: Text(
+              l10n.retry,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColorScheme.onAccent,
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.spaceSm),
+        FocusableButton(
+          focusNode: _backFocus,
+          borderRadius: 14,
+          padding: EdgeInsets.zero,
+          onPressed: widget.onExit,
+          onNavigateUp: retryFocus.requestFocus,
+          onBack: widget.onExit,
+          semanticLabel: l10n.back,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 11),
+            child: Text(
+              l10n.back,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: AppColorScheme.onSurface.withValues(alpha: 0.75),
+                fontSize: 15,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.ContextWrapper
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.graphics.Typeface
 import android.media.AudioDeviceCallback
@@ -18,6 +19,7 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.view.Gravity
+import android.view.PixelCopy
 import android.view.Display
 import android.view.Surface
 import android.view.SurfaceView
@@ -863,6 +865,76 @@ class Media3VideoView(
     private val audioClockListener: (Long) -> Unit = { maybeRecoverAudioClock(it) }
     private var isPlayerReleased = false
     private var firstFrameRendered = false
+
+    // Picture sampling. A tuner's failover placeholder is a black video that
+    // decodes, renders and runs its clock like any channel; only the pixels
+    // say there is nothing to see. A thumbnail of the surface is read about
+    // once a second while a live channel plays, every five once a picture
+    // has been seen; tunneled playback and old APIs cannot be read, and
+    // then a drawn frame is taken on trust. Only live is sampled: nothing
+    // else asks.
+    private var pictureBlack: Boolean? = null
+    private var pictureSamplingUnavailable = false
+    private var pictureSampleInFlight = false
+    private var lastPictureSampleMs = 0L
+    private val pictureSampleBitmap: Bitmap by lazy {
+        Bitmap.createBitmap(PICTURE_SAMPLE_W, PICTURE_SAMPLE_H, Bitmap.Config.ARGB_8888)
+    }
+    private val pictureSamplePixels = IntArray(PICTURE_SAMPLE_W * PICTURE_SAMPLE_H)
+
+    /** The inverse of [revealVideo]: a new source hides the video until its first frame. */
+    private fun hideVideoUntilFirstFrame() {
+        firstFrameRendered = false
+        firstFrameCover.visibility = View.VISIBLE
+        pictureBlack = null
+        pictureSamplingUnavailable = false
+        lastPictureSampleMs = 0L
+    }
+
+    /** True while the picture is black, null before a frame or where the pixels cannot be read. */
+    private fun pictureBlackWire(): Boolean? = when {
+        !firstFrameRendered || pictureSamplingUnavailable -> null
+        else -> pictureBlack ?: true
+    }
+
+    private fun samplePicture() {
+        if (!firstFrameRendered || !currentIsLive || isDisposed || pictureSamplingUnavailable) return
+        val now = SystemClock.elapsedRealtime()
+        val interval =
+            if (pictureBlack == false) PICTURE_SAMPLE_SHOWN_INTERVAL_MS else PICTURE_SAMPLE_INTERVAL_MS
+        if (pictureSampleInFlight || now - lastPictureSampleMs < interval) return
+        val view = videoView as? SurfaceView
+        if (view == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.N || tunnelingActive) {
+            pictureSamplingUnavailable = true
+            return
+        }
+        if (player.playbackState != Player.STATE_READY || !player.playWhenReady) return
+        if (view.width == 0 || view.height == 0 || view.holder.surface?.isValid != true) return
+        pictureSampleInFlight = true
+        lastPictureSampleMs = now
+        try {
+            PixelCopy.request(view, pictureSampleBitmap, { result ->
+                pictureSampleInFlight = false
+                if (isDisposed) return@request
+                if (result != PixelCopy.SUCCESS) {
+                    pictureSamplingUnavailable = true
+                    return@request
+                }
+                pictureSampleBitmap.getPixels(
+                    pictureSamplePixels, 0, PICTURE_SAMPLE_W, 0, 0, PICTURE_SAMPLE_W, PICTURE_SAMPLE_H,
+                )
+                var brightest = 0
+                for (p in pictureSamplePixels) {
+                    val m = maxOf(Color.red(p), Color.green(p), Color.blue(p))
+                    if (m > brightest) brightest = m
+                }
+                pictureBlack = brightest < PICTURE_BLACK_LEVEL
+            }, mainHandler)
+        } catch (e: Exception) {
+            pictureSampleInFlight = false
+            pictureSamplingUnavailable = true
+        }
+    }
     private val externalSubtitleConfigurations = mutableListOf<MediaItem.SubtitleConfiguration>()
 
     /**
@@ -1374,8 +1446,7 @@ class Media3VideoView(
         if (!isPlayerReleased) return
         isPlayerReleased = false
         isDisposed = false
-        firstFrameRendered = false
-        firstFrameCover.visibility = View.VISIBLE
+        hideVideoUntilFirstFrame()
         recreateVideoView()
         player = createPlayer()
         playerHasLoadedSource = false
@@ -2258,7 +2329,7 @@ class Media3VideoView(
         }
     }
 
-    fun stateSnapshot(): Map<String, Any> = stateMap()
+    fun stateSnapshot(): Map<String, Any?> = stateMap()
 
     fun trackSnapshot(): Map<String, Any?> = trackStateMap()
 
@@ -2371,8 +2442,7 @@ class Media3VideoView(
             ?.toInt()
             ?.takeIf { it > 0 }
         pendingClosedCaptionId = null
-        firstFrameRendered = false
-        firstFrameCover.visibility = View.VISIBLE
+        hideVideoUntilFirstFrame()
         cancelPendingSubtitleCue(clearView = true)
         clearAssSubtitleScript()
         applyTrackSelectorForCurrentSource()
@@ -4332,7 +4402,7 @@ class Media3VideoView(
         return names
     }
 
-    private fun stateMap(): Map<String, Any> {
+    private fun stateMap(): Map<String, Any?> {
         val duration = player.duration
         val bufferedPosition = player.bufferedPosition
         val videoSize = player.videoSize
@@ -4352,6 +4422,7 @@ class Media3VideoView(
             "volumeBoostLevel" to userVolumeBoostLevel,
             "subtitleRendererMode" to activeSubtitleRendererMode.wireValue,
             "subtitleRendererModeRequested" to requestedSubtitleRendererMode.wireValue,
+            "pictureBlack" to pictureBlackWire(),
         )
     }
 
@@ -4370,6 +4441,7 @@ class Media3VideoView(
     private fun startTicker() {
         val runnable = object : Runnable {
             override fun run() {
+                samplePicture()
                 emitState()
                 mainHandler.postDelayed(this, 250L)
             }
@@ -4397,3 +4469,10 @@ class Media3VideoView(
         }
     }
 }
+
+private const val PICTURE_SAMPLE_W = 32
+private const val PICTURE_SAMPLE_H = 18
+private const val PICTURE_SAMPLE_INTERVAL_MS = 1000L
+private const val PICTURE_SAMPLE_SHOWN_INTERVAL_MS = 5000L
+// Brightest channel of any sampled pixel below this is a black picture.
+private const val PICTURE_BLACK_LEVEL = 24

--- a/packages/playback_core/lib/playback_core.dart
+++ b/packages/playback_core/lib/playback_core.dart
@@ -10,6 +10,7 @@ export 'src/player_backend.dart';
 export 'src/player_service.dart';
 export 'src/queue_service.dart';
 export 'src/player_state.dart';
+export 'src/live_source_probe.dart';
 export 'src/media_stream_resolver.dart';
 export 'src/track_ordinal_mapper.dart';
 export 'src/stream_resolution_result.dart';

--- a/packages/playback_core/lib/src/live_source_probe.dart
+++ b/packages/playback_core/lib/src/live_source_probe.dart
@@ -1,0 +1,29 @@
+/// Bringup error code for a live channel the server could not get from its
+/// tuner. Set on [PlaybackBringupState.error] when the PlaybackInfo request
+/// fails outright for a channel, or when the server answers with the
+/// placeholder source it hands back after its own probe of the tuner feed
+/// failed. Either way the tuner has already done its retrying, so the viewer
+/// can be told the channel is unavailable rather than left on a spinner.
+const String liveChannelUnavailableError = 'liveChannelUnavailable';
+
+/// Whether a live media source is the server's probe-failed placeholder.
+///
+/// Jellyfin opens the tuner stream, waits, and probes it. When the tuner
+/// closes the connection without sending anything, the probe fails, but the
+/// server still answers PlaybackInfo with HTTP 200 and a stub source: a video
+/// stream with no codec and no dimensions, and an audio stream with no codec.
+/// Starting a player on that source only produces a failed manifest request a
+/// few seconds later, so it is treated as "channel unavailable" up front.
+///
+/// Audio-only channels carry no video stream at all and are left alone. A real
+/// probed source always names a codec and a frame size.
+bool liveSourceProbeFailed(List<Map<String, dynamic>> mediaStreams) {
+  final video = mediaStreams.where((s) => s['Type'] == 'Video');
+  if (video.isEmpty) return false;
+  return video.every(_streamIsUnprobed);
+}
+
+bool _streamIsUnprobed(Map<String, dynamic> stream) {
+  final codec = stream['Codec']?.toString().trim() ?? '';
+  return codec.isEmpty && stream['Width'] == null && stream['Height'] == null;
+}

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -185,6 +185,9 @@ class PlaybackManager implements AudioOwnable {
   final _bringupStateController =
       StreamController<PlaybackBringupState>.broadcast();
   final _sessionEndedController = StreamController<void>.broadcast();
+  final _pictureShownController = StreamController<bool>.broadcast();
+  bool _pictureShown = true;
+  bool _backendPictureShown = false;
   PlaybackBringupState _bringupState = const PlaybackBringupState.idle();
 
   PlayerBackend? get backend => _backend;
@@ -217,6 +220,19 @@ class PlaybackManager implements AudioOwnable {
   Stream<PlaybackBringupState> get bringupStateStream =>
       _bringupStateController.stream;
   Stream<void> get sessionEndedStream => _sessionEndedController.stream;
+
+  /// Whether there is a picture to see. False from the start of a bringup
+  /// until the backend has drawn a frame with something in it, on the
+  /// backends that can tell ([PlayerBackend.pictureShownStream]); true from
+  /// ready on the others, and for a source without video.
+  bool get pictureShown => _pictureShown;
+  Stream<bool> get pictureShownStream => _pictureShownController.stream;
+
+  void _setPictureShown(bool shown, {bool force = false}) {
+    if (!force && shown == _pictureShown) return;
+    _pictureShown = shown;
+    _pictureShownController.add(shown);
+  }
   StreamResolutionResult? get currentResolution => _currentResolution;
 
   /// Item that gained a stream on the server after this session resolved. The
@@ -743,6 +759,17 @@ class PlaybackManager implements AudioOwnable {
         errorStream.listen(_onBackendErrorEvent, onError: (_) {}),
       );
     }
+    final pictureShownStream = backend.pictureShownStream;
+    if (pictureShownStream != null) {
+      _streamSubs.add(
+        pictureShownStream.listen((shown) {
+          _backendPictureShown = shown;
+          if (_bringupState.phase == PlaybackBringupPhase.ready) {
+            _setPictureShown(shown);
+          }
+        }),
+      );
+    }
   }
 
   void _disposeStreamSubs() {
@@ -1266,6 +1293,8 @@ class PlaybackManager implements AudioOwnable {
         backend: _traceBackendName(_backend),
       ),
     );
+    _backendPictureShown = false;
+    _setPictureShown(false);
     await _stopAndReportCurrent();
     _resetBackendSelectionLock();
     _audioStreamIndex = audioStreamIndex;
@@ -1994,6 +2023,14 @@ class PlaybackManager implements AudioOwnable {
         backend: _traceBackendName(_backend),
         playMethod: resolution.playMethod.name,
       ),
+    );
+    // Said again after ready even when unchanged, so a listener that starts
+    // a session on ready hears the picture that belongs to it.
+    _setPictureShown(
+      _backend?.pictureShownStream == null || !resolution.hasVideoStream
+          ? true
+          : _backendPictureShown,
+      force: true,
     );
   }
 
@@ -3175,6 +3212,7 @@ class PlaybackManager implements AudioOwnable {
     _backendChangedController.close();
     _bringupStateController.close();
     _sessionEndedController.close();
+    _pictureShownController.close();
     for (final backend in _retainedBackends.toList()) {
       backend.dispose();
     }

--- a/packages/playback_core/lib/src/playback_manager.dart
+++ b/packages/playback_core/lib/src/playback_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'live_source_probe.dart';
 import 'media_stream_resolver.dart';
 import 'playback_arbiter.dart';
 import 'player_backend.dart';
@@ -1325,20 +1326,28 @@ class PlaybackManager implements AudioOwnable {
     );
   }
 
-  bool _isPreroll(dynamic item) {
-    if (item == null) return false;
+  /// The server item behind a queue entry, whichever shape it arrived in:
+  /// a raw map, or anything carrying one as `rawData`.
+  Map? _rawDataOf(dynamic item) {
+    if (item == null) return null;
+    if (item is Map) return item;
     try {
-      if (item is Map) {
-        return item['__moonfinIsPreroll'] == true;
-      }
       final dynamic dynItem = item;
       final rawData = dynItem.rawData;
-      if (rawData is Map) {
-        return rawData['__moonfinIsPreroll'] == true;
-      }
-    } catch (_) {}
-    return false;
+      return rawData is Map ? rawData : null;
+    } catch (_) {
+      return null;
+    }
   }
+
+  /// Whether a queue item is a live TV channel.
+  bool _isLiveTvItem(dynamic item) {
+    final type = _rawDataOf(item)?['Type']?.toString();
+    return type == 'TvChannel' || type == 'LiveTvChannel';
+  }
+
+  bool _isPreroll(dynamic item) =>
+      _rawDataOf(item)?['__moonfinIsPreroll'] == true;
 
   Future<void> _playCurrentItem({
     Duration startPosition = Duration.zero,
@@ -1439,21 +1448,63 @@ class PlaybackManager implements AudioOwnable {
       }
     }
 
-    final resolution = await _resolver!.resolve(
-      item,
-      deviceProfile: profile,
-      maxStreamingBitrate: maxBitrate,
-      audioStreamIndex: _audioStreamIndex,
-      subtitleStreamIndex: _subtitleStreamIndex,
-      startTimeTicks: startTicks,
-      mediaSourceId: _mediaSourceId,
-      enableDirectPlay: enableDirectPlay,
-      enableDirectStream: enableDirectStream,
-      enableTranscoding: enableTranscoding,
-    );
+    final StreamResolutionResult resolution;
+    try {
+      resolution = await _resolver!.resolve(
+        item,
+        deviceProfile: profile,
+        maxStreamingBitrate: maxBitrate,
+        audioStreamIndex: _audioStreamIndex,
+        subtitleStreamIndex: _subtitleStreamIndex,
+        startTimeTicks: startTicks,
+        mediaSourceId: _mediaSourceId,
+        enableDirectPlay: enableDirectPlay,
+        enableDirectStream: enableDirectStream,
+        enableTranscoding: enableTranscoding,
+      );
+    } catch (_) {
+      // A channel the server refuses outright (no tuner has it, every tuner
+      // slot is busy, the tuner host is down) fails here with a server error.
+      // The exception still reaches the caller, but the bringup state names
+      // the failure so the live player can say the channel is unavailable
+      // instead of showing the raw exception text.
+      if (sessionToken == _playbackSessionToken && _isLiveTvItem(item)) {
+        _setBringupState(
+          PlaybackBringupState(
+            phase: PlaybackBringupPhase.failed,
+            sessionToken: sessionToken,
+            itemId: itemId,
+            backend: _traceBackendName(_backend),
+            error: liveChannelUnavailableError,
+          ),
+        );
+      }
+      rethrow;
+    }
 
     if (sessionToken != _playbackSessionToken) {
       _cleanupPreemptedSession(item, resolution);
+      return;
+    }
+
+    // The server opened the tuner stream but its probe found nothing in it,
+    // and it answered with a placeholder source anyway. The tuner has already
+    // given up on the channel by then, so the player is not started on a
+    // manifest that can only fail. The live session the server opened for the
+    // probe is released the same way a stopped stream would release it.
+    if (resolution.liveStreamId != null &&
+        liveSourceProbeFailed(resolution.mediaStreams)) {
+      unawaited(_service?.closeLiveStream(resolution.liveStreamId!));
+      _setBringupState(
+        PlaybackBringupState(
+          phase: PlaybackBringupPhase.failed,
+          sessionToken: sessionToken,
+          itemId: itemId,
+          backend: _traceBackendName(_backend),
+          playMethod: resolution.playMethod.name,
+          error: liveChannelUnavailableError,
+        ),
+      );
       return;
     }
 

--- a/packages/playback_core/lib/src/player_backend.dart
+++ b/packages/playback_core/lib/src/player_backend.dart
@@ -72,6 +72,12 @@ abstract class PlayerBackend {
   Stream<bool> get completedStream;
   Stream<Map<String, dynamic>>? get errorStream => null;
 
+  /// Whether there is a picture to see: true once a frame that is not
+  /// black has been drawn, false while the picture is absent or black. Only
+  /// the backends that can tell provide it; elsewhere a clock that runs is
+  /// the only sign of a picture.
+  Stream<bool>? get pictureShownStream => null;
+
   Map<String, dynamic> getDeviceProfile({bool useProgressiveTranscode = false});
 
   Future<void> setPlaybackSpeed(double speed);

--- a/packages/playback_core/lib/src/stream_resolution_result.dart
+++ b/packages/playback_core/lib/src/stream_resolution_result.dart
@@ -38,6 +38,9 @@ class StreamResolutionResult {
   final List<String> transcodingReasons;
   final String? hybridAudioUrl;
 
+  /// Whether the source carries video at all; a radio channel does not.
+  bool get hasVideoStream => mediaStreams.any((s) => s['Type'] == 'Video');
+
   /// Whether the server offered this source for direct play, and whether this
   /// resolve asked for it. A transcode that names no reason was declined by
   /// one of these two, and without them a report can't say which. Null where

--- a/test/playback/aether_stall_payload_test.dart
+++ b/test/playback/aether_stall_payload_test.dart
@@ -50,6 +50,9 @@ class _ErrorBackend extends Fake implements PlayerBackend {
   @override
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
   @override
   Stream<Map<String, dynamic>>? get errorStream => _errors.stream;

--- a/test/playback/live_tv_stream_status_test.dart
+++ b/test/playback/live_tv_stream_status_test.dart
@@ -323,17 +323,15 @@ void main() {
         tracker.statusAt(t0.add(const Duration(seconds: 7))),
         LiveTvStreamStatus.connecting,
       );
-      tracker.onPlaying(true, t0.add(const Duration(seconds: 7)));
-      for (var i = 0; i < 3; i++) {
-        tracker.onPosition(
-          Duration(milliseconds: 250 * i),
-          t0.add(Duration(seconds: 7, milliseconds: 250 * i)),
-        );
-      }
-      // Past eight seconds, but the clock has been stepping since seven.
+      showFrames(
+        t0.add(const Duration(seconds: 7)),
+        span: const Duration(milliseconds: 500),
+      );
+      // Past eight seconds, but the clock has been stepping since seven:
+      // frames are on screen, and the spinner is already gone.
       expect(
         tracker.statusAt(t0.add(const Duration(milliseconds: 8200))),
-        LiveTvStreamStatus.connecting,
+        LiveTvStreamStatus.playing,
       );
       showFrames(
         t0.add(const Duration(milliseconds: 7750)),
@@ -345,15 +343,87 @@ void main() {
       );
     });
 
+    test('the first clean steps show as playing before the run is proven', () {
+      // Taken from a macOS log: the stream opened at 1.2s, the clock
+      // started at 3.0s, and the viewer looked at a spinner over the
+      // picture until the two-second proof was in at 5.0s.
+      tuneIn(t0);
+      tracker.onBuffering(true, t0.add(const Duration(milliseconds: 300)));
+      tracker.onBuffering(false, t0.add(const Duration(seconds: 2)));
+      showFrames(
+        t0.add(const Duration(seconds: 2)),
+        span: const Duration(milliseconds: 500),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 2600))),
+        LiveTvStreamStatus.playing,
+      );
+      // A leap takes that away again until a run is proven.
+      showFrames(
+        t0.add(const Duration(milliseconds: 2750)),
+        from: const Duration(seconds: 100),
+        span: const Duration(milliseconds: 750),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 3600))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('where frames are reported, a running clock alone is no picture', () {
+      // Taken from an Android TV emulator: ExoPlayer ran its clock on the
+      // dead channel's sound track for minutes over a black screen, and
+      // never drew a frame.
+      tuneIn(t0);
+      tracker.onPictureShown(false, t0);
+      showFrames(
+        t0.add(const Duration(seconds: 1)),
+        span: const Duration(seconds: 40),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 4))),
+        LiveTvStreamStatus.connecting,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 12))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('where frames are reported, the first frame makes it playing', () {
+      tuneIn(t0);
+      tracker.onPictureShown(false, t0);
+      showFrames(
+        t0.add(const Duration(seconds: 1)),
+        span: const Duration(seconds: 1),
+      );
+      // A second of clock over no picture proved nothing.
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.connecting,
+      );
+      tracker.onPictureShown(true, t0.add(const Duration(seconds: 2)));
+      showFrames(
+        t0.add(const Duration(milliseconds: 2250)),
+        from: const Duration(milliseconds: 1250),
+        span: const Duration(seconds: 2),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 4))),
+        LiveTvStreamStatus.playing,
+      );
+    });
+
     test('a clock that froze after a few steps runs the wait out', () {
       tuneIn(t0);
-      tracker.onPlaying(true, t0.add(const Duration(seconds: 5)));
-      for (var i = 0; i < 3; i++) {
-        tracker.onPosition(
-          Duration(milliseconds: 250 * i),
-          t0.add(Duration(seconds: 5, milliseconds: 250 * i)),
-        );
-      }
+      showFrames(
+        t0.add(const Duration(seconds: 5)),
+        span: const Duration(milliseconds: 500),
+      );
       expect(
         tracker.statusAt(t0.add(const Duration(seconds: 10))),
         LiveTvStreamStatus.stillTrying,

--- a/test/playback/live_tv_stream_status_test.dart
+++ b/test/playback/live_tv_stream_status_test.dart
@@ -116,6 +116,68 @@ void main() {
       );
     });
 
+    test('a bringup that never lands runs out rather than waiting for ever', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 29))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(minutes: 20))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a run too short to prove a channel played leaves it unavailable', () {
+      tuneIn(t0);
+      // Short of the run that proves a channel played, so the failure that
+      // follows is one that never came up rather than one that was lost.
+      showFrames(t0, span: const Duration(milliseconds: 1500));
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.failed),
+        t0.add(const Duration(seconds: 2)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 4))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a clock that stops stepping is no longer frames on the way', () {
+      tuneIn(t0);
+      showFrames(t0, span: const Duration(seconds: 1));
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 1500))),
+        LiveTvStreamStatus.playing,
+      );
+      // Two seconds on from the last step is past the gap one step may leave,
+      // so this is a clock that stopped rather than one still going.
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 3))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('a step longer than a decode gap is a leap, not a step', () {
+      tuneIn(t0);
+      tracker.onPlaying(true, t0);
+      tracker.onPosition(Duration.zero, t0);
+      // Six seconds of content in a quarter second is the tuner jumping to a
+      // new live edge, not frames arriving.
+      tracker.onPosition(
+        const Duration(seconds: 6),
+        t0.add(const Duration(milliseconds: 250)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 300))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
     test('a failure before ready is unavailable, not lost', () {
       tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
       tracker.onBringup(

--- a/test/playback/live_tv_stream_status_test.dart
+++ b/test/playback/live_tv_stream_status_test.dart
@@ -132,6 +132,42 @@ void main() {
       );
     });
 
+    test('a channel stopped before it ever had a picture is unavailable', () {
+      // The tuner answered and the player was started, but no frame ever
+      // arrived and the manager stopped it. Reporting idle here left the
+      // viewer on a black screen with nothing on it.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.idle, token: 1),
+        t0.add(const Duration(seconds: 3)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 3))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a channel that never came up says connecting for a moment first', () {
+      // So a Retry press is seen to do something before the card returns.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(phase(PlaybackBringupPhase.idle, token: 1), t0);
+      expect(tracker.statusAt(t0), LiveTvStreamStatus.connecting);
+    });
+
+    test('stopping a channel that did play is idle, not a failure card', () {
+      // The viewer leaving a working channel has nothing to report.
+      tuneIn(t0);
+      showFrames(t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.idle, token: 1),
+        t0.add(const Duration(seconds: 30)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.idle,
+      );
+    });
+
     test('a failure after ready is lost', () {
       tuneIn(t0);
       showFrames(t0);

--- a/test/playback/live_tv_stream_status_test.dart
+++ b/test/playback/live_tv_stream_status_test.dart
@@ -1,0 +1,554 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/playback/live_tv_stream_status.dart';
+import 'package:playback_core/playback_core.dart';
+
+void main() {
+  final t0 = DateTime(2026, 9, 12, 0, 45);
+
+  PlaybackBringupState phase(
+    PlaybackBringupPhase p, {
+    int? token,
+    String? error,
+  }) {
+    return PlaybackBringupState(
+      phase: p,
+      sessionToken: token,
+      itemId: 'channel',
+      error: error,
+    );
+  }
+
+  group('LiveTvStreamStatusTracker', () {
+    late LiveTvStreamStatusTracker tracker;
+
+    setUp(() {
+      tracker = LiveTvStreamStatusTracker();
+    });
+
+    /// A channel change that the server answered at once: resolved and on
+    /// screen at [at], with no frame shown yet.
+    void tuneIn(DateTime at) {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), at);
+      tracker.onBringup(phase(PlaybackBringupPhase.ready, token: 1), at);
+    }
+
+    /// Frames on screen: playing, with the clock stepping four times a
+    /// second the way both backends report it, for [span] (three seconds
+    /// unless told otherwise).
+    void showFrames(
+      DateTime at, {
+      Duration from = Duration.zero,
+      Duration span = const Duration(seconds: 3),
+    }) {
+      tracker.onPlaying(true, at);
+      for (var i = 0; i <= span.inMilliseconds ~/ 250; i++) {
+        tracker.onPosition(
+          from + Duration(milliseconds: 250 * i),
+          at.add(Duration(milliseconds: 250 * i)),
+        );
+      }
+    }
+
+    /// The tuner feeding broken timestamps: every second the player stalls
+    /// and leaps to a new live edge, then creeps forward for a few samples.
+    void leapEverySecond(DateTime from, Duration forSeconds) {
+      for (var k = 0; k < forSeconds.inSeconds; k++) {
+        final at = from.add(Duration(seconds: k));
+        tracker.onBuffering(true, at);
+        tracker.onPlaying(false, at);
+        tracker.onPlaying(true, at.add(const Duration(milliseconds: 50)));
+        tracker.onBuffering(false, at.add(const Duration(milliseconds: 50)));
+        for (var i = 0; i < 4; i++) {
+          tracker.onPosition(
+            Duration(seconds: 100 * (k + 1), milliseconds: 250 * i),
+            at.add(Duration(milliseconds: 50 + 250 * i)),
+          );
+        }
+      }
+    }
+
+    test('is idle before any bringup', () {
+      expect(tracker.statusAt(t0), LiveTvStreamStatus.idle);
+    });
+
+    test('a fresh channel change is connecting, then still trying', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.stoppingPrevious), t0);
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      expect(tracker.statusAt(t0), LiveTvStreamStatus.connecting);
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 5))),
+        LiveTvStreamStatus.connecting,
+      );
+      // The server is holding the request open: the tuner is retrying.
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 6))),
+        LiveTvStreamStatus.stillTrying,
+      );
+    });
+
+    test('the bringup clock starts at the first in-progress phase', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.stoppingPrevious), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.resolving, token: 1),
+        t0.add(const Duration(seconds: 3)),
+      );
+      // Six seconds after the change began, even though resolving started
+      // only three seconds ago.
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 6))),
+        LiveTvStreamStatus.stillTrying,
+      );
+    });
+
+    test('ready plus frames moving means playing', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.ready, token: 1),
+        t0.add(const Duration(seconds: 3)),
+      );
+      showFrames(
+        t0.add(const Duration(seconds: 4)),
+        span: const Duration(minutes: 1),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(minutes: 1))),
+        LiveTvStreamStatus.playing,
+      );
+    });
+
+    test('a failure before ready is unavailable, not lost', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(
+          PlaybackBringupPhase.failed,
+          token: 1,
+          error: liveChannelUnavailableError,
+        ),
+        t0.add(const Duration(seconds: 3)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 3))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a failure after ready is lost', () {
+      tuneIn(t0);
+      showFrames(t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.failed, token: 1, error: 'Source error'),
+        t0.add(const Duration(seconds: 30)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.lost,
+      );
+    });
+
+    test('a mid-play stall is buffering, then reconnecting, then lost', () {
+      tuneIn(t0);
+      showFrames(t0);
+      final stall = t0.add(const Duration(seconds: 20));
+      tracker.onBuffering(true, stall);
+      expect(tracker.statusAt(stall), LiveTvStreamStatus.buffering);
+      expect(
+        tracker.statusAt(stall.add(const Duration(seconds: 3))),
+        LiveTvStreamStatus.buffering,
+      );
+      expect(
+        tracker.statusAt(stall.add(const Duration(seconds: 4))),
+        LiveTvStreamStatus.reconnecting,
+      );
+      expect(
+        tracker.statusAt(stall.add(const Duration(seconds: 44))),
+        LiveTvStreamStatus.reconnecting,
+      );
+      expect(
+        tracker.statusAt(stall.add(const Duration(seconds: 45))),
+        LiveTvStreamStatus.lost,
+      );
+    });
+
+    test('a stall that recovers goes back to playing once frames move', () {
+      tuneIn(t0);
+      showFrames(t0);
+      final stall = t0.add(const Duration(seconds: 20));
+      tracker.onBuffering(true, stall);
+      final recovered = stall.add(const Duration(seconds: 8));
+      tracker.onBuffering(false, recovered);
+      // The player says it is no longer buffering, but until the clock has
+      // run cleanly for a while that is what a broken feed says too.
+      expect(tracker.statusAt(recovered), LiveTvStreamStatus.reconnecting);
+      showFrames(recovered, from: const Duration(seconds: 20));
+      expect(
+        tracker.statusAt(recovered.add(const Duration(seconds: 3))),
+        LiveTvStreamStatus.playing,
+      );
+    });
+
+    test('a clock that leaps every second is not a channel playing', () {
+      // Taken from a tvOS report: the tuner's feed carried broken
+      // timestamps, the segmenter cut 1782 one-second segments in 85
+      // seconds, and AVPlayer stalled and jumped to a new live edge every
+      // second (25s, 94s, 186s, 301s...) while the screen stayed black.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.ready, token: 1),
+        t0.add(const Duration(seconds: 3)),
+      );
+      leapEverySecond(
+        t0.add(const Duration(seconds: 4)),
+        const Duration(seconds: 40),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 12))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a playing channel whose clock starts leaping is lost', () {
+      tuneIn(t0);
+      showFrames(t0, span: const Duration(seconds: 10));
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 9))),
+        LiveTvStreamStatus.playing,
+      );
+      final broken = t0.add(const Duration(seconds: 10));
+      leapEverySecond(broken, const Duration(seconds: 50));
+      expect(
+        tracker.statusAt(broken.add(const Duration(seconds: 5))),
+        LiveTvStreamStatus.reconnecting,
+      );
+      expect(
+        tracker.statusAt(broken.add(const Duration(seconds: 46))),
+        LiveTvStreamStatus.lost,
+      );
+    });
+
+    test(
+      'a clock that freezes after playing is a stall the player never reports',
+      () {
+        tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+        tracker.onBringup(phase(PlaybackBringupPhase.ready, token: 1), t0);
+        showFrames(t0);
+        // The last step was at t0+3s; nothing has been said since.
+        expect(
+          tracker.statusAt(t0.add(const Duration(seconds: 4))),
+          LiveTvStreamStatus.playing,
+        );
+        expect(
+          tracker.statusAt(t0.add(const Duration(seconds: 8))),
+          LiveTvStreamStatus.reconnecting,
+        );
+        expect(
+          tracker.statusAt(t0.add(const Duration(seconds: 49))),
+          LiveTvStreamStatus.lost,
+        );
+      },
+    );
+
+    test('on screen but never playing is still trying, then unavailable', () {
+      // tvOS reports ready as soon as its player is presented, black and
+      // waiting on a manifest the dropped tuner will never fill.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.ready, token: 1),
+        t0.add(const Duration(seconds: 3)),
+      );
+      tracker.onBuffering(true, t0.add(const Duration(seconds: 3)));
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 4))),
+        LiveTvStreamStatus.connecting,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 12))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 29))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('playing with a clock that never moves is not playing', () {
+      // The tvOS player says playing as soon as its clock is told to run,
+      // still black on a manifest the dropped tuner never filled.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.ready, token: 1),
+        t0.add(const Duration(seconds: 2)),
+      );
+      tracker.onPlaying(true, t0.add(const Duration(seconds: 2)));
+      for (var i = 0; i < 40; i++) {
+        tracker.onPosition(
+          Duration.zero,
+          t0.add(Duration(seconds: 2, milliseconds: 250 * i)),
+        );
+      }
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 6))),
+        LiveTvStreamStatus.connecting,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 10))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      // A stall on a channel that never showed a frame is not a lost feed.
+      tracker.onBuffering(true, t0.add(const Duration(seconds: 12)));
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 20))),
+        LiveTvStreamStatus.stillTrying,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a channel whose clock starts within the allowance never says '
+        'still trying', () {
+      // A healthy tvOS channel: on screen at once, a few seconds of engine
+      // warm-up, then the clock steps. The two seconds it takes to prove
+      // the frames must not push the wait over the line.
+      tuneIn(t0);
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 7))),
+        LiveTvStreamStatus.connecting,
+      );
+      tracker.onPlaying(true, t0.add(const Duration(seconds: 7)));
+      for (var i = 0; i < 3; i++) {
+        tracker.onPosition(
+          Duration(milliseconds: 250 * i),
+          t0.add(Duration(seconds: 7, milliseconds: 250 * i)),
+        );
+      }
+      // Past eight seconds, but the clock has been stepping since seven.
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 8200))),
+        LiveTvStreamStatus.connecting,
+      );
+      showFrames(
+        t0.add(const Duration(milliseconds: 7750)),
+        from: const Duration(milliseconds: 750),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 11))),
+        LiveTvStreamStatus.playing,
+      );
+    });
+
+    test('a clock that froze after a few steps runs the wait out', () {
+      tuneIn(t0);
+      tracker.onPlaying(true, t0.add(const Duration(seconds: 5)));
+      for (var i = 0; i < 3; i++) {
+        tracker.onPosition(
+          Duration(milliseconds: 250 * i),
+          t0.add(Duration(seconds: 5, milliseconds: 250 * i)),
+        );
+      }
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 10))),
+        LiveTvStreamStatus.stillTrying,
+      );
+    });
+
+    test('a single jump of the clock is not a frame', () {
+      tuneIn(t0);
+      tracker.onPlaying(true, t0);
+      tracker.onPosition(Duration.zero, t0);
+      // The live edge is found: the clock leaps to the stream's own time.
+      tracker.onPosition(const Duration(hours: 3), t0);
+      tracker.onPosition(const Duration(hours: 3), t0);
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 30))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('a failure after ready but before any frame is unavailable', () {
+      tuneIn(t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.failed, token: 1, error: 'Source error'),
+        t0.add(const Duration(seconds: 8)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 8))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('an instant refusal shows connecting for a moment first', () {
+      // A retry on a channel the server refuses fails within a few hundred
+      // milliseconds; without this the card would just redraw.
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(
+          PlaybackBringupPhase.failed,
+          token: 1,
+          error: liveChannelUnavailableError,
+        ),
+        t0.add(const Duration(milliseconds: 300)),
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 300))),
+        LiveTvStreamStatus.connecting,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 1100))),
+        LiveTvStreamStatus.connecting,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(milliseconds: 1200))),
+        LiveTvStreamStatus.unavailable,
+      );
+    });
+
+    test('buffering before ready never counts as a stall', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.opening, token: 1), t0);
+      tracker.onBuffering(true, t0);
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('a new channel change after a failure starts clean', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      tracker.onBringup(
+        phase(PlaybackBringupPhase.failed, token: 1, error: 'x'),
+        t0,
+      );
+      expect(
+        tracker.statusAt(t0.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.unavailable,
+      );
+      final retry = t0.add(const Duration(seconds: 10));
+      tracker.onBringup(phase(PlaybackBringupPhase.stoppingPrevious), retry);
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 2), retry);
+      expect(tracker.statusAt(retry), LiveTvStreamStatus.connecting);
+      expect(
+        tracker.statusAt(retry.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('a re-resolve with a new token restarts the bringup clock', () {
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 1), t0);
+      final again = t0.add(const Duration(seconds: 4));
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 2), again);
+      expect(
+        tracker.statusAt(again.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('the player running out on its own after playing is lost', () {
+      // Seen on tvOS: the engine served what it held as a finished asset
+      // once the tuner stopped feeding it, AVPlayer ran that out and said
+      // completed, and the manager stopped the channel and announced the
+      // session's end. The screen was black with nothing on it.
+      tuneIn(t0);
+      showFrames(t0, span: const Duration(seconds: 10));
+      final stopped = t0.add(const Duration(seconds: 12));
+      tracker.onBringup(const PlaybackBringupState.idle(), stopped);
+      expect(tracker.statusAt(stopped), LiveTvStreamStatus.idle);
+      tracker.onEnded(stopped);
+      expect(tracker.statusAt(stopped), LiveTvStreamStatus.lost);
+      expect(
+        tracker.statusAt(stopped.add(const Duration(minutes: 1))),
+        LiveTvStreamStatus.lost,
+      );
+    });
+
+    test('the player running out before any frame is unavailable', () {
+      tuneIn(t0);
+      final stopped = t0.add(const Duration(seconds: 8));
+      tracker.onBringup(const PlaybackBringupState.idle(), stopped);
+      tracker.onEnded(stopped);
+      expect(tracker.statusAt(stopped), LiveTvStreamStatus.unavailable);
+    });
+
+    test('a channel change after the player ran out starts clean', () {
+      tuneIn(t0);
+      showFrames(t0);
+      tracker.onBringup(const PlaybackBringupState.idle(), t0);
+      tracker.onEnded(t0.add(const Duration(seconds: 5)));
+      final retry = t0.add(const Duration(seconds: 10));
+      tracker.onBringup(phase(PlaybackBringupPhase.resolving, token: 2), retry);
+      expect(tracker.statusAt(retry), LiveTvStreamStatus.connecting);
+      expect(
+        tracker.statusAt(retry.add(const Duration(seconds: 2))),
+        LiveTvStreamStatus.connecting,
+      );
+    });
+
+    test('a session end with no channel on record is ignored', () {
+      tracker.onEnded(t0);
+      expect(tracker.statusAt(t0), LiveTvStreamStatus.idle);
+    });
+
+    test('idle clears everything', () {
+      tuneIn(t0);
+      tracker.onBuffering(true, t0);
+      tracker.onBringup(const PlaybackBringupState.idle(), t0);
+      expect(
+        tracker.statusAt(t0.add(const Duration(minutes: 1))),
+        LiveTvStreamStatus.idle,
+      );
+    });
+  });
+
+  group('liveSourceProbeFailed', () {
+    test(
+      'recognises the placeholder Jellyfin returns after a failed probe',
+      () {
+        // Shape taken from a Jellyfin log where the tuner closed the stream
+        // with no data and ffprobe found neither streams nor format.
+        final streams = <Map<String, dynamic>>[
+          {
+            'Type': 'Video',
+            'Codec': null,
+            'Width': null,
+            'Height': null,
+            'BitRate': 2000000,
+            'IsInterlaced': true,
+            'Index': -1,
+          },
+          {'Type': 'Audio', 'Codec': null, 'BitRate': 192000, 'Index': -1},
+        ];
+        expect(liveSourceProbeFailed(streams), isTrue);
+      },
+    );
+
+    test('a probed source with a codec and frame size is fine', () {
+      final streams = <Map<String, dynamic>>[
+        {'Type': 'Video', 'Codec': 'h264', 'Width': 1280, 'Height': 720},
+        {'Type': 'Audio', 'Codec': 'aac', 'Channels': 2},
+      ];
+      expect(liveSourceProbeFailed(streams), isFalse);
+    });
+
+    test('a codec without dimensions is not the placeholder', () {
+      final streams = <Map<String, dynamic>>[
+        {'Type': 'Video', 'Codec': 'h264', 'Width': null, 'Height': null},
+      ];
+      expect(liveSourceProbeFailed(streams), isFalse);
+    });
+
+    test('an audio-only channel has no video stream to judge', () {
+      final streams = <Map<String, dynamic>>[
+        {'Type': 'Audio', 'Codec': 'aac', 'Channels': 2},
+      ];
+      expect(liveSourceProbeFailed(streams), isFalse);
+      expect(liveSourceProbeFailed(const []), isFalse);
+    });
+  });
+}

--- a/test/playback/media3_stall_watchdog_test.dart
+++ b/test/playback/media3_stall_watchdog_test.dart
@@ -50,6 +50,9 @@ class _ErrorBackend extends Fake implements PlayerBackend {
   @override
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
   @override
   Stream<Map<String, dynamic>>? get errorStream => _errors.stream;

--- a/test/playback/playback_manager_downloaded_subtitle_test.dart
+++ b/test/playback/playback_manager_downloaded_subtitle_test.dart
@@ -49,6 +49,9 @@ class _TestBackend extends Fake implements PlayerBackend {
   @override
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
   @override
   Stream<Map<String, dynamic>>? get errorStream => null;

--- a/test/playback/playback_manager_late_error_test.dart
+++ b/test/playback/playback_manager_late_error_test.dart
@@ -46,6 +46,9 @@ class _ErrorBackend extends Fake implements PlayerBackend {
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
 
   @override

--- a/test/playback/playback_manager_paused_reresolve_test.dart
+++ b/test/playback/playback_manager_paused_reresolve_test.dart
@@ -43,6 +43,9 @@ class _TestBackend extends Fake implements PlayerBackend {
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
 
   @override

--- a/test/playback/playback_manager_stale_session_test.dart
+++ b/test/playback/playback_manager_stale_session_test.dart
@@ -47,6 +47,9 @@ class _TestBackend extends Fake implements PlayerBackend {
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
 
   @override

--- a/test/playback/previous_restarts_when_first_test.dart
+++ b/test/playback/previous_restarts_when_first_test.dart
@@ -29,6 +29,9 @@ class _TestBackend extends Fake implements PlayerBackend {
   Stream<bool> get bufferingStream => const Stream<bool>.empty();
 
   @override
+  Stream<bool>? get pictureShownStream => null;
+
+  @override
   Stream<bool> get completedStream => const Stream<bool>.empty();
 
   @override

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -159,6 +159,10 @@ final class AppleTvPlayerViewController: UIViewController {
 
     private let loadingOverlay = UIView()
     private let loadingSpinner = UIActivityIndicatorView(style: .large)
+    // A line of status over the picture, such as the live tuner still
+    // trying. Not an alert on purpose: an alert takes the Menu press, and
+    // the viewer must be able to leave a channel that is not coming.
+    private let statusLabel = PaddedLabel()
     private var loadingDismissed = false
 
     private var isLive = false
@@ -552,6 +556,36 @@ final class AppleTvPlayerViewController: UIViewController {
         setupLiveOverlays()
         setupSkipSegment()
         setupLoadingOverlay()
+        setupStatusMessage()
+    }
+
+    private func setupStatusMessage() {
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.insets = UIEdgeInsets(top: 14, left: 28, bottom: 14, right: 28)
+        statusLabel.backgroundColor = UIColor(white: 0, alpha: 0.6)
+        statusLabel.layer.cornerRadius = 14
+        statusLabel.clipsToBounds = true
+        statusLabel.textColor = .white
+        statusLabel.font = .systemFont(ofSize: 31, weight: .semibold)
+        statusLabel.textAlignment = .center
+        statusLabel.numberOfLines = 2
+        statusLabel.isHidden = true
+        statusLabel.isUserInteractionEnabled = false
+        view.addSubview(statusLabel)
+        NSLayoutConstraint.activate([
+            statusLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            statusLabel.topAnchor.constraint(equalTo: view.centerYAnchor, constant: 60),
+            statusLabel.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.6),
+        ])
+    }
+
+    func showStatusMessage(_ message: String) {
+        statusLabel.text = message
+        statusLabel.isHidden = false
+    }
+
+    func hideStatusMessage() {
+        statusLabel.isHidden = true
     }
 
     private func setupLoadingOverlay() {
@@ -2458,19 +2492,8 @@ final class AppleTvPlayerViewController: UIViewController {
     /// as the press having been ignored.
     func showSubtitleProgress(_ message: String) {
         let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
-        let previous = subtitleProgressAlert
         subtitleProgressAlert = alert
-        let show = { [weak self] in
-            // A hide or a newer message may have come in while the old alert
-            // was going down; then this one is stale.
-            guard let self, self.subtitleProgressAlert === alert else { return }
-            self.present(alert, animated: true)
-        }
-        if let previous, previous.presentingViewController != nil {
-            previous.dismiss(animated: true, completion: show)
-        } else {
-            show()
-        }
+        present(alert, animated: true)
     }
 
     /// Take the progress alert down. A message turns it into an alert the viewer

--- a/tvos/Runner/Playback/AppleTvPlayerViewController.swift
+++ b/tvos/Runner/Playback/AppleTvPlayerViewController.swift
@@ -2458,8 +2458,19 @@ final class AppleTvPlayerViewController: UIViewController {
     /// as the press having been ignored.
     func showSubtitleProgress(_ message: String) {
         let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        let previous = subtitleProgressAlert
         subtitleProgressAlert = alert
-        present(alert, animated: true)
+        let show = { [weak self] in
+            // A hide or a newer message may have come in while the old alert
+            // was going down; then this one is stale.
+            guard let self, self.subtitleProgressAlert === alert else { return }
+            self.present(alert, animated: true)
+        }
+        if let previous, previous.presentingViewController != nil {
+            previous.dismiss(animated: true, completion: show)
+        } else {
+            show()
+        }
     }
 
     /// Take the progress alert down. A message turns it into an alert the viewer
@@ -2482,6 +2493,10 @@ final class AppleTvPlayerViewController: UIViewController {
             return
         }
         subtitleProgressAlert = nil
+        guard existing.presentingViewController != nil else {
+            next()
+            return
+        }
         existing.dismiss(animated: true) { next() }
     }
 

--- a/tvos/Runner/Playback/AppleTvVideoChannel.swift
+++ b/tvos/Runner/Playback/AppleTvVideoChannel.swift
@@ -109,6 +109,10 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
             playerVC?.showSubtitleProgress((args["message"] as? String) ?? "Working\u{2026}")
         case "hideSubtitleProgress":
             playerVC?.hideSubtitleProgress(message: args["message"] as? String)
+        case "showStatusMessage":
+            playerVC?.showStatusMessage((args["message"] as? String) ?? "")
+        case "hideStatusMessage":
+            playerVC?.hideStatusMessage()
         case "configureSubtitleStyle":
             lastSubtitleStyle = args
             applySubtitleStyle(args)

--- a/tvos/Runner/Playback/AppleTvVideoChannel.swift
+++ b/tvos/Runner/Playback/AppleTvVideoChannel.swift
@@ -337,7 +337,18 @@ final class AppleTvVideoChannel: NSObject, FlutterStreamHandler {
         lastClosedCaptionCount = -1
         didComplete = false
         if let vc {
-            vc.dismiss(animated: false) { [weak self] in
+            // The controller reports an exit from viewDidDisappear, which a
+            // dismissal ordered from Dart also triggers. That exit is the
+            // viewer's own Menu press, so it must not fire here: the live
+            // host takes the player down to show its own card, and a
+            // reported exit would pop that route as well.
+            vc.onExit = nil
+            // UIKit dismisses the topmost presentation of whatever this is
+            // called on. With a progress alert up, `vc.dismiss` would take
+            // down the alert and leave the player on screen; asking the
+            // presenter takes down the player and anything over it.
+            let presenter = vc.presentingViewController ?? vc
+            presenter.dismiss(animated: false) { [weak self] in
                 Task { @MainActor in self?.send(["event": "dismissed"]) }
             }
         } else {


### PR DESCRIPTION
# Pull Request

## Summary
Live TV channels that fail on the tuner side (Dispatcharr behind Jellyfin) used to leave the viewer on a black screen or a spinner with nothing to press, because the server never says whether the tuner is retrying or has given up. This PR adds a tracker that turns the bringup phases, buffering, the playback clock, the session end and (on Android) the rendered picture into a status: connecting, still trying, playing, buffering, reconnecting, unavailable or lost. Both live players show a spinner with a line for the waiting states and a Retry / Back card for the two failures. On tvOS the waiting states appear as a label over the native player and a failure dismisses the player so the card is what the viewer sees.

## Related Issues

- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Performance improvement
- [x] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made

- New `LiveTvStreamStatusTracker` (pure, fixed-clock testable) and `LiveTvStreamStatusMonitor` in `lib/playback/live_tv_stream_status.dart`, with 33 unit tests taken from real tvOS, macOS and Android TV logs.
- `LiveTvStreamStatusOverlay`: spinner with a message for the waiting states, Retry / Back card for `unavailable` and `lost`, wired into `live_tv_player_screen.dart` and `appletv_livetv_player_host_screen.dart`.
- `PlaybackManager`: a live resolve that throws, or answers with the placeholder Jellyfin returns after a failed probe, becomes a failed bringup under `liveChannelUnavailableError` and the probe's live session is released; new `pictureShown` state and stream.
- `PlayerBackend.pictureShownStream` (optional). The Media3 view samples its surface for a black picture while a live channel plays, so a failover placeholder (black video with a sound track, which ExoPlayer plays normally) no longer counts as playing.
- Playing is declared as soon as a well-behaved clock steps after the stream opens; "still trying" is counted from the stream opening with an eight-second allowance that stops counting once the clock steps.
- tvOS native: tuner status shown as a label instead of an alert (the alert swallowed the Menu press); the player is dismissed from its presenter so a dismissal with an alert up takes the player down too; a dismissal ordered from Dart no longer reports a user exit.
- Seven new localization keys in `app_en.arb`.

## Platform
- [ ] Android
- [x] Android TV
- [ ] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing

- [x] Tested on emulator / simulator (Android TV + Android)
- [x] Tested on physical device (macOS + Apple TV)
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open a live channel whose upstream is down (tuner serving its failover placeholder). Expec then "The tuner is still trying to get this channel…" a few seconds after the stream opens,then the "Channel unavailable" card with Retry focused within thirty seconds. Back and the Menu button return to the guide at every stage.
2. Press Retry on the card: the channel is opened again and the card returns if it still fail
3. Open a working channel: the spinner leaves as soon as the picture starts, with no "still trying" message.
4. On tvOS, while the "still trying" label is showing, press Menu: the player closes and the
5. Run `flutter test test/playback`.

## Screenshots (if applicable)

<img width="829" height="507" alt="Screenshot 2026-09-12 at 12 39 59" src="https://github.com/user-attachments/assets/5b015da5-867a-4257-810c-f41d998c0408" />
<img width="829" height="507" alt="Screenshot 2026-09-12 at 12 39 44" src="https://github.com/user-attachments/assets/18ce6e99-bbe4-446a-a8cc-d923ae24970c" />


## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced