### PR TITLE
Add encoded letterbox crop for desktop and Android

### DIFF
--- a/ios/Runner/Playback/AetherVideoPlatformView.swift
+++ b/ios/Runner/Playback/AetherVideoPlatformView.swift
@@ -91,7 +91,7 @@ final class AetherVideoPlatformView: NSObject, FlutterPlatformView {
     private static func zoomMode(fromWire value: String) -> ZoomMode? {
         switch value {
         case "fit", "Fit": return .fit
-        case "autoCrop", "Auto Crop", "Fill": return .autoCrop
+        case "autoCrop", "Auto Crop": return .autoCrop
         case "stretch", "Stretch": return .stretch
         default: return nil
         }

--- a/ios/Runner/Playback/AetherVideoPlatformView.swift
+++ b/ios/Runner/Playback/AetherVideoPlatformView.swift
@@ -91,7 +91,7 @@ final class AetherVideoPlatformView: NSObject, FlutterPlatformView {
     private static func zoomMode(fromWire value: String) -> ZoomMode? {
         switch value {
         case "fit", "Fit": return .fit
-        case "autoCrop", "Auto Crop": return .autoCrop
+        case "autoCrop", "Auto Crop", "Fill": return .autoCrop
         case "stretch", "Stretch": return .stretch
         default: return nil
         }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4124,15 +4124,15 @@
   "@fit": {
     "description": "Zoom mode: fit"
   },
-  "autoCrop": "Fill",
+  "autoCrop": "Auto Crop",
   "@autoCrop": {
-    "description": "Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection."
+    "description": "Zoom mode: cover the screen, clipping overflow. Not black-bar detection."
   },
   "cropBlackBars": "Crop black bars",
   "@cropBlackBars": {
-    "description": "Setting to detect and crop letterbox/pillarbox bars via libmpv cropdetect"
+    "description": "Setting to detect and crop encoded letterbox/pillarbox bars"
   },
-  "settingsCropBlackBarsDescription": "Detect encoded letterbox, crop it, then fill the screen (mpv).",
+  "settingsCropBlackBarsDescription": "Detect encoded letterbox bars, crop them, then fill the screen.",
   "@settingsCropBlackBarsDescription": {
     "description": "Description for the crop black bars playback setting"
   },
@@ -9326,7 +9326,7 @@
   "settingsDoNothing": "Do Nothing",
   "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
   "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-  "settingsPlayerZoomDescription": "Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.",
+  "settingsPlayerZoomDescription": "Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.",
   "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
   "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
   "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4124,9 +4124,17 @@
   "@fit": {
     "description": "Zoom mode: fit"
   },
-  "autoCrop": "Auto Crop",
+  "autoCrop": "Fill",
   "@autoCrop": {
-    "description": "Zoom mode: auto crop"
+    "description": "Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection."
+  },
+  "cropBlackBars": "Crop black bars",
+  "@cropBlackBars": {
+    "description": "Setting to detect and crop letterbox/pillarbox bars via libmpv cropdetect"
+  },
+  "settingsCropBlackBarsDescription": "Detect encoded letterbox, crop it, then fill the screen (mpv).",
+  "@settingsCropBlackBarsDescription": {
+    "description": "Description for the crop black bars playback setting"
   },
   "stretch": "Stretch",
   "@stretch": {
@@ -9318,7 +9326,7 @@
   "settingsDoNothing": "Do Nothing",
   "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
   "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-  "settingsPlayerZoomDescription": "How video should be scaled to fit the screen.",
+  "settingsPlayerZoomDescription": "Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.",
   "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
   "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
   "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4126,7 +4126,7 @@
   },
   "autoCrop": "Auto Crop",
   "@autoCrop": {
-    "description": "Zoom mode: cover the screen, clipping overflow. Not black-bar detection."
+    "description": "Zoom mode: auto crop"
   },
   "cropBlackBars": "Crop black bars",
   "@cropBlackBars": {
@@ -9326,7 +9326,7 @@
   "settingsDoNothing": "Do Nothing",
   "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
   "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-  "settingsPlayerZoomDescription": "Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.",
+  "settingsPlayerZoomDescription": "How video should be scaled to fit the screen.",
   "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
   "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
   "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -2830,7 +2830,7 @@
     },
     "autoCrop": "Auto Crop",
     "@autoCrop": {
-        "description": "Zoom mode: cover the screen, clipping overflow. Not black-bar detection."
+        "description": "Zoom mode: auto crop"
     },
     "stretch": "Stretch",
     "@stretch": {
@@ -6593,7 +6593,7 @@
     "settingsDoNothing": "Do Nothing",
     "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
     "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-    "settingsPlayerZoomDescription": "Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.",
+    "settingsPlayerZoomDescription": "How video should be scaled to fit the screen.",
     "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
     "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
     "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -2828,9 +2828,9 @@
     "@fit": {
         "description": "Zoom mode: fit"
     },
-    "autoCrop": "Fill",
+    "autoCrop": "Auto Crop",
     "@autoCrop": {
-        "description": "Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection."
+        "description": "Zoom mode: cover the screen, clipping overflow. Not black-bar detection."
     },
     "stretch": "Stretch",
     "@stretch": {
@@ -6593,7 +6593,7 @@
     "settingsDoNothing": "Do Nothing",
     "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
     "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-    "settingsPlayerZoomDescription": "Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.",
+    "settingsPlayerZoomDescription": "Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.",
     "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
     "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
     "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_en_GB.arb
+++ b/lib/l10n/app_en_GB.arb
@@ -2828,9 +2828,9 @@
     "@fit": {
         "description": "Zoom mode: fit"
     },
-    "autoCrop": "Auto Crop",
+    "autoCrop": "Fill",
     "@autoCrop": {
-        "description": "Zoom mode: auto crop"
+        "description": "Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection."
     },
     "stretch": "Stretch",
     "@stretch": {
@@ -6593,7 +6593,7 @@
     "settingsDoNothing": "Do Nothing",
     "settingsMaxBitrateDescription": "Cap the streaming bitrate. Content above this threshold will be transcoded to fit.",
     "settingsMaxResolutionDescription": "Limit the maximum resolution the player will request. Higher-resolution content will be transcoded down.",
-    "settingsPlayerZoomDescription": "How video should be scaled to fit the screen.",
+    "settingsPlayerZoomDescription": "Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.",
     "settingsPlaybackEngineAndroidTv": "Playback Engine (Android TV)",
     "settingsPlaybackEngineAndroidTvDescription": "Choose the default playback engine on Android TV devices. Changes apply to the next playback session.",
     "settingsPlaybackEngineMedia3Recommended": "Media3 (recommended)",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5326,7 +5326,7 @@ abstract class AppLocalizations {
   /// **'Fit'**
   String get fit;
 
-  /// Zoom mode: cover the screen, clipping overflow. Not black-bar detection.
+  /// Zoom mode: auto crop
   ///
   /// In en, this message translates to:
   /// **'Auto Crop'**
@@ -17317,7 +17317,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsPlayerZoomDescription.
   ///
   /// In en, this message translates to:
-  /// **'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.'**
+  /// **'How video should be scaled to fit the screen.'**
   String get settingsPlayerZoomDescription;
 
   /// No description provided for @settingsPlaybackEngineAndroidTv.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5326,11 +5326,23 @@ abstract class AppLocalizations {
   /// **'Fit'**
   String get fit;
 
-  /// Zoom mode: auto crop
+  /// Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection.
   ///
   /// In en, this message translates to:
-  /// **'Auto Crop'**
+  /// **'Fill'**
   String get autoCrop;
+
+  /// Setting to detect and crop letterbox/pillarbox bars via libmpv cropdetect
+  ///
+  /// In en, this message translates to:
+  /// **'Crop black bars'**
+  String get cropBlackBars;
+
+  /// Description for the crop black bars playback setting
+  ///
+  /// In en, this message translates to:
+  /// **'Detect encoded letterbox, crop it, then fill the screen (mpv).'**
+  String get settingsCropBlackBarsDescription;
 
   /// Zoom mode: stretch
   ///
@@ -17305,7 +17317,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsPlayerZoomDescription.
   ///
   /// In en, this message translates to:
-  /// **'How video should be scaled to fit the screen.'**
+  /// **'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.'**
   String get settingsPlayerZoomDescription;
 
   /// No description provided for @settingsPlaybackEngineAndroidTv.

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -5326,13 +5326,13 @@ abstract class AppLocalizations {
   /// **'Fit'**
   String get fit;
 
-  /// Zoom mode: fill the screen (cover), clipping overflow. Not black-bar detection.
+  /// Zoom mode: cover the screen, clipping overflow. Not black-bar detection.
   ///
   /// In en, this message translates to:
-  /// **'Fill'**
+  /// **'Auto Crop'**
   String get autoCrop;
 
-  /// Setting to detect and crop letterbox/pillarbox bars via libmpv cropdetect
+  /// Setting to detect and crop encoded letterbox/pillarbox bars
   ///
   /// In en, this message translates to:
   /// **'Crop black bars'**
@@ -5341,7 +5341,7 @@ abstract class AppLocalizations {
   /// Description for the crop black bars playback setting
   ///
   /// In en, this message translates to:
-  /// **'Detect encoded letterbox, crop it, then fill the screen (mpv).'**
+  /// **'Detect encoded letterbox bars, crop them, then fill the screen.'**
   String get settingsCropBlackBarsDescription;
 
   /// Zoom mode: stretch
@@ -17317,7 +17317,7 @@ abstract class AppLocalizations {
   /// No description provided for @settingsPlayerZoomDescription.
   ///
   /// In en, this message translates to:
-  /// **'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.'**
+  /// **'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.'**
   String get settingsPlayerZoomDescription;
 
   /// No description provided for @settingsPlaybackEngineAndroidTv.

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3049,7 +3049,7 @@ class AppLocalizationsAf extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Strek';

--- a/lib/l10n/app_localizations_af.dart
+++ b/lib/l10n/app_localizations_af.dart
@@ -3045,6 +3045,13 @@ class AppLocalizationsAf extends AppLocalizations {
   String get autoCrop => 'Outo-snoei';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Strek';
 
   @override

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3059,7 +3059,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'تمتد';

--- a/lib/l10n/app_localizations_ar.dart
+++ b/lib/l10n/app_localizations_ar.dart
@@ -3055,6 +3055,13 @@ class AppLocalizationsAr extends AppLocalizations {
   String get autoCrop => 'الاقتصاص التلقائي';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'تمتد';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3055,6 +3055,13 @@ class AppLocalizationsBe extends AppLocalizations {
   String get autoCrop => 'Аўтаматычнае абрэзка';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Расцяжка';
 
   @override

--- a/lib/l10n/app_localizations_be.dart
+++ b/lib/l10n/app_localizations_be.dart
@@ -3059,7 +3059,7 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Расцяжка';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3055,7 +3055,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Разтягане';

--- a/lib/l10n/app_localizations_bg.dart
+++ b/lib/l10n/app_localizations_bg.dart
@@ -3051,6 +3051,13 @@ class AppLocalizationsBg extends AppLocalizations {
   String get autoCrop => 'Автоматично изрязване';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Разтягане';
 
   @override

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3036,7 +3036,7 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'প্রসারিত';

--- a/lib/l10n/app_localizations_bn.dart
+++ b/lib/l10n/app_localizations_bn.dart
@@ -3032,6 +3032,13 @@ class AppLocalizationsBn extends AppLocalizations {
   String get autoCrop => 'অটো ক্রপ';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'প্রসারিত';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3076,6 +3076,13 @@ class AppLocalizationsCa extends AppLocalizations {
   String get autoCrop => 'Retall automàtic';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Estirar';
 
   @override

--- a/lib/l10n/app_localizations_ca.dart
+++ b/lib/l10n/app_localizations_ca.dart
@@ -3080,7 +3080,7 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Estirar';

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3055,6 +3055,13 @@ class AppLocalizationsCs extends AppLocalizations {
   String get autoCrop => 'Automatické oříznutí';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Úsek';
 
   @override

--- a/lib/l10n/app_localizations_cs.dart
+++ b/lib/l10n/app_localizations_cs.dart
@@ -3059,7 +3059,7 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Úsek';

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3066,6 +3066,13 @@ class AppLocalizationsCy extends AppLocalizations {
   String get autoCrop => 'Cnwd Auto';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Ymestyn';
 
   @override

--- a/lib/l10n/app_localizations_cy.dart
+++ b/lib/l10n/app_localizations_cy.dart
@@ -3070,7 +3070,7 @@ class AppLocalizationsCy extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Ymestyn';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3045,7 +3045,7 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Strække';

--- a/lib/l10n/app_localizations_da.dart
+++ b/lib/l10n/app_localizations_da.dart
@@ -3041,6 +3041,13 @@ class AppLocalizationsDa extends AppLocalizations {
   String get autoCrop => 'Automatisk beskæring';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Strække';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3128,6 +3128,13 @@ class AppLocalizationsDe extends AppLocalizations {
   String get autoCrop => 'Automatisch zuschneiden';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Strecken';
 
   @override

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -3132,7 +3132,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Strecken';

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3070,6 +3070,13 @@ class AppLocalizationsEl extends AppLocalizations {
   String get autoCrop => 'Αυτόματη περικοπή';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Τέντωμα';
 
   @override

--- a/lib/l10n/app_localizations_el.dart
+++ b/lib/l10n/app_localizations_el.dart
@@ -3074,7 +3074,7 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Τέντωμα';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3026,7 +3026,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fit => 'Fit';
 
   @override
-  String get autoCrop => 'Auto Crop';
+  String get autoCrop => 'Fill';
+
+  @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
 
   @override
   String get stretch => 'Stretch';
@@ -9708,7 +9715,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'How video should be scaled to fit the screen.';
+      'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
@@ -14733,7 +14740,14 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get fit => 'Fit';
 
   @override
-  String get autoCrop => 'Auto Crop';
+  String get autoCrop => 'Fill';
+
+  @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
 
   @override
   String get stretch => 'Stretch';
@@ -21336,7 +21350,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'How video should be scaled to fit the screen.';
+      'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9715,7 +9715,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.';
+      'How video should be scaled to fit the screen.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
@@ -21343,7 +21343,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.';
+      'How video should be scaled to fit the screen.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -3026,14 +3026,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get fit => 'Fit';
 
   @override
-  String get autoCrop => 'Fill';
+  String get autoCrop => 'Auto Crop';
 
   @override
   String get cropBlackBars => 'Crop black bars';
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Stretch';
@@ -9715,7 +9715,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.';
+      'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';
@@ -14740,14 +14740,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
   String get fit => 'Fit';
 
   @override
-  String get autoCrop => 'Fill';
-
-  @override
-  String get cropBlackBars => 'Crop black bars';
-
-  @override
-  String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+  String get autoCrop => 'Auto Crop';
 
   @override
   String get stretch => 'Stretch';
@@ -21350,7 +21343,7 @@ class AppLocalizationsEnGb extends AppLocalizationsEn {
 
   @override
   String get settingsPlayerZoomDescription =>
-      'Fit shows the whole picture. Fill covers the screen and clips overflow. Stretch ignores aspect ratio.';
+      'Fit shows the whole picture. Auto Crop covers the screen and clips overflow. Stretch ignores aspect ratio.';
 
   @override
   String get settingsPlaybackEngineAndroidTv => 'Playback Engine (Android TV)';

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3039,6 +3039,13 @@ class AppLocalizationsEo extends AppLocalizations {
   String get autoCrop => 'Aŭtomata Tondado';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Streĉi';
 
   @override

--- a/lib/l10n/app_localizations_eo.dart
+++ b/lib/l10n/app_localizations_eo.dart
@@ -3043,7 +3043,7 @@ class AppLocalizationsEo extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Streĉi';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3061,7 +3061,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Estirar';

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -3057,6 +3057,13 @@ class AppLocalizationsEs extends AppLocalizations {
   String get autoCrop => 'Recorte automático';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Estirar';
 
   @override

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3052,7 +3052,7 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Venitada';

--- a/lib/l10n/app_localizations_et.dart
+++ b/lib/l10n/app_localizations_et.dart
@@ -3048,6 +3048,13 @@ class AppLocalizationsEt extends AppLocalizations {
   String get autoCrop => 'Automaatne kärpimine';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Venitada';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3027,6 +3027,13 @@ class AppLocalizationsFa extends AppLocalizations {
   String get autoCrop => 'برش خودکار';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'کشش';
 
   @override

--- a/lib/l10n/app_localizations_fa.dart
+++ b/lib/l10n/app_localizations_fa.dart
@@ -3031,7 +3031,7 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'کشش';

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3050,6 +3050,13 @@ class AppLocalizationsFi extends AppLocalizations {
   String get autoCrop => 'Automaattinen rajaus';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Venytä';
 
   @override

--- a/lib/l10n/app_localizations_fi.dart
+++ b/lib/l10n/app_localizations_fi.dart
@@ -3054,7 +3054,7 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Venytä';

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3072,6 +3072,13 @@ class AppLocalizationsFr extends AppLocalizations {
   String get autoCrop => 'Recadrage auto';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Étirer';
 
   @override

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -3076,7 +3076,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Étirer';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3073,7 +3073,7 @@ class AppLocalizationsGl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Estirar';

--- a/lib/l10n/app_localizations_gl.dart
+++ b/lib/l10n/app_localizations_gl.dart
@@ -3069,6 +3069,13 @@ class AppLocalizationsGl extends AppLocalizations {
   String get autoCrop => 'Recorte automático';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Estirar';
 
   @override

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3027,7 +3027,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'לִמְתוֹחַ';

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -3023,6 +3023,13 @@ class AppLocalizationsHe extends AppLocalizations {
   String get autoCrop => 'חיתוך אוטומטי';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'לִמְתוֹחַ';
 
   @override

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3036,7 +3036,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'खींचना';

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -3032,6 +3032,13 @@ class AppLocalizationsHi extends AppLocalizations {
   String get autoCrop => 'ऑटो क्रॉप';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'खींचना';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3157,6 +3157,13 @@ class AppLocalizationsHr extends AppLocalizations {
   String get autoCrop => 'Automatsko obrezivanje';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Istegnite se';
 
   @override

--- a/lib/l10n/app_localizations_hr.dart
+++ b/lib/l10n/app_localizations_hr.dart
@@ -3161,7 +3161,7 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Istegnite se';

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3055,6 +3055,13 @@ class AppLocalizationsHu extends AppLocalizations {
   String get autoCrop => 'Automatikus kivágás';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Nyújtás';
 
   @override

--- a/lib/l10n/app_localizations_hu.dart
+++ b/lib/l10n/app_localizations_hu.dart
@@ -3059,7 +3059,7 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Nyújtás';

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3043,6 +3043,13 @@ class AppLocalizationsId extends AppLocalizations {
   String get autoCrop => 'Crop Otomatis';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Rentangkan';
 
   @override

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -3047,7 +3047,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Rentangkan';

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3052,6 +3052,13 @@ class AppLocalizationsIt extends AppLocalizations {
   String get autoCrop => 'Ritaglio Automatico';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Estendi';
 
   @override

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -3056,7 +3056,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Estendi';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2994,6 +2994,13 @@ class AppLocalizationsJa extends AppLocalizations {
   String get autoCrop => '自動トリミング';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'ストレッチ';
 
   @override

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2998,7 +2998,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'ストレッチ';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3052,7 +3052,7 @@ class AppLocalizationsKk extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Созылу';

--- a/lib/l10n/app_localizations_kk.dart
+++ b/lib/l10n/app_localizations_kk.dart
@@ -3048,6 +3048,13 @@ class AppLocalizationsKk extends AppLocalizations {
   String get autoCrop => 'Автоматты қию';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Созылу';
 
   @override

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3056,7 +3056,7 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'ಸ್ಟ್ರೆಚ್';

--- a/lib/l10n/app_localizations_kn.dart
+++ b/lib/l10n/app_localizations_kn.dart
@@ -3052,6 +3052,13 @@ class AppLocalizationsKn extends AppLocalizations {
   String get autoCrop => 'ಸ್ವಯಂ ಬೆಳೆ';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'ಸ್ಟ್ರೆಚ್';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2995,7 +2995,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => '뻗기';

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -2991,6 +2991,13 @@ class AppLocalizationsKo extends AppLocalizations {
   String get autoCrop => '자동 자르기';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => '뻗기';
 
   @override

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3056,7 +3056,7 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Ištempti';

--- a/lib/l10n/app_localizations_lt.dart
+++ b/lib/l10n/app_localizations_lt.dart
@@ -3052,6 +3052,13 @@ class AppLocalizationsLt extends AppLocalizations {
   String get autoCrop => 'Automatinis apkarpymas';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Ištempti';
 
   @override

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3061,7 +3061,7 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Izstiepties';

--- a/lib/l10n/app_localizations_lv.dart
+++ b/lib/l10n/app_localizations_lv.dart
@@ -3057,6 +3057,13 @@ class AppLocalizationsLv extends AppLocalizations {
   String get autoCrop => 'Automātiskā apgriešana';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Izstiepties';
 
   @override

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3059,7 +3059,7 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Истегнете се';

--- a/lib/l10n/app_localizations_mk.dart
+++ b/lib/l10n/app_localizations_mk.dart
@@ -3055,6 +3055,13 @@ class AppLocalizationsMk extends AppLocalizations {
   String get autoCrop => 'Автоматско отсекување';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Истегнете се';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3053,6 +3053,13 @@ class AppLocalizationsMl extends AppLocalizations {
   String get autoCrop => 'ഓട്ടോ ക്രോപ്പ്';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'വലിച്ചുനീട്ടുക';
 
   @override

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -3057,7 +3057,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'വലിച്ചുനീട്ടുക';

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3042,6 +3042,13 @@ class AppLocalizationsMn extends AppLocalizations {
   String get autoCrop => 'Автомат тайрах';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Сунгах';
 
   @override

--- a/lib/l10n/app_localizations_mn.dart
+++ b/lib/l10n/app_localizations_mn.dart
@@ -3046,7 +3046,7 @@ class AppLocalizationsMn extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Сунгах';

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3039,6 +3039,13 @@ class AppLocalizationsNb extends AppLocalizations {
   String get autoCrop => 'Automatisk beskjæring';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Strekke';
 
   @override

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -3043,7 +3043,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Strekke';

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3054,6 +3054,13 @@ class AppLocalizationsNl extends AppLocalizations {
   String get autoCrop => 'Automatisch bijsnijden';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Strek';
 
   @override

--- a/lib/l10n/app_localizations_nl.dart
+++ b/lib/l10n/app_localizations_nl.dart
@@ -3058,7 +3058,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Strek';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3040,7 +3040,7 @@ class AppLocalizationsPa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'ਖਿੱਚੋ';

--- a/lib/l10n/app_localizations_pa.dart
+++ b/lib/l10n/app_localizations_pa.dart
@@ -3036,6 +3036,13 @@ class AppLocalizationsPa extends AppLocalizations {
   String get autoCrop => 'ਆਟੋ ਕ੍ਰੌਪ';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'ਖਿੱਚੋ';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3182,6 +3182,13 @@ class AppLocalizationsPl extends AppLocalizations {
   String get autoCrop => 'Automatyczne przycinanie';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Rozciągnij';
 
   @override

--- a/lib/l10n/app_localizations_pl.dart
+++ b/lib/l10n/app_localizations_pl.dart
@@ -3186,7 +3186,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Rozciągnij';

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3051,6 +3051,13 @@ class AppLocalizationsPt extends AppLocalizations {
   String get autoCrop => 'Corte Automático';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Esticar';
 
   @override

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -3055,7 +3055,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Esticar';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3062,7 +3062,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Întinde';

--- a/lib/l10n/app_localizations_ro.dart
+++ b/lib/l10n/app_localizations_ro.dart
@@ -3058,6 +3058,13 @@ class AppLocalizationsRo extends AppLocalizations {
   String get autoCrop => 'Decupare automată';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Întinde';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3064,6 +3064,13 @@ class AppLocalizationsRu extends AppLocalizations {
   String get autoCrop => 'Автоматическая обрезка';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Потягиваться';
 
   @override

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -3068,7 +3068,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Потягиваться';

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3038,6 +3038,13 @@ class AppLocalizationsSi extends AppLocalizations {
   String get autoCrop => 'ස්වයංක්‍රීය බෝග';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'දිගු කරන්න';
 
   @override

--- a/lib/l10n/app_localizations_si.dart
+++ b/lib/l10n/app_localizations_si.dart
@@ -3042,7 +3042,7 @@ class AppLocalizationsSi extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'දිගු කරන්න';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3066,7 +3066,7 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Natiahnuť';

--- a/lib/l10n/app_localizations_sk.dart
+++ b/lib/l10n/app_localizations_sk.dart
@@ -3062,6 +3062,13 @@ class AppLocalizationsSk extends AppLocalizations {
   String get autoCrop => 'Automatické orezanie';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Natiahnuť';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3064,6 +3064,13 @@ class AppLocalizationsSl extends AppLocalizations {
   String get autoCrop => 'Samodejno obrezovanje';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Raztegni';
 
   @override

--- a/lib/l10n/app_localizations_sl.dart
+++ b/lib/l10n/app_localizations_sl.dart
@@ -3068,7 +3068,7 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Raztegni';

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3058,6 +3058,13 @@ class AppLocalizationsSq extends AppLocalizations {
   String get autoCrop => 'Prirje automatike';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Shtrihu';
 
   @override

--- a/lib/l10n/app_localizations_sq.dart
+++ b/lib/l10n/app_localizations_sq.dart
@@ -3062,7 +3062,7 @@ class AppLocalizationsSq extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Shtrihu';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3164,7 +3164,7 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Развучи';

--- a/lib/l10n/app_localizations_sr.dart
+++ b/lib/l10n/app_localizations_sr.dart
@@ -3160,6 +3160,13 @@ class AppLocalizationsSr extends AppLocalizations {
   String get autoCrop => 'Ауто Цроп';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Развучи';
 
   @override

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3051,7 +3051,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Sträcka';

--- a/lib/l10n/app_localizations_sv.dart
+++ b/lib/l10n/app_localizations_sv.dart
@@ -3047,6 +3047,13 @@ class AppLocalizationsSv extends AppLocalizations {
   String get autoCrop => 'Autobeskärning';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Sträcka';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3057,6 +3057,13 @@ class AppLocalizationsSw extends AppLocalizations {
   String get autoCrop => 'Mazao ya Kiotomatiki';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Nyosha';
 
   @override

--- a/lib/l10n/app_localizations_sw.dart
+++ b/lib/l10n/app_localizations_sw.dart
@@ -3061,7 +3061,7 @@ class AppLocalizationsSw extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Nyosha';

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3057,6 +3057,13 @@ class AppLocalizationsTa extends AppLocalizations {
   String get autoCrop => 'தானியங்கு பயிர்';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'நீட்டவும்';
 
   @override

--- a/lib/l10n/app_localizations_ta.dart
+++ b/lib/l10n/app_localizations_ta.dart
@@ -3061,7 +3061,7 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'நீட்டவும்';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3057,7 +3057,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'సాగదీయండి';

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -3053,6 +3053,13 @@ class AppLocalizationsTe extends AppLocalizations {
   String get autoCrop => 'ఆటో క్రాప్';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'సాగదీయండి';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3023,6 +3023,13 @@ class AppLocalizationsTh extends AppLocalizations {
   String get autoCrop => 'ครอบตัดอัตโนมัติ';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'ยืด';
 
   @override

--- a/lib/l10n/app_localizations_th.dart
+++ b/lib/l10n/app_localizations_th.dart
@@ -3027,7 +3027,7 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'ยืด';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3063,7 +3063,7 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Mag-stretch';

--- a/lib/l10n/app_localizations_tl.dart
+++ b/lib/l10n/app_localizations_tl.dart
@@ -3059,6 +3059,13 @@ class AppLocalizationsTl extends AppLocalizations {
   String get autoCrop => 'Auto I-crop';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Mag-stretch';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3037,6 +3037,13 @@ class AppLocalizationsTr extends AppLocalizations {
   String get autoCrop => 'Otomatik Kırp';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Uzat';
 
   @override

--- a/lib/l10n/app_localizations_tr.dart
+++ b/lib/l10n/app_localizations_tr.dart
@@ -3041,7 +3041,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Uzat';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3048,7 +3048,7 @@ class AppLocalizationsUg extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'سوزۇش';

--- a/lib/l10n/app_localizations_ug.dart
+++ b/lib/l10n/app_localizations_ug.dart
@@ -3044,6 +3044,13 @@ class AppLocalizationsUg extends AppLocalizations {
   String get autoCrop => 'ئاپتوماتىك كېسىش';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'سوزۇش';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3062,6 +3062,13 @@ class AppLocalizationsUk extends AppLocalizations {
   String get autoCrop => 'Автоматичне обрізання';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Розтягнути';
 
   @override

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -3066,7 +3066,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Розтягнути';

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3045,6 +3045,13 @@ class AppLocalizationsVi extends AppLocalizations {
   String get autoCrop => 'Tự động cắt';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => 'Kéo dài';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -3049,7 +3049,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => 'Kéo dài';

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2980,6 +2980,13 @@ class AppLocalizationsYue extends AppLocalizations {
   String get autoCrop => '自動裁切';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => '拉緊';
 
   @override

--- a/lib/l10n/app_localizations_yue.dart
+++ b/lib/l10n/app_localizations_yue.dart
@@ -2984,7 +2984,7 @@ class AppLocalizationsYue extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => '拉緊';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2974,7 +2974,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsCropBlackBarsDescription =>
-      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+      'Detect encoded letterbox bars, crop them, then fill the screen.';
 
   @override
   String get stretch => '拉伸';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2970,6 +2970,13 @@ class AppLocalizationsZh extends AppLocalizations {
   String get autoCrop => '自动裁剪';
 
   @override
+  String get cropBlackBars => 'Crop black bars';
+
+  @override
+  String get settingsCropBlackBarsDescription =>
+      'Detect encoded letterbox, crop it, then fill the screen (mpv).';
+
+  @override
   String get stretch => '拉伸';
 
   @override

--- a/lib/playback/aether_backend.dart
+++ b/lib/playback/aether_backend.dart
@@ -15,6 +15,7 @@ import 'device_profile_builder.dart';
 import 'dolby_vision_av1.dart';
 import 'engine_trust.dart';
 import 'known_defects.dart';
+import 'letterbox_croppers.dart';
 import 'server_transcode_capabilities.dart';
 
 /// Playback backend driving the native AetherEngine wrapper over a method
@@ -581,6 +582,12 @@ class AetherBackend implements PlayerBackend {
 
   @override
   bool get supportsRuntimeTrackSelection => true;
+
+  @override
+  LetterboxCropper get letterboxCropper => const AetherLetterboxCropper();
+
+  @override
+  bool get supportsLetterboxCrop => letterboxCropper.isSupported;
 
   @override
   bool get supportsDirectPlayAudioSwitch => false;

--- a/lib/playback/appletv_backend.dart
+++ b/lib/playback/appletv_backend.dart
@@ -14,6 +14,7 @@ import 'device_profile_builder.dart';
 import 'dolby_vision_av1.dart';
 import 'engine_trust.dart';
 import 'known_defects.dart';
+import 'letterbox_croppers.dart';
 import 'server_transcode_capabilities.dart';
 
 class AppleTvBackend implements PlayerBackend {
@@ -801,6 +802,12 @@ class AppleTvBackend implements PlayerBackend {
 
   @override
   bool get supportsRuntimeTrackSelection => true;
+
+  @override
+  LetterboxCropper get letterboxCropper => const AppleTvLetterboxCropper();
+
+  @override
+  bool get supportsLetterboxCrop => letterboxCropper.isSupported;
 
   @override
   bool get supportsDirectPlayAudioSwitch => false;

--- a/lib/playback/html_video_backend_stub.dart
+++ b/lib/playback/html_video_backend_stub.dart
@@ -5,6 +5,7 @@ import 'package:playback_core/playback_core.dart';
 
 import '../preference/user_preferences.dart';
 import 'html_video_backend_profile.dart';
+import 'letterbox_croppers.dart';
 
 class HtmlVideoBackend extends PlayerBackend {
   HtmlVideoBackend(this._prefs);
@@ -136,6 +137,9 @@ class HtmlVideoBackend extends PlayerBackend {
 
   @override
   bool get supportsRuntimeTrackSelection => false;
+
+  @override
+  LetterboxCropper get letterboxCropper => const HtmlLetterboxCropper();
 
   @override
   bool get requiresStartupMediaReadyCheck => false;

--- a/lib/playback/html_video_backend_web.dart
+++ b/lib/playback/html_video_backend_web.dart
@@ -9,6 +9,7 @@ import 'package:web/web.dart' as web;
 
 import '../preference/user_preferences.dart';
 import 'html_video_backend_profile.dart';
+import 'letterbox_croppers.dart';
 import 'web_subtitle_overlay_web.dart';
 
 extension type _MoonfinHlsBridge._(JSObject _) implements JSObject {
@@ -791,6 +792,9 @@ class HtmlVideoBackend extends PlayerBackend {
 
   @override
   bool get supportsRuntimeTrackSelection => false;
+
+  @override
+  LetterboxCropper get letterboxCropper => const HtmlLetterboxCropper();
 
   @override
   bool get requiresStartupMediaReadyCheck => false;

--- a/lib/playback/letterbox_croppers.dart
+++ b/lib/playback/letterbox_croppers.dart
@@ -2,14 +2,14 @@ import 'package:playback_core/playback_core.dart';
 
 import '../util/platform_detection.dart';
 
-/// True where a cropper actually runs: Linux/Windows libmpv, Android TV
-/// Media3 (and libmpv if that engine is selected).
+/// True where a cropper actually runs: Linux/Windows libmpv, Android Media3
+/// (and libmpv if that engine is selected).
 ///
-/// Hidden on Android phone, iOS, macOS, web, and tvOS.
+/// Hidden on iOS, macOS, web, and tvOS.
 bool letterboxCropAvailable() =>
     PlatformDetection.isLinux ||
     PlatformDetection.isWindows ||
-    (PlatformDetection.isAndroid && PlatformDetection.isTV);
+    PlatformDetection.isAndroid;
 
 /// Settings / search-index gate. Same as [letterboxCropAvailable].
 bool letterboxCropSettingVisible() => letterboxCropAvailable();

--- a/lib/playback/letterbox_croppers.dart
+++ b/lib/playback/letterbox_croppers.dart
@@ -1,0 +1,44 @@
+import 'package:playback_core/playback_core.dart';
+
+import '../util/platform_detection.dart';
+
+/// True where a cropper actually runs: Linux/Windows libmpv, Android TV
+/// Media3 (and libmpv if that engine is selected).
+///
+/// Hidden on Android phone, iOS, macOS, web, and tvOS.
+bool letterboxCropAvailable() =>
+    PlatformDetection.isLinux ||
+    PlatformDetection.isWindows ||
+    (PlatformDetection.isAndroid && PlatformDetection.isTV);
+
+/// Settings / search-index gate. Same as [letterboxCropAvailable].
+bool letterboxCropSettingVisible() => letterboxCropAvailable();
+
+/// iOS/macOS Aether. Sample via AVPlayerItemVideoOutput, crop with
+/// AVVideoComposition. HDR / Dolby Vision make a composition path painful.
+class AetherLetterboxCropper extends UnsupportedLetterboxCropper {
+  const AetherLetterboxCropper()
+    : super(
+        unimplementedReason:
+            'Aether: needs frame sampling + AVVideoComposition crop; '
+            'HDR/Dolby Vision blocks a cheap composition path.',
+      );
+}
+
+/// tvOS Aether. Same as [AetherLetterboxCropper].
+class AppleTvLetterboxCropper extends UnsupportedLetterboxCropper {
+  const AppleTvLetterboxCropper()
+    : super(
+        unimplementedReason:
+            'tvOS Aether: needs frame sampling + AVVideoComposition crop.',
+      );
+}
+
+/// Web HTML video / HLS. CSS object-fit cover is not cropdetect.
+class HtmlLetterboxCropper extends UnsupportedLetterboxCropper {
+  const HtmlLetterboxCropper()
+    : super(
+        unimplementedReason:
+            'HTML video: object-fit cover is not encoded-bar crop.',
+      );
+}

--- a/lib/playback/media3_letterbox_crop.dart
+++ b/lib/playback/media3_letterbox_crop.dart
@@ -11,6 +11,56 @@ class Media3LetterboxCrop {
   static const minRatio = LetterboxCrop.minRatio;
   static const autoDelay = Duration(seconds: 4);
 
+  /// One PixelCopy is one frame, so a fade or a dark scene at that moment would
+  /// crop real picture for the rest of the title. mpv's cropdetect avoids that
+  /// by accumulating, and taking the widest of a few frames is the same idea.
+  static const sampleCount = 3;
+  static const sampleGap = Duration(milliseconds: 700);
+
+  /// A PixelCopy that never answers would otherwise hold the detect open for
+  /// as long as the player lives.
+  static const detectTimeout = Duration(seconds: 2);
+
+  /// The widest rectangle across [samples], so the darkest frame cant decide
+  /// the crop on its own. Null when nothing usable came back.
+  static Map<String, int>? widest(List<Map<String, int>> samples) {
+    int? left;
+    int? top;
+    int? right;
+    int? bottom;
+    int? sourceWidth;
+    int? sourceHeight;
+    for (final sample in samples) {
+      final x = sample['x'];
+      final y = sample['y'];
+      final w = sample['w'];
+      final h = sample['h'];
+      if (x == null || y == null || w == null || h == null) continue;
+      left = (left == null || x < left) ? x : left;
+      top = (top == null || y < top) ? y : top;
+      right = (right == null || x + w > right) ? x + w : right;
+      bottom = (bottom == null || y + h > bottom) ? y + h : bottom;
+      sourceWidth ??= sample['sourceWidth'];
+      sourceHeight ??= sample['sourceHeight'];
+    }
+    if (left == null ||
+        top == null ||
+        right == null ||
+        bottom == null ||
+        sourceWidth == null ||
+        sourceHeight == null) {
+      return null;
+    }
+    return <String, int>{
+      'w': right - left,
+      'h': bottom - top,
+      'x': left,
+      'y': top,
+      'sourceWidth': sourceWidth,
+      'sourceHeight': sourceHeight,
+    };
+  }
+
   static LetterboxCropRect? decide(Map<String, int> detected) {
     final w = detected['w'];
     final h = detected['h'];
@@ -55,6 +105,8 @@ class Media3LetterboxCropper extends LetterboxCropper {
     this._host, {
     required bool supported,
     this.autoDelay = Media3LetterboxCrop.autoDelay,
+    this.sampleCount = Media3LetterboxCrop.sampleCount,
+    this.sampleGap = Media3LetterboxCrop.sampleGap,
   }) : _supported = supported;
 
   final Media3LetterboxHost _host;
@@ -62,6 +114,12 @@ class Media3LetterboxCropper extends LetterboxCropper {
 
   @visibleForTesting
   final Duration autoDelay;
+
+  @visibleForTesting
+  final int sampleCount;
+
+  @visibleForTesting
+  final Duration sampleGap;
 
   int _generation = 0;
   bool _enabled = false;
@@ -141,24 +199,27 @@ class Media3LetterboxCropper extends LetterboxCropper {
       final remaining = _host.duration - _host.position;
       if (_host.duration > Duration.zero &&
           remaining < autoDelay + const Duration(seconds: 1)) {
-        debugPrint('[letterbox_crop] media3 skip: not enough time left');
         return;
       }
       if (!_isCurrent(generation)) return;
 
-      final detected = await _host.detectLetterbox();
-      if (!_isCurrent(generation) || detected == null) {
-        debugPrint('[letterbox_crop] media3 detect missed');
-        return;
+      final samples = <Map<String, int>>[];
+      for (var i = 0; i < sampleCount; i++) {
+        if (i > 0 && !await _delay(generation, sampleGap)) return;
+        final sample = await _host.detectLetterbox().timeout(
+          Media3LetterboxCrop.detectTimeout,
+          onTimeout: () => null,
+        );
+        if (!_isCurrent(generation)) return;
+        if (sample != null) samples.add(sample);
       }
-      final rect = Media3LetterboxCrop.decide(detected);
-      debugPrint(
-        '[letterbox_crop] media3 detect=$detected -> ${rect?.videoCrop}',
-      );
+
+      final merged = Media3LetterboxCrop.widest(samples);
+      if (merged == null) return;
+      final rect = Media3LetterboxCrop.decide(merged);
       if (rect == null || !_isCurrent(generation)) return;
 
       await _host.setLetterboxCrop(rect);
-      debugPrint('[letterbox_crop] media3 applied ${rect.videoCrop}');
       _doneUrl = _host.currentUrl;
     } finally {
       if (generation == _generation) {

--- a/lib/playback/media3_letterbox_crop.dart
+++ b/lib/playback/media3_letterbox_crop.dart
@@ -1,0 +1,196 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:playback_core/playback_core.dart';
+
+/// Android TV Media3 letterbox crop. Sample via PixelCopy, apply as layout
+/// zoom into the crop rectangle (SurfaceView / tunneling cannot use Effects).
+class Media3LetterboxCrop {
+  static const lumaLimit = 24;
+  static const round = 2;
+  static const minRatio = LetterboxCrop.minRatio;
+  static const autoDelay = Duration(seconds: 4);
+
+  static LetterboxCropRect? decide(Map<String, int> detected) {
+    final w = detected['w'];
+    final h = detected['h'];
+    final x = detected['x'];
+    final y = detected['y'];
+    final sourceWidth = detected['sourceWidth'];
+    final sourceHeight = detected['sourceHeight'];
+    if (w == null ||
+        h == null ||
+        x == null ||
+        y == null ||
+        sourceWidth == null ||
+        sourceHeight == null) {
+      return null;
+    }
+    return LetterboxCrop.decide(
+      width: w,
+      height: h,
+      x: x,
+      y: y,
+      sourceWidth: sourceWidth,
+      sourceHeight: sourceHeight,
+      minRatio: minRatio,
+    );
+  }
+}
+
+/// Native detect/apply surface the Android TV cropper needs.
+abstract class Media3LetterboxHost {
+  Future<Map<String, int>?> detectLetterbox();
+  Future<void> setLetterboxCrop(LetterboxCropRect? rect);
+  bool get isPlaying;
+  Duration get position;
+  Duration get duration;
+  Stream<bool> get playingStream;
+  String? get currentUrl;
+  bool get isDisposed;
+}
+
+class Media3LetterboxCropper extends LetterboxCropper {
+  Media3LetterboxCropper(
+    this._host, {
+    required bool supported,
+    this.autoDelay = Media3LetterboxCrop.autoDelay,
+  }) : _supported = supported;
+
+  final Media3LetterboxHost _host;
+  final bool _supported;
+
+  @visibleForTesting
+  final Duration autoDelay;
+
+  int _generation = 0;
+  bool _enabled = false;
+  String? _doneUrl;
+  bool _inFlight = false;
+
+  @override
+  bool get isSupported => _supported;
+
+  @override
+  String? get unimplementedReason =>
+      _supported ? null : 'Letterbox crop on Media3 ships on Android TV only.';
+
+  @override
+  Future<void> setEnabled(bool enabled) async {
+    final changed = enabled != _enabled;
+    _enabled = enabled;
+    if (!isSupported || !changed) return;
+    final url = _host.currentUrl;
+    if (url == null || url.isEmpty) return;
+    await _sync();
+  }
+
+  @override
+  Future<void> onSourceOpened(String url) async {
+    if (_doneUrl != url) _doneUrl = null;
+    if (!isSupported) return;
+    await _sync();
+  }
+
+  Future<void> _sync() async {
+    if (!_enabled) {
+      _generation++;
+      await reset();
+      _doneUrl = null;
+      return;
+    }
+    final url = _host.currentUrl;
+    if (url == null || url.isEmpty) return;
+    if (_doneUrl == url) return;
+    if (_inFlight) return;
+
+    _inFlight = true;
+    final generation = ++_generation;
+    await reset();
+    if (!_isCurrent(generation)) {
+      if (generation == _generation) _inFlight = false;
+      return;
+    }
+    unawaited(_run(generation));
+  }
+
+  @override
+  Future<void> reset() async {
+    if (!isSupported) return;
+    await _host.setLetterboxCrop(null);
+  }
+
+  /// Stale in-flight detect without touching the view during teardown.
+  void cancel() {
+    _generation++;
+    _inFlight = false;
+  }
+
+  Future<void> _run(int generation) async {
+    try {
+      if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+      if (_host.position < autoDelay) {
+        if (!await _delay(generation, autoDelay)) {
+          return;
+        }
+      }
+      if (_host.isPlaying != true) {
+        if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+      }
+
+      final remaining = _host.duration - _host.position;
+      if (_host.duration > Duration.zero &&
+          remaining < autoDelay + const Duration(seconds: 1)) {
+        debugPrint('[letterbox_crop] media3 skip: not enough time left');
+        return;
+      }
+      if (!_isCurrent(generation)) return;
+
+      final detected = await _host.detectLetterbox();
+      if (!_isCurrent(generation) || detected == null) {
+        debugPrint('[letterbox_crop] media3 detect missed');
+        return;
+      }
+      final rect = Media3LetterboxCrop.decide(detected);
+      debugPrint(
+        '[letterbox_crop] media3 detect=$detected -> ${rect?.videoCrop}',
+      );
+      if (rect == null || !_isCurrent(generation)) return;
+
+      await _host.setLetterboxCrop(rect);
+      debugPrint('[letterbox_crop] media3 applied ${rect.videoCrop}');
+      _doneUrl = _host.currentUrl;
+    } finally {
+      if (generation == _generation) {
+        _inFlight = false;
+      }
+    }
+  }
+
+  bool _isCurrent(int generation) {
+    return !_host.isDisposed && generation == _generation;
+  }
+
+  Future<bool> _delay(int generation, Duration duration) async {
+    if (duration <= Duration.zero) return _isCurrent(generation);
+    await Future<void>.delayed(duration);
+    return _isCurrent(generation);
+  }
+
+  Future<bool> _waitWhileCurrent(
+    int generation, {
+    required bool untilPlaying,
+  }) async {
+    if (_host.isPlaying == untilPlaying) {
+      return _isCurrent(generation);
+    }
+    try {
+      await _host.playingStream
+          .firstWhere((playing) => playing == untilPlaying)
+          .timeout(const Duration(seconds: 30));
+    } catch (_) {
+      return false;
+    }
+    return _isCurrent(generation);
+  }
+}

--- a/lib/playback/media3_letterbox_crop.dart
+++ b/lib/playback/media3_letterbox_crop.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:playback_core/playback_core.dart';
 
-/// Android TV Media3 letterbox crop. Sample via PixelCopy, apply as layout
+/// Android Media3 letterbox crop. Sample via PixelCopy, apply as layout
 /// zoom into the crop rectangle (SurfaceView / tunneling cannot use Effects).
 class Media3LetterboxCrop {
   static const lumaLimit = 24;
@@ -73,7 +73,7 @@ class Media3LetterboxCropper extends LetterboxCropper {
 
   @override
   String? get unimplementedReason =>
-      _supported ? null : 'Letterbox crop on Media3 ships on Android TV only.';
+      _supported ? null : 'Letterbox crop on Media3 ships on Android only.';
 
   @override
   Future<void> setEnabled(bool enabled) async {

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -12,6 +12,7 @@ import '../util/platform_detection.dart';
 
 import 'device_profile_builder.dart';
 import 'known_defects.dart';
+import 'media3_letterbox_crop.dart';
 import 'server_transcode_capabilities.dart';
 
 class Media3PlayerBackend extends PlayerBackend {
@@ -20,6 +21,11 @@ class Media3PlayerBackend extends PlayerBackend {
   static const _audioSinkErrorThreshold = 2;
 
   Media3PlayerBackend(this._prefs) {
+    _letterboxCropper = Media3LetterboxCropper(
+      _Media3LetterboxHost(this),
+      supported: PlatformDetection.isAndroid && PlatformDetection.isTV,
+    );
+    _prefs.addListener(_onPreferencesChanged);
     _eventSub = _events.receiveBroadcastStream().listen(
       _handleEvent,
       onError: (_) {},
@@ -85,6 +91,8 @@ class Media3PlayerBackend extends PlayerBackend {
   }
 
   final UserPreferences _prefs;
+  late final Media3LetterboxCropper _letterboxCropper;
+  String? _currentUrl;
 
   StreamSubscription<dynamic>? _eventSub;
 
@@ -923,6 +931,7 @@ class Media3PlayerBackend extends PlayerBackend {
         : payload['url']?.toString() ?? '';
     if (_disposed || url.isEmpty) return;
 
+    _currentUrl = url;
     final mediaType = payload['mediaType']?.toString() ?? 'video';
     final container = payload['container']?.toString();
     final videoRangeType = payload['videoRangeType']?.toString();
@@ -1049,6 +1058,16 @@ class Media3PlayerBackend extends PlayerBackend {
     if (autoPlay) {
       await _invoke<void>('play');
     }
+    if (isPreview || mediaType == 'audio') {
+      unawaited(_letterboxCropper.reset());
+    } else {
+      unawaited(() async {
+        await _letterboxCropper.setEnabled(
+          _prefs.get(UserPreferences.cropBlackBars),
+        );
+        await _letterboxCropper.onSourceOpened(url);
+      }());
+    }
   }
 
   @override
@@ -1156,7 +1175,8 @@ class Media3PlayerBackend extends PlayerBackend {
       // codec has a software decoder behind it.
       universalAudioDecode: true,
       maxResolution: maxResolution,
-      pgsDirectPlay: _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
+      pgsDirectPlay:
+          _prefs.get(UserPreferences.pgsDirectPlay) && canRenderBitmapSubtitles,
       assDirectPlay: _prefs.get(UserPreferences.assDirectPlay),
       supportsAvc: PlatformDetection.supportsAvc,
       supportsAvcHigh10: PlatformDetection.supportsAvcHigh10,
@@ -1257,7 +1277,6 @@ class Media3PlayerBackend extends PlayerBackend {
     await _invoke<void>('setAudioTrack', {'index': index});
   }
 
-
   @override
   Future<void> setSubtitleTrack(
     int index, {
@@ -1276,7 +1295,8 @@ class Media3PlayerBackend extends PlayerBackend {
   }
 
   @override
-  List<EmbeddedCaptionTrack> get embeddedCaptionTracks => _embeddedCaptionTracks;
+  List<EmbeddedCaptionTrack> get embeddedCaptionTracks =>
+      _embeddedCaptionTracks;
 
   @override
   Stream<void> get tracksChangedStream => _tracksChangedController.stream;
@@ -1334,10 +1354,12 @@ class Media3PlayerBackend extends PlayerBackend {
     _audioDelayDebounce = Timer(const Duration(milliseconds: 350), () {
       _audioDelayDebounce = null;
       if (_disposed) return;
-      unawaited(_invoke<void>('setAudioDelay', {
-        'seconds': _audioDelaySeconds,
-        'delayMs': (_audioDelaySeconds * 1000).round(),
-      }));
+      unawaited(
+        _invoke<void>('setAudioDelay', {
+          'seconds': _audioDelaySeconds,
+          'delayMs': (_audioDelaySeconds * 1000).round(),
+        }),
+      );
     });
   }
 
@@ -1424,6 +1446,9 @@ class Media3PlayerBackend extends PlayerBackend {
   bool get supportsRuntimeTrackSelection => true;
 
   @override
+  LetterboxCropper get letterboxCropper => _letterboxCropper;
+
+  @override
   bool get supportsDirectPlayAudioSwitch => true;
 
   @override
@@ -1440,10 +1465,19 @@ class Media3PlayerBackend extends PlayerBackend {
   @override
   bool get canRenderBitmapSubtitles => true;
 
+  void _onPreferencesChanged() {
+    if (_disposed) return;
+    unawaited(
+      _letterboxCropper.setEnabled(_prefs.get(UserPreferences.cropBlackBars)),
+    );
+  }
+
   @override
   void dispose() {
     if (_disposed) return;
     _disposed = true;
+    _letterboxCropper.cancel();
+    _prefs.removeListener(_onPreferencesChanged);
     _audioDelayDebounce?.cancel();
     _audioDelayDebounce = null;
     _watchdogTimer?.cancel();
@@ -1460,6 +1494,79 @@ class Media3PlayerBackend extends PlayerBackend {
     _pictureShownStream.close();
     _tracksChangedController.close();
   }
+}
+
+class _Media3LetterboxHost implements Media3LetterboxHost {
+  _Media3LetterboxHost(this._backend);
+
+  final Media3PlayerBackend _backend;
+
+  @override
+  Future<Map<String, int>?> detectLetterbox() async {
+    final raw = await _backend._invoke<dynamic>('detectLetterbox');
+    if (raw is! Map) return null;
+    int? n(String key) {
+      final value = raw[key];
+      if (value is int) return value;
+      if (value is num) return value.round();
+      return int.tryParse(value?.toString() ?? '');
+    }
+
+    final w = n('w');
+    final h = n('h');
+    final x = n('x');
+    final y = n('y');
+    final sourceWidth = n('sourceWidth');
+    final sourceHeight = n('sourceHeight');
+    if (w == null ||
+        h == null ||
+        x == null ||
+        y == null ||
+        sourceWidth == null ||
+        sourceHeight == null) {
+      return null;
+    }
+    return <String, int>{
+      'w': w,
+      'h': h,
+      'x': x,
+      'y': y,
+      'sourceWidth': sourceWidth,
+      'sourceHeight': sourceHeight,
+    };
+  }
+
+  @override
+  Future<void> setLetterboxCrop(LetterboxCropRect? rect) async {
+    if (rect == null) {
+      await _backend._invoke<void>('setLetterboxCrop', {'clear': true});
+      return;
+    }
+    await _backend._invoke<void>('setLetterboxCrop', {
+      'w': rect.w,
+      'h': rect.h,
+      'x': rect.x,
+      'y': rect.y,
+    });
+  }
+
+  @override
+  bool get isPlaying => _backend._isPlaying;
+
+  @override
+  Duration get position => _backend._position;
+
+  @override
+  Duration get duration => _backend._duration;
+
+  @override
+  Stream<bool> get playingStream => _backend._playingStream.stream;
+
+  @override
+  String? get currentUrl => _backend._currentUrl;
+
+  @override
+  bool get isDisposed => _backend._disposed;
 }
 
 /// What the native side does with a Dolby Vision profile 7 stream. Names

--- a/lib/playback/media3_player_backend.dart
+++ b/lib/playback/media3_player_backend.dart
@@ -23,7 +23,7 @@ class Media3PlayerBackend extends PlayerBackend {
   Media3PlayerBackend(this._prefs) {
     _letterboxCropper = Media3LetterboxCropper(
       _Media3LetterboxHost(this),
-      supported: PlatformDetection.isAndroid && PlatformDetection.isTV,
+      supported: PlatformDetection.isAndroid,
     );
     _prefs.addListener(_onPreferencesChanged);
     _eventSub = _events.receiveBroadcastStream().listen(

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -16,6 +16,7 @@ import '../util/platform_detection.dart';
 import 'device_profile_builder.dart';
 import 'hdr_output_controller.dart';
 import 'known_defects.dart';
+import 'letterbox_croppers.dart';
 import 'mpv_letterbox_crop.dart';
 import 'server_transcode_capabilities.dart';
 
@@ -192,11 +193,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
   bool _audioPassthroughApplyInProgress = false;
   bool _audioPassthroughApplyQueued = false;
   bool _isDisposed = false;
-  int _letterboxCropGeneration = 0;
-  String? _letterboxHwdecBackup;
-  bool? _lastLetterboxCropEnabled;
-  String? _letterboxCropDoneUrl;
-  bool _letterboxCropInFlight = false;
+  late final MpvLetterboxCropper _letterboxCropper;
   String? _appliedCustomMpvConfPath;
   DateTime? _appliedCustomMpvConfMtime;
   static final Map<String, _ParsedMpvConfCacheEntry> _parsedMpvConfCache =
@@ -425,6 +422,10 @@ class MediaKitPlayerBackend extends PlayerBackend {
     this._onNativeHandleReady,
     this._hwDecodingEnabled,
   ) {
+    _letterboxCropper = MpvLetterboxCropper(
+      _MediaKitLetterboxHost(this),
+      supported: letterboxCropAvailable(),
+    );
     _prefs.addListener(_onPreferencesChanged);
     _ccTracksSub = _player.stream.tracks.listen(
       (_) => unawaited(_refreshEmbeddedCaptionTracks()),
@@ -550,6 +551,9 @@ class MediaKitPlayerBackend extends PlayerBackend {
   bool get supportsRuntimeTrackSelection => true;
 
   @override
+  LetterboxCropper get letterboxCropper => _letterboxCropper;
+
+  @override
   bool get requiresStartupMediaReadyCheck => true;
 
   @override
@@ -653,9 +657,6 @@ class MediaKitPlayerBackend extends PlayerBackend {
         : payload['url']?.toString() ?? '';
     if (url.isEmpty) return;
 
-    if (url != _currentUrl) {
-      _letterboxCropDoneUrl = null;
-    }
     _currentUrl = url;
     _isStale = true;
     _embeddedCaptionTracks = const [];
@@ -690,7 +691,12 @@ class MediaKitPlayerBackend extends PlayerBackend {
       _enableNativeSubtitleRendering();
     }
     await _maybeEngageNativeHdr();
-    unawaited(_startLetterboxCropIfEnabled());
+    unawaited(() async {
+      await _letterboxCropper.setEnabled(
+        _prefs.get(UserPreferences.cropBlackBars),
+      );
+      await _letterboxCropper.onSourceOpened(url);
+    }());
   }
 
   /// Gives mpv its own D3D11 window when the content is HDR and the display is
@@ -1355,7 +1361,9 @@ class MediaKitPlayerBackend extends PlayerBackend {
       return;
     }
 
-    _syncLetterboxCropWithPref();
+    unawaited(
+      _letterboxCropper.setEnabled(_prefs.get(UserPreferences.cropBlackBars)),
+    );
 
     if (_audioPassthroughApplyInProgress) {
       _audioPassthroughApplyQueued = true;
@@ -2416,246 +2424,67 @@ class MediaKitPlayerBackend extends PlayerBackend {
     return controller.stream;
   }
 
-  void _syncLetterboxCropWithPref() {
-    final enabled = _prefs.get(UserPreferences.cropBlackBars);
-    if (enabled == _lastLetterboxCropEnabled) return;
-    if (_currentUrl == null || _currentUrl!.isEmpty) {
-      _lastLetterboxCropEnabled = enabled;
-      return;
-    }
-    unawaited(_startLetterboxCropIfEnabled());
-  }
-
-  Future<void> _startLetterboxCropIfEnabled() async {
-    final enabled = _prefs.get(UserPreferences.cropBlackBars);
-    _lastLetterboxCropEnabled = enabled;
-    if (enabled != true) {
-      ++_letterboxCropGeneration;
-      await _cleanupLetterboxCrop(restoreHwdec: true);
-      _letterboxCropDoneUrl = null;
-      return;
-    }
-    if (_player.platform is! NativePlayer) return;
-    if (_currentUrl != null && _letterboxCropDoneUrl == _currentUrl) return;
-    if (_letterboxCropInFlight) return;
-
-    final generation = ++_letterboxCropGeneration;
-    await _cleanupLetterboxCrop(restoreHwdec: true);
-    if (!_isCurrentLetterbox(generation)) return;
-    _letterboxCropInFlight = true;
-    unawaited(_runLetterboxCrop(generation));
-  }
-
-  Future<void> _runLetterboxCrop(int generation) async {
-    final native = _player.platform;
-    if (native is! NativePlayer) {
-      if (generation == _letterboxCropGeneration) {
-        _letterboxCropInFlight = false;
-      }
-      return;
-    }
-
-    LetterboxCropRect? rect;
-    try {
-      try {
-        if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
-        if (_player.state.position < MpvLetterboxCrop.autoDelay) {
-          if (!await _delayLetterbox(generation, MpvLetterboxCrop.autoDelay)) {
-            return;
-          }
-        }
-        if (_player.state.playing != true) {
-          if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
-        }
-
-        final remaining = _player.state.duration - _player.state.position;
-        if (_player.state.duration > Duration.zero &&
-            remaining <
-                MpvLetterboxCrop.detectDuration + const Duration(seconds: 1)) {
-          debugPrint('[letterbox_crop] skip: not enough time left');
-          return;
-        }
-        if (!_isCurrentLetterbox(generation)) return;
-
-        final hwdecCurrent = await _tryNativeGetProperty(
-          native,
-          'hwdec-current',
-        );
-        final detectHwdec = MpvLetterboxCrop.hwdecForCropdetect(hwdecCurrent);
-        if (detectHwdec != null) {
-          _letterboxHwdecBackup = await _tryNativeGetProperty(native, 'hwdec');
-          debugPrint(
-            '[letterbox_crop] hwdec $hwdecCurrent -> $detectHwdec '
-            '(was $_letterboxHwdecBackup)',
-          );
-          await _nativeSetProperty(native, 'hwdec', detectHwdec);
-          if (!await _delayLetterbox(
-            generation,
-            const Duration(milliseconds: 400),
-          )) {
-            return;
-          }
-        }
-
-        final inserted = await _tryNativeCommand(native, [
-          'vf',
-          'pre',
-          MpvLetterboxCrop.filterSpec,
-        ]);
-        debugPrint(
-          '[letterbox_crop] vf insert=$inserted spec=${MpvLetterboxCrop.filterSpec}',
-        );
-        if (!inserted || !_isCurrentLetterbox(generation)) return;
-
-        if (!await _delayLetterbox(
-          generation,
-          MpvLetterboxCrop.detectDuration,
-        )) {
-          return;
-        }
-
-        final lavfi = <String, String>{};
-        for (final key in const ['w', 'h', 'x', 'y']) {
-          final value = await _tryNativeGetProperty(
-            native,
-            MpvLetterboxCrop.metadataProperty(key),
-          );
-          if (value != null) lavfi[key] = value;
-        }
-        if (lavfi.length < 4) {
-          final blob = await _tryNativeGetProperty(
-            native,
-            'vf-metadata/${MpvLetterboxCrop.filterLabel}',
-          );
-          debugPrint('[letterbox_crop] vf-metadata blob=$blob');
-          lavfi.addAll(MpvLetterboxCrop.parseVfMetadata(blob));
-        }
-
-        final width =
-            int.tryParse(await _tryNativeGetProperty(native, 'width') ?? '') ??
-            0;
-        final height =
-            int.tryParse(await _tryNativeGetProperty(native, 'height') ?? '') ??
-            0;
-        rect = MpvLetterboxCrop.decide(
-          lavfi: lavfi,
-          sourceWidth: width,
-          sourceHeight: height,
-        );
-        debugPrint(
-          '[letterbox_crop] lavfi=$lavfi ${width}x$height -> ${rect?.videoCrop}',
-        );
-      } finally {
-        await _removeLetterboxFilter(native);
-        if (rect == null) {
-          await _restoreLetterboxHwdec(native);
-        }
-      }
-
-      if (rect == null || !_isCurrentLetterbox(generation)) return;
-      if (!await _delayLetterbox(
-        generation,
-        const Duration(milliseconds: 200),
-      )) {
-        await _restoreLetterboxHwdec(native);
-        return;
-      }
-      await _applyVideoCrop(native, rect);
-      final hwdecNow = await _tryNativeGetProperty(native, 'hwdec-current');
-      debugPrint('[letterbox_crop] applied ${rect.videoCrop} hwdec=$hwdecNow');
-      _letterboxCropDoneUrl = _currentUrl;
-    } finally {
-      if (generation == _letterboxCropGeneration) {
-        _letterboxCropInFlight = false;
-      }
-    }
-  }
-
-  bool _isCurrentLetterbox(int generation) {
-    return !_isDisposed && generation == _letterboxCropGeneration;
-  }
-
-  Future<bool> _delayLetterbox(int generation, Duration duration) async {
-    await Future<void>.delayed(duration);
-    return _isCurrentLetterbox(generation);
-  }
-
-  Future<bool> _waitWhileCurrent(
-    int generation, {
-    required bool untilPlaying,
-  }) async {
-    if (_player.state.playing == untilPlaying) {
-      return _isCurrentLetterbox(generation);
-    }
-    try {
-      await _player.stream.playing
-          .firstWhere((playing) => playing == untilPlaying)
-          .timeout(const Duration(seconds: 30));
-    } catch (_) {
-      return false;
-    }
-    return _isCurrentLetterbox(generation);
-  }
-
-  Future<void> _cleanupLetterboxCrop({required bool restoreHwdec}) async {
-    final native = _player.platform;
-    if (native is! NativePlayer) return;
-    await _removeLetterboxFilter(native);
-    await _clearVideoCrop(native);
-    if (restoreHwdec) {
-      await _restoreLetterboxHwdec(native);
-    }
-  }
-
-  Future<void> _applyVideoCrop(
-    NativePlayer native,
-    LetterboxCropRect rect,
-  ) async {
-    await _tryNativeCommand(native, [
-      'vf',
-      'add',
-      MpvLetterboxCrop.appliedFilterSpec(rect),
-    ]);
-    debugPrint('[letterbox_crop] vf crop ${rect.videoCrop}');
-  }
-
-  Future<void> _clearVideoCrop(NativePlayer native) async {
-    await _tryNativeCommand(native, [
-      'vf',
-      'remove',
-      '@${MpvLetterboxCrop.appliedFilterLabel}',
-    ]);
-    await _tryNativeCommand(native, ['set', 'video-crop', '']);
-    await _tryNativeCommand(native, [
-      'set',
-      'file-local-options/video-crop',
-      '',
-    ]);
-  }
-
-  Future<void> _removeLetterboxFilter(NativePlayer native) async {
-    await _tryNativeCommand(native, [
-      'vf',
-      'remove',
-      '@${MpvLetterboxCrop.filterLabel}',
-    ]);
-  }
-
-  Future<void> _restoreLetterboxHwdec(NativePlayer native) async {
-    final backup = _letterboxHwdecBackup;
-    _letterboxHwdecBackup = null;
-    if (backup == null || backup.isEmpty) return;
-    await _nativeSetProperty(native, 'hwdec', backup);
-  }
-
   @override
   void dispose() {
     _isDisposed = true;
-    _letterboxCropGeneration++;
+    _letterboxCropper.cancel();
     _prefs.removeListener(_onPreferencesChanged);
     _ccTracksSub?.cancel();
     _videoParamsSub?.cancel();
     _tracksChangedController.close();
     _player.dispose();
   }
+}
+
+class _MediaKitLetterboxHost implements MpvLetterboxHost {
+  _MediaKitLetterboxHost(this._backend);
+
+  final MediaKitPlayerBackend _backend;
+
+  NativePlayer? get _native {
+    final platform = _backend._player.platform;
+    return platform is NativePlayer ? platform : null;
+  }
+
+  @override
+  bool get hasNativePlayer => _native != null;
+
+  @override
+  Future<String?> getProperty(String key) async {
+    final native = _native;
+    if (native == null) return null;
+    return _backend._tryNativeGetProperty(native, key);
+  }
+
+  @override
+  Future<void> setProperty(String key, String value) async {
+    final native = _native;
+    if (native == null) return;
+    await MediaKitPlayerBackend._nativeSetProperty(native, key, value);
+  }
+
+  @override
+  Future<bool> command(List<String> args) async {
+    final native = _native;
+    if (native == null) return false;
+    return MediaKitPlayerBackend._tryNativeCommand(native, args);
+  }
+
+  @override
+  bool get isPlaying => _backend._player.state.playing;
+
+  @override
+  Duration get position => _backend._player.state.position;
+
+  @override
+  Duration get duration => _backend._player.state.duration;
+
+  @override
+  Stream<bool> get playingStream => _backend._player.stream.playing;
+
+  @override
+  String? get currentUrl => _backend._currentUrl;
+
+  @override
+  bool get isDisposed => _backend._isDisposed;
 }

--- a/lib/playback/media_kit_player_backend.dart
+++ b/lib/playback/media_kit_player_backend.dart
@@ -16,6 +16,7 @@ import '../util/platform_detection.dart';
 import 'device_profile_builder.dart';
 import 'hdr_output_controller.dart';
 import 'known_defects.dart';
+import 'mpv_letterbox_crop.dart';
 import 'server_transcode_capabilities.dart';
 
 class _ParsedMpvConfCacheEntry {
@@ -191,6 +192,11 @@ class MediaKitPlayerBackend extends PlayerBackend {
   bool _audioPassthroughApplyInProgress = false;
   bool _audioPassthroughApplyQueued = false;
   bool _isDisposed = false;
+  int _letterboxCropGeneration = 0;
+  String? _letterboxHwdecBackup;
+  bool? _lastLetterboxCropEnabled;
+  String? _letterboxCropDoneUrl;
+  bool _letterboxCropInFlight = false;
   String? _appliedCustomMpvConfPath;
   DateTime? _appliedCustomMpvConfMtime;
   static final Map<String, _ParsedMpvConfCacheEntry> _parsedMpvConfCache =
@@ -647,6 +653,9 @@ class MediaKitPlayerBackend extends PlayerBackend {
         : payload['url']?.toString() ?? '';
     if (url.isEmpty) return;
 
+    if (url != _currentUrl) {
+      _letterboxCropDoneUrl = null;
+    }
     _currentUrl = url;
     _isStale = true;
     _embeddedCaptionTracks = const [];
@@ -681,6 +690,7 @@ class MediaKitPlayerBackend extends PlayerBackend {
       _enableNativeSubtitleRendering();
     }
     await _maybeEngageNativeHdr();
+    unawaited(_startLetterboxCropIfEnabled());
   }
 
   /// Gives mpv its own D3D11 window when the content is HDR and the display is
@@ -1344,6 +1354,8 @@ class MediaKitPlayerBackend extends PlayerBackend {
     if (_isDisposed) {
       return;
     }
+
+    _syncLetterboxCropWithPref();
 
     if (_audioPassthroughApplyInProgress) {
       _audioPassthroughApplyQueued = true;
@@ -2404,9 +2416,242 @@ class MediaKitPlayerBackend extends PlayerBackend {
     return controller.stream;
   }
 
+  void _syncLetterboxCropWithPref() {
+    final enabled = _prefs.get(UserPreferences.cropBlackBars);
+    if (enabled == _lastLetterboxCropEnabled) return;
+    if (_currentUrl == null || _currentUrl!.isEmpty) {
+      _lastLetterboxCropEnabled = enabled;
+      return;
+    }
+    unawaited(_startLetterboxCropIfEnabled());
+  }
+
+  Future<void> _startLetterboxCropIfEnabled() async {
+    final enabled = _prefs.get(UserPreferences.cropBlackBars);
+    _lastLetterboxCropEnabled = enabled;
+    if (enabled != true) {
+      ++_letterboxCropGeneration;
+      await _cleanupLetterboxCrop(restoreHwdec: true);
+      _letterboxCropDoneUrl = null;
+      return;
+    }
+    if (_player.platform is! NativePlayer) return;
+    if (_currentUrl != null && _letterboxCropDoneUrl == _currentUrl) return;
+    if (_letterboxCropInFlight) return;
+
+    final generation = ++_letterboxCropGeneration;
+    await _cleanupLetterboxCrop(restoreHwdec: true);
+    if (!_isCurrentLetterbox(generation)) return;
+    _letterboxCropInFlight = true;
+    unawaited(_runLetterboxCrop(generation));
+  }
+
+  Future<void> _runLetterboxCrop(int generation) async {
+    final native = _player.platform;
+    if (native is! NativePlayer) {
+      if (generation == _letterboxCropGeneration) {
+        _letterboxCropInFlight = false;
+      }
+      return;
+    }
+
+    LetterboxCropRect? rect;
+    try {
+      try {
+        if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+        if (_player.state.position < MpvLetterboxCrop.autoDelay) {
+          if (!await _delayLetterbox(generation, MpvLetterboxCrop.autoDelay)) {
+            return;
+          }
+        }
+        if (_player.state.playing != true) {
+          if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+        }
+
+        final remaining = _player.state.duration - _player.state.position;
+        if (_player.state.duration > Duration.zero &&
+            remaining <
+                MpvLetterboxCrop.detectDuration + const Duration(seconds: 1)) {
+          debugPrint('[letterbox_crop] skip: not enough time left');
+          return;
+        }
+        if (!_isCurrentLetterbox(generation)) return;
+
+        final hwdecCurrent = await _tryNativeGetProperty(
+          native,
+          'hwdec-current',
+        );
+        final detectHwdec = MpvLetterboxCrop.hwdecForCropdetect(hwdecCurrent);
+        if (detectHwdec != null) {
+          _letterboxHwdecBackup = await _tryNativeGetProperty(native, 'hwdec');
+          debugPrint(
+            '[letterbox_crop] hwdec $hwdecCurrent -> $detectHwdec '
+            '(was $_letterboxHwdecBackup)',
+          );
+          await _nativeSetProperty(native, 'hwdec', detectHwdec);
+          if (!await _delayLetterbox(
+            generation,
+            const Duration(milliseconds: 400),
+          )) {
+            return;
+          }
+        }
+
+        final inserted = await _tryNativeCommand(native, [
+          'vf',
+          'pre',
+          MpvLetterboxCrop.filterSpec,
+        ]);
+        debugPrint(
+          '[letterbox_crop] vf insert=$inserted spec=${MpvLetterboxCrop.filterSpec}',
+        );
+        if (!inserted || !_isCurrentLetterbox(generation)) return;
+
+        if (!await _delayLetterbox(
+          generation,
+          MpvLetterboxCrop.detectDuration,
+        )) {
+          return;
+        }
+
+        final lavfi = <String, String>{};
+        for (final key in const ['w', 'h', 'x', 'y']) {
+          final value = await _tryNativeGetProperty(
+            native,
+            MpvLetterboxCrop.metadataProperty(key),
+          );
+          if (value != null) lavfi[key] = value;
+        }
+        if (lavfi.length < 4) {
+          final blob = await _tryNativeGetProperty(
+            native,
+            'vf-metadata/${MpvLetterboxCrop.filterLabel}',
+          );
+          debugPrint('[letterbox_crop] vf-metadata blob=$blob');
+          lavfi.addAll(MpvLetterboxCrop.parseVfMetadata(blob));
+        }
+
+        final width =
+            int.tryParse(await _tryNativeGetProperty(native, 'width') ?? '') ??
+            0;
+        final height =
+            int.tryParse(await _tryNativeGetProperty(native, 'height') ?? '') ??
+            0;
+        rect = MpvLetterboxCrop.decide(
+          lavfi: lavfi,
+          sourceWidth: width,
+          sourceHeight: height,
+        );
+        debugPrint(
+          '[letterbox_crop] lavfi=$lavfi ${width}x$height -> ${rect?.videoCrop}',
+        );
+      } finally {
+        await _removeLetterboxFilter(native);
+        if (rect == null) {
+          await _restoreLetterboxHwdec(native);
+        }
+      }
+
+      if (rect == null || !_isCurrentLetterbox(generation)) return;
+      if (!await _delayLetterbox(
+        generation,
+        const Duration(milliseconds: 200),
+      )) {
+        await _restoreLetterboxHwdec(native);
+        return;
+      }
+      await _applyVideoCrop(native, rect);
+      final hwdecNow = await _tryNativeGetProperty(native, 'hwdec-current');
+      debugPrint('[letterbox_crop] applied ${rect.videoCrop} hwdec=$hwdecNow');
+      _letterboxCropDoneUrl = _currentUrl;
+    } finally {
+      if (generation == _letterboxCropGeneration) {
+        _letterboxCropInFlight = false;
+      }
+    }
+  }
+
+  bool _isCurrentLetterbox(int generation) {
+    return !_isDisposed && generation == _letterboxCropGeneration;
+  }
+
+  Future<bool> _delayLetterbox(int generation, Duration duration) async {
+    await Future<void>.delayed(duration);
+    return _isCurrentLetterbox(generation);
+  }
+
+  Future<bool> _waitWhileCurrent(
+    int generation, {
+    required bool untilPlaying,
+  }) async {
+    if (_player.state.playing == untilPlaying) {
+      return _isCurrentLetterbox(generation);
+    }
+    try {
+      await _player.stream.playing
+          .firstWhere((playing) => playing == untilPlaying)
+          .timeout(const Duration(seconds: 30));
+    } catch (_) {
+      return false;
+    }
+    return _isCurrentLetterbox(generation);
+  }
+
+  Future<void> _cleanupLetterboxCrop({required bool restoreHwdec}) async {
+    final native = _player.platform;
+    if (native is! NativePlayer) return;
+    await _removeLetterboxFilter(native);
+    await _clearVideoCrop(native);
+    if (restoreHwdec) {
+      await _restoreLetterboxHwdec(native);
+    }
+  }
+
+  Future<void> _applyVideoCrop(
+    NativePlayer native,
+    LetterboxCropRect rect,
+  ) async {
+    await _tryNativeCommand(native, [
+      'vf',
+      'add',
+      MpvLetterboxCrop.appliedFilterSpec(rect),
+    ]);
+    debugPrint('[letterbox_crop] vf crop ${rect.videoCrop}');
+  }
+
+  Future<void> _clearVideoCrop(NativePlayer native) async {
+    await _tryNativeCommand(native, [
+      'vf',
+      'remove',
+      '@${MpvLetterboxCrop.appliedFilterLabel}',
+    ]);
+    await _tryNativeCommand(native, ['set', 'video-crop', '']);
+    await _tryNativeCommand(native, [
+      'set',
+      'file-local-options/video-crop',
+      '',
+    ]);
+  }
+
+  Future<void> _removeLetterboxFilter(NativePlayer native) async {
+    await _tryNativeCommand(native, [
+      'vf',
+      'remove',
+      '@${MpvLetterboxCrop.filterLabel}',
+    ]);
+  }
+
+  Future<void> _restoreLetterboxHwdec(NativePlayer native) async {
+    final backup = _letterboxHwdecBackup;
+    _letterboxHwdecBackup = null;
+    if (backup == null || backup.isEmpty) return;
+    await _nativeSetProperty(native, 'hwdec', backup);
+  }
+
   @override
   void dispose() {
     _isDisposed = true;
+    _letterboxCropGeneration++;
     _prefs.removeListener(_onPreferencesChanged);
     _ccTracksSub?.cancel();
     _videoParamsSub?.cancel();

--- a/lib/playback/mpv_letterbox_crop.dart
+++ b/lib/playback/mpv_letterbox_crop.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+
+/// One-shot letterbox crop, matching stock mpv `autocrop.lua` without Lua.
+///
+/// Insert lavfi `cropdetect`, read `vf-metadata`, then set `video-crop`.
+class MpvLetterboxCrop {
+  /// Persistent lavfi crop applied after detect. Label must differ from detect.
+  static const appliedFilterLabel = 'moonfin-letterbox-applied';
+
+  static const filterLabel = 'moonfin-letterbox';
+  static const detectLimit = '24/255';
+  static const detectRound = 2;
+  static const minRatio = 0.5;
+  static const autoDelay = Duration(seconds: 4);
+  static const detectDuration = Duration(seconds: 1);
+
+  static const _lavfiPrefix = 'lavfi.cropdetect.';
+
+  /// `vf pre @label:cropdetect=...`
+  static String get filterSpec =>
+      '@$filterLabel:cropdetect=limit=$detectLimit:round=$detectRound:reset=0';
+
+  static String metadataProperty(String key) =>
+      'vf-metadata/$filterLabel/$_lavfiPrefix$key';
+
+  /// Non-copy hwdec cannot feed cropdetect. Same exceptions as autocrop.lua.
+  static bool mustDisableHwdec(String? hwdecCurrent) {
+    if (hwdecCurrent == null || hwdecCurrent.isEmpty) return false;
+    if (hwdecCurrent == 'no' ||
+        hwdecCurrent == 'crystalhd' ||
+        hwdecCurrent == 'rkmpp') {
+      return false;
+    }
+    return !hwdecCurrent.endsWith('-copy');
+  }
+
+  /// Keep GPU decode; copy-back is enough for cropdetect. `no` is software.
+  static const copyHwdec = 'auto-copy';
+
+  static String? hwdecForCropdetect(String? hwdecCurrent) {
+    if (!mustDisableHwdec(hwdecCurrent)) return null;
+    return copyHwdec;
+  }
+
+  static String appliedFilterSpec(LetterboxCropRect rect) =>
+      '@$appliedFilterLabel:crop=${rect.w}:${rect.h}:${rect.x}:${rect.y}';
+
+  static Map<String, String> parseVfMetadata(String? raw) {
+    if (raw == null || raw.isEmpty || raw == 'null') return const {};
+    final out = <String, String>{};
+
+    final jsonStart = raw.trimLeft();
+    if (jsonStart.startsWith('{')) {
+      final decoded = _tryDecodeJsonMap(jsonStart);
+      if (decoded != null) {
+        for (final entry in decoded.entries) {
+          final name = _stripLavfiPrefix(entry.key);
+          if (name != null) out[name] = '${entry.value}';
+        }
+        if (out.isNotEmpty) return out;
+      }
+    }
+
+    final pattern = RegExp(
+      r'lavfi\.cropdetect\.([a-z]+)\s*[:=]\s*"?(-?\d+(?:\.\d+)?)"?',
+      caseSensitive: false,
+    );
+    for (final match in pattern.allMatches(raw)) {
+      out[match.group(1)!] = match.group(2)!;
+    }
+    return out;
+  }
+
+  static LetterboxCropRect? decide({
+    required Map<String, String> lavfi,
+    required int sourceWidth,
+    required int sourceHeight,
+  }) {
+    if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+    final w = int.tryParse(lavfi['w'] ?? '');
+    final h = int.tryParse(lavfi['h'] ?? '');
+    final x = int.tryParse(lavfi['x'] ?? '');
+    final y = int.tryParse(lavfi['y'] ?? '');
+    if (w == null || h == null || x == null || y == null) return null;
+    if (w <= 0 || h <= 0) return null;
+
+    final effective = x > 0 || y > 0 || w < sourceWidth || h < sourceHeight;
+    if (!effective) return null;
+
+    final minW = sourceWidth * minRatio;
+    final minH = sourceHeight * minRatio;
+    if (w < minW || h < minH) return null;
+
+    return LetterboxCropRect(w: w, h: h, x: x, y: y);
+  }
+
+  static String? _stripLavfiPrefix(String key) {
+    if (key.startsWith(_lavfiPrefix)) {
+      return key.substring(_lavfiPrefix.length);
+    }
+    if (key.length == 1 && 'whxy'.contains(key)) return key;
+    return null;
+  }
+
+  static Map<String, Object?>? _tryDecodeJsonMap(String raw) {
+    try {
+      final value = jsonDecode(raw);
+      if (value is Map) {
+        return value.map((key, v) => MapEntry(key.toString(), v));
+      }
+    } catch (_) {}
+    return null;
+  }
+}
+
+class LetterboxCropRect {
+  const LetterboxCropRect({
+    required this.w,
+    required this.h,
+    required this.x,
+    required this.y,
+  });
+
+  final int w;
+  final int h;
+  final int x;
+  final int y;
+
+  String get videoCrop => '${w}x$h+$x+$y';
+
+  @override
+  bool operator ==(Object other) =>
+      other is LetterboxCropRect &&
+      other.w == w &&
+      other.h == h &&
+      other.x == x &&
+      other.y == y;
+
+  @override
+  int get hashCode => Object.hash(w, h, x, y);
+}

--- a/lib/playback/mpv_letterbox_crop.dart
+++ b/lib/playback/mpv_letterbox_crop.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:playback_core/playback_core.dart';
 
 /// libmpv cropdetect helpers. Matching stock mpv `autocrop.lua` without Lua.
@@ -138,6 +137,7 @@ class MpvLetterboxCropper extends LetterboxCropper {
   int _generation = 0;
   String? _hwdecBackup;
   bool _enabled = false;
+  bool _applied = false;
   String? _doneUrl;
   bool _inFlight = false;
 
@@ -169,7 +169,9 @@ class MpvLetterboxCropper extends LetterboxCropper {
   Future<void> _sync() async {
     if (!_enabled) {
       _generation++;
-      await reset();
+      // Clearing video-crop with nothing of ours applied would wipe it for
+      // anyone who set it in their own mpv.conf.
+      if (_applied || _hwdecBackup != null) await reset();
       _doneUrl = null;
       return;
     }
@@ -192,6 +194,7 @@ class MpvLetterboxCropper extends LetterboxCropper {
   @override
   Future<void> reset() async {
     if (!_host.hasNativePlayer) return;
+    _applied = false;
     await _removeDetectFilter();
     await _clearVideoCrop();
     await _restoreHwdec();
@@ -226,7 +229,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
         if (_host.duration > Duration.zero &&
             remaining <
                 MpvLetterboxCrop.detectDuration + const Duration(seconds: 1)) {
-          debugPrint('[letterbox_crop] skip: not enough time left');
           return;
         }
         if (!_isCurrent(generation)) return;
@@ -235,10 +237,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
         final detectHwdec = MpvLetterboxCrop.hwdecForCropdetect(hwdecCurrent);
         if (detectHwdec != null) {
           _hwdecBackup = await _host.getProperty('hwdec');
-          debugPrint(
-            '[letterbox_crop] hwdec $hwdecCurrent -> $detectHwdec '
-            '(was $_hwdecBackup)',
-          );
           await _host.setProperty('hwdec', detectHwdec);
           if (!await _delay(generation, const Duration(milliseconds: 400))) {
             return;
@@ -250,9 +248,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
           'pre',
           MpvLetterboxCrop.filterSpec,
         ]);
-        debugPrint(
-          '[letterbox_crop] vf insert=$inserted spec=${MpvLetterboxCrop.filterSpec}',
-        );
         if (!inserted || !_isCurrent(generation)) return;
 
         if (!await _delay(generation, MpvLetterboxCrop.detectDuration)) {
@@ -270,7 +265,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
           final blob = await _host.getProperty(
             'vf-metadata/${MpvLetterboxCrop.filterLabel}',
           );
-          debugPrint('[letterbox_crop] vf-metadata blob=$blob');
           lavfi.addAll(MpvLetterboxCrop.parseVfMetadata(blob));
         }
 
@@ -281,9 +275,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
           lavfi: lavfi,
           sourceWidth: width,
           sourceHeight: height,
-        );
-        debugPrint(
-          '[letterbox_crop] lavfi=$lavfi ${width}x$height -> ${rect?.videoCrop}',
         );
       } finally {
         await _removeDetectFilter();
@@ -298,8 +289,6 @@ class MpvLetterboxCropper extends LetterboxCropper {
         return;
       }
       await _applyVideoCrop(rect);
-      final hwdecNow = await _host.getProperty('hwdec-current');
-      debugPrint('[letterbox_crop] applied ${rect.videoCrop} hwdec=$hwdecNow');
       _doneUrl = _host.currentUrl;
     } finally {
       if (generation == _generation) {
@@ -340,7 +329,7 @@ class MpvLetterboxCropper extends LetterboxCropper {
       'add',
       MpvLetterboxCrop.appliedFilterSpec(rect),
     ]);
-    debugPrint('[letterbox_crop] vf crop ${rect.videoCrop}');
+    _applied = true;
   }
 
   Future<void> _clearVideoCrop() async {

--- a/lib/playback/mpv_letterbox_crop.dart
+++ b/lib/playback/mpv_letterbox_crop.dart
@@ -147,7 +147,7 @@ class MpvLetterboxCropper extends LetterboxCropper {
   @override
   String? get unimplementedReason => _supported
       ? null
-      : 'Letterbox crop on libmpv ships on desktop and Android TV.';
+      : 'Letterbox crop on libmpv ships on desktop and Android.';
 
   @override
   Future<void> setEnabled(bool enabled) async {

--- a/lib/playback/mpv_letterbox_crop.dart
+++ b/lib/playback/mpv_letterbox_crop.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:convert';
 
-/// One-shot letterbox crop, matching stock mpv `autocrop.lua` without Lua.
-///
-/// Insert lavfi `cropdetect`, read `vf-metadata`, then set `video-crop`.
+import 'package:flutter/foundation.dart';
+import 'package:playback_core/playback_core.dart';
+
+/// libmpv cropdetect helpers. Matching stock mpv `autocrop.lua` without Lua.
 class MpvLetterboxCrop {
   /// Persistent lavfi crop applied after detect. Label must differ from detect.
   static const appliedFilterLabel = 'moonfin-letterbox-applied';
@@ -10,7 +12,7 @@ class MpvLetterboxCrop {
   static const filterLabel = 'moonfin-letterbox';
   static const detectLimit = '24/255';
   static const detectRound = 2;
-  static const minRatio = 0.5;
+  static const minRatio = LetterboxCrop.minRatio;
   static const autoDelay = Duration(seconds: 4);
   static const detectDuration = Duration(seconds: 1);
 
@@ -76,22 +78,20 @@ class MpvLetterboxCrop {
     required int sourceWidth,
     required int sourceHeight,
   }) {
-    if (sourceWidth <= 0 || sourceHeight <= 0) return null;
     final w = int.tryParse(lavfi['w'] ?? '');
     final h = int.tryParse(lavfi['h'] ?? '');
     final x = int.tryParse(lavfi['x'] ?? '');
     final y = int.tryParse(lavfi['y'] ?? '');
     if (w == null || h == null || x == null || y == null) return null;
-    if (w <= 0 || h <= 0) return null;
-
-    final effective = x > 0 || y > 0 || w < sourceWidth || h < sourceHeight;
-    if (!effective) return null;
-
-    final minW = sourceWidth * minRatio;
-    final minH = sourceHeight * minRatio;
-    if (w < minW || h < minH) return null;
-
-    return LetterboxCropRect(w: w, h: h, x: x, y: y);
+    return LetterboxCrop.decide(
+      width: w,
+      height: h,
+      x: x,
+      y: y,
+      sourceWidth: sourceWidth,
+      sourceHeight: sourceHeight,
+      minRatio: minRatio,
+    );
   }
 
   static String? _stripLavfiPrefix(String key) {
@@ -113,29 +113,254 @@ class MpvLetterboxCrop {
   }
 }
 
-class LetterboxCropRect {
-  const LetterboxCropRect({
-    required this.w,
-    required this.h,
-    required this.x,
-    required this.y,
-  });
+/// libmpv property/command surface the desktop cropper needs.
+abstract class MpvLetterboxHost {
+  bool get hasNativePlayer;
+  Future<String?> getProperty(String key);
+  Future<void> setProperty(String key, String value);
+  Future<bool> command(List<String> args);
+  bool get isPlaying;
+  Duration get position;
+  Duration get duration;
+  Stream<bool> get playingStream;
+  String? get currentUrl;
+  bool get isDisposed;
+}
 
-  final int w;
-  final int h;
-  final int x;
-  final int y;
+/// Desktop libmpv [LetterboxCropper]. The only shipping implementation.
+class MpvLetterboxCropper extends LetterboxCropper {
+  MpvLetterboxCropper(this._host, {required bool supported})
+    : _supported = supported;
 
-  String get videoCrop => '${w}x$h+$x+$y';
+  final MpvLetterboxHost _host;
+  final bool _supported;
+
+  int _generation = 0;
+  String? _hwdecBackup;
+  bool _enabled = false;
+  String? _doneUrl;
+  bool _inFlight = false;
 
   @override
-  bool operator ==(Object other) =>
-      other is LetterboxCropRect &&
-      other.w == w &&
-      other.h == h &&
-      other.x == x &&
-      other.y == y;
+  bool get isSupported => _supported;
 
   @override
-  int get hashCode => Object.hash(w, h, x, y);
+  String? get unimplementedReason => _supported
+      ? null
+      : 'Letterbox crop on libmpv ships on desktop and Android TV.';
+
+  @override
+  Future<void> setEnabled(bool enabled) async {
+    final changed = enabled != _enabled;
+    _enabled = enabled;
+    if (!isSupported || !changed) return;
+    final url = _host.currentUrl;
+    if (url == null || url.isEmpty) return;
+    await _sync();
+  }
+
+  @override
+  Future<void> onSourceOpened(String url) async {
+    if (_doneUrl != url) _doneUrl = null;
+    if (!isSupported) return;
+    await _sync();
+  }
+
+  Future<void> _sync() async {
+    if (!_enabled) {
+      _generation++;
+      await reset();
+      _doneUrl = null;
+      return;
+    }
+    if (!_host.hasNativePlayer) return;
+    final url = _host.currentUrl;
+    if (url == null || url.isEmpty) return;
+    if (_doneUrl == url) return;
+    if (_inFlight) return;
+
+    _inFlight = true;
+    final generation = ++_generation;
+    await reset();
+    if (!_isCurrent(generation)) {
+      if (generation == _generation) _inFlight = false;
+      return;
+    }
+    unawaited(_run(generation));
+  }
+
+  @override
+  Future<void> reset() async {
+    if (!_host.hasNativePlayer) return;
+    await _removeDetectFilter();
+    await _clearVideoCrop();
+    await _restoreHwdec();
+  }
+
+  /// Stale in-flight detect without touching filters during player teardown.
+  void cancel() {
+    _generation++;
+    _inFlight = false;
+  }
+
+  Future<void> _run(int generation) async {
+    if (!_host.hasNativePlayer) {
+      if (generation == _generation) _inFlight = false;
+      return;
+    }
+
+    LetterboxCropRect? rect;
+    try {
+      try {
+        if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+        if (_host.position < MpvLetterboxCrop.autoDelay) {
+          if (!await _delay(generation, MpvLetterboxCrop.autoDelay)) {
+            return;
+          }
+        }
+        if (_host.isPlaying != true) {
+          if (!await _waitWhileCurrent(generation, untilPlaying: true)) return;
+        }
+
+        final remaining = _host.duration - _host.position;
+        if (_host.duration > Duration.zero &&
+            remaining <
+                MpvLetterboxCrop.detectDuration + const Duration(seconds: 1)) {
+          debugPrint('[letterbox_crop] skip: not enough time left');
+          return;
+        }
+        if (!_isCurrent(generation)) return;
+
+        final hwdecCurrent = await _host.getProperty('hwdec-current');
+        final detectHwdec = MpvLetterboxCrop.hwdecForCropdetect(hwdecCurrent);
+        if (detectHwdec != null) {
+          _hwdecBackup = await _host.getProperty('hwdec');
+          debugPrint(
+            '[letterbox_crop] hwdec $hwdecCurrent -> $detectHwdec '
+            '(was $_hwdecBackup)',
+          );
+          await _host.setProperty('hwdec', detectHwdec);
+          if (!await _delay(generation, const Duration(milliseconds: 400))) {
+            return;
+          }
+        }
+
+        final inserted = await _host.command([
+          'vf',
+          'pre',
+          MpvLetterboxCrop.filterSpec,
+        ]);
+        debugPrint(
+          '[letterbox_crop] vf insert=$inserted spec=${MpvLetterboxCrop.filterSpec}',
+        );
+        if (!inserted || !_isCurrent(generation)) return;
+
+        if (!await _delay(generation, MpvLetterboxCrop.detectDuration)) {
+          return;
+        }
+
+        final lavfi = <String, String>{};
+        for (final key in const ['w', 'h', 'x', 'y']) {
+          final value = await _host.getProperty(
+            MpvLetterboxCrop.metadataProperty(key),
+          );
+          if (value != null) lavfi[key] = value;
+        }
+        if (lavfi.length < 4) {
+          final blob = await _host.getProperty(
+            'vf-metadata/${MpvLetterboxCrop.filterLabel}',
+          );
+          debugPrint('[letterbox_crop] vf-metadata blob=$blob');
+          lavfi.addAll(MpvLetterboxCrop.parseVfMetadata(blob));
+        }
+
+        final width = int.tryParse(await _host.getProperty('width') ?? '') ?? 0;
+        final height =
+            int.tryParse(await _host.getProperty('height') ?? '') ?? 0;
+        rect = MpvLetterboxCrop.decide(
+          lavfi: lavfi,
+          sourceWidth: width,
+          sourceHeight: height,
+        );
+        debugPrint(
+          '[letterbox_crop] lavfi=$lavfi ${width}x$height -> ${rect?.videoCrop}',
+        );
+      } finally {
+        await _removeDetectFilter();
+        if (rect == null) {
+          await _restoreHwdec();
+        }
+      }
+
+      if (rect == null || !_isCurrent(generation)) return;
+      if (!await _delay(generation, const Duration(milliseconds: 200))) {
+        await _restoreHwdec();
+        return;
+      }
+      await _applyVideoCrop(rect);
+      final hwdecNow = await _host.getProperty('hwdec-current');
+      debugPrint('[letterbox_crop] applied ${rect.videoCrop} hwdec=$hwdecNow');
+      _doneUrl = _host.currentUrl;
+    } finally {
+      if (generation == _generation) {
+        _inFlight = false;
+      }
+    }
+  }
+
+  bool _isCurrent(int generation) {
+    return !_host.isDisposed && generation == _generation;
+  }
+
+  Future<bool> _delay(int generation, Duration duration) async {
+    await Future<void>.delayed(duration);
+    return _isCurrent(generation);
+  }
+
+  Future<bool> _waitWhileCurrent(
+    int generation, {
+    required bool untilPlaying,
+  }) async {
+    if (_host.isPlaying == untilPlaying) {
+      return _isCurrent(generation);
+    }
+    try {
+      await _host.playingStream
+          .firstWhere((playing) => playing == untilPlaying)
+          .timeout(const Duration(seconds: 30));
+    } catch (_) {
+      return false;
+    }
+    return _isCurrent(generation);
+  }
+
+  Future<void> _applyVideoCrop(LetterboxCropRect rect) async {
+    await _host.command([
+      'vf',
+      'add',
+      MpvLetterboxCrop.appliedFilterSpec(rect),
+    ]);
+    debugPrint('[letterbox_crop] vf crop ${rect.videoCrop}');
+  }
+
+  Future<void> _clearVideoCrop() async {
+    await _host.command([
+      'vf',
+      'remove',
+      '@${MpvLetterboxCrop.appliedFilterLabel}',
+    ]);
+    await _host.command(['set', 'video-crop', '']);
+    await _host.command(['set', 'file-local-options/video-crop', '']);
+  }
+
+  Future<void> _removeDetectFilter() async {
+    await _host.command(['vf', 'remove', '@${MpvLetterboxCrop.filterLabel}']);
+  }
+
+  Future<void> _restoreHwdec() async {
+    final backup = _hwdecBackup;
+    _hwdecBackup = null;
+    if (backup == null || backup.isEmpty) return;
+    await _host.setProperty('hwdec', backup);
+  }
 }

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1806,6 +1806,12 @@ class UserPreferences extends ChangeNotifier {
     values: ZoomMode.values,
   );
 
+  /// One-shot libmpv cropdetect → `video-crop`. Desktop mpv only.
+  static final cropBlackBars = Preference(
+    key: 'crop_black_bars',
+    defaultValue: false,
+  );
+
   static final desktopScrollWheelAction = EnumPreference(
     key: 'desktop_scroll_wheel_action',
     defaultValue: DesktopScrollWheelAction.volume,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1806,7 +1806,8 @@ class UserPreferences extends ChangeNotifier {
     values: ZoomMode.values,
   );
 
-  /// One-shot libmpv cropdetect → `video-crop`. Desktop mpv only.
+  /// One-shot encoded-letterbox crop. libmpv on Linux/Windows; Media3
+  /// (and libmpv if selected) on Android TV. Hidden elsewhere.
   static final cropBlackBars = Preference(
     key: 'crop_black_bars',
     defaultValue: false,

--- a/lib/preference/user_preferences.dart
+++ b/lib/preference/user_preferences.dart
@@ -1807,7 +1807,8 @@ class UserPreferences extends ChangeNotifier {
   );
 
   /// One-shot encoded-letterbox crop. libmpv on Linux/Windows; Media3
-  /// (and libmpv if selected) on Android TV. Hidden elsewhere.
+  /// (and libmpv if selected) on Android phone and TV. Hidden on iOS,
+  /// macOS, web, and tvOS.
   static final cropBlackBars = Preference(
     key: 'crop_black_bars',
     defaultValue: false,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -239,6 +239,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   final GlobalKey _topOverlayKey = GlobalKey();
   final GlobalKey _bottomOverlayKey = GlobalKey();
   late ZoomMode _zoomMode;
+  late bool _cropLocksZoom;
   double _audioDelay = 0.0;
   double _subtitleDelay = 0.0;
   bool _subtitleActive = false;
@@ -813,6 +814,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _themeMusicService.setExternalAudioActive(true);
     _segmentService = _createSegmentService();
     _zoomMode = _prefs.get(UserPreferences.playerZoomMode);
+    _cropLocksZoom = _prefs.get(UserPreferences.cropBlackBars);
     // Media3 only takes the zoom mode from this call, and the backend change it
     // listens for never fires when it was already the one playing.
     unawaited(_syncMedia3ZoomMode());
@@ -827,7 +829,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       unawaited(_syncMedia3ZoomMode());
     });
     _syncPlayManager?.addListener(_onSyncPlayChanged);
-    _prefs.addListener(_syncMediaQueuingPreference);
+    _prefs.addListener(_onPlaybackPrefsChanged);
     _syncMediaQueuingPreference();
     _applySubtitleStyle();
     _scheduleHide();
@@ -1001,7 +1003,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     }
     _screensaverPlayingSub?.cancel();
     _screensaverController.setPlaybackActive(false);
-    _prefs.removeListener(_syncMediaQueuingPreference);
+    _prefs.removeListener(_onPlaybackPrefsChanged);
     _syncPlayManager?.removeListener(_onSyncPlayChanged);
     _manager.autoAdvanceEnabled = true;
     WidgetsBinding.instance.removeObserver(this);
@@ -2088,7 +2090,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       topSubtitle: topSubtitle,
       artworkUrl: artworkUrl,
       showClock: false,
-      zoomModeLabel: _zoomModeLabel(_zoomMode),
+      zoomModeLabel: _zoomModeLabel(_activeZoomMode),
       streamInfoSections: streamInfoSections,
       hasCastCrew: hasCastCrew,
       castPeople: castPeople,
@@ -2133,13 +2135,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         unawaited(_pushMedia3UiMetadata());
         return;
       case 'toggleZoom':
-        final modes = ZoomMode.values;
-        final next = modes[(_zoomMode.index + 1) % modes.length];
-        setState(() => _zoomMode = next);
-        _prefs.set(UserPreferences.playerZoomMode, next);
-        _showZoomModeToast(next);
-        unawaited(_syncMedia3ZoomMode());
-        unawaited(_pushMedia3UiMetadata());
+        _cyclePlayerZoom();
         return;
       case 'castPlay':
         unawaited(_runCastAction((k) => _castService.play(k)));
@@ -2378,11 +2374,27 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     return DateTime.now().isBefore(until);
   }
 
+  void _onPlaybackPrefsChanged() {
+    _syncMediaQueuingPreference();
+    if (!mounted) return;
+    final zoom = _prefs.get(UserPreferences.playerZoomMode);
+    final crop = _prefs.get(UserPreferences.cropBlackBars);
+    if (zoom == _zoomMode && crop == _cropLocksZoom) return;
+    setState(() {
+      _zoomMode = zoom;
+      _cropLocksZoom = crop;
+    });
+    unawaited(_syncMedia3ZoomMode());
+  }
+
   void _syncMediaQueuingPreference() {
     _manager.autoAdvanceEnabled = _prefs.get(
       UserPreferences.autoplayNextEpisode,
     );
   }
+
+  ZoomMode get _activeZoomMode =>
+      _cropLocksZoom ? ZoomMode.autoCrop : _zoomMode;
 
   void _onSyncPlayChanged() {
     if (mounted) setState(() {});
@@ -4063,7 +4075,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       child: Trickplay(
         fillFrame: true,
         content: (_) => FittedBox(
-          fit: _zoomToFit(_zoomMode),
+          fit: _zoomToFit(_activeZoomMode),
           child: SizedBox(
             width: tile.thumbWidth,
             height: tile.thumbHeight,
@@ -4077,7 +4089,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Widget _buildVideoSurface() {
     if (PlatformDetection.isIOS || PlatformDetection.isMacOS) {
       return Positioned.fill(
-        child: AetherVideoView(key: _videoSurfaceKey, zoomMode: _zoomMode.name),
+        child: AetherVideoView(
+          key: _videoSurfaceKey,
+          zoomMode: _activeZoomMode.name,
+        ),
       );
     }
 
@@ -4094,7 +4109,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final htmlBackend = _activeHtmlVideoBackend;
     if (htmlBackend != null) {
       return Positioned.fill(
-        child: htmlBackend.buildView(fit: _zoomToFit(_zoomMode)),
+        child: htmlBackend.buildView(fit: _zoomToFit(_activeZoomMode)),
       );
     }
 
@@ -4127,7 +4142,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return Positioned.fill(
         child: NativeVideoView(
           player: mediaKitBackend.player,
-          zoomMode: _nativeZoomMode(_zoomMode),
+          zoomMode: _nativeZoomMode(_activeZoomMode),
           fill: Colors.black,
           videoOutput: selectedVo,
           hardwareDecodingEnabled: hwDecodingEnabled,
@@ -4149,7 +4164,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             controls: NoVideoControls,
             width: constraints.maxWidth,
             height: constraints.maxHeight,
-            fit: _zoomToFit(_zoomMode),
+            fit: _zoomToFit(_activeZoomMode),
             fill: Colors.black,
             pauseUponEnteringBackgroundMode:
                 !PlatformDetection.isIOS && !PlatformDetection.isAndroid,
@@ -4175,7 +4190,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Future<void> _syncMedia3ZoomMode() async {
     final backend = _activeMedia3Backend;
     if (backend == null) return;
-    await backend.setZoomMode(_media3ZoomModeWire(_zoomMode));
+    await backend.setZoomMode(_media3ZoomModeWire(_activeZoomMode));
   }
 
   bool _isBringupInProgress(PlaybackBringupPhase phase) {
@@ -5587,7 +5602,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
               iconSize: secondaryIconSize,
               tooltip: l10n.playerTooltipPlaybackQuality,
             ),
-          if (shows(OsdButton.zoom))
+          if (shows(OsdButton.zoom) && !_cropLocksZoom)
             OsdButton.zoom: _buildZoomButton(
               size: secondaryIconSize,
               extent: secondaryExtent,
@@ -5652,7 +5667,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             (button) => button.id,
             _prefs,
           ))
-            ?byButton[button],
+            if (byButton[button] != null)
+              KeyedSubtree(
+                key: ValueKey(button.id),
+                child: byButton[button]!,
+              ),
         ]);
 
         final orderedSecondaryButtons = PlatformDetection.isTV
@@ -5674,31 +5693,26 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 isLandscape && estimatedWidth <= constraints.maxWidth;
 
             if (canFitLandscapeRow) {
-              return SizedBox(
-                height: secondaryExtent,
-                child: Row(
-                  mainAxisAlignment: PlatformDetection.isTV
-                      ? MainAxisAlignment.start
-                      : MainAxisAlignment.spaceEvenly,
-                  children: orderedSecondaryButtons,
-                ),
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: PlatformDetection.isTV
+                    ? MainAxisAlignment.start
+                    : MainAxisAlignment.spaceEvenly,
+                children: orderedSecondaryButtons,
               );
             }
 
-            return SizedBox(
-              height: secondaryExtent,
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    for (final button in orderedSecondaryButtons)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 2),
-                        child: button,
-                      ),
-                  ],
-                ),
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  for (final button in orderedSecondaryButtons)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 2),
+                      child: button,
+                    ),
+                ],
               ),
             );
           },
@@ -6579,7 +6593,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         tooltip: PlatformDetection.useDesktopUi ? tooltip : null,
         icon: AdaptiveIcon(icon, color: iconColor, size: size),
         padding: EdgeInsets.zero,
-        constraints: const BoxConstraints(),
+        constraints: BoxConstraints.tightFor(width: extent, height: extent),
+        style: IconButton.styleFrom(
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          visualDensity: VisualDensity.compact,
+          padding: EdgeInsets.zero,
+          minimumSize: Size(extent, extent),
+          maximumSize: Size(extent, extent),
+        ),
       ),
     );
   }
@@ -7030,6 +7051,17 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _showControls();
   }
 
+  void _cyclePlayerZoom() {
+    if (_cropLocksZoom) return;
+    final modes = ZoomMode.values;
+    final next = modes[(_zoomMode.index + 1) % modes.length];
+    setState(() => _zoomMode = next);
+    _prefs.set(UserPreferences.playerZoomMode, next);
+    _showZoomModeToast(next);
+    unawaited(_syncMedia3ZoomMode());
+    unawaited(_pushMedia3UiMetadata());
+  }
+
   Widget _buildZoomButton({
     double size = 24,
     double extent = 48,
@@ -7037,7 +7069,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     FocusNode? focusNode,
     VoidCallback? onRightBoundary,
   }) {
-    final icon = switch (_zoomMode) {
+    final icon = switch (_activeZoomMode) {
       ZoomMode.fit => Icons.fit_screen_rounded,
       ZoomMode.autoCrop => Icons.crop_rounded,
       ZoomMode.stretch => Icons.open_in_full_rounded,
@@ -7046,15 +7078,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       icon,
       size: size,
       extent: extent,
-      onPressed: () {
-        final modes = ZoomMode.values;
-        final next = modes[(_zoomMode.index + 1) % modes.length];
-        setState(() => _zoomMode = next);
-        _prefs.set(UserPreferences.playerZoomMode, next);
-        _showZoomModeToast(next);
-        unawaited(_syncMedia3ZoomMode());
-        unawaited(_pushMedia3UiMetadata());
-      },
+      onPressed: _cyclePlayerZoom,
       tooltip: tooltip,
       focusNode: focusNode,
       onRightBoundary: onRightBoundary,
@@ -7124,10 +7148,12 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   String _zoomModeLabel(ZoomMode mode) {
-    final spaced = mode.name.replaceAllMapped(_camelCaseSpaceRe, (_) => ' ');
-    return spaced.isEmpty
-        ? mode.name
-        : '${spaced[0].toUpperCase()}${spaced.substring(1)}';
+    final l10n = AppLocalizations.of(context);
+    return switch (mode) {
+      ZoomMode.fit => l10n.fit,
+      ZoomMode.autoCrop => l10n.autoCrop,
+      ZoomMode.stretch => l10n.stretch,
+    };
   }
 
   String _tooltipMessage(String label, {String? shortcut}) {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -4097,10 +4097,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Widget _buildVideoSurface() {
     if (PlatformDetection.isIOS || PlatformDetection.isMacOS) {
       return Positioned.fill(
-        child: AetherVideoView(
-          key: _videoSurfaceKey,
-          zoomMode: _activeZoomMode.name,
-        ),
+        child: AetherVideoView(key: _videoSurfaceKey, zoomMode: _activeZoomMode.name),
       );
     }
 
@@ -5675,11 +5672,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             (button) => button.id,
             _prefs,
           ))
-            if (byButton[button] != null)
-              KeyedSubtree(
-                key: ValueKey(button.id),
-                child: byButton[button]!,
-              ),
+            ?byButton[button],
         ]);
 
         final orderedSecondaryButtons = PlatformDetection.isTV
@@ -5701,26 +5694,31 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                 isLandscape && estimatedWidth <= constraints.maxWidth;
 
             if (canFitLandscapeRow) {
-              return Row(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: PlatformDetection.isTV
-                    ? MainAxisAlignment.start
-                    : MainAxisAlignment.spaceEvenly,
-                children: orderedSecondaryButtons,
+              return SizedBox(
+                height: secondaryExtent,
+                child: Row(
+                  mainAxisAlignment: PlatformDetection.isTV
+                      ? MainAxisAlignment.start
+                      : MainAxisAlignment.spaceEvenly,
+                  children: orderedSecondaryButtons,
+                ),
               );
             }
 
-            return SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  for (final button in orderedSecondaryButtons)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 2),
-                      child: button,
-                    ),
-                ],
+            return SizedBox(
+              height: secondaryExtent,
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    for (final button in orderedSecondaryButtons)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 2),
+                        child: button,
+                      ),
+                  ],
+                ),
               ),
             );
           },
@@ -6601,14 +6599,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         tooltip: PlatformDetection.useDesktopUi ? tooltip : null,
         icon: AdaptiveIcon(icon, color: iconColor, size: size),
         padding: EdgeInsets.zero,
-        constraints: BoxConstraints.tightFor(width: extent, height: extent),
-        style: IconButton.styleFrom(
-          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-          visualDensity: VisualDensity.compact,
-          padding: EdgeInsets.zero,
-          minimumSize: Size(extent, extent),
-          maximumSize: Size(extent, extent),
-        ),
+        constraints: const BoxConstraints(),
       ),
     );
   }
@@ -7156,12 +7147,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   String _zoomModeLabel(ZoomMode mode) {
-    final l10n = AppLocalizations.of(context);
-    return switch (mode) {
-      ZoomMode.fit => l10n.fit,
-      ZoomMode.autoCrop => l10n.autoCrop,
-      ZoomMode.stretch => l10n.stretch,
-    };
+    final spaced = mode.name.replaceAllMapped(_camelCaseSpaceRe, (_) => ' ');
+    return spaced.isEmpty
+        ? mode.name
+        : '${spaced[0].toUpperCase()}${spaced.substring(1)}';
   }
 
   String _tooltipMessage(String label, {String? shortcut}) {

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -814,7 +814,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _themeMusicService.setExternalAudioActive(true);
     _segmentService = _createSegmentService();
     _zoomMode = _prefs.get(UserPreferences.playerZoomMode);
-    _cropLocksZoom = _prefs.get(UserPreferences.cropBlackBars);
+    _cropLocksZoom = _computeCropLocksZoom();
     // Media3 only takes the zoom mode from this call, and the backend change it
     // listens for never fires when it was already the one playing.
     unawaited(_syncMedia3ZoomMode());
@@ -871,7 +871,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         unawaited(backend.setVolume(_playerVolume));
       }
       if (!mounted) return;
-      setState(() {});
+      final cropLocks = _computeCropLocksZoom();
+      setState(() {
+        _cropLocksZoom = cropLocks;
+      });
     });
     _syncMedia3VolumeBoostLevel(resetWhenUnavailable: true);
     if (PlatformDetection.isTV) {
@@ -2378,11 +2381,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _syncMediaQueuingPreference();
     if (!mounted) return;
     final zoom = _prefs.get(UserPreferences.playerZoomMode);
-    final crop = _prefs.get(UserPreferences.cropBlackBars);
-    if (zoom == _zoomMode && crop == _cropLocksZoom) return;
+    final cropLocks = _computeCropLocksZoom();
+    if (zoom == _zoomMode && cropLocks == _cropLocksZoom) return;
     setState(() {
       _zoomMode = zoom;
-      _cropLocksZoom = crop;
+      _cropLocksZoom = cropLocks;
     });
     unawaited(_syncMedia3ZoomMode());
   }
@@ -2395,6 +2398,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
 
   ZoomMode get _activeZoomMode =>
       _cropLocksZoom ? ZoomMode.autoCrop : _zoomMode;
+
+  bool _computeCropLocksZoom() {
+    return _prefs.get(UserPreferences.cropBlackBars) &&
+        (_activeBackend?.supportsLetterboxCrop ?? false);
+  }
 
   void _onSyncPlayChanged() {
     if (mounted) setState(() {});

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -239,7 +239,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   final GlobalKey _topOverlayKey = GlobalKey();
   final GlobalKey _bottomOverlayKey = GlobalKey();
   late ZoomMode _zoomMode;
-  late bool _cropLocksZoom;
   double _audioDelay = 0.0;
   double _subtitleDelay = 0.0;
   bool _subtitleActive = false;
@@ -814,7 +813,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _themeMusicService.setExternalAudioActive(true);
     _segmentService = _createSegmentService();
     _zoomMode = _prefs.get(UserPreferences.playerZoomMode);
-    _cropLocksZoom = _computeCropLocksZoom();
     // Media3 only takes the zoom mode from this call, and the backend change it
     // listens for never fires when it was already the one playing.
     unawaited(_syncMedia3ZoomMode());
@@ -871,10 +869,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         unawaited(backend.setVolume(_playerVolume));
       }
       if (!mounted) return;
-      final cropLocks = _computeCropLocksZoom();
-      setState(() {
-        _cropLocksZoom = cropLocks;
-      });
+      setState(() {});
     });
     _syncMedia3VolumeBoostLevel(resetWhenUnavailable: true);
     if (PlatformDetection.isTV) {
@@ -2093,7 +2088,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       topSubtitle: topSubtitle,
       artworkUrl: artworkUrl,
       showClock: false,
-      zoomModeLabel: _zoomModeLabel(_activeZoomMode),
+      zoomModeLabel: _zoomModeLabel(_zoomMode),
       streamInfoSections: streamInfoSections,
       hasCastCrew: hasCastCrew,
       castPeople: castPeople,
@@ -2381,12 +2376,8 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _syncMediaQueuingPreference();
     if (!mounted) return;
     final zoom = _prefs.get(UserPreferences.playerZoomMode);
-    final cropLocks = _computeCropLocksZoom();
-    if (zoom == _zoomMode && cropLocks == _cropLocksZoom) return;
-    setState(() {
-      _zoomMode = zoom;
-      _cropLocksZoom = cropLocks;
-    });
+    if (zoom == _zoomMode) return;
+    setState(() => _zoomMode = zoom);
     unawaited(_syncMedia3ZoomMode());
   }
 
@@ -2394,14 +2385,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     _manager.autoAdvanceEnabled = _prefs.get(
       UserPreferences.autoplayNextEpisode,
     );
-  }
-
-  ZoomMode get _activeZoomMode =>
-      _cropLocksZoom ? ZoomMode.autoCrop : _zoomMode;
-
-  bool _computeCropLocksZoom() {
-    return _prefs.get(UserPreferences.cropBlackBars) &&
-        (_activeBackend?.supportsLetterboxCrop ?? false);
   }
 
   void _onSyncPlayChanged() {
@@ -4083,7 +4066,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       child: Trickplay(
         fillFrame: true,
         content: (_) => FittedBox(
-          fit: _zoomToFit(_activeZoomMode),
+          fit: _zoomToFit(_zoomMode),
           child: SizedBox(
             width: tile.thumbWidth,
             height: tile.thumbHeight,
@@ -4097,7 +4080,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Widget _buildVideoSurface() {
     if (PlatformDetection.isIOS || PlatformDetection.isMacOS) {
       return Positioned.fill(
-        child: AetherVideoView(key: _videoSurfaceKey, zoomMode: _activeZoomMode.name),
+        child: AetherVideoView(key: _videoSurfaceKey, zoomMode: _zoomMode.name),
       );
     }
 
@@ -4114,7 +4097,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final htmlBackend = _activeHtmlVideoBackend;
     if (htmlBackend != null) {
       return Positioned.fill(
-        child: htmlBackend.buildView(fit: _zoomToFit(_activeZoomMode)),
+        child: htmlBackend.buildView(fit: _zoomToFit(_zoomMode)),
       );
     }
 
@@ -4147,7 +4130,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       return Positioned.fill(
         child: NativeVideoView(
           player: mediaKitBackend.player,
-          zoomMode: _nativeZoomMode(_activeZoomMode),
+          zoomMode: _nativeZoomMode(_zoomMode),
           fill: Colors.black,
           videoOutput: selectedVo,
           hardwareDecodingEnabled: hwDecodingEnabled,
@@ -4169,7 +4152,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             controls: NoVideoControls,
             width: constraints.maxWidth,
             height: constraints.maxHeight,
-            fit: _zoomToFit(_activeZoomMode),
+            fit: _zoomToFit(_zoomMode),
             fill: Colors.black,
             pauseUponEnteringBackgroundMode:
                 !PlatformDetection.isIOS && !PlatformDetection.isAndroid,
@@ -4195,7 +4178,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   Future<void> _syncMedia3ZoomMode() async {
     final backend = _activeMedia3Backend;
     if (backend == null) return;
-    await backend.setZoomMode(_media3ZoomModeWire(_activeZoomMode));
+    await backend.setZoomMode(_media3ZoomModeWire(_zoomMode));
   }
 
   bool _isBringupInProgress(PlaybackBringupPhase phase) {
@@ -5607,7 +5590,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
               iconSize: secondaryIconSize,
               tooltip: l10n.playerTooltipPlaybackQuality,
             ),
-          if (shows(OsdButton.zoom) && !_cropLocksZoom)
+          if (shows(OsdButton.zoom))
             OsdButton.zoom: _buildZoomButton(
               size: secondaryIconSize,
               extent: secondaryExtent,
@@ -7051,7 +7034,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _cyclePlayerZoom() {
-    if (_cropLocksZoom) return;
     final modes = ZoomMode.values;
     final next = modes[(_zoomMode.index + 1) % modes.length];
     setState(() => _zoomMode = next);
@@ -7068,7 +7050,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     FocusNode? focusNode,
     VoidCallback? onRightBoundary,
   }) {
-    final icon = switch (_activeZoomMode) {
+    final icon = switch (_zoomMode) {
       ZoomMode.fit => Icons.fit_screen_rounded,
       ZoomMode.autoCrop => Icons.crop_rounded,
       ZoomMode.stretch => Icons.open_in_full_rounded,

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1144,9 +1144,18 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
     ),
     video.leaf('player_zoom_mode', l10n.playerZoomMode, keywords: [
       'aspect ratio',
-      'crop',
+      'fill',
+      'cover',
       'stretch',
     ]),
+    if (PlatformDetection.isLinux || PlatformDetection.isWindows)
+      video.leaf('crop_black_bars', l10n.cropBlackBars, keywords: [
+        'letterbox',
+        'cropdetect',
+        'black bars',
+        'autocrop',
+        'mpv',
+      ]),
     playbackTime.screen(keywords: [
       'time left',
       'time remaining',

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1152,9 +1152,8 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
         'letterbox',
         'cropdetect',
         'black bars',
-        'autocrop',
         'mpv',
-        'android tv',
+        'android',
       ]),
     playbackTime.screen(keywords: [
       'time left',

--- a/lib/ui/screens/settings/panel/settings_search_index.dart
+++ b/lib/ui/screens/settings/panel/settings_search_index.dart
@@ -1144,17 +1144,17 @@ List<_SettingsSearchEntry> _buildSettingsSearchIndex({
     ),
     video.leaf('player_zoom_mode', l10n.playerZoomMode, keywords: [
       'aspect ratio',
-      'fill',
-      'cover',
+      'crop',
       'stretch',
     ]),
-    if (PlatformDetection.isLinux || PlatformDetection.isWindows)
+    if (letterboxCropSettingVisible())
       video.leaf('crop_black_bars', l10n.cropBlackBars, keywords: [
         'letterbox',
         'cropdetect',
         'black bars',
         'autocrop',
         'mpv',
+        'android tv',
       ]),
     playbackTime.screen(keywords: [
       'time left',

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -23,17 +23,34 @@ class _VideoPlaybackScreen extends StatelessWidget {
                 subtitle: l10n.dimVideoShowOverview,
                 icon: Icons.pause_circle_outline,
               ),
-              EnumPreferenceTile<ZoomMode>(
-                preference: UserPreferences.playerZoomMode,
-                title: l10n.playerZoomMode,
-                description: l10n.settingsPlayerZoomDescription,
-                icon: Icons.zoom_out_map,
-                labelOf: (v) => switch (v) {
-                  ZoomMode.fit => l10n.fit,
-                  ZoomMode.autoCrop => l10n.autoCrop,
-                  ZoomMode.stretch => l10n.stretch,
+              ListenableBuilder(
+                listenable: prefs,
+                builder: (context, _) {
+                  final cropLocksZoom = prefs.get(
+                    UserPreferences.cropBlackBars,
+                  );
+                  return EnumPreferenceTile<ZoomMode>(
+                    preference: UserPreferences.playerZoomMode,
+                    title: l10n.playerZoomMode,
+                    description: l10n.settingsPlayerZoomDescription,
+                    icon: Icons.zoom_out_map,
+                    enabled: !cropLocksZoom,
+                    labelOf: (v) => switch (v) {
+                      ZoomMode.fit => l10n.fit,
+                      ZoomMode.autoCrop => l10n.autoCrop,
+                      ZoomMode.stretch => l10n.stretch,
+                    },
+                  );
                 },
               ),
+              if (PlatformDetection.isLinux || PlatformDetection.isWindows)
+                SwitchPreferenceTile(
+                  preference: UserPreferences.cropBlackBars,
+                  title: l10n.cropBlackBars,
+                  subtitle: l10n.settingsCropBlackBarsDescription,
+                  icon: Icons.crop_16_9_outlined,
+                  isThreeLine: true,
+                ),
               _TvSettingsListTile(
                 leading: const Icon(Icons.timer_outlined),
                 title: Text(l10n.playbackTimeDisplay),

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -23,23 +23,15 @@ class _VideoPlaybackScreen extends StatelessWidget {
                 subtitle: l10n.dimVideoShowOverview,
                 icon: Icons.pause_circle_outline,
               ),
-              ListenableBuilder(
-                listenable: prefs,
-                builder: (context, _) {
-                  final cropLocksZoom = letterboxCropSettingVisible() &&
-                      prefs.get(UserPreferences.cropBlackBars);
-                  return EnumPreferenceTile<ZoomMode>(
-                    preference: UserPreferences.playerZoomMode,
-                    title: l10n.playerZoomMode,
-                    description: l10n.settingsPlayerZoomDescription,
-                    icon: Icons.zoom_out_map,
-                    enabled: !cropLocksZoom,
-                    labelOf: (v) => switch (v) {
-                      ZoomMode.fit => l10n.fit,
-                      ZoomMode.autoCrop => l10n.autoCrop,
-                      ZoomMode.stretch => l10n.stretch,
-                    },
-                  );
+              EnumPreferenceTile<ZoomMode>(
+                preference: UserPreferences.playerZoomMode,
+                title: l10n.playerZoomMode,
+                description: l10n.settingsPlayerZoomDescription,
+                icon: Icons.zoom_out_map,
+                labelOf: (v) => switch (v) {
+                  ZoomMode.fit => l10n.fit,
+                  ZoomMode.autoCrop => l10n.autoCrop,
+                  ZoomMode.stretch => l10n.stretch,
                 },
               ),
               if (letterboxCropSettingVisible())
@@ -48,7 +40,6 @@ class _VideoPlaybackScreen extends StatelessWidget {
                   title: l10n.cropBlackBars,
                   subtitle: l10n.settingsCropBlackBarsDescription,
                   icon: Icons.crop_16_9_outlined,
-                  isThreeLine: true,
                 ),
               _TvSettingsListTile(
                 leading: const Icon(Icons.timer_outlined),

--- a/lib/ui/screens/settings/panel/video_playback_screen.dart
+++ b/lib/ui/screens/settings/panel/video_playback_screen.dart
@@ -26,9 +26,8 @@ class _VideoPlaybackScreen extends StatelessWidget {
               ListenableBuilder(
                 listenable: prefs,
                 builder: (context, _) {
-                  final cropLocksZoom = prefs.get(
-                    UserPreferences.cropBlackBars,
-                  );
+                  final cropLocksZoom = letterboxCropSettingVisible() &&
+                      prefs.get(UserPreferences.cropBlackBars);
                   return EnumPreferenceTile<ZoomMode>(
                     preference: UserPreferences.playerZoomMode,
                     title: l10n.playerZoomMode,
@@ -43,7 +42,7 @@ class _VideoPlaybackScreen extends StatelessWidget {
                   );
                 },
               ),
-              if (PlatformDetection.isLinux || PlatformDetection.isWindows)
+              if (letterboxCropSettingVisible())
                 SwitchPreferenceTile(
                   preference: UserPreferences.cropBlackBars,
                   title: l10n.cropBlackBars,

--- a/lib/ui/screens/settings/settings_side_panel.dart
+++ b/lib/ui/screens/settings/settings_side_panel.dart
@@ -46,6 +46,7 @@ import '../../../l10n/app_localizations.dart';
 import '../../../playback/audio_capability_profile.dart';
 import '../../../playback/audio_capability_probe.dart';
 import '../../../playback/external_player_service.dart';
+import '../../../playback/letterbox_croppers.dart';
 import '../../../preference/preference_constants.dart';
 import '../../../preference/user_preferences.dart';
 import '../../../preference/home_section_config.dart';

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -412,12 +412,7 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
             secondary: secondary,
             title: Text(widget.title, style: _kSettingsTitleTextStyle),
             subtitle: widget.subtitle != null
-                ? Text(
-                    widget.subtitle!,
-                    style: _kSettingsSubtitleTextStyle,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  )
+                ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
                 : null,
             isThreeLine: widget.isThreeLine,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -531,19 +526,12 @@ class _EnumPreferenceTileState<T extends Enum>
                   ? Text(
                       widget.description!,
                       style: _kSettingsDescriptionTextStyle,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
                     )
                   : null,
               isThreeLine: widget.description != null,
               titleAlignment: ListTileTitleAlignment.center,
-              contentPadding: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 4,
-              ),
-              onTap: widget.enabled
-                  ? () => _showPicker(context, current)
-                  : null,
+              contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              onTap: widget.enabled ? () => _showPicker(context, current) : null,
             ),
           );
         },

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -331,7 +331,6 @@ class SwitchPreferenceTile extends StatefulWidget {
 
   final bool inverted;
   final bool enabled;
-  final bool isThreeLine;
   final FocusNode? focusNode;
 
   const SwitchPreferenceTile({
@@ -345,7 +344,6 @@ class SwitchPreferenceTile extends StatefulWidget {
     this.onChangedValue,
     this.inverted = false,
     this.enabled = true,
-    this.isThreeLine = false,
     this.focusNode,
   });
 
@@ -414,7 +412,6 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
             subtitle: widget.subtitle != null
                 ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
                 : null,
-            isThreeLine: widget.isThreeLine,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             value: widget.inverted ? !value : value,
             onChanged: widget.enabled
@@ -444,7 +441,6 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
   final ValueChanged<T>? onChangedValue;
   final List<T>? values;
   final bool autofocus;
-  final bool enabled;
 
   const EnumPreferenceTile({
     super.key,
@@ -459,7 +455,6 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
     this.onChangedValue,
     this.values,
     this.autofocus = false,
-    this.enabled = true,
   });
 
   @override
@@ -505,34 +500,30 @@ class _EnumPreferenceTileState<T extends Enum>
         builder: (context, value, _) {
           final current = values.contains(value) ? value : values.first;
           final label = widget.labelOf(current);
-          return Opacity(
-            opacity: widget.enabled ? 1.0 : 0.45,
-            child: ListTile(
-              autofocus: widget.autofocus && widget.enabled,
-              enabled: widget.enabled,
-              leading: widget.icon != null
-                  ? buildSettingsLeadingIconShell(
-                      context,
-                      icon: Icon(widget.icon),
-                      focused: focused,
-                      iconColor: focused && settingsTileInvertsOnFocus
-                          ? AppColors.black.withValues(alpha: 0.54)
-                          : AppColorScheme.onSurface.withValues(alpha: 0.78),
-                    )
-                  : null,
-              title: Text(widget.title, style: _kSettingsTitleTextStyle),
-              trailing: buildSettingsSelectionBubble(context, label, focused),
-              subtitle: widget.description != null
-                  ? Text(
-                      widget.description!,
-                      style: _kSettingsDescriptionTextStyle,
-                    )
-                  : null,
-              isThreeLine: widget.description != null,
-              titleAlignment: ListTileTitleAlignment.center,
-              contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              onTap: widget.enabled ? () => _showPicker(context, current) : null,
-            ),
+          return ListTile(
+            autofocus: widget.autofocus,
+            leading: widget.icon != null
+                ? buildSettingsLeadingIconShell(
+                    context,
+                    icon: Icon(widget.icon),
+                    focused: focused,
+                    iconColor: focused && settingsTileInvertsOnFocus
+                        ? AppColors.black.withValues(alpha: 0.54)
+                        : AppColorScheme.onSurface.withValues(alpha: 0.78),
+                  )
+                : null,
+            title: Text(widget.title, style: _kSettingsTitleTextStyle),
+            trailing: buildSettingsSelectionBubble(context, label, focused),
+            subtitle: widget.description != null
+                ? Text(
+                    widget.description!,
+                    style: _kSettingsDescriptionTextStyle,
+                  )
+                : null,
+            isThreeLine: widget.description != null,
+            titleAlignment: ListTileTitleAlignment.center,
+            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            onTap: () => _showPicker(context, current),
           );
         },
       ),
@@ -540,7 +531,6 @@ class _EnumPreferenceTileState<T extends Enum>
   }
 
   void _showPicker(BuildContext context, T current) async {
-    if (!widget.enabled) return;
     if (_pickerOpen) return;
     _pickerOpen = true;
     final values = widget.values ?? widget.preference.values.toList();

--- a/lib/ui/widgets/settings/preference_tiles.dart
+++ b/lib/ui/widgets/settings/preference_tiles.dart
@@ -331,6 +331,7 @@ class SwitchPreferenceTile extends StatefulWidget {
 
   final bool inverted;
   final bool enabled;
+  final bool isThreeLine;
   final FocusNode? focusNode;
 
   const SwitchPreferenceTile({
@@ -344,6 +345,7 @@ class SwitchPreferenceTile extends StatefulWidget {
     this.onChangedValue,
     this.inverted = false,
     this.enabled = true,
+    this.isThreeLine = false,
     this.focusNode,
   });
 
@@ -410,8 +412,14 @@ class _SwitchPreferenceTileState extends State<SwitchPreferenceTile> {
             secondary: secondary,
             title: Text(widget.title, style: _kSettingsTitleTextStyle),
             subtitle: widget.subtitle != null
-                ? Text(widget.subtitle!, style: _kSettingsSubtitleTextStyle)
+                ? Text(
+                    widget.subtitle!,
+                    style: _kSettingsSubtitleTextStyle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  )
                 : null,
+            isThreeLine: widget.isThreeLine,
             contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
             value: widget.inverted ? !value : value,
             onChanged: widget.enabled
@@ -441,6 +449,7 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
   final ValueChanged<T>? onChangedValue;
   final List<T>? values;
   final bool autofocus;
+  final bool enabled;
 
   const EnumPreferenceTile({
     super.key,
@@ -455,6 +464,7 @@ class EnumPreferenceTile<T extends Enum> extends StatefulWidget {
     this.onChangedValue,
     this.values,
     this.autofocus = false,
+    this.enabled = true,
   });
 
   @override
@@ -500,30 +510,41 @@ class _EnumPreferenceTileState<T extends Enum>
         builder: (context, value, _) {
           final current = values.contains(value) ? value : values.first;
           final label = widget.labelOf(current);
-          return ListTile(
-            autofocus: widget.autofocus,
-            leading: widget.icon != null
-                ? buildSettingsLeadingIconShell(
-                    context,
-                    icon: Icon(widget.icon),
-                    focused: focused,
-                    iconColor: focused && settingsTileInvertsOnFocus
-                        ? AppColors.black.withValues(alpha: 0.54)
-                        : AppColorScheme.onSurface.withValues(alpha: 0.78),
-                  )
-                : null,
-            title: Text(widget.title, style: _kSettingsTitleTextStyle),
-            trailing: buildSettingsSelectionBubble(context, label, focused),
-            subtitle: widget.description != null
-                ? Text(
-                    widget.description!,
-                    style: _kSettingsDescriptionTextStyle,
-                  )
-                : null,
-            isThreeLine: widget.description != null,
-            titleAlignment: ListTileTitleAlignment.center,
-            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-            onTap: () => _showPicker(context, current),
+          return Opacity(
+            opacity: widget.enabled ? 1.0 : 0.45,
+            child: ListTile(
+              autofocus: widget.autofocus && widget.enabled,
+              enabled: widget.enabled,
+              leading: widget.icon != null
+                  ? buildSettingsLeadingIconShell(
+                      context,
+                      icon: Icon(widget.icon),
+                      focused: focused,
+                      iconColor: focused && settingsTileInvertsOnFocus
+                          ? AppColors.black.withValues(alpha: 0.54)
+                          : AppColorScheme.onSurface.withValues(alpha: 0.78),
+                    )
+                  : null,
+              title: Text(widget.title, style: _kSettingsTitleTextStyle),
+              trailing: buildSettingsSelectionBubble(context, label, focused),
+              subtitle: widget.description != null
+                  ? Text(
+                      widget.description!,
+                      style: _kSettingsDescriptionTextStyle,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    )
+                  : null,
+              isThreeLine: widget.description != null,
+              titleAlignment: ListTileTitleAlignment.center,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 4,
+              ),
+              onTap: widget.enabled
+                  ? () => _showPicker(context, current)
+                  : null,
+            ),
           );
         },
       ),
@@ -531,6 +552,7 @@ class _EnumPreferenceTileState<T extends Enum>
   }
 
   void _showPicker(BuildContext context, T current) async {
+    if (!widget.enabled) return;
     if (_pickerOpen) return;
     _pickerOpen = true;
     final values = widget.values ?? widget.preference.values.toList();

--- a/macos/Runner/Playback/MacosAetherVideoPlatformView.swift
+++ b/macos/Runner/Playback/MacosAetherVideoPlatformView.swift
@@ -96,7 +96,7 @@ final class MacosAetherVideoContainerView: NSView {
     private static func zoomMode(fromWire value: String) -> ZoomMode? {
         switch value {
         case "fit", "Fit": return .fit
-        case "autoCrop", "Auto Crop", "Fill": return .autoCrop
+        case "autoCrop", "Auto Crop": return .autoCrop
         case "stretch", "Stretch": return .stretch
         default: return nil
         }

--- a/macos/Runner/Playback/MacosAetherVideoPlatformView.swift
+++ b/macos/Runner/Playback/MacosAetherVideoPlatformView.swift
@@ -96,7 +96,7 @@ final class MacosAetherVideoContainerView: NSView {
     private static func zoomMode(fromWire value: String) -> ZoomMode? {
         switch value {
         case "fit", "Fit": return .fit
-        case "autoCrop", "Auto Crop": return .autoCrop
+        case "autoCrop", "Auto Crop", "Fill": return .autoCrop
         case "stretch", "Stretch": return .stretch
         default: return nil
         }

--- a/packages/moonfin_native_video/android/build.gradle
+++ b/packages/moonfin_native_video/android/build.gradle
@@ -112,6 +112,4 @@ dependencies {
     // ass-media declares this at runtime scope, but its public API hands back
     // AssRender and AssFrame, so driving libass here needs it at compile time.
     implementation("io.github.peerless2012:ass-kt:0.4.0")
-
-    testImplementation("junit:junit:4.13.2")
 }

--- a/packages/moonfin_native_video/android/build.gradle
+++ b/packages/moonfin_native_video/android/build.gradle
@@ -112,4 +112,6 @@ dependencies {
     // ass-media declares this at runtime scope, but its public API hands back
     // AssRender and AssFrame, so driving libass here needs it at compile time.
     implementation("io.github.peerless2012:ass-kt:0.4.0")
+
+    testImplementation("junit:junit:4.13.2")
 }

--- a/packages/moonfin_native_video/android/gradle.properties
+++ b/packages/moonfin_native_video/android/gradle.properties
@@ -1,2 +1,0 @@
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/moonfin_native_video/android/gradle.properties
+++ b/packages/moonfin_native_video/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/LetterboxBarScanner.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/LetterboxBarScanner.kt
@@ -1,0 +1,118 @@
+package org.moonfin.nativevideo
+
+/**
+ * Finds encoded letterbox bars in an ARGB frame.
+ *
+ * Same thresholds as mpv `cropdetect=limit=24/255:round=2`. The rectangle is
+ * in coded-pixel space ([sourceWidth] x [sourceHeight]), not view pixels.
+ */
+data class LetterboxCropRect(
+    val w: Int,
+    val h: Int,
+    val x: Int,
+    val y: Int,
+) {
+    fun toWireMap(sourceWidth: Int, sourceHeight: Int): Map<String, Int> = mapOf(
+        "w" to w,
+        "h" to h,
+        "x" to x,
+        "y" to y,
+        "sourceWidth" to sourceWidth,
+        "sourceHeight" to sourceHeight,
+    )
+}
+
+object LetterboxBarScanner {
+    const val LUMA_LIMIT = 24
+    const val ROUND = 2
+
+    fun scanArgb(
+        pixels: IntArray,
+        width: Int,
+        height: Int,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        lumaLimit: Int = LUMA_LIMIT,
+        round: Int = ROUND,
+    ): LetterboxCropRect? {
+        if (
+            width <= 0 ||
+            height <= 0 ||
+            sourceWidth <= 0 ||
+            sourceHeight <= 0 ||
+            pixels.size < width * height
+        ) {
+            return null
+        }
+
+        var minX = width
+        var minY = height
+        var maxX = -1
+        var maxY = -1
+        for (y in 0 until height) {
+            val row = y * width
+            for (x in 0 until width) {
+                if (luma(pixels[row + x]) > lumaLimit) {
+                    if (x < minX) minX = x
+                    if (x > maxX) maxX = x
+                    if (y < minY) minY = y
+                    if (y > maxY) maxY = y
+                }
+            }
+        }
+        if (maxX < 0) {
+            return null
+        }
+
+        val srcX = mapToSource(minX, width, sourceWidth)
+        val srcY = mapToSource(minY, height, sourceHeight)
+        val srcW = (mapToSource(maxX + 1, width, sourceWidth) - srcX)
+            .coerceAtLeast(0)
+        val srcH = (mapToSource(maxY + 1, height, sourceHeight) - srcY)
+            .coerceAtLeast(0)
+        return roundRect(srcX, srcY, srcW, srcH, sourceWidth, sourceHeight, round)
+    }
+
+    internal fun luma(pixel: Int): Int {
+        val r = (pixel ushr 16) and 0xFF
+        val g = (pixel ushr 8) and 0xFF
+        val b = pixel and 0xFF
+        return (77 * r + 150 * g + 29 * b) shr 8
+    }
+
+    internal fun mapToSource(viewCoord: Int, viewSize: Int, sourceSize: Int): Int {
+        if (viewSize <= 0) return 0
+        return ((viewCoord.toLong() * sourceSize) / viewSize).toInt()
+            .coerceIn(0, sourceSize)
+    }
+
+    internal fun roundRect(
+        x: Int,
+        y: Int,
+        w: Int,
+        h: Int,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        round: Int,
+    ): LetterboxCropRect? {
+        if (w <= 0 || h <= 0) return null
+        val step = round.coerceAtLeast(1)
+        var rx = alignDown(x.coerceAtLeast(0), step)
+        var ry = alignDown(y.coerceAtLeast(0), step)
+        var rw = alignDown(w, step)
+        var rh = alignDown(h, step)
+        if (rx + rw > sourceWidth) {
+            rw = alignDown(sourceWidth - rx, step)
+        }
+        if (ry + rh > sourceHeight) {
+            rh = alignDown(sourceHeight - ry, step)
+        }
+        if (rw <= 0 || rh <= 0) return null
+        return LetterboxCropRect(w = rw, h = rh, x = rx, y = ry)
+    }
+
+    private fun alignDown(value: Int, round: Int): Int {
+        if (round <= 1 || value <= 0) return value.coerceAtLeast(0)
+        return value - (value % round)
+    }
+}

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/LetterboxCropLayout.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/LetterboxCropLayout.kt
@@ -1,0 +1,76 @@
+package org.moonfin.nativevideo
+
+import kotlin.math.roundToInt
+
+/**
+ * Sizes the full coded surface so a crop rectangle covers or fits the
+ * container. Asymmetric bars need TOP|START + offsets, not Gravity.CENTER.
+ */
+object LetterboxCropLayout {
+    data class Bounds(
+        val width: Int,
+        val height: Int,
+        val left: Int,
+        val top: Int,
+    )
+
+    fun compute(
+        containerWidth: Int,
+        containerHeight: Int,
+        sourceWidth: Float,
+        sourceHeight: Float,
+        cropX: Float,
+        cropY: Float,
+        cropW: Float,
+        cropH: Float,
+        cover: Boolean,
+    ): Bounds {
+        if (
+            containerWidth <= 0 ||
+            containerHeight <= 0 ||
+            sourceWidth <= 0f ||
+            sourceHeight <= 0f ||
+            cropW <= 0f ||
+            cropH <= 0f
+        ) {
+            return Bounds(
+                width = containerWidth.coerceAtLeast(1),
+                height = containerHeight.coerceAtLeast(1),
+                left = 0,
+                top = 0,
+            )
+        }
+
+        val containerAspect = containerWidth.toFloat() / containerHeight.toFloat()
+        val cropAspect = cropW / cropH
+        val (targetW, targetH) = if (cover) {
+            if (containerAspect > cropAspect) {
+                val width = containerWidth.toFloat()
+                width to (width / cropAspect)
+            } else {
+                val height = containerHeight.toFloat()
+                (height * cropAspect) to height
+            }
+        } else {
+            if (containerAspect > cropAspect) {
+                val height = containerHeight.toFloat()
+                (height * cropAspect) to height
+            } else {
+                val width = containerWidth.toFloat()
+                width to (width / cropAspect)
+            }
+        }
+
+        val scale = targetW / cropW
+        val viewW = (sourceWidth * scale).roundToInt().coerceAtLeast(1)
+        val viewH = (sourceHeight * scale).roundToInt().coerceAtLeast(1)
+        val targetLeft = (containerWidth - targetW) / 2f
+        val targetTop = (containerHeight - targetH) / 2f
+        return Bounds(
+            width = viewW,
+            height = viewH,
+            left = (targetLeft - cropX * scale).roundToInt(),
+            top = (targetTop - cropY * scale).roundToInt(),
+        )
+    }
+}

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3Bridge.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3Bridge.kt
@@ -316,6 +316,7 @@ object Media3Bridge {
             "setVolume",
             "setSpeed",
             "setZoomMode",
+            "setLetterboxCrop",
             "setAudioTrack",
             "setSubtitleTrack",
             "setClosedCaptionTrack",

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -19,7 +19,6 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.view.Gravity
-import android.view.PixelCopy
 import android.view.Display
 import android.view.PixelCopy
 import android.view.Surface
@@ -3197,7 +3196,13 @@ class Media3VideoView(
             return
         }
         when (val view = videoView) {
-            is SurfaceView -> copySurfaceForLetterbox(view, sourceW, sourceH, result)
+            // Tunneled output never lands in a buffer this side can read.
+            is SurfaceView ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && !tunnelingActive) {
+                    copySurfaceForLetterbox(view, sourceW, sourceH, result)
+                } else {
+                    result.success(null)
+                }
             is TextureView -> copyTextureForLetterbox(view, sourceW, sourceH, result)
             else -> result.success(null)
         }
@@ -3230,10 +3235,6 @@ class Media3VideoView(
         sourceHeight: Int,
         result: MethodChannel.Result,
     ) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            result.success(null)
-            return
-        }
         val surface = view.holder.surface
         if (surface == null || !surface.isValid || view.width <= 0 || view.height <= 0) {
             result.success(null)

--- a/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
+++ b/packages/moonfin_native_video/android/src/main/kotlin/org/moonfin/nativevideo/Media3VideoView.kt
@@ -21,6 +21,7 @@ import android.os.SystemClock
 import android.view.Gravity
 import android.view.PixelCopy
 import android.view.Display
+import android.view.PixelCopy
 import android.view.Surface
 import android.view.SurfaceView
 import android.view.TextureView
@@ -683,6 +684,8 @@ class Media3VideoView(
     private val subtitleView = SubtitleView(context)
     private val containerView: FrameLayout = FrameLayout(context).also { container ->
         container.setBackgroundColor(Color.BLACK)
+        container.clipChildren = true
+        container.clipToPadding = true
         // Hold the screen awake while a real player surface is attached so the
         // OS screensaver cannot interrupt playback if the wakelock lapses.
         // Previews stay excluded so browsing does not keep the screen on.
@@ -818,6 +821,7 @@ class Media3VideoView(
     private var pendingExternalSubtitleUrl: String? = null
     private var pendingAudioIndex: Int? = null
     private var zoomMode = ZoomMode.FIT
+    private var letterboxCrop: LetterboxCropRect? = null
     private var videoWidthPx = 0
     private var videoHeightPx = 0
     private var videoPixelRatio = 1f
@@ -2115,6 +2119,15 @@ class Media3VideoView(
                     result.success(null)
                 }
 
+                "setLetterboxCrop" -> {
+                    updateLetterboxCrop(call.arguments)
+                    result.success(null)
+                }
+
+                "detectLetterbox" -> {
+                    detectLetterbox(result)
+                }
+
                 "setAudioTrack" -> {
                     val index = ((call.arguments as? Map<*, *>)?.get("index") as? Number)?.toInt() ?: 0
                     pendingAudioIndex = index
@@ -2282,6 +2295,10 @@ class Media3VideoView(
                     updateZoomMode(args)
                 }
 
+                "setLetterboxCrop" -> {
+                    updateLetterboxCrop(args)
+                }
+
                 "setAudioTrack" -> {
                     val index = (args as? Map<*, *>)?.get("index") as? Number ?: return
                     selectTrack(C.TRACK_TYPE_AUDIO, index.toInt())
@@ -2443,6 +2460,10 @@ class Media3VideoView(
             ?.takeIf { it > 0 }
         pendingClosedCaptionId = null
         hideVideoUntilFirstFrame()
+        if (letterboxCrop != null) {
+            letterboxCrop = null
+            applyVideoLayout()
+        }
         cancelPendingSubtitleCue(clearView = true)
         clearAssSubtitleScript()
         applyTrackSelectorForCurrentSource()
@@ -3148,6 +3169,130 @@ class Media3VideoView(
         applyVideoLayout()
     }
 
+    private fun updateLetterboxCrop(arguments: Any?) {
+        val args = arguments as? Map<*, *> ?: return
+        if (args["clear"] == true) {
+            if (letterboxCrop != null) {
+                letterboxCrop = null
+                applyVideoLayout()
+            }
+            return
+        }
+        val w = (args["w"] as? Number)?.toInt() ?: return
+        val h = (args["h"] as? Number)?.toInt() ?: return
+        val x = (args["x"] as? Number)?.toInt() ?: return
+        val y = (args["y"] as? Number)?.toInt() ?: return
+        val next = LetterboxCropRect(w = w, h = h, x = x, y = y)
+        if (next != letterboxCrop) {
+            letterboxCrop = next
+            applyVideoLayout()
+        }
+    }
+
+    private fun detectLetterbox(result: MethodChannel.Result) {
+        val sourceW = videoWidthPx
+        val sourceH = videoHeightPx
+        if (sourceW <= 0 || sourceH <= 0) {
+            result.success(null)
+            return
+        }
+        when (val view = videoView) {
+            is SurfaceView -> copySurfaceForLetterbox(view, sourceW, sourceH, result)
+            is TextureView -> copyTextureForLetterbox(view, sourceW, sourceH, result)
+            else -> result.success(null)
+        }
+    }
+
+    private fun copyTextureForLetterbox(
+        view: TextureView,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        result: MethodChannel.Result,
+    ) {
+        if (view.width <= 0 || view.height <= 0) {
+            result.success(null)
+            return
+        }
+        val sample = letterboxSampleSize(view.width, view.height)
+        val bitmap = view.getBitmap(sample.width, sample.height)
+        if (bitmap == null) {
+            result.success(null)
+            return
+        }
+        result.success(scanBitmap(bitmap, sourceWidth, sourceHeight)?.toWireMap(sourceWidth, sourceHeight))
+        bitmap.recycle()
+    }
+
+    @androidx.annotation.RequiresApi(Build.VERSION_CODES.N)
+    private fun copySurfaceForLetterbox(
+        view: SurfaceView,
+        sourceWidth: Int,
+        sourceHeight: Int,
+        result: MethodChannel.Result,
+    ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            result.success(null)
+            return
+        }
+        val surface = view.holder.surface
+        if (surface == null || !surface.isValid || view.width <= 0 || view.height <= 0) {
+            result.success(null)
+            return
+        }
+        val sample = letterboxSampleSize(view.width, view.height)
+        val bitmap = Bitmap.createBitmap(sample.width, sample.height, Bitmap.Config.ARGB_8888)
+        try {
+            PixelCopy.request(view, bitmap, { copyResult ->
+                if (isDisposedByFlutter || copyResult != PixelCopy.SUCCESS) {
+                    bitmap.recycle()
+                    result.success(null)
+                    return@request
+                }
+                result.success(
+                    scanBitmap(bitmap, sourceWidth, sourceHeight)
+                        ?.toWireMap(sourceWidth, sourceHeight),
+                )
+                bitmap.recycle()
+            }, mainHandler)
+        } catch (_: Throwable) {
+            bitmap.recycle()
+            result.success(null)
+        }
+    }
+
+    private fun letterboxSampleSize(viewWidth: Int, viewHeight: Int): android.util.Size {
+        val maxDim = 480
+        val width = viewWidth.coerceAtLeast(1)
+        val height = viewHeight.coerceAtLeast(1)
+        val longest = maxOf(width, height)
+        if (longest <= maxDim) {
+            return android.util.Size(width, height)
+        }
+        val scale = maxDim.toFloat() / longest.toFloat()
+        return android.util.Size(
+            (width * scale).roundToInt().coerceAtLeast(1),
+            (height * scale).roundToInt().coerceAtLeast(1),
+        )
+    }
+
+    private fun scanBitmap(
+        bitmap: Bitmap,
+        sourceWidth: Int,
+        sourceHeight: Int,
+    ): LetterboxCropRect? {
+        val width = bitmap.width
+        val height = bitmap.height
+        val pixels = IntArray(width * height)
+        bitmap.getPixels(pixels, 0, width, 0, 0, width, height)
+        return LetterboxBarScanner.scanArgb(
+            pixels = pixels,
+            width = width,
+            height = height,
+            sourceWidth = sourceWidth,
+            sourceHeight = sourceHeight,
+        )
+    }
+
     // The Dart side only reports a codec when it drives the selection itself.
     // Media3 picks the track on its own for a preferred text language or a
     // closed caption, so the selected track's mime type is the reliable test
@@ -3194,10 +3339,32 @@ class Media3VideoView(
         // vertical offset is a fraction of this view's height, so pinning text
         // to a letterboxed box would make one setting land at a different
         // on-screen position for every aspect ratio.
-        fun applyBounds(width: Int, height: Int) {
-            applyLayoutBounds(videoView, videoLayoutParams, width, height)
+        fun applyBounds(
+            width: Int,
+            height: Int,
+            gravity: Int = Gravity.CENTER,
+            leftMargin: Int = 0,
+            topMargin: Int = 0,
+        ) {
+            applyLayoutBounds(
+                videoView,
+                videoLayoutParams,
+                width,
+                height,
+                gravity,
+                leftMargin,
+                topMargin,
+            )
             if (selectedSubtitleIsAss) {
-                applyLayoutBounds(subtitleView, subtitleLayoutParams, width, height)
+                applyLayoutBounds(
+                    subtitleView,
+                    subtitleLayoutParams,
+                    width,
+                    height,
+                    gravity,
+                    leftMargin,
+                    topMargin,
+                )
             } else {
                 applyLayoutBounds(
                     subtitleView,
@@ -3224,6 +3391,29 @@ class Media3VideoView(
             applyBounds(
                 FrameLayout.LayoutParams.MATCH_PARENT,
                 FrameLayout.LayoutParams.MATCH_PARENT,
+            )
+            return
+        }
+
+        val crop = letterboxCrop
+        if (crop != null && crop.w > 0 && crop.h > 0) {
+            val bounds = LetterboxCropLayout.compute(
+                containerWidth = containerWidth,
+                containerHeight = containerHeight,
+                sourceWidth = sourceWidth,
+                sourceHeight = sourceHeight,
+                cropX = crop.x * videoPixelRatio,
+                cropY = crop.y.toFloat(),
+                cropW = crop.w * videoPixelRatio,
+                cropH = crop.h.toFloat(),
+                cover = zoomMode == ZoomMode.CROP,
+            )
+            applyBounds(
+                bounds.width,
+                bounds.height,
+                Gravity.TOP or Gravity.START,
+                bounds.left,
+                bounds.top,
             )
             return
         }
@@ -3269,18 +3459,29 @@ class Media3VideoView(
         layoutParams: FrameLayout.LayoutParams,
         width: Int,
         height: Int,
+        gravity: Int = Gravity.CENTER,
+        leftMargin: Int = 0,
+        topMargin: Int = 0,
     ) {
         if (
             layoutParams.width == width &&
             layoutParams.height == height &&
-            layoutParams.gravity == Gravity.CENTER
+            layoutParams.gravity == gravity &&
+            layoutParams.leftMargin == leftMargin &&
+            layoutParams.topMargin == topMargin &&
+            layoutParams.rightMargin == 0 &&
+            layoutParams.bottomMargin == 0
         ) {
             return
         }
 
         layoutParams.width = width
         layoutParams.height = height
-        layoutParams.gravity = Gravity.CENTER
+        layoutParams.gravity = gravity
+        layoutParams.leftMargin = leftMargin
+        layoutParams.topMargin = topMargin
+        layoutParams.rightMargin = 0
+        layoutParams.bottomMargin = 0
         view.layoutParams = layoutParams
     }
 

--- a/packages/moonfin_native_video/android/src/test/kotlin/org/moonfin/nativevideo/LetterboxBarScannerTest.kt
+++ b/packages/moonfin_native_video/android/src/test/kotlin/org/moonfin/nativevideo/LetterboxBarScannerTest.kt
@@ -1,0 +1,150 @@
+package org.moonfin.nativevideo
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LetterboxBarScannerTest {
+    @Test
+    fun findsLetterboxBarsAtSourceSize() {
+        val width = 192
+        val height = 108
+        val bar = 14
+        val pixels = letterboxFrame(width, height, bar)
+        val rect = LetterboxBarScanner.scanArgb(
+            pixels = pixels,
+            width = width,
+            height = height,
+            sourceWidth = 1920,
+            sourceHeight = 1080,
+        )
+        assertNotNull(rect)
+        assertEquals(0, rect!!.x)
+        assertEquals(1920, rect.w)
+        assertEquals(140, rect.y)
+        assertEquals(800, rect.h)
+    }
+
+    @Test
+    fun findsPillarbox() {
+        val width = 192
+        val height = 108
+        val bar = 24
+        val pixels = IntArray(width * height)
+        val content = 0xFF808080.toInt()
+        for (y in 0 until height) {
+            for (x in bar until width - bar) {
+                pixels[y * width + x] = content
+            }
+        }
+        val rect = LetterboxBarScanner.scanArgb(
+            pixels = pixels,
+            width = width,
+            height = height,
+            sourceWidth = 1920,
+            sourceHeight = 1080,
+        )
+        assertNotNull(rect)
+        assertEquals(0, rect!!.y)
+        assertEquals(1080, rect.h)
+        assertEquals(240, rect.x)
+        assertEquals(1440, rect.w)
+    }
+
+    @Test
+    fun allBlackIsNull() {
+        val pixels = IntArray(64 * 36)
+        assertNull(
+            LetterboxBarScanner.scanArgb(
+                pixels = pixels,
+                width = 64,
+                height = 36,
+                sourceWidth = 1920,
+                sourceHeight = 1080,
+            ),
+        )
+    }
+
+    @Test
+    fun fullFrameHasNoInset() {
+        val width = 64
+        val height = 36
+        val pixels = IntArray(width * height) { 0xFF808080.toInt() }
+        val rect = LetterboxBarScanner.scanArgb(
+            pixels = pixels,
+            width = width,
+            height = height,
+            sourceWidth = 1920,
+            sourceHeight = 1080,
+        )
+        assertNotNull(rect)
+        assertEquals(0, rect!!.x)
+        assertEquals(0, rect.y)
+        assertEquals(1920, rect.w)
+        assertEquals(1080, rect.h)
+    }
+
+    @Test
+    fun lumaThresholdMatchesCropdetect() {
+        assertTrue(LetterboxBarScanner.luma(0xFF000000.toInt()) <= LetterboxBarScanner.LUMA_LIMIT)
+        assertTrue(LetterboxBarScanner.luma(0xFF101010.toInt()) <= LetterboxBarScanner.LUMA_LIMIT)
+        assertTrue(LetterboxBarScanner.luma(0xFF808080.toInt()) > LetterboxBarScanner.LUMA_LIMIT)
+    }
+}
+
+class LetterboxCropLayoutTest {
+    @Test
+    fun coverZoomsLetterboxIntoSixteenByNine() {
+        val bounds = LetterboxCropLayout.compute(
+            containerWidth = 1920,
+            containerHeight = 1080,
+            sourceWidth = 1920f,
+            sourceHeight = 1080f,
+            cropX = 0f,
+            cropY = 138f,
+            cropW = 1920f,
+            cropH = 804f,
+            cover = true,
+        )
+        assertTrue(bounds.width > 1920)
+        assertTrue(bounds.left < 0)
+        assertTrue(bounds.top < 0)
+        val scale = bounds.width / 1920f
+        val cropTopOnScreen = bounds.top + 138f * scale
+        val cropHeightOnScreen = 804f * scale
+        assertEquals(0.0, cropTopOnScreen.toDouble(), 1.5)
+        assertEquals(1080.0, cropHeightOnScreen.toDouble(), 1.5)
+    }
+
+    @Test
+    fun fitKeepsCenteredLetterbox() {
+        val bounds = LetterboxCropLayout.compute(
+            containerWidth = 1920,
+            containerHeight = 1080,
+            sourceWidth = 1920f,
+            sourceHeight = 1080f,
+            cropX = 0f,
+            cropY = 138f,
+            cropW = 1920f,
+            cropH = 804f,
+            cover = false,
+        )
+        assertEquals(1920, bounds.width)
+        assertEquals(1080, bounds.height)
+        assertEquals(0, bounds.left)
+        assertEquals(0, bounds.top)
+    }
+}
+
+private fun letterboxFrame(width: Int, height: Int, bar: Int): IntArray {
+    val pixels = IntArray(width * height)
+    val content = 0xFF808080.toInt()
+    for (y in bar until height - bar) {
+        for (x in 0 until width) {
+            pixels[y * width + x] = content
+        }
+    }
+    return pixels
+}

--- a/packages/playback_core/lib/playback_core.dart
+++ b/packages/playback_core/lib/playback_core.dart
@@ -6,6 +6,7 @@ library;
 
 export 'src/playback_manager.dart';
 export 'src/playback_arbiter.dart';
+export 'src/letterbox_crop.dart';
 export 'src/player_backend.dart';
 export 'src/player_service.dart';
 export 'src/queue_service.dart';

--- a/packages/playback_core/lib/src/letterbox_crop.dart
+++ b/packages/playback_core/lib/src/letterbox_crop.dart
@@ -1,0 +1,113 @@
+/// Encoded-letterbox crop. Not cover-zoom.
+///
+/// Cover-zoom (Auto Crop / aspect-fill / `BoxFit.cover`) scales the whole coded
+/// picture to fill the window, so black bars baked into a 16:9 file stay. A
+/// [LetterboxCropper] finds those bars and removes them; the player can then
+/// fill the cropped picture.
+///
+/// Shipping implementations: desktop libmpv (`cropdetect` → `vf crop`) and
+/// Android TV Media3 (PixelCopy scan → layout zoom into the crop).
+/// Other engines return [UnsupportedLetterboxCropper] until they grow a
+/// detector and a crop path.
+library;
+
+class LetterboxCropRect {
+  const LetterboxCropRect({
+    required this.w,
+    required this.h,
+    required this.x,
+    required this.y,
+  });
+
+  final int w;
+  final int h;
+  final int x;
+  final int y;
+
+  String get videoCrop => '${w}x$h+$x+$y';
+
+  @override
+  bool operator ==(Object other) =>
+      other is LetterboxCropRect &&
+      other.w == w &&
+      other.h == h &&
+      other.x == x &&
+      other.y == y;
+
+  @override
+  int get hashCode => Object.hash(w, h, x, y);
+}
+
+/// Shared accept/reject rules for a detected crop rectangle.
+abstract final class LetterboxCrop {
+  /// Drop a detect that would keep less than this fraction of the source.
+  static const minRatio = 0.5;
+
+  /// [null] when the detect is missing, full-frame, or an over-crop.
+  static LetterboxCropRect? decide({
+    required int width,
+    required int height,
+    required int x,
+    required int y,
+    required int sourceWidth,
+    required int sourceHeight,
+    double minRatio = LetterboxCrop.minRatio,
+  }) {
+    if (sourceWidth <= 0 || sourceHeight <= 0) return null;
+    if (width <= 0 || height <= 0) return null;
+
+    final effective =
+        x > 0 || y > 0 || width < sourceWidth || height < sourceHeight;
+    if (!effective) return null;
+
+    final minW = sourceWidth * minRatio;
+    final minH = sourceHeight * minRatio;
+    if (width < minW || height < minH) return null;
+
+    return LetterboxCropRect(w: width, h: height, x: x, y: y);
+  }
+}
+
+/// Per-engine letterbox crop. Backends own detection and applying the crop.
+///
+/// Implement this on a new player; do not special-case platforms in the UI.
+/// Settings and the Auto Crop zoom lock after detect both key off [isSupported].
+abstract class LetterboxCropper {
+  const LetterboxCropper();
+
+  /// Detector + crop path exist on this engine.
+  bool get isSupported;
+
+  /// Why this engine cannot crop yet. Null when [isSupported] is true.
+  String? get unimplementedReason =>
+      isSupported ? null : 'Letterbox crop is not implemented on this player.';
+
+  /// User preference flipped. No-op when unsupported.
+  Future<void> setEnabled(bool enabled);
+
+  /// New title. Detect is one-shot per [url].
+  Future<void> onSourceOpened(String url);
+
+  /// Drop an applied crop (preference off, failed detect). Not dispose.
+  Future<void> reset();
+}
+
+/// Default for engines with no detector yet.
+class UnsupportedLetterboxCropper extends LetterboxCropper {
+  const UnsupportedLetterboxCropper({this.unimplementedReason});
+
+  @override
+  final String? unimplementedReason;
+
+  @override
+  bool get isSupported => false;
+
+  @override
+  Future<void> setEnabled(bool enabled) async {}
+
+  @override
+  Future<void> onSourceOpened(String url) async {}
+
+  @override
+  Future<void> reset() async {}
+}

--- a/packages/playback_core/lib/src/letterbox_crop.dart
+++ b/packages/playback_core/lib/src/letterbox_crop.dart
@@ -1,12 +1,11 @@
 /// Encoded-letterbox crop. Not cover-zoom.
 ///
-/// Cover-zoom (Auto Crop / aspect-fill / `BoxFit.cover`) scales the whole coded
-/// picture to fill the window, so black bars baked into a 16:9 file stay. A
-/// [LetterboxCropper] finds those bars and removes them; the player can then
-/// fill the cropped picture.
+/// Cover-zoom scales the whole coded picture to fill the window, so black bars
+/// baked into a 16:9 file stay. A [LetterboxCropper] finds those bars and
+/// removes them; the player can then fill the cropped picture.
 ///
 /// Shipping implementations: desktop libmpv (`cropdetect` → `vf crop`) and
-/// Android TV Media3 (PixelCopy scan → layout zoom into the crop).
+/// Android Media3 (PixelCopy scan → layout zoom into the crop).
 /// Other engines return [UnsupportedLetterboxCropper] until they grow a
 /// detector and a crop path.
 library;
@@ -71,7 +70,7 @@ abstract final class LetterboxCrop {
 /// Per-engine letterbox crop. Backends own detection and applying the crop.
 ///
 /// Implement this on a new player; do not special-case platforms in the UI.
-/// Settings and the Auto Crop zoom lock after detect both key off [isSupported].
+/// Settings and the zoom lock after detect both key off [isSupported].
 abstract class LetterboxCropper {
   const LetterboxCropper();
 

--- a/packages/playback_core/lib/src/player_backend.dart
+++ b/packages/playback_core/lib/src/player_backend.dart
@@ -1,3 +1,5 @@
+import 'letterbox_crop.dart';
+
 enum SubtitleRendererMode { native, assOverlay }
 
 /// A caption track the player found inside the video itself, like the CEA-608
@@ -174,6 +176,14 @@ abstract class PlayerBackend {
   /// nudges the rate where this is true, and holds the player instead where
   /// it is not.
   bool get supportsSmoothRateChange => true;
+
+  /// Detect encoded letterbox and crop it. Cover-zoom is not this.
+  ///
+  /// Desktop libmpv ships a cropper. Media3 / Aether / Tizen / HTML return
+  /// [UnsupportedLetterboxCropper] until they implement [LetterboxCropper].
+  LetterboxCropper get letterboxCropper => const UnsupportedLetterboxCropper();
+
+  bool get supportsLetterboxCrop => letterboxCropper.isSupported;
 
   void dispose();
 }

--- a/test/playback/mpv_letterbox_crop_test.dart
+++ b/test/playback/mpv_letterbox_crop_test.dart
@@ -1,5 +1,45 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/playback/letterbox_croppers.dart';
+import 'package:moonfin/playback/media3_letterbox_crop.dart';
 import 'package:moonfin/playback/mpv_letterbox_crop.dart';
+import 'package:playback_core/playback_core.dart';
+
+class _RecordingHost implements MpvLetterboxHost {
+  final commands = <List<String>>[];
+
+  @override
+  bool hasNativePlayer = true;
+
+  @override
+  bool isDisposed = false;
+
+  @override
+  bool isPlaying = true;
+
+  @override
+  Duration position = Duration.zero;
+
+  @override
+  Duration duration = const Duration(minutes: 10);
+
+  @override
+  String? currentUrl = 'file://movie.mkv';
+
+  @override
+  Stream<bool> get playingStream => const Stream.empty();
+
+  @override
+  Future<String?> getProperty(String key) async => null;
+
+  @override
+  Future<void> setProperty(String key, String value) async {}
+
+  @override
+  Future<bool> command(List<String> args) async {
+    commands.add(args);
+    return true;
+  }
+}
 
 void main() {
   group('MpvLetterboxCrop.parseVfMetadata', () {
@@ -26,10 +66,13 @@ void main() {
     });
   });
 
-  group('MpvLetterboxCrop.decide', () {
+  group('LetterboxCrop.decide', () {
     test('crops letterbox bars', () {
-      final rect = MpvLetterboxCrop.decide(
-        lavfi: {'w': '1920', 'h': '804', 'x': '0', 'y': '138'},
+      final rect = LetterboxCrop.decide(
+        width: 1920,
+        height: 804,
+        x: 0,
+        y: 138,
         sourceWidth: 1920,
         sourceHeight: 1080,
       );
@@ -39,8 +82,11 @@ void main() {
 
     test('skips a full-frame detect', () {
       expect(
-        MpvLetterboxCrop.decide(
-          lavfi: {'w': '1920', 'h': '1080', 'x': '0', 'y': '0'},
+        LetterboxCrop.decide(
+          width: 1920,
+          height: 1080,
+          x: 0,
+          y: 0,
           sourceWidth: 1920,
           sourceHeight: 1080,
         ),
@@ -50,13 +96,27 @@ void main() {
 
     test('skips an over-crop', () {
       expect(
-        MpvLetterboxCrop.decide(
-          lavfi: {'w': '100', 'h': '100', 'x': '0', 'y': '0'},
+        LetterboxCrop.decide(
+          width: 100,
+          height: 100,
+          x: 0,
+          y: 0,
           sourceWidth: 1920,
           sourceHeight: 1080,
         ),
         isNull,
       );
+    });
+  });
+
+  group('MpvLetterboxCrop.decide', () {
+    test('crops letterbox bars from lavfi', () {
+      final rect = MpvLetterboxCrop.decide(
+        lavfi: {'w': '1920', 'h': '804', 'x': '0', 'y': '138'},
+        sourceWidth: 1920,
+        sourceHeight: 1080,
+      );
+      expect(rect, const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138));
     });
   });
 
@@ -79,4 +139,149 @@ void main() {
       expect(MpvLetterboxCrop.hwdecForCropdetect('no'), isNull);
     });
   });
+
+  group('LetterboxCropper stubs', () {
+    test('Aether/HTML are unsupported no-ops', () async {
+      const croppers = <LetterboxCropper>[
+        AetherLetterboxCropper(),
+        AppleTvLetterboxCropper(),
+        HtmlLetterboxCropper(),
+      ];
+      for (final cropper in croppers) {
+        expect(cropper.isSupported, isFalse);
+        expect(cropper.unimplementedReason, isNotNull);
+        await cropper.setEnabled(true);
+        await cropper.onSourceOpened('file://x');
+        await cropper.reset();
+      }
+    });
+
+    test('unsupported mpv cropper never talks to libmpv', () async {
+      final host = _RecordingHost();
+      final cropper = MpvLetterboxCropper(host, supported: false);
+      expect(cropper.isSupported, isFalse);
+      await cropper.setEnabled(true);
+      await cropper.onSourceOpened('file://movie.mkv');
+      expect(host.commands, isEmpty);
+    });
+  });
+
+  group('Media3LetterboxCrop.decide', () {
+    test('crops letterbox bars from a PixelCopy detect', () {
+      final rect = Media3LetterboxCrop.decide({
+        'w': 1920,
+        'h': 804,
+        'x': 0,
+        'y': 138,
+        'sourceWidth': 1920,
+        'sourceHeight': 1080,
+      });
+      expect(rect, const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138));
+    });
+
+    test('skips a full-frame detect', () {
+      expect(
+        Media3LetterboxCrop.decide({
+          'w': 1920,
+          'h': 1080,
+          'x': 0,
+          'y': 0,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        }),
+        isNull,
+      );
+    });
+  });
+
+  group('Media3LetterboxCropper', () {
+    test('unsupported never talks to native', () async {
+      final host = _Media3RecordingHost();
+      final cropper = Media3LetterboxCropper(host, supported: false);
+      expect(cropper.isSupported, isFalse);
+      await cropper.setEnabled(true);
+      await cropper.onSourceOpened('file://movie.mkv');
+      expect(host.detectCalls, 0);
+      expect(host.applied, isEmpty);
+    });
+
+    test('supported detect applies crop', () async {
+      final host = _Media3RecordingHost();
+      final cropper = Media3LetterboxCropper(
+        host,
+        supported: true,
+        autoDelay: Duration.zero,
+      );
+      await cropper.setEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+      expect(host.detectCalls, 1);
+      expect(
+        host.applied.last,
+        const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138),
+      );
+    });
+
+    test('full-frame detect does not apply a crop', () async {
+      final host = _Media3RecordingHost()
+        ..detectResult = {
+          'w': 1920,
+          'h': 1080,
+          'x': 0,
+          'y': 0,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        };
+      final cropper = Media3LetterboxCropper(
+        host,
+        supported: true,
+        autoDelay: Duration.zero,
+      );
+      await cropper.setEnabled(true);
+      await Future<void>.delayed(Duration.zero);
+      expect(host.detectCalls, 1);
+      expect(host.applied, everyElement(isNull));
+    });
+  });
+}
+
+class _Media3RecordingHost implements Media3LetterboxHost {
+  Map<String, int>? detectResult = const {
+    'w': 1920,
+    'h': 804,
+    'x': 0,
+    'y': 138,
+    'sourceWidth': 1920,
+    'sourceHeight': 1080,
+  };
+  final applied = <LetterboxCropRect?>[];
+  int detectCalls = 0;
+
+  @override
+  bool isDisposed = false;
+
+  @override
+  bool isPlaying = true;
+
+  @override
+  Duration position = Duration.zero;
+
+  @override
+  Duration duration = const Duration(minutes: 10);
+
+  @override
+  String? currentUrl = 'file://movie.mkv';
+
+  @override
+  Stream<bool> get playingStream => const Stream.empty();
+
+  @override
+  Future<Map<String, int>?> detectLetterbox() async {
+    detectCalls++;
+    return detectResult;
+  }
+
+  @override
+  Future<void> setLetterboxCrop(LetterboxCropRect? rect) async {
+    applied.add(rect);
+  }
 }

--- a/test/playback/mpv_letterbox_crop_test.dart
+++ b/test/playback/mpv_letterbox_crop_test.dart
@@ -194,6 +194,72 @@ void main() {
     });
   });
 
+  group('Media3LetterboxCrop.widest', () {
+    test('a dark frame does not win over a lit one', () {
+      final merged = Media3LetterboxCrop.widest([
+        {
+          'w': 1920,
+          'h': 804,
+          'x': 0,
+          'y': 138,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        },
+        {
+          'w': 1000,
+          'h': 400,
+          'x': 400,
+          'y': 300,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        },
+      ]);
+      expect(merged, {
+        'w': 1920,
+        'h': 804,
+        'x': 0,
+        'y': 138,
+        'sourceWidth': 1920,
+        'sourceHeight': 1080,
+      });
+    });
+
+    test('grows to cover every sample', () {
+      final merged = Media3LetterboxCrop.widest([
+        {
+          'w': 800,
+          'h': 400,
+          'x': 100,
+          'y': 200,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        },
+        {
+          'w': 800,
+          'h': 400,
+          'x': 300,
+          'y': 100,
+          'sourceWidth': 1920,
+          'sourceHeight': 1080,
+        },
+      ]);
+      expect(merged?['x'], 100);
+      expect(merged?['y'], 100);
+      expect(merged?['w'], 1000);
+      expect(merged?['h'], 500);
+    });
+
+    test('nothing usable is null', () {
+      expect(Media3LetterboxCrop.widest(const []), isNull);
+      expect(
+        Media3LetterboxCrop.widest([
+          {'sourceWidth': 1920, 'sourceHeight': 1080},
+        ]),
+        isNull,
+      );
+    });
+  });
+
   group('Media3LetterboxCropper', () {
     test('unsupported never talks to native', () async {
       final host = _Media3RecordingHost();
@@ -211,10 +277,29 @@ void main() {
         host,
         supported: true,
         autoDelay: Duration.zero,
+        sampleCount: 1,
+        sampleGap: Duration.zero,
       );
       await cropper.setEnabled(true);
       await Future<void>.delayed(Duration.zero);
       expect(host.detectCalls, 1);
+      expect(
+        host.applied.last,
+        const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138),
+      );
+    });
+
+    test('samples more than one frame before deciding', () async {
+      final host = _Media3RecordingHost();
+      final cropper = Media3LetterboxCropper(
+        host,
+        supported: true,
+        autoDelay: Duration.zero,
+        sampleGap: Duration.zero,
+      );
+      await cropper.setEnabled(true);
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(host.detectCalls, Media3LetterboxCrop.sampleCount);
       expect(
         host.applied.last,
         const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138),
@@ -235,6 +320,8 @@ void main() {
         host,
         supported: true,
         autoDelay: Duration.zero,
+        sampleCount: 1,
+        sampleGap: Duration.zero,
       );
       await cropper.setEnabled(true);
       await Future<void>.delayed(Duration.zero);

--- a/test/playback/mpv_letterbox_crop_test.dart
+++ b/test/playback/mpv_letterbox_crop_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/playback/mpv_letterbox_crop.dart';
+
+void main() {
+  group('MpvLetterboxCrop.parseVfMetadata', () {
+    test('reads JSON lavfi keys', () {
+      const raw =
+          '{"lavfi.cropdetect.w":"1920","lavfi.cropdetect.h":"804","lavfi.cropdetect.x":"0","lavfi.cropdetect.y":"138"}';
+      expect(MpvLetterboxCrop.parseVfMetadata(raw), {
+        'w': '1920',
+        'h': '804',
+        'x': '0',
+        'y': '138',
+      });
+    });
+
+    test('reads key=value lavfi dump', () {
+      const raw =
+          'lavfi.cropdetect.w=1920 lavfi.cropdetect.h=804 lavfi.cropdetect.x=0 lavfi.cropdetect.y=138';
+      expect(MpvLetterboxCrop.parseVfMetadata(raw)['h'], '804');
+    });
+
+    test('empty input is empty map', () {
+      expect(MpvLetterboxCrop.parseVfMetadata(null), isEmpty);
+      expect(MpvLetterboxCrop.parseVfMetadata('null'), isEmpty);
+    });
+  });
+
+  group('MpvLetterboxCrop.decide', () {
+    test('crops letterbox bars', () {
+      final rect = MpvLetterboxCrop.decide(
+        lavfi: {'w': '1920', 'h': '804', 'x': '0', 'y': '138'},
+        sourceWidth: 1920,
+        sourceHeight: 1080,
+      );
+      expect(rect, const LetterboxCropRect(w: 1920, h: 804, x: 0, y: 138));
+      expect(rect!.videoCrop, '1920x804+0+138');
+    });
+
+    test('skips a full-frame detect', () {
+      expect(
+        MpvLetterboxCrop.decide(
+          lavfi: {'w': '1920', 'h': '1080', 'x': '0', 'y': '0'},
+          sourceWidth: 1920,
+          sourceHeight: 1080,
+        ),
+        isNull,
+      );
+    });
+
+    test('skips an over-crop', () {
+      expect(
+        MpvLetterboxCrop.decide(
+          lavfi: {'w': '100', 'h': '100', 'x': '0', 'y': '0'},
+          sourceWidth: 1920,
+          sourceHeight: 1080,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('MpvLetterboxCrop.mustDisableHwdec', () {
+    test('keeps copy and software decoders', () {
+      expect(MpvLetterboxCrop.mustDisableHwdec('no'), isFalse);
+      expect(MpvLetterboxCrop.mustDisableHwdec('auto-copy'), isFalse);
+      expect(MpvLetterboxCrop.mustDisableHwdec('vaapi-copy'), isFalse);
+    });
+
+    test('disables zero-copy hwdec', () {
+      expect(MpvLetterboxCrop.mustDisableHwdec('vaapi'), isTrue);
+      expect(MpvLetterboxCrop.mustDisableHwdec('auto'), isTrue);
+      expect(MpvLetterboxCrop.mustDisableHwdec('nvdec'), isTrue);
+    });
+
+    test('hwdecForCropdetect prefers auto-copy over software', () {
+      expect(MpvLetterboxCrop.hwdecForCropdetect('nvdec'), 'auto-copy');
+      expect(MpvLetterboxCrop.hwdecForCropdetect('vaapi-copy'), isNull);
+      expect(MpvLetterboxCrop.hwdecForCropdetect('no'), isNull);
+    });
+  });
+}

--- a/tvos/Runner/Playback/Aether/PlayerTypes.swift
+++ b/tvos/Runner/Playback/Aether/PlayerTypes.swift
@@ -93,13 +93,7 @@ enum ZoomMode: String, StringRepresentableEnum, CaseIterable {
     case autoCrop = "Auto Crop"
     case stretch = "Stretch"
 
-    var displayName: String {
-        switch self {
-        case .fit: return "Fit"
-        case .autoCrop: return "Fill"
-        case .stretch: return "Stretch"
-        }
-    }
+    var displayName: String { rawValue }
 
     var next: ZoomMode {
         let all = ZoomMode.allCases

--- a/tvos/Runner/Playback/Aether/PlayerTypes.swift
+++ b/tvos/Runner/Playback/Aether/PlayerTypes.swift
@@ -93,7 +93,13 @@ enum ZoomMode: String, StringRepresentableEnum, CaseIterable {
     case autoCrop = "Auto Crop"
     case stretch = "Stretch"
 
-    var displayName: String { rawValue }
+    var displayName: String {
+        switch self {
+        case .fit: return "Fit"
+        case .autoCrop: return "Fill"
+        case .stretch: return "Stretch"
+        }
+    }
 
     var next: ZoomMode {
         let all = ZoomMode.allCases


### PR DESCRIPTION
## Summary
Adds a **Crop black bars** playback toggle that detects encoded letterbox/pillarbox and crops it, then fills the screen. This is a separate setting from zoom **Auto Crop** on purpose.

[#1523](https://github.com/Moonfin-Client/Moonfin-Core/issues/1523) is why: **Auto Crop is cover-zoom** (`BoxFit.cover` / aspect-fill). It scales the whole coded frame to fill the window and clips overflow. It does **not** find or remove black bars baked into a 16:9 file. Putting real bar-detection into that zoom control would make the existing confusion worse, so this ships as its own toggle next to zoom until that naming is sorted. If #1523 lands (rename Auto Crop so zoom is clearly fill/cover, not a crop), this can move into zoom settings.

## Related Issues
- Related to #1523

## Type of Change
- [x] New feature

## Changes Made
- Desktop libmpv: `cropdetect` then `vf crop`
- Android Media3 (phone and TV): PixelCopy (TextureView `getBitmap` fallback), then layout zoom into the crop rect (SurfaceView + tunneling cannot use Media3 Crop effects)
- Shared `LetterboxCropper` in `playback_core`; Aether / HTML / tvOS are explicit stubs
- Setting is hidden where no cropper runs

## Platform
- [x] Android
- [x] Android TV
- [x] Windows
- [x] Linux
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS

No devices on hand for iOS / macOS / tvOS / web. The cropper interface is there so those platforms can follow this path.

## Testing
- [x] Tested on emulator / simulator
- [x] Tested on physical device
- [x] Manual testing completed

### Test Steps
1. Settings → Playback & SyncPlay → Video Playback Preferences → enable **Crop black bars** (off by default)
2. Play a title with encoded letterbox (not just window pillarboxing)
3. After a few seconds the bars should crop and the picture should fill
4. Confirm zoom **Auto Crop** is still cover-zoom and is not this detect

Tested on Linux (libmpv) and Android TV emulator (Media3). Phone uses the same Media3 path; iOS/macOS/tvOS/web untested.

## Checklist
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code

Made with [Cursor](https://cursor.com)