### PR TITLE
feat-ui - Badgering the Badges - Apply consistent visual elements to badges to enhance legibility

### DIFF
--- a/lib/ui/screens/detail/item_detail_screen.dart
+++ b/lib/ui/screens/detail/item_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../theme/focus_foreground.dart';
 import '../../widgets/bounded_network_image.dart';
 import '../../widgets/offline_aware_image.dart';
 import '../../widgets/identify_dialog.dart';
+import '../../widgets/media_badge.dart';
 import 'detail_admin_actions.dart';
 
 import 'package:flutter/foundation.dart';
@@ -4440,37 +4441,13 @@ class DetailPosterImage extends StatelessWidget {
             Positioned(
               top: 6,
               left: 6,
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.6),
-                  shape: BoxShape.circle,
-                ),
-                child: const AdaptiveIcon(
-                  Icons.favorite,
-                  color: Color(0xFFFF4757),
-                  size: 16,
-                ),
-              ),
+              child: MediaFavoriteBadge(size: 26),
             ),
           if (item.isPlayed)
             Positioned(
               top: 6,
               right: 6,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: AppColorScheme.accent,
-                  shape: BoxShape.circle,
-                ),
-                child: const Padding(
-                  padding: EdgeInsets.all(3),
-                  child: AdaptiveIcon(
-                    Icons.check,
-                    color: Colors.white,
-                    size: 12,
-                  ),
-                ),
-              ),
+              child: MediaWatchedBadge(size: 26),
             ),
           if ((item.playedPercentage ?? 0) > 0)
             Positioned(
@@ -4592,37 +4569,13 @@ class _EpisodeThumbnail extends StatelessWidget {
             Positioned(
               top: 6,
               left: 6,
-              child: Container(
-                padding: const EdgeInsets.all(4),
-                decoration: BoxDecoration(
-                  color: Colors.black.withValues(alpha: 0.6),
-                  shape: BoxShape.circle,
-                ),
-                child: const AdaptiveIcon(
-                  Icons.favorite,
-                  color: Color(0xFFFF4757),
-                  size: 14,
-                ),
-              ),
+              child: MediaFavoriteBadge(size: 24),
             ),
           if (item.isPlayed)
             Positioned(
               top: 6,
               right: 6,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  color: AppColorScheme.accent,
-                  shape: BoxShape.circle,
-                ),
-                child: const Padding(
-                  padding: EdgeInsets.all(3),
-                  child: AdaptiveIcon(
-                    Icons.check,
-                    color: Colors.white,
-                    size: 10,
-                  ),
-                ),
-              ),
+              child: MediaWatchedBadge(size: 24),
             ),
           if ((item.playedPercentage ?? 0) > 0)
             Positioned(

--- a/lib/ui/screens/detail/modern/widgets/season_card.dart
+++ b/lib/ui/screens/detail/modern/widgets/season_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../widgets/focus/focusable_wrapper.dart';
+import '../../../../widgets/media_badge.dart';
 import '../../../../widgets/seerr/seerr_status_dot.dart';
 
 /// Glassy season card with a subtle background image, title, episode count and a
@@ -121,43 +122,13 @@ class SeasonCard extends StatelessWidget {
                 Positioned(
                   top: 6,
                   right: 6,
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      color: AppColorScheme.badgeWatched,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(3),
-                      child: Icon(
-                        Icons.check,
-                        color: AppColorScheme.onBadge,
-                        size: 13,
-                      ),
-                    ),
-                  ),
+                  child: MediaWatchedBadge(size: 22),
                 )
               else if (unplayedCount != null && unplayedCount! > 0)
                 Positioned(
                   top: 6,
                   right: 6,
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 5,
-                      vertical: 1,
-                    ),
-                    decoration: BoxDecoration(
-                      color: AppColorScheme.badgeUnplayed,
-                      borderRadius: AppRadius.circular(8),
-                    ),
-                    child: Text(
-                      '$unplayedCount',
-                      style: TextStyle(
-                        color: AppColorScheme.onBadge,
-                        fontSize: 10,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
+                  child: MediaUnplayedBadge(count: unplayedCount!),
                 ),
               Positioned(
                 left: 8,

--- a/lib/ui/screens/detail/nouveau/shared/nouveau_landscape_media_card.dart
+++ b/lib/ui/screens/detail/nouveau/shared/nouveau_landscape_media_card.dart
@@ -8,6 +8,7 @@ import '../../../../../data/models/aggregated_item.dart';
 import '../../../../../l10n/app_localizations.dart';
 import '../../../../../util/focus/dpad_keys.dart';
 import '../../../../widgets/focus/focusable_wrapper.dart';
+import '../../../../widgets/media_badge.dart';
 import '../../../../widgets/offline_aware_image.dart';
 
 class NouveauLandscapeMediaCard extends StatefulWidget {
@@ -899,13 +900,11 @@ class _NouveauFavoriteIndicator extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColorScheme.recordingActive,
         shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.28),
-            blurRadius: 10,
-            offset: const Offset(0, 3),
-          ),
-        ],
+        border: Border.all(
+          color: Colors.white,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
       ),
       alignment: Alignment.center,
       child: const Icon(Icons.favorite_rounded, color: Colors.white, size: 17),

