### PR TITLE
fix(macOS): keep the video view swap out of Swift's exclusivity check

### DIFF
--- a/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
+++ b/tvos/Runner/Playback/Aether/AetherPlayerWrapper.swift
@@ -389,7 +389,13 @@ final class AetherPlayerWrapper: NSObject, ObservableObject {
     // MARK: - Surface
 
     func attachVideoView(_ view: PlatformView) {
+        // Hold the outgoing view until the store is done: its deinit calls
+        // detachVideoView, which reads videoView, and releasing it inside the
+        // assignment would overlap that read with the write (a Swift
+        // exclusivity violation, fatal at runtime).
+        let previous = videoView
         videoView = view
+        withExtendedLifetime(previous) {}
         playerView.frame = view.bounds
         subtitleOverlay.frame = view.bounds
         #if canImport(UIKit)


### PR DESCRIPTION
# Pull Request

## Summary
`AetherPlayerWrapper.attachVideoView` stored the incoming view directly over the
outgoing one. The outgoing view is released as part of that assignment, and its
`deinit` calls `detachVideoView`, which reads `videoView` — a read that overlaps
the write it came from. Swift's exclusivity checking treats that as a violation
and traps at runtime. Holding the outgoing view alive until the store has
finished keeps the read and the write apart.

macOS and tvOS both compile the Aether sources, so despite living under `tvos/`
this is a shared-code fix.

## Related Issues
- Closes #
- Fixes #
- Related to #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
- Keep a reference to the outgoing video view across the `videoView` assignment
  in `attachVideoView`, released via `withExtendedLifetime` once the store is
  complete, so the deinit-triggered `detachVideoView` read no longer overlaps
  the write.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [x] tvOS
- [ ] Web
- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] All / Shared code

## Testing
- [ ] Tested on emulator / simulator
- [x] Tested on physical device
- [ ] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Start playback so a video view is attached to the Aether player.
2. Cause the surface to be swapped while playback is live — reattaching a new
   view over the existing one (the path that previously tripped the exclusivity
   trap).
3. Confirm playback continues and the process does not trap.

## Screenshots (if applicable)
N/A — no UI change.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced