### PR TITLE
Improve playback scrub thumbnail preloading

### DIFF
--- a/lib/data/models/trickplay_prefetch_planner.dart
+++ b/lib/data/models/trickplay_prefetch_planner.dart
@@ -3,6 +3,36 @@ import 'trickplay_info.dart';
 class TrickplayPrefetchPlanner {
   const TrickplayPrefetchPlanner._();
 
+  /// Resolve actual seek destinations, including irregular timestamped frames.
+  /// A set keeps sprite sheets shared by multiple destinations from repeating.
+  static List<int> planSeekImageIndexes({
+    required TrickplayInfo info,
+    required Duration position,
+    required Duration totalDuration,
+    required int forwardStepMs,
+    required int backwardStepMs,
+    required bool directionForward,
+  }) {
+    if (!info.isValid || totalDuration <= Duration.zero) return const [];
+    final lastMs = totalDuration.inMilliseconds - 1;
+    final indexes = <int>{};
+    void addPosition(int offsetMs) {
+      final target = (position.inMilliseconds + offsetMs).clamp(0, lastMs);
+      indexes.add(info.resolveTile(Duration(milliseconds: target)).imageIndex);
+    }
+
+    final forward = forwardStepMs.clamp(1, 1 << 31);
+    final backward = backwardStepMs.clamp(1, 1 << 31);
+    addPosition(0);
+    for (var step = 1; step <= 6; step++) {
+      addPosition(step * (directionForward ? forward : -backward));
+    }
+    for (var step = 1; step <= 2; step++) {
+      addPosition(step * (directionForward ? -backward : forward));
+    }
+    return indexes.toList();
+  }
+
   static int _lastSheetIndex(TrickplayInfo info, Duration totalDuration) {
     final lastMs = (totalDuration.inMilliseconds - 1).clamp(
       0,
@@ -38,7 +68,9 @@ class TrickplayPrefetchPlanner {
     final currentIndex = info.resolveTile(position).imageIndex;
     final lastIndex = _lastSheetIndex(info, totalDuration);
     final all = List.generate(lastIndex + 1, (i) => i);
-    all.sort((a, b) => (a - currentIndex).abs().compareTo((b - currentIndex).abs()));
+    all.sort(
+      (a, b) => (a - currentIndex).abs().compareTo((b - currentIndex).abs()),
+    );
     return all.length > maxSheets ? all.sublist(0, maxSheets) : all;
   }
 }

--- a/lib/data/models/trickplay_prefetch_planner.dart
+++ b/lib/data/models/trickplay_prefetch_planner.dart
@@ -3,6 +3,10 @@ import 'trickplay_info.dart';
 class TrickplayPrefetchPlanner {
   const TrickplayPrefetchPlanner._();
 
+  /// Scrubbing carries on the way it started, so the run ahead is the longer.
+  static const _stepsAhead = 6;
+  static const _stepsBehind = 2;
+
   /// Resolve actual seek destinations, including irregular timestamped frames.
   /// A set keeps sprite sheets shared by multiple destinations from repeating.
   static List<int> planSeekImageIndexes({
@@ -21,13 +25,13 @@ class TrickplayPrefetchPlanner {
       indexes.add(info.resolveTile(Duration(milliseconds: target)).imageIndex);
     }
 
-    final forward = forwardStepMs.clamp(1, 1 << 31);
-    final backward = backwardStepMs.clamp(1, 1 << 31);
+    final forward = forwardStepMs < 1 ? 1 : forwardStepMs;
+    final backward = backwardStepMs < 1 ? 1 : backwardStepMs;
     addPosition(0);
-    for (var step = 1; step <= 6; step++) {
+    for (var step = 1; step <= _stepsAhead; step++) {
       addPosition(step * (directionForward ? forward : -backward));
     }
-    for (var step = 1; step <= 2; step++) {
+    for (var step = 1; step <= _stepsBehind; step++) {
       addPosition(step * (directionForward ? -backward : forward));
     }
     return indexes.toList();

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -233,6 +233,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   bool _isPausedScrubActive = false;
   final Set<int> _prefetchedTrickplayIndexes = {};
   bool _touchTrickplayPrefetchStarted = false;
+  Duration? _lastTrickplayPreviewPosition;
   Duration? _hoverPosition;
   double? _topOverlayHeight;
   double? _bottomOverlayHeight;
@@ -2176,6 +2177,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final mediaSourceId = _manager.currentResolution?.mediaSourceId;
     _prefetchedTrickplayIndexes.clear();
     _touchTrickplayPrefetchStarted = false;
+    _lastTrickplayPreviewPosition = null;
     if (mounted) {
       setState(() {
         _trickplayInfo = null;
@@ -2218,6 +2220,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _trickplayInfo = info?.isValid == true ? info : null;
       _trickplayMediaSourceId = mediaSourceId;
     });
+    if (_controlsVisible) {
+      _prefetchTrickplayDirectional(_state.position, forward: true);
+    }
   }
 
   void _refreshTrickplayIfNeeded() {
@@ -2231,6 +2236,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
   }
 
   void _handleTrickplayAmbientPrefetch(Duration position) {
+    if (_controlsVisible) {
+      _prefetchTrickplayDirectional(position, forward: true);
+    }
     if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
       return;
     }
@@ -2273,11 +2281,25 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     );
   }
 
+  // Called by both the strip/single preview and the full-screen preview, so
+  // hover, dragging and keyboard/remote scrubbing all warm upcoming images.
+  void _prefetchVisibleTrickplayPreview(Duration position) {
+    if (_state.duration <= Duration.zero) return;
+    final previous = _lastTrickplayPreviewPosition ?? _state.position;
+    if (_lastTrickplayPreviewPosition == position) return;
+    _lastTrickplayPreviewPosition = position;
+    final generation = _trickplayLoadGeneration;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || generation != _trickplayLoadGeneration) return;
+      if (_lastTrickplayPreviewPosition != position) return;
+      _prefetchTrickplayDirectional(position, forward: position >= previous);
+    });
+  }
+
   void _prefetchTrickplayDirectional(
     Duration position, {
     required bool forward,
   }) {
-    if (!PlatformDetection.isTV) return;
     if (_prefs.get(UserPreferences.trickPlayMode) == TrickplayMode.disabled) {
       return;
     }
@@ -2285,12 +2307,13 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final duration = _state.duration;
     if (info == null || !info.isValid || duration <= Duration.zero) return;
     _precacheTrickplayIndexes(
-      TrickplayPrefetchPlanner.planImageIndexes(
+      TrickplayPrefetchPlanner.planSeekImageIndexes(
         info: info,
         position: position,
         totalDuration: duration,
         directionForward: forward,
-        sheetsAhead: 2,
+        forwardStepMs: _prefs.get(UserPreferences.skipForwardLength),
+        backwardStepMs: _prefs.get(UserPreferences.skipBackLength),
       ),
     );
   }
@@ -2308,6 +2331,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       if (token != null && token.isNotEmpty)
         'Authorization': 'MediaBrowser Token="$token"',
     };
+    final generation = _trickplayLoadGeneration;
     for (final index in indexes) {
       if (!_prefetchedTrickplayIndexes.add(index)) continue;
       if (!mounted) return;
@@ -2317,7 +2341,10 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         itemId: itemId,
         client: client,
       );
-      if (url == null) continue;
+      if (url == null) {
+        _prefetchedTrickplayIndexes.remove(index);
+        continue;
+      }
       unawaited(
         precacheImage(
           CachedNetworkImageProvider(
@@ -2325,6 +2352,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             headers: headers.isEmpty ? null : headers,
           ),
           context,
+          onError: (_, _) {
+            if (generation == _trickplayLoadGeneration) {
+              _prefetchedTrickplayIndexes.remove(index);
+            }
+          },
         ).catchError((_) {}),
       );
     }
@@ -2927,7 +2959,11 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
       _syncPrerollOsdState();
       return;
     }
