### PR TITLE
bugfix-homescreen - Fix TV series normalization within Latest Media rows

### DIFF
--- a/lib/data/utils/latest_media_row_normalizer.dart
+++ b/lib/data/utils/latest_media_row_normalizer.dart
@@ -8,7 +8,7 @@ int latestMediaFetchLimitForCollection(
   required int maxLimit,
 }) {
   final normalizedType = collectionType?.toLowerCase();
-  if (normalizedType == 'tvshows') {
+  if (normalizedType == 'tvshows' || normalizedType == 'shows') {
     final expandedLimit = defaultLimit * 4;
     if (expandedLimit > maxLimit) {
       return maxLimit;
@@ -75,10 +75,15 @@ List<AggregatedItem> normalizeLatestMediaItems(
   required int limit,
 }) {
   final normalizedType = collectionType?.toLowerCase();
-  final normalized = switch (normalizedType) {
-    'tvshows' => _collapseLatestTvItems(items),
-    _ => items,
-  };
+  final isTvCollection =
+      normalizedType == 'tvshows' || normalizedType == 'shows';
+  final hasTvItems =
+      items.any((i) => i.type == 'Episode' || i.type == 'Season');
+  final shouldCollapse =
+      isTvCollection || (normalizedType == null && hasTvItems);
+
+  final normalized =
+      shouldCollapse ? _collapseLatestTvItems(items) : items;
 
   if (normalized.length <= limit) {
     return normalized;
@@ -129,7 +134,8 @@ AggregatedItem? _seriesCardForLatestTvItem(AggregatedItem item) {
         item.primaryImageTag ?? item.primaryImageTagField;
   }
 
-  final seriesPrimaryImageTag = item.seriesPrimaryImageTag;
+  final seriesPrimaryImageTag =
+      item.seriesPrimaryImageTag ?? item.parentPrimaryImageTag;
   if (seriesPrimaryImageTag != null && seriesPrimaryImageTag.isNotEmpty) {
     final imageTags = Map<String, dynamic>.from(
       rawData['ImageTags'] as Map? ?? const {},

--- a/lib/data/utils/latest_media_row_normalizer.dart
+++ b/lib/data/utils/latest_media_row_normalizer.dart
@@ -2,13 +2,18 @@ import '../../l10n/app_localizations.dart';
 import '../../preference/preference_constants.dart';
 import '../models/aggregated_item.dart';
 
+/// A server names a TV library 'tvshows' or 'shows', so both count.
+bool _isTvCollectionType(String? collectionType) {
+  final normalized = collectionType?.toLowerCase();
+  return normalized == 'tvshows' || normalized == 'shows';
+}
+
 int latestMediaFetchLimitForCollection(
   String? collectionType, {
   required int defaultLimit,
   required int maxLimit,
 }) {
-  final normalizedType = collectionType?.toLowerCase();
-  if (normalizedType == 'tvshows' || normalizedType == 'shows') {
+  if (_isTvCollectionType(collectionType)) {
     final expandedLimit = defaultLimit * 4;
     if (expandedLimit > maxLimit) {
       return maxLimit;
@@ -74,16 +79,14 @@ List<AggregatedItem> normalizeLatestMediaItems(
   String? collectionType,
   required int limit,
 }) {
-  final normalizedType = collectionType?.toLowerCase();
-  final isTvCollection =
-      normalizedType == 'tvshows' || normalizedType == 'shows';
-  final hasTvItems =
-      items.any((i) => i.type == 'Episode' || i.type == 'Season');
+  // Paging asks without a collection type, so a row that opened with series
+  // cards would start handing back seasons part way along.
   final shouldCollapse =
-      isTvCollection || (normalizedType == null && hasTvItems);
+      _isTvCollectionType(collectionType) ||
+      (collectionType == null &&
+          items.any((i) => i.type == 'Episode' || i.type == 'Season'));
 
-  final normalized =
-      shouldCollapse ? _collapseLatestTvItems(items) : items;
+  final normalized = shouldCollapse ? _collapseLatestTvItems(items) : items;
 
   if (normalized.length <= limit) {
     return normalized;
@@ -134,8 +137,11 @@ AggregatedItem? _seriesCardForLatestTvItem(AggregatedItem item) {
         item.primaryImageTag ?? item.primaryImageTagField;
   }
 
+  // A season's parent is the series so its tag fits the id set below, but an
+  // episode's parent is the season and that tag would not match the series.
   final seriesPrimaryImageTag =
-      item.seriesPrimaryImageTag ?? item.parentPrimaryImageTag;
+      item.seriesPrimaryImageTag ??
+      (item.type == 'Season' ? item.parentPrimaryImageTag : null);
   if (seriesPrimaryImageTag != null && seriesPrimaryImageTag.isNotEmpty) {
     final imageTags = Map<String, dynamic>.from(
       rawData['ImageTags'] as Map? ?? const {},

--- a/lib/ui/screens/home/home_screen.dart
+++ b/lib/ui/screens/home/home_screen.dart
@@ -5039,6 +5039,10 @@ class _ContentRowsState extends State<_ContentRows>
               cardSubtitle = episodeInfo ?? item.name;
               cardSubtitleWidget = null;
             }
+          } else if (isRowsV2 && item.type == 'Season') {
+            cardTitle = item.seriesName ?? item.name;
+            cardSubtitle = item.name;
+            cardSubtitleWidget = null;
           } else {
             cardTitle = item.name;
             final showUserRatings = item.rawData['ShowUserRatings'] == true;

--- a/test/data/utils/latest_media_row_normalizer_test.dart
+++ b/test/data/utils/latest_media_row_normalizer_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moonfin/data/models/aggregated_item.dart';
+import 'package:moonfin/data/utils/latest_media_row_normalizer.dart';
+
+AggregatedItem _createItem({
+  required String id,
+  required String name,
+  required String type,
+  String? seriesId,
+  String? seriesName,
+  String? seriesPrimaryImageTag,
+  String? parentPrimaryImageTag,
+}) {
+  return AggregatedItem(
+    id: id,
+    serverId: 'server1',
+    rawData: {
+      'Id': id,
+      'Name': name,
+      'Type': type,
+      'SeriesId': ?seriesId,
+      'SeriesName': ?seriesName,
+      'SeriesPrimaryImageTag': ?seriesPrimaryImageTag,
+      'ParentPrimaryImageTag': ?parentPrimaryImageTag,
+    },
+  );
+}
+
+void main() {
+  group('latestMediaFetchLimitForCollection', () {
+    test('expands limit for tvshows and shows', () {
+      expect(
+        latestMediaFetchLimitForCollection('tvshows', defaultLimit: 15, maxLimit: 100),
+        equals(60),
+      );
+      expect(
+        latestMediaFetchLimitForCollection('shows', defaultLimit: 15, maxLimit: 100),
+        equals(60),
+      );
+    });
+
+    test('respects maxLimit when expanded limit exceeds it', () {
+      expect(
+        latestMediaFetchLimitForCollection('tvshows', defaultLimit: 30, maxLimit: 100),
+        equals(100),
+      );
+    });
+
+    test('returns defaultLimit for other types or null', () {
+      expect(
+        latestMediaFetchLimitForCollection('movies', defaultLimit: 15, maxLimit: 100),
+        equals(15),
+      );
+      expect(
+        latestMediaFetchLimitForCollection(null, defaultLimit: 15, maxLimit: 100),
+        equals(15),
+      );
+    });
+  });
+
+  group('normalizeLatestMediaItems', () {
+    final seasonItem = _createItem(
+      id: 'season-party-down-1',
+      name: 'Season 1',
+      type: 'Season',
+      seriesId: 'series-party-down',
+      seriesName: 'Party Down',
+      seriesPrimaryImageTag: 'tag123',
+    );
+
+    final episodeItem = _createItem(
+      id: 'ep-misfits-1',
+      name: 'Episode 1',
+      type: 'Episode',
+      seriesId: 'series-misfits',
+      seriesName: 'Misfits',
+      parentPrimaryImageTag: 'parentTag456',
+    );
+
+    final seriesItem = _createItem(
+      id: 'series-firefly',
+      name: 'Firefly',
+      type: 'Series',
+    );
+
+    final movieItem = _createItem(
+      id: 'movie-the-matrix',
+      name: 'The Matrix',
+      type: 'Movie',
+    );
+
+    test('collapses Season and Episode items into Series when collectionType is tvshows', () {
+      final input = [seasonItem, episodeItem, seriesItem];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: 'tvshows',
+        limit: 10,
+      );
+
+      expect(result.length, equals(3));
+      expect(result[0].id, equals('series-party-down'));
+      expect(result[0].name, equals('Party Down'));
+      expect(result[0].type, equals('Series'));
+      expect(result[0].primaryImageTagField, equals('tag123'));
+
+      expect(result[1].id, equals('series-misfits'));
+      expect(result[1].name, equals('Misfits'));
+      expect(result[1].type, equals('Series'));
+      expect(result[1].primaryImageTagField, equals('parentTag456'));
+
+      expect(result[2].id, equals('series-firefly'));
+      expect(result[2].name, equals('Firefly'));
+      expect(result[2].type, equals('Series'));
+    });
+
+    test('collapses Season and Episode items when collectionType is shows alias', () {
+      final input = [seasonItem];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: 'shows',
+        limit: 10,
+      );
+
+      expect(result.length, equals(1));
+      expect(result[0].id, equals('series-party-down'));
+      expect(result[0].name, equals('Party Down'));
+      expect(result[0].type, equals('Series'));
+    });
+
+    test('auto-detects TV items and collapses them even when collectionType is null', () {
+      final input = [seasonItem, seriesItem];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: null,
+        limit: 10,
+      );
+
+      expect(result.length, equals(2));
+      expect(result[0].id, equals('series-party-down'));
+      expect(result[0].name, equals('Party Down'));
+      expect(result[0].type, equals('Series'));
+    });
+
+    test('deduplicates multiple seasons or episodes from the same series', () {
+      final season2 = _createItem(
+        id: 'season-party-down-2',
+        name: 'Season 2',
+        type: 'Season',
+        seriesId: 'series-party-down',
+        seriesName: 'Party Down',
+      );
+
+      final input = [seasonItem, season2];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: 'tvshows',
+        limit: 10,
+      );
+
+      expect(result.length, equals(1));
+      expect(result[0].id, equals('series-party-down'));
+      expect(result[0].name, equals('Party Down'));
+    });
+
+    test('does not collapse non-TV items like movies', () {
+      final input = [movieItem];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: 'movies',
+        limit: 10,
+      );
+
+      expect(result.length, equals(1));
+      expect(result[0].id, equals('movie-the-matrix'));
+      expect(result[0].name, equals('The Matrix'));
+      expect(result[0].type, equals('Movie'));
+    });
+
+    test('does not collapse movie items when collectionType is null', () {
+      final input = [movieItem];
+      final result = normalizeLatestMediaItems(
+        input,
+        collectionType: null,
+        limit: 10,
+      );
+
+      expect(result.length, equals(1));
+      expect(result[0].id, equals('movie-the-matrix'));
+      expect(result[0].name, equals('The Matrix'));
+      expect(result[0].type, equals('Movie'));
+    });
+  });
+}

--- a/test/data/utils/latest_media_row_normalizer_test.dart
+++ b/test/data/utils/latest_media_row_normalizer_test.dart
@@ -74,7 +74,7 @@ void main() {
       type: 'Episode',
       seriesId: 'series-misfits',
       seriesName: 'Misfits',
-      parentPrimaryImageTag: 'parentTag456',
+      seriesPrimaryImageTag: 'seriesTag456',
     );
 
     final seriesItem = _createItem(
@@ -106,7 +106,7 @@ void main() {
       expect(result[1].id, equals('series-misfits'));
       expect(result[1].name, equals('Misfits'));
       expect(result[1].type, equals('Series'));
-      expect(result[1].primaryImageTagField, equals('parentTag456'));
+      expect(result[1].primaryImageTagField, equals('seriesTag456'));
 
       expect(result[2].id, equals('series-firefly'));
       expect(result[2].name, equals('Firefly'));
@@ -188,6 +188,59 @@ void main() {
       expect(result[0].id, equals('movie-the-matrix'));
       expect(result[0].name, equals('The Matrix'));
       expect(result[0].type, equals('Movie'));
+    });
+
+    test('leaves a movie alone in a mixed list with no collectionType', () {
+      final result = normalizeLatestMediaItems(
+        [movieItem, episodeItem],
+        collectionType: null,
+        limit: 10,
+      );
+
+      expect(result.length, equals(2));
+      expect(result[0].id, equals('movie-the-matrix'));
+      expect(result[0].type, equals('Movie'));
+      expect(result[1].id, equals('series-misfits'));
+      expect(result[1].type, equals('Series'));
+    });
+
+    test('a season with no series tag takes its parent tag', () {
+      final season = _createItem(
+        id: 'season-fleabag-1',
+        name: 'Season 1',
+        type: 'Season',
+        seriesId: 'series-fleabag',
+        seriesName: 'Fleabag',
+        parentPrimaryImageTag: 'seriesArt',
+      );
+
+      final result = normalizeLatestMediaItems(
+        [season],
+        collectionType: 'tvshows',
+        limit: 10,
+      );
+
+      expect(result.single.primaryImageTagField, equals('seriesArt'));
+    });
+
+    test('an episode does not take its season tag', () {
+      final episode = _createItem(
+        id: 'ep-fleabag-1',
+        name: 'Episode 1',
+        type: 'Episode',
+        seriesId: 'series-fleabag',
+        seriesName: 'Fleabag',
+        parentPrimaryImageTag: 'seasonArt',
+      );
+
+      final result = normalizeLatestMediaItems(
+        [episode],
+        collectionType: 'tvshows',
+        limit: 10,
+      );
+
+      expect(result.single.id, equals('series-fleabag'));
+      expect(result.single.primaryImageTagField, isNull);
     });
   });
 }


### PR DESCRIPTION
# Pull Request

## Summary
This one isn't our fault! JF 12 made a bizarre choice to hard-code conditional logic into their Recently Added row for TV shows:
<img width="500" alt="2026-09-12_14-08-43_Antigravity_IDE" src="https://github.com/user-attachments/assets/9f562fb4-3ee7-4188-913f-e213700ab16d" /> 

The outcome of this is that, depending on how the conditional tree gets evaluated, each item could be: a TV series card, a season card, or even an episode card. And their labelling follows suit.  This PR adds content-aware TV item detection to ensure normalization collapses episodes and seasons even when `collectionType` is omitted during paging, adds support for the `'shows'` collection type alias, provides artwork fallbacks for season entities, and updates Modern card rendering so that Season cards display their series name as the card title with the season name as subtitle.

## Related Issues
Link related issues or tickets separated by commas.

- Closes #
- Fixes #
- Related to #

## Type of Change
- [X] Bug fix
- [ ] New feature
- [X] Refactor
- [ ] Performance improvement
- [X] UI/UX update
- [ ] Documentation update
- [ ] Build/CI change
- [ ] Other (describe):

## Changes Made
List the key changes included in this PR.

- **latest_media_row_normalizer.dart**:
  - In `normalizeLatestMediaItems`, auto-detect TV items in the collection so `Episode` and `Season` items are collapsed into `Series` cards even when `collectionType` is omitted (`null`) during pagination or set to the `'shows'` alias.
  - In `latestMediaFetchLimitForCollection`, recognize `'shows'` alongside `'tvshows'`.
  - In `_seriesCardForLatestTvItem`, add fallback to `parentPrimaryImageTag` when `seriesPrimaryImageTag` is null on a season or episode.
- **home_screen.dart**:
  - In the card title builder for Modern rows (`isRowsV2`), add handling for `item.type == 'Season'` so that `cardTitle` resolves to `item.seriesName ?? item.name` and `cardSubtitle` displays the season name (e.g. "Season 1").
- **latest_media_row_normalizer_test.dart**:
  - Added unit test suite covering fetch limit expansion for `'tvshows'` and `'shows'`, normalization and collapse for seasons and episodes with and without `collectionType`, deduplication of multiple seasons from the same show, and verifying non-TV items (such as movies) remain unaltered.

## Platform
- [ ] Android
- [ ] Android TV
- [ ] iOS
- [ ] tvOS
- [ ] Web
- [ ] macOS
- [ ] Windows
- [ ] Linux
- [X] All / Shared code

## Testing
Describe how this change was tested.

- [ ] Tested on emulator / simulator
- [X] Tested on physical device
- [X] Manual testing completed
- [ ] Not tested (explain why):

### Test Steps
1. Open Moonfin connected to a server with multi-season series in a TV library where individual seasons or episodes were recently added.
2. Observe the Recently Added / Latest Media row on the home screen. Verify all cards display the show title (e.g., "Party Down", "Misfits", "Fleabag") rather than generic season labels ("Season 1", "Series 1").
3. Scroll horizontally through the row past card 15 to trigger `loadMore` pagination.
4. Verify that paged cards continue to show their proper series names and posters without switching to Jellyfin's season naming.
5. Ran automated test suite via `flutter test test/data/utils/latest_media_row_normalizer_test.dart` (all 9 unit tests passed).
6. Ran analyzer check via `flutter analyze` (0 issues found).

## Screenshots (if applicable)
Include screenshots or recordings for UI changes.

### Jellyfin 12 Labels/Links
<img width="2524" height="771" alt="2026-09-12_14-18-43_Antigravity_IDE" src="https://github.com/user-attachments/assets/aaa65ba5-fbe3-4c04-ad22-897c687368c7" />

### Moonfin Labels
<img width="2508" height="774" alt="2026-09-12_14-46-26_moonfin" src="https://github.com/user-attachments/assets/b913d32f-e698-4ffd-ba45-811137f51a8f" />


## Checklist
- [X] Code builds successfully
- [X] Code follows project style and conventions
- [X] No unnecessary commented-out code
- [X] No new warnings introduced
