### PR TITLE
bugfix(browse) - Teaching Genres How To Count

### DIFF
--- a/lib/data/utils/genre_browse_utils.dart
+++ b/lib/data/utils/genre_browse_utils.dart
@@ -1,6 +1,24 @@
 import 'package:server_core/server_core.dart';
 
-const List<String> kBrowsableGenreItemTypes = ['Movie', 'Series'];
+/// Every item type a genre row can be built from, across all the libraries
+/// that have one. Callers that only want part of this pass their own list,
+/// which [normalizeBrowsableGenreItemTypes] narrows against this.
+const List<String> kBrowsableGenreItemTypes = [
+  'Movie',
+  'Series',
+  'Audio',
+  'MusicAlbum',
+];
+
+/// Types that carry a genre or studio tag from their parent rather than
+/// standing on their own. Leaving them in a browse is what makes the page
+/// disagree with the count on the tile that opened it.
+const List<String> kNonRootBrowseItemTypes = [
+  'Playlist',
+  'Episode',
+  'Season',
+  'Folder',
+];
 
 List<String> normalizeBrowsableGenreItemTypes(List<String>? includeItemTypes) {
   final requested =
@@ -41,6 +59,8 @@ int browsableGenreCount(
     final countField = switch (type) {
       'Movie' => 'MovieCount',
       'Series' => 'SeriesCount',
+      'Audio' => 'SongCount',
+      'MusicAlbum' => 'AlbumCount',
       _ => null,
     };
 
@@ -123,20 +143,36 @@ int _asInt(dynamic value) {
   return 0;
 }
 
-(String? imageUrl, String? backdropUrl) resolveGenreFallbackArtwork({
+/// Picks the tile and backdrop art for a genre with no art of its own.
+///
+/// [selectedId] is the item the tile art came from, so a screen drawing a whole
+/// grid of genres can pass it back as [avoidIds] and get a different picture on
+/// the next tile.
+(String? imageUrl, String? backdropUrl, String? selectedId)
+resolveGenreFallbackArtwork({
   required List<Map<String, dynamic>> items,
   required ImageApi imageApi,
   required int maxWidth,
+  Set<String> avoidIds = const {},
 }) {
   if (items.isEmpty) {
-    return (null, null);
+    return (null, null, null);
   }
+
+  // Art another tile already took drops to the back rather than out, so a
+  // genre whose every item is spoken for still gets a picture.
+  final candidates = avoidIds.isEmpty
+      ? items
+      : [
+          ...items.where((i) => !avoidIds.contains(i['Id']?.toString())),
+          ...items.where((i) => avoidIds.contains(i['Id']?.toString())),
+        ];
 
   String? tileUrl;
   Map<String, dynamic>? selectedItem;
 
   // 1. Try Backdrop (always landscape)
-  for (final item in items) {
+  for (final item in candidates) {
     final bTags = item['BackdropImageTags'] as List?;
     if (bTags != null && bTags.isNotEmpty) {
       tileUrl = imageApi.getBackdropImageUrl(
@@ -151,7 +187,7 @@ int _asInt(dynamic value) {
 
   // 2. Try Primary if it is landscape/square
   if (tileUrl == null) {
-    for (final item in items) {
+    for (final item in candidates) {
       final pTag = item['PrimaryImageTag'] as String?;
       final pAr = item['PrimaryImageAspectRatio'] as num?;
       if (pTag != null && pAr != null && pAr >= 1.0) {
@@ -168,7 +204,7 @@ int _asInt(dynamic value) {
 
   // 3. Fall back to any Primary (even portrait) if nothing else is available
   if (tileUrl == null) {
-    for (final item in items) {
+    for (final item in candidates) {
       final pTag = item['PrimaryImageTag'] as String?;
       if (pTag != null) {
         tileUrl = imageApi.getPrimaryImageUrl(
@@ -183,8 +219,8 @@ int _asInt(dynamic value) {
   }
 
   String? backdropUrl;
-  for (final item in items) {
-    if (item == selectedItem && items.length > 1) continue;
+  for (final item in candidates) {
+    if (item == selectedItem && candidates.length > 1) continue;
     final bTags = item['BackdropImageTags'] as List?;
     if (bTags != null && bTags.isNotEmpty) {
       backdropUrl = imageApi.getBackdropImageUrl(
@@ -207,5 +243,5 @@ int _asInt(dynamic value) {
     }
   }
 
-  return (tileUrl, backdropUrl ?? tileUrl);
+  return (tileUrl, backdropUrl ?? tileUrl, selectedItem?['Id']?.toString());
 }

--- a/lib/data/utils/genre_browse_utils.dart
+++ b/lib/data/utils/genre_browse_utils.dart
@@ -1,6 +1,6 @@
 import 'package:server_core/server_core.dart';
 
-const List<String> kBrowsableGenreItemTypes = ['Movie', 'Series', 'Audio', 'MusicAlbum'];
+const List<String> kBrowsableGenreItemTypes = ['Movie', 'Series'];
 
 List<String> normalizeBrowsableGenreItemTypes(List<String>? includeItemTypes) {
   final requested =
@@ -41,8 +41,6 @@ int browsableGenreCount(
     final countField = switch (type) {
       'Movie' => 'MovieCount',
       'Series' => 'SeriesCount',
-      'Audio' => 'SongCount',
-      'MusicAlbum' => 'AlbumCount',
       _ => null,
     };
 

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -16,6 +16,7 @@ import '../services/user_data_sync.dart';
 import '../services/user_ratings_api.dart';
 import '../utils/alphabet_bucket.dart';
 import '../utils/bounded_concurrency.dart';
+import '../utils/genre_browse_utils.dart';
 import '../utils/playlist_utils.dart';
 
 enum LibraryBrowseState { loading, ready, error }
@@ -376,11 +377,8 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     this.overrideName,
     this.includeItemTypes,
     this.favoritesOnly = false,
-  // ignore: prefer_initializing_formals
   }) : _client = client,
-       // ignore: prefer_initializing_formals
        _prefs = prefs,
-       // ignore: prefer_initializing_formals
        _mdbListRepository = mdbListRepository {
     _sortBy = _prefs.get(UserPreferences.librarySortBy(_prefKey));
     _sortDirection = _prefs.get(UserPreferences.librarySortDirection(_prefKey));
@@ -752,35 +750,25 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'IsFolder,$sortBy';
     }
 
+    // A genre tag sits on anything the tree holds, so an unscoped browse comes
+    // back with the seasons, episodes, playlists and folder rows that the genre
+    // tile never counted. Libraries whose genres aren't browsable this way keep
+    // whatever their own branch above chose.
     if (isGenreBrowse && includeItemTypes == null) {
-      if (_collectionType == 'music') {
-        includeTypes = ['MusicAlbum'];
-      } else if (_collectionType == 'movies') {
-        if (groupCollections) {
-          includeTypes = ['Movie', 'BoxSet'];
-          collapseBoxSets = true;
-        } else {
-          includeTypes = ['Movie'];
-          collapseBoxSets = false;
-        }
-      } else if (_collectionType == 'tvshows') {
-        if (groupCollections) {
-          includeTypes = ['Series', 'BoxSet'];
-          collapseBoxSets = true;
-        } else {
-          includeTypes = ['Series'];
-          collapseBoxSets = false;
-        }
-      } else {
-        if (groupCollections) {
-          includeTypes = ['Movie', 'Series', 'BoxSet'];
-          collapseBoxSets = true;
-        } else {
-          includeTypes = ['Movie', 'Series'];
-          collapseBoxSets = false;
-        }
+      final genreTypes = switch (_collectionType) {
+        'music' => const ['MusicAlbum'],
+        'movies' => const ['Movie'],
+        'tvshows' => const ['Series'],
+        null || '' => const ['Movie', 'Series'],
+        _ => null,
+      };
+
+      if (genreTypes != null) {
+        final collapses = groupCollections && _collectionType != 'music';
+        includeTypes = collapses ? [...genreTypes, 'BoxSet'] : [...genreTypes];
+        collapseBoxSets = collapses;
+        excludeTypes = kNonRootBrowseItemTypes;
       }
-      excludeTypes = ['Playlist', 'Episode', 'Season', 'Folder'];
     }
 
     if (isStudioBrowse && includeItemTypes == null) {
@@ -791,7 +779,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         includeTypes = ['Movie', 'Series'];
         collapseBoxSets = false;
       }
-      excludeTypes = ['Playlist', 'Episode', 'Season', 'Folder'];
+      excludeTypes = kNonRootBrowseItemTypes;
     }
 
     if (isFilterBrowse && includeItemTypes == null) {

--- a/lib/data/viewmodels/library_browse_view_model.dart
+++ b/lib/data/viewmodels/library_browse_view_model.dart
@@ -376,8 +376,11 @@ class LibraryBrowseViewModel extends ChangeNotifier {
     this.overrideName,
     this.includeItemTypes,
     this.favoritesOnly = false,
+  // ignore: prefer_initializing_formals
   }) : _client = client,
+       // ignore: prefer_initializing_formals
        _prefs = prefs,
+       // ignore: prefer_initializing_formals
        _mdbListRepository = mdbListRepository {
     _sortBy = _prefs.get(UserPreferences.librarySortBy(_prefKey));
     _sortDirection = _prefs.get(UserPreferences.librarySortDirection(_prefKey));
@@ -749,10 +752,35 @@ class LibraryBrowseViewModel extends ChangeNotifier {
       sortBy = 'IsFolder,$sortBy';
     }
 
-    if (genreId != null &&
-        _collectionType == 'music' &&
-        includeItemTypes == null) {
-      includeTypes = ['MusicAlbum'];
+    if (isGenreBrowse && includeItemTypes == null) {
+      if (_collectionType == 'music') {
+        includeTypes = ['MusicAlbum'];
+      } else if (_collectionType == 'movies') {
+        if (groupCollections) {
+          includeTypes = ['Movie', 'BoxSet'];
+          collapseBoxSets = true;
+        } else {
+          includeTypes = ['Movie'];
+          collapseBoxSets = false;
+        }
+      } else if (_collectionType == 'tvshows') {
+        if (groupCollections) {
+          includeTypes = ['Series', 'BoxSet'];
+          collapseBoxSets = true;
+        } else {
+          includeTypes = ['Series'];
+          collapseBoxSets = false;
+        }
+      } else {
+        if (groupCollections) {
+          includeTypes = ['Movie', 'Series', 'BoxSet'];
+          collapseBoxSets = true;
+        } else {
+          includeTypes = ['Movie', 'Series'];
+          collapseBoxSets = false;
+        }
+      }
+      excludeTypes = ['Playlist', 'Episode', 'Season', 'Folder'];
     }
 
     if (isStudioBrowse && includeItemTypes == null) {
@@ -763,7 +791,7 @@ class LibraryBrowseViewModel extends ChangeNotifier {
         includeTypes = ['Movie', 'Series'];
         collapseBoxSets = false;
       }
-      excludeTypes = ['Playlist', 'Episode', 'Season'];
+      excludeTypes = ['Playlist', 'Episode', 'Season', 'Folder'];
     }
 
     if (isFilterBrowse && includeItemTypes == null) {

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -33,6 +33,10 @@ const _genresPageSize = 200;
 const _initialArtworkBatch = 12;
 const _backgroundArtworkConcurrency = 4;
 
+/// Only movies and series can be opened from this screen, so counting anything
+/// else puts genres in the grid that lead nowhere.
+const _videoGenreItemTypes = ['Movie', 'Series'];
+
 bool _isCompact(BuildContext context) =>
     !PlatformDetection.isTV &&
     (PlatformDetection.useMobileUi ||
@@ -62,6 +66,9 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   bool _isLoading = true;
   bool _lastGroupCollections = false;
   final Set<String> _usedArtworkIds = {};
+
+  /// A grouping toggle starts a second load, so the first stops writing.
+  int _loadToken = 0;
 
   void _onChanged() {
     if (!mounted) return;
@@ -98,6 +105,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   }
 
   Future<void> _load() async {
+    final token = ++_loadToken;
     try {
       _usedArtworkIds.clear();
       final items = <dynamic>[];
@@ -112,7 +120,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
           startIndex: startIndex,
           limit: _genresPageSize,
           fields: 'ItemCounts,PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
-          includeItemTypes: kBrowsableGenreItemTypes,
+          includeItemTypes: _videoGenreItemTypes,
         );
 
         total ??= response['TotalRecordCount'] as int?;
@@ -130,7 +138,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
             final data = g as Map<String, dynamic>;
             final itemCount = browsableGenreCount(
               data,
-              normalizedItemTypes: kBrowsableGenreItemTypes,
+              normalizedItemTypes: _videoGenreItemTypes,
             );
             return (
               data: data,
@@ -200,63 +208,65 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       }
     }
 
+    if (token != _loadToken) return;
     _isLoading = false;
     if (!_disposed && mounted) setState(() {});
 
-    _loadGenreArtwork();
+    _loadGenreArtwork(token);
   }
 
-  Future<void> _loadGenreArtwork() async {
+  Future<void> _loadGenreArtwork(int token) async {
     final groupCollections = _lastGroupCollections;
 
-    // When collections are not grouped, genres with custom artwork already have
-    // their exact MovieCount + SeriesCount from getGenres and do not need extra
-    // queries. Only genres requiring a fallback collage or collection-collapsed
-    // counts need to be queried.
-    final needsWork = _genres.where((genre) {
-      if (genre.isGenreFallback) return true;
-      return groupCollections;
-    }).toList();
+    // A genre with its own artwork already has an exact count from getGenres,
+    // so it only needs a query when grouping changes what that count means.
+    final needsWork = _genres
+        .where((genre) => genre.isGenreFallback || groupCollections)
+        .toList();
 
     if (needsWork.isEmpty) return;
 
     final toLoad = needsWork.take(_initialArtworkBatch).toList();
-    await Future.wait(toLoad.map(_loadGenreItems));
+    await Future.wait(toLoad.map((genre) => _loadGenreItems(genre, token)));
 
     if (!_disposed && needsWork.length > _initialArtworkBatch) {
       unawaited(
-        _loadGenreArtworkAsync(needsWork.skip(_initialArtworkBatch).toList()),
+        _loadGenreArtworkAsync(
+          needsWork.skip(_initialArtworkBatch).toList(),
+          token,
+        ),
       );
     }
   }
 
-  Future<void> _loadGenreArtworkAsync(List<GenreCardData> remaining) async {
+  Future<void> _loadGenreArtworkAsync(
+    List<GenreCardData> remaining,
+    int token,
+  ) async {
     for (
       var i = 0;
-      i < remaining.length && !_disposed;
+      i < remaining.length && !_disposed && token == _loadToken;
       i += _backgroundArtworkConcurrency
     ) {
       final batch = remaining.skip(i).take(_backgroundArtworkConcurrency);
-      await Future.wait(batch.map(_loadGenreItems));
+      await Future.wait(batch.map((genre) => _loadGenreItems(genre, token)));
     }
   }
 
-  Future<void> _loadGenreItems(GenreCardData genre) async {
-    if (_disposed) return;
+  Future<void> _loadGenreItems(GenreCardData genre, int token) async {
+    if (_disposed || token != _loadToken) return;
     try {
       final groupCollections = _lastGroupCollections;
       final includeItemTypes = groupCollections
           ? const ['Movie', 'Series', 'BoxSet']
-          : kBrowsableGenreItemTypes;
+          : _videoGenreItemTypes;
 
-      // When the genre already has custom artwork, we only need the total count
-      // under collection grouping. Asking for limit 0 avoids fetching items,
-      // image tags, and random sorting overhead.
+      // This genre has art of its own, so the count is all that is missing.
       if (!genre.isGenreFallback) {
         final response = await _client.itemsApi.getItems(
           genreIds: [genre.id],
           includeItemTypes: includeItemTypes,
-          excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+          excludeItemTypes: kNonRootBrowseItemTypes,
           collapseBoxSetItems: groupCollections,
           recursive: true,
           limit: 0,
@@ -279,12 +289,11 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
         return;
       }
 
-      // For fallback artwork, query random items so each genre displays a
-      // unique, representative thumbnail and avoids duplicates across cards.
+      // Four random items to build the tile from, since this genre has none.
       final response = await _client.itemsApi.getItems(
         genreIds: [genre.id],
         includeItemTypes: includeItemTypes,
-        excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+        excludeItemTypes: kNonRootBrowseItemTypes,
         sortBy: 'Random',
         sortOrder: 'Ascending',
         collapseBoxSetItems: groupCollections,
@@ -314,39 +323,16 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       );
       maps.shuffle();
 
-      // Deprioritize items that have already been chosen for another genre card
-      // to avoid duplicate artwork appearing across tiles.
-      if (_usedArtworkIds.isNotEmpty) {
-        maps.sort((a, b) {
-          final aUsed = _usedArtworkIds.contains(a['Id']?.toString());
-          final bUsed = _usedArtworkIds.contains(b['Id']?.toString());
-          if (aUsed == bUsed) return 0;
-          return aUsed ? 1 : -1;
-        });
-      }
-
-      final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
+      final (imageUrl, backdropUrl, usedId) = resolveGenreFallbackArtwork(
         items: maps,
         imageApi: _client.imageApi,
         maxWidth: _genreCardRequestMaxWidth(),
+        avoidIds: _usedArtworkIds,
       );
 
       genre.imageUrl = imageUrl;
       genre.backdropUrl = backdropUrl;
-
-      // Track the selected item's ID
-      for (final item in maps) {
-        final id = item['Id']?.toString();
-        if (id != null) {
-          final bTags = item['BackdropImageTags'] as List?;
-          final pTag = item['PrimaryImageTag'] as String?;
-          if ((bTags != null && bTags.isNotEmpty) ||
-              (pTag != null && pTag.isNotEmpty)) {
-            _usedArtworkIds.add(id);
-            break;
-          }
-        }
-      }
+      if (usedId != null) _usedArtworkIds.add(usedId);
 
       if (!_disposed && mounted) setState(() {});
     } catch (_) {}
@@ -402,7 +388,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
       for (final genre in _genres) {
         genre.imageUrl = null;
       }
-      await _loadGenreArtwork();
+      await _loadGenreArtwork(_loadToken);
     }
 
     if (previousPosterSize != _posterSize || previousImageType != _imageType) {

--- a/lib/ui/screens/browse/all_genres_screen.dart
+++ b/lib/ui/screens/browse/all_genres_screen.dart
@@ -60,14 +60,26 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
 
   List<GenreCardData> _genres = [];
   bool _isLoading = true;
+  bool _lastGroupCollections = false;
+  final Set<String> _usedArtworkIds = {};
 
   void _onChanged() {
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    final currentGroup =
+        _prefs.get(UserPreferences.groupItemsIntoCollections);
+    if (_lastGroupCollections != currentGroup) {
+      _lastGroupCollections = currentGroup;
+      _load();
+    } else {
+      setState(() {});
+    }
   }
 
   @override
   void initState() {
     super.initState();
+    _lastGroupCollections =
+        _prefs.get(UserPreferences.groupItemsIntoCollections);
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
       if (mounted) setState(() => _backdropUrl = url);
     });
@@ -87,6 +99,7 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
 
   Future<void> _load() async {
     try {
+      _usedArtworkIds.clear();
       final items = <dynamic>[];
       var startIndex = 0;
       int? total;
@@ -194,12 +207,25 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   }
 
   Future<void> _loadGenreArtwork() async {
-    final toLoad = _genres.take(_initialArtworkBatch).toList();
+    final groupCollections = _lastGroupCollections;
+
+    // When collections are not grouped, genres with custom artwork already have
+    // their exact MovieCount + SeriesCount from getGenres and do not need extra
+    // queries. Only genres requiring a fallback collage or collection-collapsed
+    // counts need to be queried.
+    final needsWork = _genres.where((genre) {
+      if (genre.isGenreFallback) return true;
+      return groupCollections;
+    }).toList();
+
+    if (needsWork.isEmpty) return;
+
+    final toLoad = needsWork.take(_initialArtworkBatch).toList();
     await Future.wait(toLoad.map(_loadGenreItems));
 
-    if (!_disposed && _genres.length > _initialArtworkBatch) {
+    if (!_disposed && needsWork.length > _initialArtworkBatch) {
       unawaited(
-        _loadGenreArtworkAsync(_genres.skip(_initialArtworkBatch).toList()),
+        _loadGenreArtworkAsync(needsWork.skip(_initialArtworkBatch).toList()),
       );
     }
   }
@@ -218,12 +244,50 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
   Future<void> _loadGenreItems(GenreCardData genre) async {
     if (_disposed) return;
     try {
+      final groupCollections = _lastGroupCollections;
+      final includeItemTypes = groupCollections
+          ? const ['Movie', 'Series', 'BoxSet']
+          : kBrowsableGenreItemTypes;
+
+      // When the genre already has custom artwork, we only need the total count
+      // under collection grouping. Asking for limit 0 avoids fetching items,
+      // image tags, and random sorting overhead.
+      if (!genre.isGenreFallback) {
+        final response = await _client.itemsApi.getItems(
+          genreIds: [genre.id],
+          includeItemTypes: includeItemTypes,
+          excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+          collapseBoxSetItems: groupCollections,
+          recursive: true,
+          limit: 0,
+          enableTotalRecordCount: true,
+        );
+
+        final rawTotalCount = response['TotalRecordCount'];
+        final totalCount = rawTotalCount is num
+            ? rawTotalCount.toInt()
+            : 0;
+        if (totalCount <= 0) {
+          if (_genres.remove(genre) && !_disposed && mounted) {
+            setState(() {});
+          }
+          return;
+        }
+
+        genre.itemCount = totalCount;
+        if (!_disposed && mounted) setState(() {});
+        return;
+      }
+
+      // For fallback artwork, query random items so each genre displays a
+      // unique, representative thumbnail and avoids duplicates across cards.
       final response = await _client.itemsApi.getItems(
         genreIds: [genre.id],
-        includeItemTypes: kBrowsableGenreItemTypes,
-        excludeItemTypes: ['Episode'],
+        includeItemTypes: includeItemTypes,
+        excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
         sortBy: 'Random',
         sortOrder: 'Ascending',
+        collapseBoxSetItems: groupCollections,
         recursive: true,
         limit: 4,
         fields: 'PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
@@ -245,20 +309,43 @@ class _AllGenresScreenState extends State<AllGenresScreen> {
 
       genre.itemCount = totalCount;
 
-      if (genre.isGenreFallback) {
-        final maps = List<Map<String, dynamic>>.from(
-          items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
-        );
-        maps.shuffle();
+      final maps = List<Map<String, dynamic>>.from(
+        items.whereType<Map>().map((item) => item.cast<String, dynamic>()),
+      );
+      maps.shuffle();
 
-        final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
-          items: maps,
-          imageApi: _client.imageApi,
-          maxWidth: _genreCardRequestMaxWidth(),
-        );
+      // Deprioritize items that have already been chosen for another genre card
+      // to avoid duplicate artwork appearing across tiles.
+      if (_usedArtworkIds.isNotEmpty) {
+        maps.sort((a, b) {
+          final aUsed = _usedArtworkIds.contains(a['Id']?.toString());
+          final bUsed = _usedArtworkIds.contains(b['Id']?.toString());
+          if (aUsed == bUsed) return 0;
+          return aUsed ? 1 : -1;
+        });
+      }
 
-        genre.imageUrl = imageUrl;
-        genre.backdropUrl = backdropUrl;
+      final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
+        items: maps,
+        imageApi: _client.imageApi,
+        maxWidth: _genreCardRequestMaxWidth(),
+      );
+
+      genre.imageUrl = imageUrl;
+      genre.backdropUrl = backdropUrl;
+
+      // Track the selected item's ID
+      for (final item in maps) {
+        final id = item['Id']?.toString();
+        if (id != null) {
+          final bTags = item['BackdropImageTags'] as List?;
+          final pTag = item['PrimaryImageTag'] as String?;
+          if ((bTags != null && bTags.isNotEmpty) ||
+              (pTag != null && pTag.isNotEmpty)) {
+            _usedArtworkIds.add(id);
+            break;
+          }
+        }
       }
 
       if (!_disposed && mounted) setState(() {});

--- a/lib/ui/screens/browse/library_browse_screen.dart
+++ b/lib/ui/screens/browse/library_browse_screen.dart
@@ -1171,7 +1171,7 @@ class _LibraryBrowseScreenState extends State<LibraryBrowseScreen>
             crossAxisCount;
         final ar = _gridBaseAspectRatio();
         final desktopTextScale = MediaQuery.textScalerOf(context).scale(1.0);
-        final textHeight = (_hasSubtitles ? 42.0 : 24.0) * desktopTextScale;
+        final textHeight = (_hasSubtitles ? 46.0 : 26.0) * desktopTextScale;
         final cellHeight = cellWidth / ar + textHeight;
         final childAspectRatio = cellWidth / cellHeight;
         // A focused card grows about its center and paints past its cell, so

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -56,6 +56,9 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   bool _lastGroupCollections = false;
   final Set<String> _usedArtworkIds = {};
 
+  /// A grouping toggle starts a second load, so the first stops writing.
+  int _loadToken = 0;
+
   bool _disposed = false;
 
   ImageType get _imageType =>
@@ -97,6 +100,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   }
 
   Future<void> _load() async {
+    final token = ++_loadToken;
     try {
       _usedArtworkIds.clear();
       final parentData = await _client.itemsApi.getItem(widget.libraryId);
@@ -181,41 +185,53 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
       }).toList();
     } catch (_) {}
 
+    if (token != _loadToken) return;
     _isLoading = false;
     if (!_disposed && mounted) setState(() {});
 
-    _loadArtwork();
+    _loadArtwork(token);
   }
 
-  Future<void> _loadArtwork() async {
+  Future<void> _loadArtwork(int token) async {
     final includeType = _includeType;
     final groupCollections = _lastGroupCollections;
+    final isVideo = includeType == 'Movie' || includeType == 'Series';
 
-    // For movies/tv without fallback artwork needed, skip if uncollapsed
-    final needsWork = _genres.where((genre) {
-      if (_collectionType == 'music') return true;
-      if (genre.isGenreFallback) return true;
-      return groupCollections &&
-          (includeType == 'Movie' || includeType == 'Series');
-    }).toList();
+    // A genre with its own artwork already has an exact count, so it only needs
+    // a query when grouping changes what that count means. Music tiles always
+    // need one, since they take their picture from the first album.
+    final needsWork = _genres
+        .where(
+          (genre) =>
+              _collectionType == 'music' ||
+              genre.isGenreFallback ||
+              (groupCollections && isVideo),
+        )
+        .toList();
 
     if (needsWork.isEmpty) return;
 
     final toLoad = needsWork.take(_initialArtworkBatch).toList();
     await Future.wait(
-      toLoad.map((genre) => _loadGenreArtwork(genre, includeType, groupCollections)),
+      toLoad.map(
+        (genre) =>
+            _loadGenreArtwork(genre, includeType, groupCollections, token),
+      ),
     );
 
     if (!_disposed && needsWork.length > _initialArtworkBatch) {
       final remaining = needsWork.skip(_initialArtworkBatch).toList();
       for (
         var i = 0;
-        i < remaining.length && !_disposed;
+        i < remaining.length && !_disposed && token == _loadToken;
         i += _backgroundArtworkConcurrency
       ) {
         final batch = remaining.skip(i).take(_backgroundArtworkConcurrency);
         await Future.wait(
-          batch.map((genre) => _loadGenreArtwork(genre, includeType, groupCollections)),
+          batch.map(
+            (genre) =>
+                _loadGenreArtwork(genre, includeType, groupCollections, token),
+          ),
         );
       }
     }
@@ -225,21 +241,22 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
     GenreCardData genre,
     String? includeType,
     bool groupCollections,
+    int token,
   ) async {
-    if (_disposed) return;
+    if (_disposed || token != _loadToken) return;
     try {
       final isVideo = includeType == 'Movie' || includeType == 'Series';
       final includeItemTypes = isVideo && groupCollections
           ? [includeType!, 'BoxSet']
           : (includeType != null ? [includeType] : const ['Movie', 'Series']);
 
-      // Fast path for non-fallback video genres under collection grouping
+      // This genre has art of its own, so the count is all that is missing.
       if (!genre.isGenreFallback && _collectionType != 'music') {
         final response = await _client.itemsApi.getItems(
           parentId: widget.libraryId,
           genreIds: [genre.id],
           includeItemTypes: includeItemTypes,
-          excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+          excludeItemTypes: kNonRootBrowseItemTypes,
           collapseBoxSetItems: groupCollections,
           recursive: true,
           limit: 0,
@@ -264,7 +281,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
         parentId: widget.libraryId,
         genreIds: [genre.id],
         includeItemTypes: includeItemTypes,
-        excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+        excludeItemTypes: kNonRootBrowseItemTypes,
         sortBy: 'Random',
         sortOrder: 'Ascending',
         collapseBoxSetItems: isVideo ? groupCollections : null,
@@ -326,39 +343,16 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
           );
           maps.shuffle();
 
-          // Deprioritize items that have already been chosen for another genre card
-          // to avoid duplicate artwork appearing across tiles.
-          if (_usedArtworkIds.isNotEmpty) {
-            maps.sort((a, b) {
-              final aUsed = _usedArtworkIds.contains(a['Id']?.toString());
-              final bUsed = _usedArtworkIds.contains(b['Id']?.toString());
-              if (aUsed == bUsed) return 0;
-              return aUsed ? 1 : -1;
-            });
-          }
-
-          final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
+          final (imageUrl, backdropUrl, usedId) = resolveGenreFallbackArtwork(
             items: maps,
             imageApi: _client.imageApi,
             maxWidth: _genreCardRequestMaxWidth(),
+            avoidIds: _usedArtworkIds,
           );
 
           genre.imageUrl = imageUrl;
           genre.backdropUrl = backdropUrl;
-
-          // Track the selected item's ID
-          for (final item in maps) {
-            final id = item['Id']?.toString();
-            if (id != null) {
-              final bTags = item['BackdropImageTags'] as List?;
-              final pTag = item['PrimaryImageTag'] as String?;
-              if ((bTags != null && bTags.isNotEmpty) ||
-                  (pTag != null && pTag.isNotEmpty)) {
-                _usedArtworkIds.add(id);
-                break;
-              }
-            }
-          }
+          if (usedId != null) _usedArtworkIds.add(usedId);
         }
       }
       if (!_disposed && mounted) setState(() {});

--- a/lib/ui/screens/browse/library_genres_screen.dart
+++ b/lib/ui/screens/browse/library_genres_screen.dart
@@ -53,6 +53,8 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   bool _isLoading = true;
   String _libraryName = '';
   String? _collectionType;
+  bool _lastGroupCollections = false;
+  final Set<String> _usedArtworkIds = {};
 
   bool _disposed = false;
 
@@ -62,12 +64,22 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   PosterSize get _posterSize => _prefs.resolveLibraryPosterSize();
 
   void _onChanged() {
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    final currentGroup =
+        _prefs.get(UserPreferences.groupItemsIntoCollections);
+    if (_lastGroupCollections != currentGroup) {
+      _lastGroupCollections = currentGroup;
+      _load();
+    } else {
+      setState(() {});
+    }
   }
 
   @override
   void initState() {
     super.initState();
+    _lastGroupCollections =
+        _prefs.get(UserPreferences.groupItemsIntoCollections);
     _backgroundSub = _backgroundService.backgroundStream.listen((url) {
       if (mounted) setState(() => _backdropUrl = url);
     });
@@ -86,6 +98,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
   Future<void> _load() async {
     try {
+      _usedArtworkIds.clear();
       final parentData = await _client.itemsApi.getItem(widget.libraryId);
       _libraryName = parentData['Name'] as String? ?? '';
       _collectionType = (parentData['CollectionType'] as String?)
@@ -176,13 +189,25 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
   Future<void> _loadArtwork() async {
     final includeType = _includeType;
-    final toLoad = _genres.take(_initialArtworkBatch).toList();
+    final groupCollections = _lastGroupCollections;
+
+    // For movies/tv without fallback artwork needed, skip if uncollapsed
+    final needsWork = _genres.where((genre) {
+      if (_collectionType == 'music') return true;
+      if (genre.isGenreFallback) return true;
+      return groupCollections &&
+          (includeType == 'Movie' || includeType == 'Series');
+    }).toList();
+
+    if (needsWork.isEmpty) return;
+
+    final toLoad = needsWork.take(_initialArtworkBatch).toList();
     await Future.wait(
-      toLoad.map((genre) => _loadGenreArtwork(genre, includeType)),
+      toLoad.map((genre) => _loadGenreArtwork(genre, includeType, groupCollections)),
     );
 
-    if (!_disposed && _genres.length > _initialArtworkBatch) {
-      final remaining = _genres.skip(_initialArtworkBatch).toList();
+    if (!_disposed && needsWork.length > _initialArtworkBatch) {
+      final remaining = needsWork.skip(_initialArtworkBatch).toList();
       for (
         var i = 0;
         i < remaining.length && !_disposed;
@@ -190,7 +215,7 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
       ) {
         final batch = remaining.skip(i).take(_backgroundArtworkConcurrency);
         await Future.wait(
-          batch.map((genre) => _loadGenreArtwork(genre, includeType)),
+          batch.map((genre) => _loadGenreArtwork(genre, includeType, groupCollections)),
         );
       }
     }
@@ -199,18 +224,50 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
   Future<void> _loadGenreArtwork(
     GenreCardData genre,
     String? includeType,
+    bool groupCollections,
   ) async {
     if (_disposed) return;
     try {
+      final isVideo = includeType == 'Movie' || includeType == 'Series';
+      final includeItemTypes = isVideo && groupCollections
+          ? [includeType!, 'BoxSet']
+          : (includeType != null ? [includeType] : const ['Movie', 'Series']);
+
+      // Fast path for non-fallback video genres under collection grouping
+      if (!genre.isGenreFallback && _collectionType != 'music') {
+        final response = await _client.itemsApi.getItems(
+          parentId: widget.libraryId,
+          genreIds: [genre.id],
+          includeItemTypes: includeItemTypes,
+          excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
+          collapseBoxSetItems: groupCollections,
+          recursive: true,
+          limit: 0,
+          enableTotalRecordCount: true,
+        );
+
+        final rawTotalCount = response['TotalRecordCount'];
+        final totalCount = rawTotalCount is num ? rawTotalCount.toInt() : 0;
+        if (totalCount <= 0) {
+          if (_genres.remove(genre) && !_disposed && mounted) {
+            setState(() {});
+          }
+          return;
+        }
+
+        genre.itemCount = totalCount;
+        if (!_disposed && mounted) setState(() {});
+        return;
+      }
+
       final response = await _client.itemsApi.getItems(
         parentId: widget.libraryId,
         genreIds: [genre.id],
-        includeItemTypes: includeType != null
-            ? [includeType]
-            : ['Movie', 'Series'],
-        excludeItemTypes: includeType == null ? ['Episode'] : null,
+        includeItemTypes: includeItemTypes,
+        excludeItemTypes: const ['Playlist', 'Episode', 'Season', 'Folder'],
         sortBy: 'Random',
         sortOrder: 'Ascending',
+        collapseBoxSetItems: isVideo ? groupCollections : null,
         recursive: true,
         limit: 4,
         fields: 'PrimaryImageTag,ImageTags,BackdropImageTags,PrimaryImageAspectRatio',
@@ -269,6 +326,17 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
           );
           maps.shuffle();
 
+          // Deprioritize items that have already been chosen for another genre card
+          // to avoid duplicate artwork appearing across tiles.
+          if (_usedArtworkIds.isNotEmpty) {
+            maps.sort((a, b) {
+              final aUsed = _usedArtworkIds.contains(a['Id']?.toString());
+              final bUsed = _usedArtworkIds.contains(b['Id']?.toString());
+              if (aUsed == bUsed) return 0;
+              return aUsed ? 1 : -1;
+            });
+          }
+
           final (imageUrl, backdropUrl) = resolveGenreFallbackArtwork(
             items: maps,
             imageApi: _client.imageApi,
@@ -277,6 +345,20 @@ class _LibraryGenresScreenState extends State<LibraryGenresScreen> {
 
           genre.imageUrl = imageUrl;
           genre.backdropUrl = backdropUrl;
+
+          // Track the selected item's ID
+          for (final item in maps) {
+            final id = item['Id']?.toString();
+            if (id != null) {
+              final bTags = item['BackdropImageTags'] as List?;
+              final pTag = item['PrimaryImageTag'] as String?;
+              if ((bTags != null && bTags.isNotEmpty) ||
+                  (pTag != null && pTag.isNotEmpty)) {
+                _usedArtworkIds.add(id);
+                break;
+              }
+            }
+          }
         }
       }
       if (!_disposed && mounted) setState(() {});

--- a/test/data/utils/genre_browse_utils_test.dart
+++ b/test/data/utils/genre_browse_utils_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/utils/genre_browse_utils.dart';
+import 'package:server_core/server_core.dart';
+
+class _FakeImageApi implements ImageApi {
+  @override
+  String getPrimaryImageUrl(
+    String itemId, {
+    int? maxWidth,
+    int? maxHeight,
+    String? tag,
+  }) => 'primary:$itemId';
+
+  @override
+  String getBackdropImageUrl(
+    String itemId, {
+    int? maxWidth,
+    int? index,
+    String? tag,
+  }) => 'backdrop:$itemId';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  // Asking for types this list doesn't carry falls back to the whole list, so
+  // dropping one here doesn't narrow a caller, it widens it to everything.
+  group('narrowing the types a genre row is built from', () {
+    test('keeps the audio types a book library browses', () {
+      expect(
+        normalizeBrowsableGenreItemTypes(const ['AudioBook', 'Audio']),
+        ['Audio'],
+      );
+      expect(normalizeBrowsableGenreItemTypes(const ['MusicAlbum']), [
+        'MusicAlbum',
+      ]);
+    });
+
+    test('counts a music genre off its own fields', () {
+      final rock = <String, dynamic>{'AlbumCount': 12, 'SongCount': 140};
+      expect(
+        browsableGenreCount(rock, normalizedItemTypes: const ['Audio']),
+        140,
+      );
+      expect(
+        browsableGenreCount(rock, normalizedItemTypes: const ['MusicAlbum']),
+        12,
+      );
+    });
+  });
+
+  // A grid of genres wants a different picture on each tile, which means
+  // knowing which item each tile took rather than working it out again.
+  test('fallback artwork reports the item it drew', () {
+    final poster = <String, dynamic>{
+      'Id': 'portrait-only',
+      'PrimaryImageTag': 'p1',
+      'PrimaryImageAspectRatio': 0.66,
+    };
+    final backdrop = <String, dynamic>{
+      'Id': 'has-backdrop',
+      'BackdropImageTags': ['b1'],
+    };
+
+    final (imageUrl, _, usedId) = resolveGenreFallbackArtwork(
+      items: [poster, backdrop],
+      imageApi: _FakeImageApi(),
+      maxWidth: 400,
+    );
+
+    expect(imageUrl, 'backdrop:has-backdrop');
+    expect(usedId, 'has-backdrop');
+  });
+
+  test('fallback artwork steps around art another tile took', () {
+    final taken = <String, dynamic>{
+      'Id': 'taken',
+      'BackdropImageTags': ['b1'],
+    };
+    final free = <String, dynamic>{
+      'Id': 'free',
+      'BackdropImageTags': ['b2'],
+    };
+
+    final (_, _, usedId) = resolveGenreFallbackArtwork(
+      items: [taken, free],
+      imageApi: _FakeImageApi(),
+      maxWidth: 400,
+      avoidIds: const {'taken'},
+    );
+    expect(usedId, 'free');
+
+    // With nothing left to move to, a repeat beats an empty tile.
+    final (imageUrl, _, _) = resolveGenreFallbackArtwork(
+      items: [taken],
+      imageApi: _FakeImageApi(),
+      maxWidth: 400,
+      avoidIds: const {'taken'},
+    );
+    expect(imageUrl, 'backdrop:taken');
+  });
+
+  test('fallback artwork reports nothing when there is nothing to draw', () {
+    final (imageUrl, backdropUrl, usedId) = resolveGenreFallbackArtwork(
+      items: const [],
+      imageApi: _FakeImageApi(),
+      maxWidth: 400,
+    );
+
+    expect(imageUrl, isNull);
+    expect(backdropUrl, isNull);
+    expect(usedId, isNull);
+  });
+}

--- a/test/data/viewmodels/library_browse_filters_test.dart
+++ b/test/data/viewmodels/library_browse_filters_test.dart
@@ -25,6 +25,11 @@ class _RecordingItemsApi implements ItemsApi {
   bool? isHd;
   bool? is4K;
   bool? is3D;
+  List<String>? includeItemTypes;
+  List<String>? excludeItemTypes;
+  List<String>? genreIds;
+  bool? collapseBoxSetItems;
+  String? collectionType;
 
   QueryFilterValues facets = QueryFilterValues.empty;
   int facetRequests = 0;
@@ -91,6 +96,10 @@ class _RecordingItemsApi implements ItemsApi {
     this.isHd = isHd;
     this.is4K = is4K;
     this.is3D = is3D;
+    this.includeItemTypes = includeItemTypes;
+    this.excludeItemTypes = excludeItemTypes;
+    this.genreIds = genreIds;
+    this.collapseBoxSetItems = collapseBoxSetItems;
     return <String, dynamic>{'TotalRecordCount': 0, 'Items': const []};
   }
 
@@ -108,7 +117,10 @@ class _RecordingItemsApi implements ItemsApi {
     String itemId, {
     String? mediaSourceId,
     String? fields,
-  }) async => <String, dynamic>{'Name': 'Movies', 'CollectionType': 'movies'};
+  }) async => <String, dynamic>{
+    'Name': 'Media',
+    'CollectionType': collectionType ?? 'movies',
+  };
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -141,16 +153,24 @@ class _FakeMdbListRepository implements MdbListRepository {
 Future<LibraryBrowseViewModel> _viewModel(
   _RecordingItemsApi api, {
   ServerType serverType = ServerType.jellyfin,
+  String libraryId = 'movies',
+  String? genreId,
   List<String>? includeItemTypes,
+  bool groupCollections = false,
 }) async {
   SharedPreferences.setMockInitialValues(<String, Object>{});
   final store = PreferenceStore();
   await store.init();
+  final prefs = UserPreferences(store);
+  if (groupCollections) {
+    prefs.set(UserPreferences.groupItemsIntoCollections, true);
+  }
   return LibraryBrowseViewModel(
-    libraryId: 'movies',
+    libraryId: libraryId,
     client: _FakeClient(api, serverType: serverType),
-    prefs: UserPreferences(store),
+    prefs: prefs,
     mdbListRepository: _FakeMdbListRepository(),
+    genreId: genreId,
     includeItemTypes: includeItemTypes,
   );
 }
@@ -285,5 +305,56 @@ void main() {
     addTearDown(emby.dispose);
     expect(emby.supportsUhdFilter, isFalse);
     expect(emby.supportsUnreleasedSeriesFilter, isFalse);
+  });
+
+  test('global genre browse includes only movies and series and excludes non-root types', () async {
+    final api = _RecordingItemsApi();
+    final vm = await _viewModel(
+      api,
+      libraryId: '',
+      genreId: 'anime-genre-id',
+    );
+    addTearDown(vm.dispose);
+
+    await vm.load();
+
+    expect(api.genreIds, ['anime-genre-id']);
+    expect(api.includeItemTypes, ['Movie', 'Series']);
+    expect(api.excludeItemTypes, ['Playlist', 'Episode', 'Season', 'Folder']);
+    expect(api.collapseBoxSetItems, isFalse);
+  });
+
+  test('global genre browse with groupCollections includes BoxSet and sets collapseBoxSetItems', () async {
+    final api = _RecordingItemsApi();
+    final vm = await _viewModel(
+      api,
+      libraryId: '',
+      genreId: 'anime-genre-id',
+      groupCollections: true,
+    );
+    addTearDown(vm.dispose);
+
+    await vm.load();
+
+    expect(api.genreIds, ['anime-genre-id']);
+    expect(api.includeItemTypes, ['Movie', 'Series', 'BoxSet']);
+    expect(api.excludeItemTypes, ['Playlist', 'Episode', 'Season', 'Folder']);
+    expect(api.collapseBoxSetItems, isTrue);
+  });
+
+  test('genre browse in music library asks for MusicAlbum', () async {
+    final api = _RecordingItemsApi()..collectionType = 'music';
+    final vm = await _viewModel(
+      api,
+      libraryId: 'music-library-id',
+      genreId: 'rock-genre-id',
+    );
+    addTearDown(vm.dispose);
+
+    await vm.load();
+
+    expect(api.genreIds, ['rock-genre-id']);
+    expect(api.includeItemTypes, ['MusicAlbum']);
+    expect(api.excludeItemTypes, ['Playlist', 'Episode', 'Season', 'Folder']);
   });
 }

--- a/test/data/viewmodels/library_browse_filters_test.dart
+++ b/test/data/viewmodels/library_browse_filters_test.dart
@@ -357,4 +357,36 @@ void main() {
     expect(api.includeItemTypes, ['MusicAlbum']);
     expect(api.excludeItemTypes, ['Playlist', 'Episode', 'Season', 'Folder']);
   });
+
+  // A book library already picked its own types, so narrowing a genre to
+  // movies and series there leaves the page with nothing to show.
+  test('genre browse in a book library keeps the book types', () async {
+    final api = _RecordingItemsApi()..collectionType = 'books';
+    final vm = await _viewModel(
+      api,
+      libraryId: 'book-library-id',
+      genreId: 'scifi-genre-id',
+    );
+    addTearDown(vm.dispose);
+
+    await vm.load();
+
+    expect(api.includeItemTypes, ['Book', 'Audio', 'AudioBook']);
+  });
+
+  test('genre browse outside the video libraries is left unscoped', () async {
+    for (final collectionType in ['audiobooks', 'musicvideos', 'homevideos']) {
+      final api = _RecordingItemsApi()..collectionType = collectionType;
+      final vm = await _viewModel(
+        api,
+        libraryId: 'lib-$collectionType',
+        genreId: 'g1',
+      );
+
+      await vm.load();
+
+      expect(api.includeItemTypes, isNull, reason: collectionType);
+      vm.dispose();
+    }
+  });
 }


### PR DESCRIPTION
# Pull Request

## Summary
Stemming from #1521 - dove into the Genres page logic and found quite a bit to clean up. Fixed an issue where clicking a genre in the global All Genres screen displayed non-root and unwanted item types (playlists, boxsets, seasons, episodes, and folders - which made the counts and included items not match the values on the main screen), excluded music albums from global video genres (to improve load time since they were never shown anyway), synchronizes tile badge counts when toggling collections grouping, and prevents duplicate artwork selection across genre cards.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #1521 
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **library_browse_view_model.dart**: Scoped global genre browsing to **Movie** and **Series** items (plus **BoxSet** when collection grouping is active with `collapseBoxSetItems = true`), explicitly excluding **Playlist**, **Episode**, **Season**, and **Folder**. Scoped library-specific genre browse queries by collection type (**Movie** for movie libraries, **Series** for tv show libraries, and **MusicAlbum** for audio libraries).
- **genre_browse_utils.dart**: Reverted `kBrowsableGenreItemTypes` to `['Movie', 'Series']` and ensured `browsableGenreCount` focuses strictly on video item counts for the global genre screen.
- **all_genres_screen.dart** & **library_genres_screen.dart**:
  - Added a listener for `groupItemsIntoCollections` changes to update genre tile badge counts in real time.
  - Optimized queries under collection grouping using `limit: 0` and `collapseBoxSetItems: true` to fetch accurate collapsed totals instantly without pulling full item lists.
  - Added deduplication logic (`_usedArtworkIds`) to random thumbnail fallback resolution to ensure distinct artwork across genre cards.
- **library_browse_screen.dart**: Adjusted card label height calculation (`textHeight`) to eliminate 1.3px layout overflow on grid items.
- **library_browse_filters_test.dart**: Added unit tests covering global genre browsing, collection grouping filters, and music library scoping.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Navigate to the global **All Genres** screen.
2. Verify tile badge counts reflect movies and series only (excluding playlists and music).
3. Toggle **Group into collections** on and off in settings; verify genre card counts update dynamically to match collapsed and uncollapsed totals.
4. Open a genre (e.g. Science Fiction, Mystery, Documentary); verify only root movies/series appear (no playlists, episodes, seasons, or ungrouped boxsets).
5. Verify grid cards render cleanly without layout overflow warnings.
6. Verify fallback thumbnail images remain distinct across genre cards.
 
## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Proper Counts with Collection Grouping ON

https://github.com/user-attachments/assets/9dbc33bf-6b9a-46aa-ba9c-ce1096f9c7d5

### Proper Counts with Collection Grouping OFF

https://github.com/user-attachments/assets/8686f4c5-b4b3-4ed6-8b4a-cfa3f489bdd9

## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