--- a/lib/ui/screens/detail/nouveau/shared/nouveau_media_rail_card.dart
+++ b/lib/ui/screens/detail/nouveau/shared/nouveau_media_rail_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../../../../widgets/media_badge.dart';
 import '../../../../widgets/offline_aware_image.dart';
 import 'nouveau_overflow_text.dart';
 
@@ -246,15 +247,11 @@ class _NouveauMediaRailCardState extends State<NouveauMediaRailCard> {
                                     decoration: BoxDecoration(
                                       color: theme.colorScheme.primary,
                                       shape: BoxShape.circle,
-                                      boxShadow: [
-                                        BoxShadow(
-                                          color: Colors.black.withValues(
-                                            alpha: 0.28,
-                                          ),
-                                          blurRadius: 10,
-                                          offset: const Offset(0, 3),
-                                        ),
-                                      ],
+                                      border: Border.all(
+                                        color: theme.colorScheme.onPrimary,
+                                        width: 1.5,
+                                      ),
+                                      boxShadow: kMediaBadgeShadow,
                                     ),
                                     alignment: Alignment.center,
                                     child: Icon(
@@ -404,13 +401,11 @@ class _NouveauFavoriteIndicator extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColorScheme.recordingActive,
         shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.28),
-            blurRadius: 10,
-            offset: const Offset(0, 3),
-          ),
-        ],
+        border: Border.all(
+          color: Colors.white,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
       ),
       alignment: Alignment.center,
       child: const Icon(Icons.favorite_rounded, color: Colors.white, size: 17),

--- a/lib/ui/screens/detail/nouveau/shared/nouveau_poster_card.dart
+++ b/lib/ui/screens/detail/nouveau/shared/nouveau_poster_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
 import '../../../../../util/platform_detection.dart';
+import '../../../../widgets/media_badge.dart';
 import '../../../../widgets/offline_aware_image.dart';
 import 'nouveau_overflow_text.dart';
 
@@ -338,13 +339,11 @@ class _NouveauPosterCardState extends State<NouveauPosterCard> {
                             decoration: BoxDecoration(
                               color: theme.colorScheme.primary,
                               shape: BoxShape.circle,
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.black.withValues(alpha: 0.28),
-                                  blurRadius: 10,
-                                  offset: const Offset(0, 3),
-                                ),
-                              ],
+                              border: Border.all(
+                                color: theme.colorScheme.onPrimary,
+                                width: 1.5,
+                              ),
+                              boxShadow: kMediaBadgeShadow,
                             ),
                             alignment: Alignment.center,
                             child: Icon(
@@ -594,13 +593,11 @@ class _NouveauFavoriteIndicator extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColorScheme.recordingActive,
         shape: BoxShape.circle,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withValues(alpha: 0.28),
-            blurRadius: 10,
-            offset: const Offset(0, 3),
-          ),
-        ],
+        border: Border.all(
+          color: Colors.white,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
       ),
       alignment: Alignment.center,
       child: const Icon(Icons.favorite_rounded, color: Colors.white, size: 17),

--- a/lib/ui/screens/detail/spotlight/spotlight_cards.dart
+++ b/lib/ui/screens/detail/spotlight/spotlight_cards.dart
@@ -8,7 +8,8 @@ import '../../../../data/viewmodels/item_detail_view_model.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../preference/user_preferences.dart';
 import '../../../widgets/seerr/seerr_item_chips.dart';
-import '../../../widgets/seerr/seerr_item_status.dart' show seerrItemTabState;
+import '../../../widgets/seerr/seerr_item_status.dart'
+    show seerrItemSeasonStatus, seerrItemTabState;
 import '../../../widgets/seerr/seerr_stats_card.dart';
 import '../item_detail_screen.dart' show DetailTrackList;
 import '../modern/modern_detail_content.dart'
@@ -244,6 +245,7 @@ class _SpotlightCardsBuilder {
     double aspectRatio = 2 / 3,
     bool landscapeCells = false,
     ValueChanged<AggregatedItem>? onTap,
+    Map<int, int>? seerrSeasonStatus,
   }) {
     return SpotlightModalSection(
       title: title,
@@ -256,6 +258,7 @@ class _SpotlightCardsBuilder {
         landscapeCells: landscapeCells,
         firstFocusNode: firstFocusNode,
         onItemTap: onTap ?? actions.openItem,
+        seerrSeasonStatus: seerrSeasonStatus,
       ),
     );
   }