+    final wasVisible = _controlsVisible;
     setState(() => _controlsVisible = true);
+    if (!wasVisible) {
+      _prefetchTrickplayDirectional(_state.position, forward: true);
+    }
     _scheduleHide();
     if (focusSeekbar) {
       _focusPreferredTvOverlayTarget();
@@ -2992,6 +3028,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         _state.duration.inMilliseconds,
       ),
     );
+    _prefetchTrickplayDirectional(clamped, forward: ms > 0);
     _seekDirect(clamped);
     _lastSeekTime = DateTime.now();
     if (showControls) {
@@ -3010,7 +3047,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         (_isSeeking ? _lastScrubCommitTarget : null) ??
         _state.position;
     final target = basePosition + Duration(milliseconds: ms);
-    _prefetchTrickplayDirectional(basePosition, forward: ms > 0);
+    _prefetchTrickplayDirectional(target, forward: ms > 0);
     _accumulateScrub(target);
   }
 
@@ -4062,6 +4099,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final seekPosition = Duration(milliseconds: _seekValue.round());
     final tile = _getTrickplayTile(seekPosition);
     if (tile == null) return const SizedBox.shrink();
+    _prefetchVisibleTrickplayPreview(seekPosition);
     return Positioned.fill(
       child: Trickplay(
         fillFrame: true,
@@ -5091,13 +5129,14 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
             ? _getTrickplayTile(previewPosition)
             : null;
         if (previewTile == null) return const SizedBox.shrink();
+        _prefetchVisibleTrickplayPreview(previewPosition!);
 
         return LayoutBuilder(
           builder: (context, constraints) {
             return _buildTrickplayPreviewArea(
               referenceTile: previewTile,
               isStrip: trickplayMode == TrickplayMode.strip,
-              seekPosition: previewPosition!,
+              seekPosition: previewPosition,
               totalDuration: duration,
               positionMs: previewPosition.inMilliseconds.toDouble(),
               durationMs: durationMs,

--- a/lib/ui/screens/playback/video_player_screen.dart
+++ b/lib/ui/screens/playback/video_player_screen.dart
@@ -2281,8 +2281,7 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     );
   }
 
-  // Called by both the strip/single preview and the full-screen preview, so
-  // hover, dragging and keyboard/remote scrubbing all warm upcoming images.
+  // Waiting for the frame collapses a burst of drag events into one prefetch.
   void _prefetchVisibleTrickplayPreview(Duration position) {
     if (_state.duration <= Duration.zero) return;
     final previous = _lastTrickplayPreviewPosition ?? _state.position;
@@ -4099,7 +4098,6 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
     final seekPosition = Duration(milliseconds: _seekValue.round());
     final tile = _getTrickplayTile(seekPosition);
     if (tile == null) return const SizedBox.shrink();
-    _prefetchVisibleTrickplayPreview(seekPosition);
     return Positioned.fill(
       child: Trickplay(
         fillFrame: true,
@@ -5030,6 +5028,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
                                       dismissVisiblePrompts: false,
                                     );
                                     setState(() => _seekValue = v);
+                                    _prefetchVisibleTrickplayPreview(
+                                      Duration(milliseconds: v.round()),
+                                    );
                                   },
                                   onChangeEnd: (v) {
                                     _suppressSeekPrompts();
@@ -5128,8 +5129,9 @@ class _VideoPlayerScreenState extends State<VideoPlayerScreen>
         final previewTile = previewPosition != null && !coverActive
             ? _getTrickplayTile(previewPosition)
             : null;
-        if (previewTile == null) return const SizedBox.shrink();
-        _prefetchVisibleTrickplayPreview(previewPosition!);
+        if (previewTile == null || previewPosition == null) {
+          return const SizedBox.shrink();
+        }
 
         return LayoutBuilder(
           builder: (context, constraints) {

--- a/lib/ui/widgets/playback/trickplay_tile_image.dart
+++ b/lib/ui/widgets/playback/trickplay_tile_image.dart
@@ -8,7 +8,7 @@ import '../adaptive/sf_symbol.dart';
 /// one means scaling the whole sheet up until a single tile covers this
 /// widget, then sliding the wanted tile into view. [sourceRect] is the tile's
 /// position in the sheet's own pixels.
-class TrickplayTileImage extends StatelessWidget {
+class TrickplayTileImage extends StatefulWidget {
   final ImageProvider sheet;
   final Rect sourceRect;
   final double thumbWidth;
@@ -27,44 +27,64 @@ class TrickplayTileImage extends StatelessWidget {
   });
 
   @override
+  State<TrickplayTileImage> createState() => _TrickplayTileImageState();
+}
+
+class _TrickplayTileImageState extends State<TrickplayTileImage> {
+  TrickplayTileImage? _displayedTile;
+
+  @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final tileW = thumbWidth * tileWidth;
-        final tileH = thumbHeight * tileHeight;
-        final sheetWidth = tileW * (constraints.maxWidth / thumbWidth);
-        final sheetHeight = tileH * (constraints.maxHeight / thumbHeight);
-        return OverflowBox(
-          // Both bounds have to be set, otherwise the sheet keeps the parent's
-          // minimum and settles at its own intrinsic size, which leaves the
-          // alignment below pointing at the wrong tile.
-          minWidth: sheetWidth,
-          minHeight: sheetHeight,
-          maxWidth: sheetWidth,
-          maxHeight: sheetHeight,
-          alignment: Alignment(
-            tileWidth <= 1
-                ? 0.0
-                : -1.0 + 2.0 * sourceRect.left / (tileW - thumbWidth),
-            tileHeight <= 1
-                ? 0.0
-                : -1.0 + 2.0 * sourceRect.top / (tileH - thumbHeight),
-          ),
-          child: Image(
-            image: sheet,
-            fit: BoxFit.fill,
-            // High rather than medium: this tile can be upscaled a lot
-            // (e.g. the Full Screen mode's video cover), and a better
-            // resampling filter is the only lever available for that - the
-            // source pixels are still a low-res thumbnail.
-            filterQuality: FilterQuality.high,
-            errorBuilder: (_, _, _) => Container(
-              color: Colors.white.withValues(alpha: 0.08),
-              alignment: Alignment.center,
-              child: AdaptiveIcon(
-                Icons.movie,
-                color: Colors.white.withValues(alpha: 0.45),
+        return Image(
+          image: widget.sheet,
+          fit: BoxFit.fill,
+          gaplessPlayback: true,
+          filterQuality: FilterQuality.high,
+          frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+            if (frame != null || wasSynchronouslyLoaded) {
+              _displayedTile = widget;
+            }
+            // Retain the crop as well as the old image until the new sheet is
+            // decoded; applying a new crop to the old sheet shows a wrong tile.
+            final tile = _displayedTile ?? widget;
+            final tileW = tile.thumbWidth * tile.tileWidth;
+            final tileH = tile.thumbHeight * tile.tileHeight;
+            final sheetWidth = tileW * (constraints.maxWidth / tile.thumbWidth);
+            final sheetHeight =
+                tileH * (constraints.maxHeight / tile.thumbHeight);
+            return OverflowBox(
+              // Both bounds have to be set, otherwise the sheet keeps the parent's
+              // minimum and settles at its own intrinsic size, which leaves the
+              // alignment below pointing at the wrong tile.
+              minWidth: sheetWidth,
+              minHeight: sheetHeight,
+              maxWidth: sheetWidth,
+              maxHeight: sheetHeight,
+              alignment: Alignment(
+                tile.tileWidth <= 1
+                    ? 0.0
+                    : -1.0 +
+                          2.0 *
+                              tile.sourceRect.left /
+                              (tileW - tile.thumbWidth),
+                tile.tileHeight <= 1
+                    ? 0.0
+                    : -1.0 +
+                          2.0 *
+                              tile.sourceRect.top /
+                              (tileH - tile.thumbHeight),
               ),
+              child: child,
+            );
+          },
+          errorBuilder: (_, _, _) => Container(
+            color: Colors.white.withValues(alpha: 0.08),
+            alignment: Alignment.center,
+            child: AdaptiveIcon(
+              Icons.movie,
+              color: Colors.white.withValues(alpha: 0.45),
             ),
           ),
         );

--- a/test/data/models/trickplay_prefetch_planner_test.dart
+++ b/test/data/models/trickplay_prefetch_planner_test.dart
@@ -13,6 +13,52 @@ void main() {
   );
   const totalDuration = Duration(minutes: 20);
 
+  group('seek destinations', () {
+    const frames = TrickplayInfo(
+      width: 100,
+      height: 60,
+      tileWidth: 1,
+      tileHeight: 1,
+      interval: 1000,
+    );
+    List<int> plan(TrickplayInfo source, int seconds, bool forward) =>
+        TrickplayPrefetchPlanner.planSeekImageIndexes(
+          info: source,
+          position: Duration(seconds: seconds),
+          totalDuration: const Duration(seconds: 100),
+          forwardStepMs: 10000,
+          backwardStepMs: 5000,
+          directionForward: forward,
+        );
+
+    test('uses configured seek steps instead of adjacent frame indexes', () {
+      expect(plan(frames, 20, true), [20, 30, 40, 50, 60, 70, 80, 15, 10]);
+      expect(plan(frames, 40, false), [40, 35, 30, 25, 20, 15, 10, 50, 60]);
+    });
+    test('clamps at both ends and deduplicates sprite sheets', () {
+      expect(plan(frames, 0, false), [0, 10, 20]);
+      expect(plan(frames, 95, true), [95, 99, 90, 85]);
+      expect(plan(info, 20, true), [0]);
+    });
+    test('resolves irregular timestamped frames at seek destinations', () {
+      final irregular = TrickplayInfo.fromThumbnailSet(
+        TrickplayThumbnailSet(
+          aspectRatio: 16 / 9,
+          thumbnails: [0, 3, 19, 28, 46, 65, 90]
+              .map(
+                (seconds) => TrickplayThumbnail(
+                  positionTicks: seconds * 10000000,
+                  imageTag: 'frame-$seconds',
+                ),
+              )
+              .toList(),
+        ),
+        width: 320,
+      );
+      expect(plan(irregular, 20, true), [2, 3, 4, 5, 1]);
+    });
+  });
+
   group('TrickplayPrefetchPlanner.planImageIndexes (directional, D-pad)', () {
     test('forward returns only sheets ahead of the current one', () {
       final indexes = TrickplayPrefetchPlanner.planImageIndexes(

--- a/test/playback/trickplay_crop_layout_test.dart
+++ b/test/playback/trickplay_crop_layout_test.dart
@@ -95,9 +95,9 @@ void main() {
         nextFrame = await _FakeSheet(3200, 1800)._frame();
       });
       await tester.pumpWidget(preview(first, sourceRect));
-    first.frame.complete(firstFrame);
-    await tester.pump();
-    await tester.pump();
+      first.frame.complete(firstFrame);
+      await tester.pump();
+      await tester.pump();
       final oldImage = tester.widget<RawImage>(find.byType(RawImage)).image!;
       final oldAlignment = tester
           .widget<OverflowBox>(find.byType(OverflowBox))
@@ -109,9 +109,9 @@ void main() {
         tester.widget<OverflowBox>(find.byType(OverflowBox)).alignment,
         oldAlignment,
       );
-    next.frame.complete(nextFrame);
-    await tester.pump();
-    await tester.pump();
+      next.frame.complete(nextFrame);
+      await tester.pump();
+      await tester.pump();
       expect(
         tester.widget<RawImage>(find.byType(RawImage)).image,
         isNot(oldImage),

--- a/test/playback/trickplay_crop_layout_test.dart
+++ b/test/playback/trickplay_crop_layout_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' as ui;
 
 import 'package:flutter/foundation.dart';
@@ -33,6 +34,20 @@ class _FakeSheet extends ImageProvider<_FakeSheet> {
   }
 }
 
+class _DelayedSheet extends ImageProvider<_DelayedSheet> {
+  final frame = Completer<ImageInfo>();
+
+  @override
+  Future<_DelayedSheet> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _DelayedSheet key,
+    ImageDecoderCallback decode,
+  ) => OneFrameImageStreamCompleter(frame.future);
+}
+
 void main() {
   // A stock Jellyfin sheet of 320x180 thumbnails in a 10x10 grid.
   const thumbWidth = 320.0;
@@ -50,6 +65,68 @@ void main() {
     2 * thumbHeight,
     thumbWidth,
     thumbHeight,
+  );
+
+  testWidgets(
+    'retains the previous image and crop until the next sheet loads',
+    (tester) async {
+      Widget preview(ImageProvider sheet, Rect crop) => Center(
+        child: SizedBox(
+          width: displayWidth,
+          height: displayHeight,
+          child: ClipRect(
+            child: TrickplayTileImage(
+              sheet: sheet,
+              sourceRect: crop,
+              thumbWidth: thumbWidth,
+              thumbHeight: thumbHeight,
+              tileWidth: tileWidth,
+              tileHeight: tileHeight,
+            ),
+          ),
+        ),
+      );
+      final first = _DelayedSheet();
+      final next = _DelayedSheet();
+      late ImageInfo firstFrame;
+      late ImageInfo nextFrame;
+      await tester.runAsync(() async {
+        firstFrame = await _FakeSheet(3200, 1800)._frame();
+        nextFrame = await _FakeSheet(3200, 1800)._frame();
+      });
+      await tester.pumpWidget(preview(first, sourceRect));
+    first.frame.complete(firstFrame);
+    await tester.pump();
+    await tester.pump();
+      final oldImage = tester.widget<RawImage>(find.byType(RawImage)).image!;
+      final oldAlignment = tester
+          .widget<OverflowBox>(find.byType(OverflowBox))
+          .alignment;
+      const nextCrop = Rect.fromLTWH(0, 0, thumbWidth, thumbHeight);
+      await tester.pumpWidget(preview(next, nextCrop));
+      expect(tester.widget<RawImage>(find.byType(RawImage)).image, oldImage);
+      expect(
+        tester.widget<OverflowBox>(find.byType(OverflowBox)).alignment,
+        oldAlignment,
+      );
+    next.frame.complete(nextFrame);
+    await tester.pump();
+    await tester.pump();
+      expect(
+        tester.widget<RawImage>(find.byType(RawImage)).image,
+        isNot(oldImage),
+      );
+      expect(
+        tester.widget<OverflowBox>(find.byType(OverflowBox)).alignment,
+        const Alignment(-1, -1),
+      );
+      // Moving within an already decoded sheet updates its crop immediately.
+      await tester.pumpWidget(preview(next, sourceRect));
+      expect(
+        tester.widget<OverflowBox>(find.byType(OverflowBox)).alignment,
+        oldAlignment,
+      );
+    },
   );
 
   testWidgets('scales the sheet so one tile fills the preview box', (


### PR DESCRIPTION
# Pull Request
Preload six seek positions ahead and two behind across input methods.
Warm previews when controls appear and retain the previous thumbnail and crop while the next image load.
Add prefetch and continuity tests.

## Summary
While scrubbing, the thumbnails which just come into view (usually to the right) take a few ms to load therefore introduce a noticeable flicker (initially black thumbnails and after it loads, the actual thumb is displayed).
This PR aims to fix this by preloading.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Performance improvement
- [ ] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):


## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [x] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [x] Tested on physical device - Android TV
- [x] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Play a video file
2. Scrub to the right or left
3. The thumbnails that just come into view are displayed smoothly without clipping or flickering

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

## Checklist
- [x] Code builds successfully
- [x] Code follows project style and conventions
- [x] No unnecessary commented-out code
- [x] No new warnings introduced