@@ -525,7 +528,13 @@ class _SpotlightCardsBuilder {
           ]) ??
           fallbackImageUrl,
       icon: Icons.video_collection_outlined,
-      sections: [_mediaSection(l10n.seasons, seasons)],
+      sections: [
+        _mediaSection(
+          l10n.seasons,
+          seasons,
+          seerrSeasonStatus: seerrItemSeasonStatus(vm),
+        ),
+      ],
     );
   }
 

--- a/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
+++ b/lib/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart
@@ -13,6 +13,7 @@ import '../../../../widgets/focus/focus_theme.dart';
 import '../../../../widgets/focus/focusable_wrapper.dart';
 import '../../../../widgets/media_card.dart';
 import '../../../../widgets/offline_aware_image.dart';
+import '../../../../widgets/seerr/seerr_status_dot.dart';
 import '../../../../widgets/seerr_icons.dart';
 import '../../modern/modern_detail_content.dart'
     show StudioLogoIndex, studioLogoUrlFor;
@@ -130,6 +131,7 @@ class SpotlightMediaGridSection extends StatelessWidget {
   final bool landscapeCells;
   final FocusNode? firstFocusNode;
   final ValueChanged<AggregatedItem> onItemTap;
+  final Map<int, int>? seerrSeasonStatus;
 
   const SpotlightMediaGridSection({
     super.key,
@@ -140,6 +142,7 @@ class SpotlightMediaGridSection extends StatelessWidget {
     this.aspectRatio = 2 / 3,
     this.landscapeCells = false,
     this.firstFocusNode,
+    this.seerrSeasonStatus,
   });
 
   @override
@@ -152,6 +155,8 @@ class SpotlightMediaGridSection extends StatelessWidget {
         : Color(prefs.get(UserPreferences.focusColor).colorValue);
     final titleColor = isNeon ? AppColorScheme.accent : null;
     final watchedBehavior = prefs.get(UserPreferences.watchedIndicatorBehavior);
+    final showAvailabilityBadges =
+        prefs.get(UserPreferences.showSeerrAvailabilityBadges);
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -185,6 +190,15 @@ class SpotlightMediaGridSection extends StatelessWidget {
                     final isSeerrItem =
                         entry.serverId == 'seerr' ||
                         entry.id.startsWith('tmdb:');
+                    final isSeason = entry.type == 'Season';
+                    final seasonSeerrStatus =
+                        isSeason && entry.indexNumber != null
+                            ? (seerrSeasonStatus?[entry.indexNumber])
+                            : null;
+                    final hasSeasonSeerrDot =
+                        showAvailabilityBadges &&
+                        SeerrMediaStatus.hasDot(seasonSeerrStatus);
+
                     return MediaCard(
                       key: ValueKey(cellKeys[i]),
                       title: entry.name,
@@ -203,13 +217,22 @@ class SpotlightMediaGridSection extends StatelessWidget {
                           ? WatchedIndicatorBehavior.never
                           : watchedBehavior,
                       seerrStatus: isSeerrItem ? entry.seerrStatus : null,
-                      overlayOccupiesTopLeft: isSeerrItem,
+                      overlayOccupiesTopLeft: isSeerrItem || hasSeasonSeerrDot,
                       imageOverlays: [
                         if (isSeerrItem)
                           const Positioned(
                             top: 6,
                             left: 6,
                             child: SeerrBadge(size: 18),
+                          ),
+                        if (hasSeasonSeerrDot)
+                          Positioned(
+                            top: 6,
+                            left: 6,
+                            child: SeerrStatusDot(
+                              status: seasonSeerrStatus,
+                              size: 18,
+                            ),
                           ),
                       ],
                       onFocus: () => spotlightScrollCellIntoView(cellContext),

--- a/lib/ui/widgets/media_badge.dart
+++ b/lib/ui/widgets/media_badge.dart
@@ -13,6 +13,15 @@ const List<BoxShadow> kMediaBadgeShadow = [
   ),
 ];
 
+/// Subscribes the caller to theme changes.
+///
+/// Badge colours come from [AppColorScheme], which reads the active theme off
+/// the registry rather than from anything handed down the tree, so without
+/// this a badge keeps its old colours until something else rebuilds it.
+void _watchTheme(BuildContext context) {
+  context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
+}
+
 /// The circular checkmark badge indicating an item has been watched/finished.
 class MediaWatchedBadge extends StatelessWidget {
   final double size;
@@ -28,8 +37,7 @@ class MediaWatchedBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
-    Theme.of(context);
+    _watchTheme(context);
     final bg = color ?? AppColorScheme.badgeWatched;
     final fg = iconColor ?? AppColorScheme.onBadge;
     final iconSize = (size * 0.62).clamp(12.0, 24.0);
@@ -73,8 +81,7 @@ class MediaUnplayedBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
-    Theme.of(context);
+    _watchTheme(context);
     final bg = color ?? AppColorScheme.badgeUnplayed;
     final fg = textColor ?? AppColorScheme.onBadge;
     final text = count > 99 ? '99+' : '$count';
@@ -85,7 +92,8 @@ class MediaUnplayedBadge extends StatelessWidget {
       alignment: Alignment.center,
       decoration: BoxDecoration(
         color: bg,
-        borderRadius: BorderRadius.circular(height / 2),
+        // Through AppRadius so the pixel theme keeps its square corners.
+        borderRadius: AppRadius.circular(height / 2),
         border: Border.all(
           color: fg,
           width: 1.5,
@@ -121,8 +129,7 @@ class MediaFavoriteBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
-    Theme.of(context);
+    _watchTheme(context);
     final bg = color ?? AppColorScheme.recordingActive;
     final fg = heartColor ?? Colors.white;
     final iconSize = (size * 0.58).clamp(12.0, 22.0);

--- a/lib/ui/widgets/media_badge.dart
+++ b/lib/ui/widgets/media_badge.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+import '../theme/app_theme_controller.dart';
+
+/// Common drop shadow applied to card-corner badges to guarantee contrast
+/// separation across arbitrary light, dark, or saturated poster artwork.
+const List<BoxShadow> kMediaBadgeShadow = [
+  BoxShadow(
+    color: Color(0x99000000), // Colors.black with alpha 0.60
+    blurRadius: 4,
+    offset: Offset(0, 1.5),
+  ),
+];
+
+/// The circular checkmark badge indicating an item has been watched/finished.
+class MediaWatchedBadge extends StatelessWidget {
+  final double size;
+  final Color? color;
+  final Color? iconColor;
+
+  const MediaWatchedBadge({
+    super.key,
+    this.size = 24.0,
+    this.color,
+    this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
+    Theme.of(context);
+    final bg = color ?? AppColorScheme.badgeWatched;
+    final fg = iconColor ?? AppColorScheme.onBadge;
+    final iconSize = (size * 0.62).clamp(12.0, 24.0);
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: fg,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.check_rounded,
+        color: fg,
+        size: iconSize,
+      ),
+    );
+  }
+}
+
+/// The pill badge indicating the number of unwatched episodes in a show or season.
+class MediaUnplayedBadge extends StatelessWidget {
+  final int count;
+  final double height;
+  final Color? color;
+  final Color? textColor;
+
+  const MediaUnplayedBadge({
+    super.key,
+    required this.count,
+    this.height = 22.0,
+    this.color,
+    this.textColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
+    Theme.of(context);
+    final bg = color ?? AppColorScheme.badgeUnplayed;
+    final fg = textColor ?? AppColorScheme.onBadge;
+    final text = count > 99 ? '99+' : '$count';
+
+    return Container(
+      constraints: BoxConstraints(minWidth: height, minHeight: height),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(height / 2),
+        border: Border.all(
+          color: fg,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: fg,
+          fontSize: 11.5,
+          fontWeight: FontWeight.bold,
+          height: 1.2,
+          decoration: TextDecoration.none,
+        ),
+      ),
+    );
+  }
+}
+
+/// The circular favorite badge indicating an item has been added to favorites.
+class MediaFavoriteBadge extends StatelessWidget {
+  final double size;
+  final Color? color;
+  final Color? heartColor;
+
+  const MediaFavoriteBadge({
+    super.key,
+    this.size = 24.0,
+    this.color,
+    this.heartColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    context.dependOnInheritedWidgetOfExactType<AppThemeScope>();
+    Theme.of(context);
+    final bg = color ?? AppColorScheme.recordingActive;
+    final fg = heartColor ?? Colors.white;
+    final iconSize = (size * 0.58).clamp(12.0, 22.0);
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: bg,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: fg,
+          width: 1.5,
+        ),
+        boxShadow: kMediaBadgeShadow,
+      ),
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.favorite_rounded,
+        color: fg,
+        size: iconSize,
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/media_card.dart
+++ b/lib/ui/widgets/media_card.dart
@@ -16,6 +16,7 @@ import '../../util/focus/scroll_utils.dart';
 import 'bounded_network_image.dart';
 import 'focus/glass_focus_halo.dart';
 import 'marquee_text.dart';
+import 'media_badge.dart';
 import 'seerr/seerr_status_dot.dart';
 import '../mixins/focus_state_mixin.dart';
 
@@ -778,14 +779,10 @@ class _CardImage extends StatelessWidget {
                 if (isFavorite)
                   Positioned(
                     top: (_showSeerrMediaTypeBadge || overlayOccupiesTopLeft)
-                        ? 28
-                        : 4,
-                    left: 4,
-                    child: Icon(
-                      Icons.favorite,
-                      color: AppColorScheme.recordingActive,
-                      size: 18,
-                    ),
+                        ? 32
+                        : 6,
+                    left: 6,
+                    child: MediaFavoriteBadge(size: 22),
                   ),
                 if (_showSeerrMediaTypeBadge)
                   Positioned(
@@ -800,7 +797,7 @@ class _CardImage extends StatelessWidget {
                     child: SeerrStatusDot(status: seerrStatus),
                   )
                 else if (_showWatchedIndicator)
-                  Positioned(top: 4, right: 4, child: _buildWatchedIndicator()),
+                  Positioned(top: 6, right: 6, child: _buildWatchedIndicator()),
                 if (playedPercentage != null && playedPercentage! > 0)
                   Positioned(
                     left: 6,
@@ -868,33 +865,10 @@ class _CardImage extends StatelessWidget {
 
   Widget _buildWatchedIndicator() {
     if (isPlayed) {
-      return DecoratedBox(
-        decoration: BoxDecoration(
-          color: AppColorScheme.badgeWatched,
-          shape: BoxShape.circle,
-        ),
-        child: Padding(
-          padding: EdgeInsets.all(2),
-          child: Icon(Icons.check, color: AppColorScheme.onBadge, size: 12),
-        ),
-      );
+      return MediaWatchedBadge(size: 22);
     }
     if (unplayedCount != null && unplayedCount! > 0) {
-      return Container(
-        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
-        decoration: BoxDecoration(
-          color: AppColorScheme.badgeUnplayed,
-          borderRadius: AppRadius.circular(8),
-        ),
-        child: Text(
-          '$unplayedCount',
-          style: TextStyle(
-            color: AppColorScheme.onBadge,
-            fontSize: 10,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-      );
+      return MediaUnplayedBadge(count: unplayedCount!);
     }
     return const SizedBox.shrink();
   }

--- a/lib/ui/widgets/seerr/seerr_item_status.dart
+++ b/lib/ui/widgets/seerr/seerr_item_status.dart
@@ -83,10 +83,7 @@ class SeerrItemDownloadBars extends StatelessWidget {
 /// The item's Seerr state once the lookup has landed and found something, and
 /// only while the viewer wants request status shown at all.
 SeerrMediaDetailState? _resolved(ItemDetailViewModel viewModel) {
-  if (!GetIt.instance.isRegistered<SeerrPreferences>() ||
-      !GetIt.instance<SeerrPreferences>().showRequestStatus) {
-    return null;
-  }
+  if (!GetIt.instance<SeerrPreferences>().showRequestStatus) return null;
   final state = viewModel.seerr?.state;
   if (state == null || state.tmdbId == 0) return null;
   return state;

--- a/lib/ui/widgets/seerr/seerr_item_status.dart
+++ b/lib/ui/widgets/seerr/seerr_item_status.dart
@@ -83,7 +83,10 @@ class SeerrItemDownloadBars extends StatelessWidget {
 /// The item's Seerr state once the lookup has landed and found something, and
 /// only while the viewer wants request status shown at all.
 SeerrMediaDetailState? _resolved(ItemDetailViewModel viewModel) {
-  if (!GetIt.instance<SeerrPreferences>().showRequestStatus) return null;
+  if (!GetIt.instance.isRegistered<SeerrPreferences>() ||
+      !GetIt.instance<SeerrPreferences>().showRequestStatus) {
+    return null;
+  }
   final state = viewModel.seerr?.state;
   if (state == null || state.tmdbId == 0) return null;
   return state;

--- a/lib/ui/widgets/seerr/seerr_status_dot.dart
+++ b/lib/ui/widgets/seerr/seerr_status_dot.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:moonfin_design/moonfin_design.dart';
 
+import '../media_badge.dart';
+
 /// Seerr media status codes, as the server reports them on `mediaInfo.status`
 /// and `mediaInfo.status4k`.
 abstract final class SeerrMediaStatus {
@@ -97,6 +99,7 @@ class SeerrStatusDot extends StatelessWidget {
             width: 1.5,
           ),
         ),
+        boxShadow: kMediaBadgeShadow,
       ),
       alignment: Alignment.center,
       child: icon,

--- a/test/ui/screens/detail/spotlight_cards_test.dart
+++ b/test/ui/screens/detail/spotlight_cards_test.dart
@@ -4,6 +4,7 @@
 // are omitted.
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:jellyfin_preference/jellyfin_preference.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:moonfin/data/models/aggregated_item.dart';
@@ -11,6 +12,7 @@ import 'package:moonfin/data/services/seerr/seerr_api_models.dart';
 import 'package:moonfin/data/viewmodels/item_detail_view_model.dart';
 import 'package:moonfin/data/viewmodels/seerr_media_detail_view_model.dart';
 import 'package:moonfin/l10n/app_localizations_en.dart';
+import 'package:moonfin/preference/seerr_preferences.dart';
 import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/ui/screens/detail/spotlight/spotlight_cards.dart';
 import 'package:server_core/server_core.dart';
@@ -21,6 +23,8 @@ class _Vm extends Mock implements ItemDetailViewModel {}
 class _SeerrVm extends Mock implements SeerrMediaDetailViewModel {}
 
 class _ImageApi extends Mock implements ImageApi {}
+
+class _SeerrPrefs extends Mock implements SeerrPreferences {}
 
 final _l10n = AppLocalizationsEn();
 
@@ -75,6 +79,12 @@ void main() {
     await store.init();
     prefs = UserPreferences(store);
 
+    // The seasons card reads Seerr's per-season status, and the app always has
+    // these preferences registered.
+    final seerrPrefs = _SeerrPrefs();
+    when(() => seerrPrefs.showRequestStatus).thenReturn(false);
+    GetIt.instance.registerSingleton<SeerrPreferences>(seerrPrefs);
+
     final imageApi = _ImageApi();
     when(
       () => imageApi.getPrimaryImageUrl(
@@ -120,6 +130,8 @@ void main() {
     when(() => vm.canManagePlaylistTracks).thenReturn(false);
     when(() => vm.seerr).thenReturn(null);
   });
+
+  tearDown(() => GetIt.instance.reset());
 
   List<SpotlightCardSpec> cardsFor(AggregatedItem item) => spotlightCardsFor(
     vm: vm,

--- a/test/ui/screens/detail/spotlight_section_modal_test.dart
+++ b/test/ui/screens/detail/spotlight_section_modal_test.dart
@@ -11,6 +11,7 @@ import 'package:moonfin/preference/user_preferences.dart';
 import 'package:moonfin/ui/screens/detail/spotlight/widgets/spotlight_modal_grids.dart';
 import 'package:moonfin/ui/screens/detail/spotlight/widgets/spotlight_section_modal.dart';
 import 'package:moonfin/ui/widgets/overlay_sheet.dart';
+import 'package:moonfin/ui/widgets/seerr/seerr_status_dot.dart';
 import 'package:moonfin/util/platform_detection.dart';
 import 'package:server_core/server_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -313,6 +314,84 @@ void main() {
     expect(returnedAction, isNotNull);
     expect(actionExecuted, isTrue);
   });
+
+  testWidgets(
+    'SpotlightMediaGridSection displays SeerrStatusDot on season cards when showSeerrAvailabilityBadges is true',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final store = PreferenceStore();
+      await store.init();
+      final prefs = UserPreferences(store);
+      await prefs.set(UserPreferences.showSeerrAvailabilityBadges, true);
+
+      final season = AggregatedItem(
+        id: 's1',
+        serverId: 'server-1',
+        rawData: const {
+          'Id': 's1',
+          'Type': 'Season',
+          'Name': 'Season 1',
+          'IndexNumber': 1,
+        },
+      );
+      final imageApi = _ImageApi();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SpotlightMediaGridSection(
+              items: [season],
+              imageApi: imageApi,
+              prefs: prefs,
+              seerrSeasonStatus: const {1: SeerrMediaStatus.available},
+              onItemTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SeerrStatusDot), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SpotlightMediaGridSection hides SeerrStatusDot on season cards when showSeerrAvailabilityBadges is false',
+    (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final store = PreferenceStore();
+      await store.init();
+      final prefs = UserPreferences(store);
+      await prefs.set(UserPreferences.showSeerrAvailabilityBadges, false);
+
+      final season = AggregatedItem(
+        id: 's1',
+        serverId: 'server-1',
+        rawData: const {
+          'Id': 's1',
+          'Type': 'Season',
+          'Name': 'Season 1',
+          'IndexNumber': 1,
+        },
+      );
+      final imageApi = _ImageApi();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SpotlightMediaGridSection(
+              items: [season],
+              imageApi: imageApi,
+              prefs: prefs,
+              seerrSeasonStatus: const {1: SeerrMediaStatus.available},
+              onItemTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SeerrStatusDot), findsNothing);
+    },
+  );
 }
 
 

--- a/test/ui/widgets/media_badge_test.dart
+++ b/test/ui/widgets/media_badge_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/preference/preference_constants.dart';
+import 'package:moonfin/ui/theme/app_theme_controller.dart';
+import 'package:moonfin/ui/widgets/media_badge.dart';
+import 'package:moonfin_design/moonfin_design.dart';
+
+void main() {
+  Widget wrap(Widget child) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(child: child),
+      ),
+    );
+  }
+
+  group('MediaWatchedBadge', () {
+    testWidgets('renders check_rounded icon with border and drop shadow', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(const MediaWatchedBadge()));
+
+      expect(find.byIcon(Icons.check_rounded), findsOneWidget);
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+
+      expect(decoration.shape, BoxShape.circle);
+      expect(decoration.border, isNotNull);
+      expect(decoration.border!.top.width, 1.5);
+      expect(decoration.boxShadow, equals(kMediaBadgeShadow));
+    });
+
+    testWidgets('respects custom size and colors', (tester) async {
+      const customColor = Color(0xFF00FF00);
+      const customIconColor = Color(0xFF000000);
+
+      await tester.pumpWidget(
+        wrap(
+          const MediaWatchedBadge(
+            size: 32,
+            color: customColor,
+            iconColor: customIconColor,
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      expect(container.constraints?.maxWidth, 32);
+      expect(container.constraints?.maxHeight, 32);
+
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, customColor);
+      expect(decoration.border!.top.color, customIconColor);
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.check_rounded));
+      expect(icon.color, customIconColor);
+      expect(icon.size, greaterThan(15));
+    });
+
+    testWidgets('dynamically updates color when theme changes via AppThemeScope', (
+      tester,
+    ) async {
+      final controller = AppThemeController(
+        ThemeRegistry.resolveById(ThemeRegistry.neonPulseId),
+        VisualThemeId.neonPulse,
+        '',
+        OledMode.off,
+      );
+
+      await tester.pumpWidget(
+        AppThemeScope(
+          controller: controller,
+          child: const MaterialApp(
+            home: Scaffold(
+              body: Center(child: MediaWatchedBadge()),
+            ),
+          ),
+        ),
+      );
+
+      var container = tester.widget<Container>(find.byType(Container));
+      var decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, const Color(0xFFFF2E92)); // Neon pulse pink
+
+      // Switch active theme to Glass via controller
+      controller.setByThemeId(VisualThemeId.glass);
+      await tester.pump();
+
+      container = tester.widget<Container>(find.byType(Container));
+      decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, const Color(0xFF30D158)); // Glass green
+    });
+  });
+
+  group('MediaUnplayedBadge', () {
+    testWidgets('renders formatted count with border and drop shadow', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(const MediaUnplayedBadge(count: 7)));
+
+      expect(find.text('7'), findsOneWidget);
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+
+      expect(decoration.borderRadius, isNotNull);
+      expect(decoration.border, isNotNull);
+      expect(decoration.border!.top.width, 1.5);
+      expect(decoration.boxShadow, equals(kMediaBadgeShadow));
+
+      final text = tester.widget<Text>(find.text('7'));
+      expect(text.style?.fontWeight, FontWeight.bold);
+    });
+
+    testWidgets('clamps counts above 99 to 99+', (tester) async {
+      await tester.pumpWidget(wrap(const MediaUnplayedBadge(count: 120)));
+
+      expect(find.text('99+'), findsOneWidget);
+    });
+  });
+
+  group('MediaFavoriteBadge', () {
+    testWidgets('renders favorite_rounded icon with border and drop shadow', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(const MediaFavoriteBadge()));
+
+      expect(find.byIcon(Icons.favorite_rounded), findsOneWidget);
+
+      final container = tester.widget<Container>(find.byType(Container));
+      final decoration = container.decoration as BoxDecoration;
+
+      expect(decoration.shape, BoxShape.circle);
+      expect(decoration.border, isNotNull);
+      expect(decoration.border!.top.width, 1.5);
+      expect(decoration.border!.top.color, Colors.white);
+      expect(decoration.boxShadow, equals(kMediaBadgeShadow));
+    });
+
+    testWidgets('respects custom size and colors', (tester) async {
+      const customBg = Color(0xFFFF4081);
+      const customHeart = Color(0xFFFFFF00);
+
+      await tester.pumpWidget(
+        wrap(
+          const MediaFavoriteBadge(
+            size: 28,
+            color: customBg,
+            heartColor: customHeart,
+          ),
+        ),
+      );
+
+      final container = tester.widget<Container>(find.byType(Container));
+      expect(container.constraints?.maxWidth, 28);
+      expect(container.constraints?.maxHeight, 28);
+
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.color, customBg);
+      expect(decoration.border!.top.color, customHeart);
+
+      final icon = tester.widget<Icon>(find.byIcon(Icons.favorite_rounded));
+      expect(icon.color, customHeart);
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Summary
Updates media corner badges (watched status, unplayed episode counts, favorite indicators, and Seerr availability dots) across cards and detail screens to improve visibility and legibility. Adds high-contrast 1.5px border rings and elevation drop shadows to ensure badges remain distinct against arbitrary bright, dark, or saturated poster artwork (such as favorite hearts on red artwork like Grindhouse or checkmarks on light artwork like Ted Lasso). Also integrates reactive `AppThemeScope` subscriptions into the badge widgets so that theme color switches immediately update existing badges across all screens without requiring a reload.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- Created unified media_badge.dart defining MediaWatchedBadge, MediaUnplayedBadge, MediaFavoriteBadge, and kMediaBadgeShadow.
- Added a crisp 1.5px high-contrast border ring and subtle drop shadow (kMediaBadgeShadow) to card corner badges to guarantee visual separation across arbitrary poster art.
- Subscribed badge widgets to AppThemeScope so runtime theme switches (e.g., Neon Pulse to Glass or Moonfin) immediately invalidate and repaint active badges across existing routes.
- Updated MediaCard (media_card.dart) to use MediaWatchedBadge, MediaUnplayedBadge, and MediaFavoriteBadge, replacing ad-hoc inline decorations.
- Updated ItemDetailScreen (item_detail_screen.dart), SeasonCard (season_card.dart), and Nouveau cards (nouveau_poster_card.dart, nouveau_media_rail_card.dart, and nouveau_landscape_media_card.dart) to use unified badges.
- Enhanced SeerrStatusDot (seerr_status_dot.dart) with kMediaBadgeShadow to ensure availability dots stand out on busy artwork.
- Added comprehensive unit tests in media_badge_test.dart verifying rendering, sizing, count clamping, and dynamic theme reactivity.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Run unit test suite: `flutter test test/ui/widgets/media_badge_test.dart test/ui/widgets/media_card_focus_gap_test.dart` (all 11 tests pass).
2. Launch on Android TV and Windows desktop (mfdbA, mfdbW).
3. Verify watched checkmarks and favorite hearts on high-contrast posters (e.g., Grindhouse, Deadwood, Ted Lasso).
4. Switch themes in Settings (e.g., Neon Pulse -> Glass -> Moonfin) and verify that watched and unplayed badges dynamically update their colors across the Home Screen without an app restart.

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Prior to PR
<img width="200" alt="2026-09-12_03-45-41_moonfin" src="https://github.com/user-attachments/assets/1e630538-dc7c-4719-8dcd-fe78066643b3" />
<img width="5712" height="4284" alt="E3B346F8-1903-4E9C-A6DB-3DC30190FDF4" src="https://github.com/user-attachments/assets/caeb26fa-6b5b-4559-a341-6193ec4b2750" />
<img width="2534" height="1514" alt="watchedindicators" src="https://github.com/user-attachments/assets/8f492d10-25df-44d4-adc6-9adac9b72af3" />

### Moonfin Theme
<img width="3840" height="2160" alt="moonfin1" src="https://github.com/user-attachments/assets/f5831c14-8619-4f80-9064-f23df45e46bc" />
<img width="3840" height="2160" alt="moonfin2" src="https://github.com/user-attachments/assets/a79d424b-eb08-4d85-91cc-30c115b32227" />

### Neon Pulse
<img width="3840" height="2160" alt="neonpulse" src="https://github.com/user-attachments/assets/df656371-d130-4b37-8f2e-76a556fd87cf" />
<img width="3840" height="2160" alt="neonpulse2" src="https://github.com/user-attachments/assets/89192c07-84bc-4305-8d69-e73c43a3586e" />

### Glass
<img width="3840" height="2160" alt="glass1" src="https://github.com/user-attachments/assets/ed19376d-4571-467f-bc3a-b07fb65f2f31" />
<img width="3840" height="2160" alt="glass2" src="https://github.com/user-attachments/assets/bba3b372-68ca-4966-a13f-22de03c965af" />

### 8-Bit Hero
<img width="3840" height="2160" alt="8bit1" src="https://github.com/user-attachments/assets/4430bd98-140d-4f0b-a5fb-0b195c232573" />
<img width="3840" height="2160" alt="8bit2" src="https://github.com/user-attachments/assets/a93304a8-4091-405a-bda9-06f9d21ea0e2" />

### Nouveau Details Page
<img width="2534" height="1514" alt="2026-09-12_04-52-34_moonfin" src="https://github.com/user-attachments/assets/fbcbbfd6-1414-4a9d-9ae6-eaff3f3ef4f5" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
